### PR TITLE
Add Remodex-style voice-to-text flow for Codex chats

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -34,6 +34,8 @@ import {
   type ProviderTurnStartResult,
   RuntimeMode,
   ProviderInteractionMode,
+  type ServerVoiceTranscriptionInput,
+  type ServerVoiceTranscriptionResult,
 } from "@t3tools/contracts";
 import { readActiveCodexProviderEnvKey } from "@t3tools/shared/codexConfig";
 import { normalizeModelSlug } from "@t3tools/shared/model";
@@ -50,6 +52,7 @@ import {
   parseCodexCliVersion,
 } from "./provider/codexCliVersion";
 import { isNonFatalCodexErrorMessage } from "./codexErrorClassification.ts";
+import { transcribeVoiceWithChatGptSession } from "./voiceTranscription.ts";
 
 type PendingRequestKey = string;
 
@@ -159,6 +162,11 @@ interface CodexAccountSnapshot {
   readonly type: "apiKey" | "chatgpt" | "unknown";
   readonly planType: CodexPlanType | null;
   readonly sparkEnabled: boolean;
+}
+
+interface CodexVoiceTranscriptionAuthContext {
+  readonly authMethod: "chatgpt" | "chatgptAuthTokens";
+  readonly token: string;
 }
 
 export interface CodexAppServerSendTurnInput {
@@ -1552,6 +1560,20 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     return result;
   }
 
+  async transcribeVoice(
+    input: ServerVoiceTranscriptionInput,
+  ): Promise<ServerVoiceTranscriptionResult> {
+    return transcribeVoiceWithChatGptSession({
+      request: input,
+      resolveAuth: (refreshToken) =>
+        this.resolveVoiceTranscriptionAuth({
+          cwd: input.cwd,
+          ...(input.threadId ? { threadId: input.threadId } : {}),
+          refreshToken,
+        }),
+    });
+  }
+
   getComposerCapabilities(): ProviderComposerCapabilities {
     return {
       provider: "codex",
@@ -1612,6 +1634,32 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       return firstActive;
     }
     return this.getOrCreateDiscoverySession(process.cwd());
+  }
+
+  private async resolveVoiceTranscriptionAuth(input: {
+    readonly cwd?: string;
+    readonly threadId?: string;
+    readonly refreshToken: boolean;
+  }): Promise<CodexVoiceTranscriptionAuthContext> {
+    const context = await this.resolveContextForDiscovery(input.threadId, input.cwd);
+    const response = await this.sendRequest<Record<string, unknown>>(context, "getAuthStatus", {
+      includeToken: true,
+      refreshToken: input.refreshToken,
+    });
+    const authMethod = this.readString(response, "authMethod");
+    const token = this.readString(response, "authToken");
+
+    if (!token) {
+      throw new Error("No ChatGPT session token is available. Sign in to ChatGPT in Codex.");
+    }
+    if (authMethod !== "chatgpt" && authMethod !== "chatgptAuthTokens") {
+      throw new Error("Voice transcription requires a ChatGPT-authenticated Codex session.");
+    }
+
+    return {
+      authMethod,
+      token,
+    };
   }
 
   private async getOrCreateDiscoverySession(cwd: string): Promise<CodexSessionContext> {

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -16,6 +16,7 @@ import {
   type ProviderReadPluginResult,
   type ProviderListSkillsResult,
   type ProviderRuntimeEvent,
+  type ServerVoiceTranscriptionResult,
   type ThreadTokenUsageSnapshot,
   type ProviderUserInputAnswers,
   RuntimeItemId,
@@ -1694,6 +1695,18 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
           }),
       }).pipe(Effect.map((result) => result satisfies ProviderListModelsResult));
 
+    const transcribeVoice: NonNullable<CodexAdapterShape["transcribeVoice"]> = (input) =>
+      Effect.tryPromise({
+        try: () => manager.transcribeVoice(input),
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "voice/transcribe",
+            detail: toMessage(cause, "voice/transcribe failed"),
+            cause,
+          }),
+      }).pipe(Effect.map((result) => result satisfies ServerVoiceTranscriptionResult));
+
     const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
 
     yield* Effect.acquireRelease(
@@ -1765,6 +1778,7 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
       listPlugins,
       readPlugin,
       listModels,
+      transcribeVoice,
       streamEvents: Stream.fromQueue(runtimeEventQueue),
     } satisfies CodexAdapterShape;
   });

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -85,9 +85,44 @@ function extractAuthBoolean(value: unknown): boolean | undefined {
   return undefined;
 }
 
+function extractAuthMethod(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const nested = extractAuthMethod(entry);
+      if (nested !== undefined) return nested;
+    }
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object") return undefined;
+
+  const record = value as Record<string, unknown>;
+  for (const key of ["authMethod", "auth_type", "authType"] as const) {
+    if (typeof record[key] === "string") {
+      const trimmed = record[key].trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  }
+  for (const key of ["auth", "status", "session", "account"] as const) {
+    const nested = extractAuthMethod(record[key]);
+    if (nested !== undefined) return nested;
+  }
+  return undefined;
+}
+
+function resolveVoiceTranscriptionAvailability(authMethod: string | undefined): boolean | undefined {
+  if (!authMethod) {
+    return undefined;
+  }
+  return authMethod === "chatgpt" || authMethod === "chatgptAuthTokens";
+}
+
 export function parseAuthStatusFromOutput(result: CommandResult): {
   readonly status: ServerProviderStatusState;
   readonly authStatus: ServerProviderAuthStatus;
+  readonly voiceTranscriptionAvailable?: boolean;
   readonly message?: string;
 } {
   const lowerOutput = `${result.stdout}\n${result.stderr}`.toLowerCase();
@@ -121,20 +156,40 @@ export function parseAuthStatusFromOutput(result: CommandResult): {
   const parsedAuth = (() => {
     const trimmed = result.stdout.trim();
     if (!trimmed || (!trimmed.startsWith("{") && !trimmed.startsWith("["))) {
-      return { attemptedJsonParse: false as const, auth: undefined as boolean | undefined };
+      return {
+        attemptedJsonParse: false as const,
+        auth: undefined as boolean | undefined,
+        authMethod: undefined as string | undefined,
+      };
     }
     try {
+      const parsed = JSON.parse(trimmed);
       return {
         attemptedJsonParse: true as const,
-        auth: extractAuthBoolean(JSON.parse(trimmed)),
+        auth: extractAuthBoolean(parsed),
+        authMethod: extractAuthMethod(parsed),
       };
     } catch {
-      return { attemptedJsonParse: false as const, auth: undefined as boolean | undefined };
+      return {
+        attemptedJsonParse: false as const,
+        auth: undefined as boolean | undefined,
+        authMethod: undefined as string | undefined,
+      };
     }
   })();
 
   if (parsedAuth.auth === true) {
-    return { status: "ready", authStatus: "authenticated" };
+    return {
+      status: "ready",
+      authStatus: "authenticated",
+      ...(resolveVoiceTranscriptionAvailability(parsedAuth.authMethod) !== undefined
+        ? {
+            voiceTranscriptionAvailable: resolveVoiceTranscriptionAvailability(
+              parsedAuth.authMethod,
+            ),
+          }
+        : {}),
+    };
   }
   if (parsedAuth.auth === false) {
     return {
@@ -343,6 +398,7 @@ export const checkCodexProviderStatus: Effect.Effect<
       status: "ready" as const,
       available: true,
       authStatus: "unknown" as const,
+      voiceTranscriptionAvailable: false,
       checkedAt,
       message: "Using a custom Codex model provider; OpenAI login check skipped.",
     } satisfies ServerProviderStatus;
@@ -385,6 +441,9 @@ export const checkCodexProviderStatus: Effect.Effect<
     status: parsed.status,
     available: true,
     authStatus: parsed.authStatus,
+    ...(parsed.voiceTranscriptionAvailable !== undefined
+      ? { voiceTranscriptionAvailable: parsed.voiceTranscriptionAvailable }
+      : {}),
     checkedAt,
     ...(parsed.message ? { message: parsed.message } : {}),
   } satisfies ServerProviderStatus;

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -30,6 +30,8 @@ import type {
   ProviderSteerTurnInput,
   ProviderSession,
   ProviderSessionStartInput,
+  ServerVoiceTranscriptionInput,
+  ServerVoiceTranscriptionResult,
   ThreadId,
   ProviderTurnStartResult,
   TurnId,
@@ -206,4 +208,11 @@ export interface ProviderAdapterShape<TError> {
    * List models directly from the provider runtime when supported.
    */
   readonly listModels?: () => Effect.Effect<ProviderListModelsResult, TError>;
+
+  /**
+   * Transcribe one captured voice clip into plain text when supported.
+   */
+  readonly transcribeVoice?: (
+    input: ServerVoiceTranscriptionInput,
+  ) => Effect.Effect<ServerVoiceTranscriptionResult, TError>;
 }

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -23,6 +23,7 @@ import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRe
 import { makeProviderServiceLive } from "./provider/Layers/ProviderService";
 import { ProviderDiscoveryServiceLive } from "./provider/Layers/ProviderDiscoveryService";
 import { ProviderSessionDirectoryLive } from "./provider/Layers/ProviderSessionDirectory";
+import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
 import { ProviderDiscoveryService } from "./provider/Services/ProviderDiscoveryService";
 import { ProviderService } from "./provider/Services/ProviderService";
 import { makeEventNdjsonLogger } from "./provider/Layers/EventNdjsonLogger";
@@ -54,7 +55,7 @@ const makeRuntimePtyAdapterLayer = () =>
   }).pipe(Layer.unwrap);
 
 export function makeServerProviderLayer(): Layer.Layer<
-  ProviderService | ProviderDiscoveryService,
+  ProviderService | ProviderDiscoveryService | ProviderAdapterRegistry,
   ProviderUnsupportedError,
   SqlClient.SqlClient | ServerConfig | FileSystem.FileSystem | AnalyticsService
 > {
@@ -86,7 +87,7 @@ export function makeServerProviderLayer(): Layer.Layer<
     const providerDiscoveryLayer = ProviderDiscoveryServiceLive.pipe(
       Layer.provide(adapterRegistryLayer),
     );
-    return Layer.mergeAll(providerServiceLayer, providerDiscoveryLayer);
+    return Layer.mergeAll(providerServiceLayer, providerDiscoveryLayer, adapterRegistryLayer);
   }).pipe(Layer.unwrap);
 }
 

--- a/apps/server/src/voiceTranscription.ts
+++ b/apps/server/src/voiceTranscription.ts
@@ -1,0 +1,167 @@
+// FILE: voiceTranscription.ts
+// Purpose: Validates Remodex-style WAV payloads and proxies them to ChatGPT transcription.
+// Layer: Server utility
+// Exports: transcribeVoiceWithChatGptSession
+// Depends on: OpenAI/ChatGPT session auth supplied by Codex app-server callers.
+
+import { Buffer } from "node:buffer";
+
+import type {
+  ServerVoiceTranscriptionInput,
+  ServerVoiceTranscriptionResult,
+} from "@t3tools/contracts";
+
+const CHATGPT_TRANSCRIPTIONS_URL = "https://chatgpt.com/backend-api/transcribe";
+const MAX_AUDIO_BYTES = 10 * 1024 * 1024;
+const MAX_DURATION_MS = 120_000;
+
+export interface ChatGptVoiceAuthContext {
+  readonly token: string;
+  readonly transcriptionUrl?: string;
+}
+
+// Validate the captured WAV clip and retry once if the ChatGPT session needs a refresh.
+export async function transcribeVoiceWithChatGptSession(input: {
+  readonly request: ServerVoiceTranscriptionInput;
+  readonly resolveAuth: (refreshToken: boolean) => Promise<ChatGptVoiceAuthContext>;
+  readonly fetchImpl?: typeof fetch;
+}): Promise<ServerVoiceTranscriptionResult> {
+  const fetchImpl = input.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    throw new Error("Voice transcription is unavailable in this runtime.");
+  }
+
+  const audioBuffer = decodeVoiceAudio(input.request);
+  let auth = await input.resolveAuth(false);
+  let response = await requestTranscription({
+    fetchImpl,
+    audioBuffer,
+    mimeType: input.request.mimeType,
+    token: auth.token,
+    transcriptionUrl: auth.transcriptionUrl,
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    auth = await input.resolveAuth(true);
+    response = await requestTranscription({
+      fetchImpl,
+      audioBuffer,
+      mimeType: input.request.mimeType,
+      token: auth.token,
+      transcriptionUrl: auth.transcriptionUrl,
+    });
+  }
+
+  if (!response.ok) {
+    throw new Error(await readTranscriptionErrorMessage(response));
+  }
+
+  const payload = (await response.json().catch(() => null)) as {
+    text?: unknown;
+    transcript?: unknown;
+  } | null;
+  const text = readString(payload?.text) ?? readString(payload?.transcript);
+  if (!text) {
+    throw new Error("The transcription response did not include any text.");
+  }
+
+  return { text };
+}
+
+// Keep the server-side contract strict so the private backend only sees normalized clips.
+function decodeVoiceAudio(input: ServerVoiceTranscriptionInput): Buffer {
+  if (input.mimeType !== "audio/wav") {
+    throw new Error("Only WAV audio is supported for voice transcription.");
+  }
+  if (input.sampleRateHz !== 24_000) {
+    throw new Error("Voice transcription requires 24 kHz mono WAV audio.");
+  }
+  if (input.durationMs <= 0) {
+    throw new Error("Voice messages must include a positive duration.");
+  }
+  if (input.durationMs > MAX_DURATION_MS) {
+    throw new Error("Voice messages are limited to 120 seconds.");
+  }
+
+  const normalizedBase64 = normalizeBase64(input.audioBase64);
+  if (!normalizedBase64 || !isLikelyBase64(normalizedBase64)) {
+    throw new Error("The recorded audio could not be decoded.");
+  }
+
+  const audioBuffer = Buffer.from(normalizedBase64, "base64");
+  if (!audioBuffer.length || audioBuffer.toString("base64") !== normalizedBase64) {
+    throw new Error("The recorded audio could not be decoded.");
+  }
+  if (audioBuffer.length > MAX_AUDIO_BYTES) {
+    throw new Error("Voice messages are limited to 10 MB.");
+  }
+  if (!isLikelyWavBuffer(audioBuffer)) {
+    throw new Error("The recorded audio is not a valid WAV file.");
+  }
+
+  return audioBuffer;
+}
+
+async function requestTranscription(input: {
+  readonly fetchImpl: typeof fetch;
+  readonly audioBuffer: Buffer;
+  readonly mimeType: string;
+  readonly token: string;
+  readonly transcriptionUrl?: string;
+}): Promise<Response> {
+  const formData = new FormData();
+  formData.append("file", new Blob([input.audioBuffer], { type: input.mimeType }), "voice.wav");
+
+  return input.fetchImpl(input.transcriptionUrl ?? CHATGPT_TRANSCRIPTIONS_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.token}`,
+    },
+    body: formData,
+  });
+}
+
+async function readTranscriptionErrorMessage(response: Response): Promise<string> {
+  let errorMessage = `Transcription failed with status ${response.status}.`;
+  try {
+    const payload = (await response.json()) as {
+      error?: { message?: unknown };
+      message?: unknown;
+    } | null;
+    const providerMessage =
+      readString(payload?.error?.message) ?? readString(payload?.message) ?? null;
+    if (providerMessage) {
+      errorMessage = providerMessage;
+    }
+  } catch {
+    // Keep the generic status-based message when the provider body is empty or invalid.
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    return "Your ChatGPT login has expired. Sign in again.";
+  }
+
+  return errorMessage;
+}
+
+function normalizeBase64(value: string): string | null {
+  const normalized = value.trim().replace(/\s+/g, "");
+  return normalized.length > 0 ? normalized : null;
+}
+
+function isLikelyBase64(value: string): boolean {
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+}
+
+function isLikelyWavBuffer(buffer: Buffer): boolean {
+  return (
+    buffer.length >= 12 &&
+    buffer.toString("ascii", 0, 4) === "RIFF" &&
+    buffer.toString("ascii", 8, 12) === "WAVE"
+  );
+}
+
+function readString(value: unknown): string | null {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized.length > 0 ? normalized : null;
+}

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -59,6 +59,7 @@ import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnap
 import { OrchestrationReactor } from "./orchestration/Services/OrchestrationReactor";
 import { ProviderService } from "./provider/Services/ProviderService";
 import { ProviderDiscoveryService } from "./provider/Services/ProviderDiscoveryService";
+import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
 import { ProviderHealth } from "./provider/Services/ProviderHealth";
 import { CheckpointDiffQuery } from "./checkpointing/Services/CheckpointDiffQuery";
 import { clamp } from "effect/Number";
@@ -274,6 +275,7 @@ export type ServerCoreRuntimeServices =
   | OrchestrationReactor
   | ProviderService
   | ProviderDiscoveryService
+  | ProviderAdapterRegistry
   | ProviderHealth;
 
 export type ServerRuntimeServices =
@@ -382,6 +384,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
   const keybindingsManager = yield* Keybindings;
   const providerHealth = yield* ProviderHealth;
   const providerDiscoveryService = yield* ProviderDiscoveryService;
+  const providerAdapterRegistry = yield* ProviderAdapterRegistry;
   const git = yield* GitCore;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -1105,6 +1108,27 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
           providers: providerStatuses,
           availableEditors,
         };
+
+      case WS_METHODS.serverTranscribeVoice: {
+        const body = stripRequestTag(request.body);
+        const adapter = yield* providerAdapterRegistry.getByProvider(body.provider);
+        if (!adapter.transcribeVoice) {
+          return yield* new RouteRequestError({
+            message: `Voice transcription is unavailable for provider '${body.provider}'.`,
+          });
+        }
+        return yield* adapter.transcribeVoice(body).pipe(
+          Effect.mapError(
+            (cause) =>
+              new RouteRequestError({
+                message:
+                  cause instanceof Error && cause.message.length > 0
+                    ? cause.message
+                    : "Voice transcription failed.",
+              }),
+          ),
+        );
+      }
 
       case WS_METHODS.serverUpsertKeybinding: {
         const body = stripRequestTag(request.body);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -194,6 +194,7 @@ import {
   type TerminalContextSelection,
 } from "../lib/terminalContext";
 import { deriveLatestContextWindowSnapshot, deriveCumulativeCostUsd } from "../lib/contextWindow";
+import { formatVoiceRecordingDuration, useVoiceRecorder } from "../lib/voiceRecorder";
 import { shouldUseCompactComposerFooter } from "./composerFooterLayout";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
 import { collectTerminalIdsFromLayout } from "../terminalPaneLayout";
@@ -216,6 +217,7 @@ import { ComposerExtrasMenu } from "./chat/ComposerExtrasMenu";
 import { ComposerPendingApprovalPanel } from "./chat/ComposerPendingApprovalPanel";
 import { ComposerPendingUserInputPanel } from "./chat/ComposerPendingUserInputPanel";
 import { ComposerPlanFollowUpBanner } from "./chat/ComposerPlanFollowUpBanner";
+import { ComposerVoiceButton } from "./chat/ComposerVoiceButton";
 import { ComposerImageAttachmentChip } from "./chat/ComposerImageAttachmentChip";
 import { ActivePlanCard } from "./chat/ActivePlanCard";
 import { useChatAutoScrollController } from "./chat/useChatAutoScrollController";
@@ -506,6 +508,14 @@ export default function ChatView({
   const composerImages = composerDraft.images;
   const composerTerminalContexts = composerDraft.terminalContexts;
   const queuedComposerTurns = composerDraft.queuedTurns;
+  const {
+    isRecording: isVoiceRecording,
+    durationMs: voiceRecordingDurationMs,
+    startRecording: startVoiceRecording,
+    stopRecording: stopVoiceRecording,
+    cancelRecording: cancelVoiceRecording,
+  } = useVoiceRecorder();
+  const [isVoiceTranscribing, setIsVoiceTranscribing] = useState(false);
   const composerSendState = useMemo(
     () =>
       deriveComposerSendState({
@@ -921,6 +931,11 @@ export default function ChatView({
     : null;
   const selectedProvider: ProviderKind =
     lockedProvider ?? selectedProviderByThreadId ?? threadProvider ?? settings.defaultProvider;
+  const voiceTranscriptionRequestIdRef = useRef(0);
+  const voiceThreadIdRef = useRef(threadId);
+  const voiceProviderRef = useRef<ProviderKind>(selectedProvider);
+  voiceThreadIdRef.current = threadId;
+  voiceProviderRef.current = selectedProvider;
   const customModelsByProvider = useMemo(() => getCustomModelsByProvider(settings), [settings]);
   const { modelOptions: composerModelOptions, selectedModel } = useEffectiveComposerModelState({
     threadId,
@@ -1665,6 +1680,17 @@ export default function ChatView({
     () => providerStatuses.find((status) => status.provider === selectedProvider) ?? null,
     [selectedProvider, providerStatuses],
   );
+  const voiceRecordingDurationLabel = useMemo(
+    () => formatVoiceRecordingDuration(voiceRecordingDurationMs),
+    [voiceRecordingDurationMs],
+  );
+  const canRenderVoiceNotes =
+    selectedProvider === "codex" && activeProviderStatus?.authStatus !== "unauthenticated";
+  const canStartVoiceNotes =
+    selectedProvider === "codex" &&
+    activeProviderStatus?.authStatus !== "unauthenticated" &&
+    activeProviderStatus?.voiceTranscriptionAvailable !== false;
+  const showVoiceNotesControl = canRenderVoiceNotes || isVoiceRecording || isVoiceTranscribing;
   const activeProjectCwd = activeProject?.cwd ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const hasNativeUserMessages = useMemo(
@@ -2767,6 +2793,9 @@ export default function ChatView({
   }, [selectedProvider]);
 
   useEffect(() => {
+    voiceTranscriptionRequestIdRef.current += 1;
+    void cancelVoiceRecording();
+    setIsVoiceTranscribing(false);
     setOptimisticUserMessages((existing) => {
       for (const message of existing) {
         revokeUserMessagePreviewUrls(message);
@@ -2782,7 +2811,16 @@ export default function ChatView({
     dragDepthRef.current = 0;
     setIsDragOverComposer(false);
     setExpandedImage(null);
-  }, [threadId]);
+  }, [cancelVoiceRecording, threadId]);
+
+  useEffect(() => {
+    if (canStartVoiceNotes || !isVoiceRecording) {
+      return;
+    }
+    voiceTranscriptionRequestIdRef.current += 1;
+    void cancelVoiceRecording();
+    setIsVoiceTranscribing(false);
+  }, [canStartVoiceNotes, cancelVoiceRecording, isVoiceRecording]);
 
   useEffect(() => {
     let cancelled = false;
@@ -3225,6 +3263,146 @@ export default function ChatView({
     setTerminalWorkspaceTab,
     surfaceMode,
     toggleTerminalVisibility,
+  ]);
+
+  // Merge a completed voice transcript into the existing draft without disturbing queued images.
+  const appendVoiceTranscriptToComposer = useCallback(
+    (transcript: string) => {
+      const trimmedTranscript = transcript.trim();
+      if (trimmedTranscript.length === 0) {
+        return;
+      }
+
+      const currentPrompt = promptRef.current;
+      const nextPrompt =
+        currentPrompt.trim().length === 0
+          ? trimmedTranscript
+          : `${currentPrompt.replace(/\s+$/, "")}\n${trimmedTranscript}`;
+      promptRef.current = nextPrompt;
+      setPrompt(nextPrompt);
+      setComposerCursor(collapseExpandedComposerCursor(nextPrompt, nextPrompt.length));
+      setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
+      scheduleComposerFocus();
+    },
+    [scheduleComposerFocus, setPrompt],
+  );
+
+  // Start or stop the microphone recorder, then send the normalized WAV clip to the server.
+  const onComposerVoiceToggle = useCallback(async () => {
+    if (!activeProject) {
+      return;
+    }
+    if (selectedProvider !== "codex") {
+      toastManager.add({
+        type: "error",
+        title: "Voice notes currently work only with Codex.",
+      });
+      return;
+    }
+    if (activeProviderStatus?.authStatus === "unauthenticated") {
+      toastManager.add({
+        type: "error",
+        title: "Sign in to ChatGPT in Codex before using voice notes.",
+      });
+      return;
+    }
+    if (!canStartVoiceNotes) {
+      toastManager.add({
+        type: "error",
+        title: "Voice notes require a ChatGPT-authenticated Codex session.",
+      });
+      return;
+    }
+    if (pendingUserInputs.length > 0) {
+      toastManager.add({
+        type: "error",
+        title: "Answer plan questions before recording a voice note.",
+      });
+      return;
+    }
+
+    if (isVoiceRecording) {
+      const api = readNativeApi();
+      if (!api) {
+        toastManager.add({
+          type: "error",
+          title: "Voice transcription is unavailable right now.",
+        });
+        void cancelVoiceRecording();
+        return;
+      }
+
+      setIsVoiceTranscribing(true);
+      const requestId = voiceTranscriptionRequestIdRef.current + 1;
+      voiceTranscriptionRequestIdRef.current = requestId;
+      const requestThreadId = threadId;
+      const requestProvider = selectedProvider;
+      const isCurrentVoiceRequest = () =>
+        voiceTranscriptionRequestIdRef.current === requestId &&
+        voiceThreadIdRef.current === requestThreadId &&
+        voiceProviderRef.current === requestProvider;
+      try {
+        const payload = await stopVoiceRecording();
+        if (!isCurrentVoiceRequest()) {
+          return;
+        }
+        if (!payload) {
+          toastManager.add({
+            type: "warning",
+            title: "No audio was captured.",
+          });
+          return;
+        }
+        const result = await api.server.transcribeVoice({
+          provider: "codex",
+          cwd: activeProject.cwd,
+          ...(activeThread ? { threadId: activeThread.id } : {}),
+          ...payload,
+        });
+        if (!isCurrentVoiceRequest()) {
+          return;
+        }
+        appendVoiceTranscriptToComposer(result.text);
+      } catch (error) {
+        if (!isCurrentVoiceRequest()) {
+          return;
+        }
+        toastManager.add({
+          type: "error",
+          title: "Voice transcription failed",
+          description:
+            error instanceof Error ? error.message : "The voice note could not be transcribed.",
+        });
+      } finally {
+        if (isCurrentVoiceRequest()) {
+          setIsVoiceTranscribing(false);
+        }
+      }
+      return;
+    }
+
+    try {
+      await startVoiceRecording();
+    } catch (error) {
+      toastManager.add({
+        type: "error",
+        title: "Could not start recording",
+        description: error instanceof Error ? error.message : "The microphone could not be opened.",
+      });
+    }
+  }, [
+    activeProject,
+    activeProviderStatus?.authStatus,
+    activeThread,
+    appendVoiceTranscriptToComposer,
+    canStartVoiceNotes,
+    cancelVoiceRecording,
+    isVoiceRecording,
+    pendingUserInputs.length,
+    selectedProvider,
+    startVoiceRecording,
+    stopVoiceRecording,
+    threadId,
   ]);
 
   // --- Composer attachment entry points -------------------------------------
@@ -5362,6 +5540,19 @@ export default function ChatView({
                             onToggleFastMode={toggleFastMode}
                             onSetPlanMode={setPlanMode}
                           />
+
+                          {showVoiceNotesControl ? (
+                            <ComposerVoiceButton
+                              compact={isComposerFooterCompact}
+                              disabled={isComposerApprovalState || isConnecting || isSendBusy}
+                              isRecording={isVoiceRecording}
+                              isTranscribing={isVoiceTranscribing}
+                              durationLabel={voiceRecordingDurationLabel}
+                              onClick={() => {
+                                void onComposerVoiceToggle();
+                              }}
+                            />
+                          ) : null}
 
                           {/* Provider/model picker */}
                           <ProviderModelPicker

--- a/apps/web/src/components/chat/ComposerVoiceButton.tsx
+++ b/apps/web/src/components/chat/ComposerVoiceButton.tsx
@@ -1,0 +1,57 @@
+// FILE: ComposerVoiceButton.tsx
+// Purpose: Renders the composer mic control for recording and transcribing a voice note.
+// Layer: Chat composer presentation
+// Depends on: shared button styling and caller-owned voice recording state callbacks.
+
+import { memo } from "react";
+
+import { Loader2Icon, MicIcon, StopIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import { Button } from "../ui/button";
+
+export const ComposerVoiceButton = memo(function ComposerVoiceButton(props: {
+  compact: boolean;
+  disabled?: boolean;
+  isRecording: boolean;
+  isTranscribing: boolean;
+  durationLabel: string;
+  onClick: () => void;
+}) {
+  const label = props.isTranscribing
+    ? "Transcribing voice note"
+    : props.isRecording
+      ? `Stop voice note (${props.durationLabel})`
+      : "Record voice note";
+
+  return (
+    <Button
+      size="sm"
+      variant="ghost"
+      className={cn(
+        "shrink-0 px-2 text-muted-foreground/70 hover:text-foreground/80",
+        props.isRecording && "text-red-500 hover:text-red-500",
+      )}
+      disabled={props.disabled || props.isTranscribing}
+      aria-label={label}
+      title={label}
+      onClick={props.onClick}
+    >
+      {props.isTranscribing ? (
+        <Loader2Icon aria-hidden="true" className="size-4 animate-spin" />
+      ) : props.isRecording ? (
+        <StopIcon aria-hidden="true" className="size-4" />
+      ) : (
+        <MicIcon aria-hidden="true" className="size-4" />
+      )}
+      {!props.compact && (
+        <span className="ml-1.5 text-xs font-medium">
+          {props.isTranscribing
+            ? "Transcribing"
+            : props.isRecording
+              ? props.durationLabel
+              : "Voice"}
+        </span>
+      )}
+    </Button>
+  );
+});

--- a/apps/web/src/lib/icons.tsx
+++ b/apps/web/src/lib/icons.tsx
@@ -47,11 +47,13 @@ import {
   IconLockOpen,
   IconMaximize,
   IconMinimize,
+  IconMicrophone,
   IconPalette,
   IconPaperclip,
   IconPin,
   IconPinnedFilled,
   IconPlayerPlay,
+  IconPlayerStop,
   IconPlus,
   IconRefresh,
   IconRocket,
@@ -136,6 +138,7 @@ export const LockIcon = adaptIcon(IconLock);
 export const LockOpenIcon = adaptIcon(IconLockOpen);
 export const Maximize2 = adaptIcon(IconMaximize);
 export const Minimize2 = adaptIcon(IconMinimize);
+export const MicIcon = adaptIcon(IconMicrophone);
 export const PanelLeftCloseIcon = adaptIcon(IconLayoutSidebarLeftCollapse);
 export const PanelLeftIcon = adaptIcon(IconLayoutSidebarLeftExpand);
 export const PanelRightCloseIcon = adaptIcon(IconLayoutSidebarRightCollapse);
@@ -150,6 +153,7 @@ export const RotateCcwIcon = adaptIcon(IconRotate2);
 export const Rows3Icon = adaptIcon(IconLayoutDistributeHorizontal);
 export const SearchIcon = adaptIcon(IconSearch);
 export const SettingsIcon = adaptIcon(IconSettings);
+export const StopIcon = adaptIcon(IconPlayerStop);
 export const SquarePenIcon = adaptIcon(IconEdit);
 export const SquareSplitHorizontal: LucideIcon = (props) => (
   <PiSquareSplitHorizontal className={props.className} style={props.style} />

--- a/apps/web/src/lib/voiceRecorder.ts
+++ b/apps/web/src/lib/voiceRecorder.ts
@@ -1,0 +1,314 @@
+// FILE: voiceRecorder.ts
+// Purpose: Captures microphone audio in the browser and normalizes it to Remodex-style WAV clips.
+// Layer: Client utility hook
+// Exports: useVoiceRecorder, formatVoiceRecordingDuration
+// Depends on: browser media devices, Web Audio API, and FileReader for base64 encoding.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const TARGET_SAMPLE_RATE = 24_000;
+const BUFFER_SIZE = 4_096;
+
+export interface VoiceRecordingPayload {
+  readonly audioBase64: string;
+  readonly mimeType: "audio/wav";
+  readonly sampleRateHz: number;
+  readonly durationMs: number;
+}
+
+interface RecorderRuntime {
+  readonly audioContext: AudioContext;
+  readonly sourceNode: MediaStreamAudioSourceNode;
+  readonly processorNode: ScriptProcessorNode;
+  readonly silentGainNode: GainNode;
+  readonly stream: MediaStream;
+  readonly chunks: Float32Array[];
+  readonly startedAt: number;
+  sampleRateHz: number;
+}
+
+export function formatVoiceRecordingDuration(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1_000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export function useVoiceRecorder() {
+  const runtimeRef = useRef<RecorderRuntime | null>(null);
+  const timerRef = useRef<number | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const [durationMs, setDurationMs] = useState(0);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const teardownRuntime = useCallback(async () => {
+    const runtime = runtimeRef.current;
+    runtimeRef.current = null;
+    clearTimer();
+    setIsRecording(false);
+
+    if (!runtime) {
+      setDurationMs(0);
+      return null;
+    }
+
+    runtime.processorNode.onaudioprocess = null;
+    runtime.sourceNode.disconnect();
+    runtime.processorNode.disconnect();
+    runtime.silentGainNode.disconnect();
+    runtime.stream.getTracks().forEach((track) => track.stop());
+    await runtime.audioContext.close().catch(() => undefined);
+
+    const sampleRateHz = runtime.sampleRateHz;
+    const duration = Math.max(0, performance.now() - runtime.startedAt);
+    setDurationMs(0);
+
+    return {
+      chunks: runtime.chunks,
+      sampleRateHz,
+      durationMs: duration,
+    };
+  }, [clearTimer]);
+
+  const startRecording = useCallback(async () => {
+    if (runtimeRef.current) {
+      throw new Error("Voice recording is already running.");
+    }
+    if (!navigator.mediaDevices?.getUserMedia) {
+      throw new Error("Microphone recording is unavailable in this browser.");
+    }
+
+    let stream: MediaStream | null = null;
+    let audioContext: AudioContext | null = null;
+    let sourceNode: MediaStreamAudioSourceNode | null = null;
+    let processorNode: ScriptProcessorNode | null = null;
+    let silentGainNode: GainNode | null = null;
+
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+        },
+      });
+      audioContext = new AudioContext();
+      await audioContext.resume();
+
+      sourceNode = audioContext.createMediaStreamSource(stream);
+      processorNode = audioContext.createScriptProcessor(BUFFER_SIZE, 1, 1);
+      silentGainNode = audioContext.createGain();
+      silentGainNode.gain.value = 0;
+
+      const runtime: RecorderRuntime = {
+        audioContext,
+        sourceNode,
+        processorNode,
+        silentGainNode,
+        stream,
+        chunks: [],
+        startedAt: performance.now(),
+        sampleRateHz: audioContext.sampleRate,
+      };
+
+      processorNode.onaudioprocess = (event) => {
+        const inputBuffer = event.inputBuffer;
+        const channelCount = inputBuffer.numberOfChannels;
+        const frameCount = inputBuffer.length;
+        const monoSamples = new Float32Array(frameCount);
+
+        for (let channelIndex = 0; channelIndex < channelCount; channelIndex += 1) {
+          const channelData = inputBuffer.getChannelData(channelIndex);
+          for (let sampleIndex = 0; sampleIndex < frameCount; sampleIndex += 1) {
+            monoSamples[sampleIndex] =
+              (monoSamples[sampleIndex] ?? 0) + (channelData[sampleIndex] ?? 0);
+          }
+        }
+
+        const normalizer = channelCount > 0 ? channelCount : 1;
+        for (let sampleIndex = 0; sampleIndex < frameCount; sampleIndex += 1) {
+          monoSamples[sampleIndex] = (monoSamples[sampleIndex] ?? 0) / normalizer;
+        }
+
+        runtime.chunks.push(monoSamples);
+      };
+
+      sourceNode.connect(processorNode);
+      processorNode.connect(silentGainNode);
+      silentGainNode.connect(audioContext.destination);
+
+      runtimeRef.current = runtime;
+      setDurationMs(0);
+      setIsRecording(true);
+      timerRef.current = window.setInterval(() => {
+        const activeRuntime = runtimeRef.current;
+        if (!activeRuntime) {
+          return;
+        }
+        setDurationMs(Math.max(0, performance.now() - activeRuntime.startedAt));
+      }, 200);
+    } catch (error) {
+      processorNode?.disconnect();
+      sourceNode?.disconnect();
+      silentGainNode?.disconnect();
+      stream?.getTracks().forEach((track) => track.stop());
+      await audioContext?.close().catch(() => undefined);
+      throw error;
+    }
+  }, []);
+
+  const stopRecording = useCallback(async (): Promise<VoiceRecordingPayload | null> => {
+    const recorded = await teardownRuntime();
+    if (!recorded) {
+      return null;
+    }
+
+    const mergedSamples = mergeFloat32Chunks(recorded.chunks);
+    if (mergedSamples.length === 0) {
+      return null;
+    }
+
+    const resampledSamples = resampleLinear(
+      mergedSamples,
+      recorded.sampleRateHz,
+      TARGET_SAMPLE_RATE,
+    );
+    if (resampledSamples.length === 0) {
+      return null;
+    }
+
+    const wavBytes = encodeMono16BitWav(resampledSamples, TARGET_SAMPLE_RATE);
+    const audioBase64 = await blobToBase64(new Blob([wavBytes], { type: "audio/wav" }));
+
+    return {
+      audioBase64,
+      mimeType: "audio/wav",
+      sampleRateHz: TARGET_SAMPLE_RATE,
+      durationMs: Math.max(
+        1,
+        Math.round((resampledSamples.length / TARGET_SAMPLE_RATE) * 1_000) || recorded.durationMs,
+      ),
+    };
+  }, [teardownRuntime]);
+
+  const cancelRecording = useCallback(async () => {
+    await teardownRuntime();
+  }, [teardownRuntime]);
+
+  useEffect(
+    () => () => {
+      void teardownRuntime();
+    },
+    [teardownRuntime],
+  );
+
+  return {
+    isRecording,
+    durationMs,
+    startRecording,
+    stopRecording,
+    cancelRecording,
+  };
+}
+
+function mergeFloat32Chunks(chunks: readonly Float32Array[]): Float32Array {
+  let totalLength = 0;
+  for (const chunk of chunks) {
+    totalLength += chunk.length;
+  }
+  const merged = new Float32Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return merged;
+}
+
+function resampleLinear(
+  samples: Float32Array,
+  inputSampleRateHz: number,
+  outputSampleRateHz: number,
+): Float32Array {
+  if (!Number.isFinite(inputSampleRateHz) || inputSampleRateHz <= 0) {
+    return new Float32Array(0);
+  }
+  if (inputSampleRateHz === outputSampleRateHz) {
+    return samples.slice();
+  }
+
+  const ratio = inputSampleRateHz / outputSampleRateHz;
+  const outputLength = Math.max(1, Math.round(samples.length / ratio));
+  const output = new Float32Array(outputLength);
+
+  for (let index = 0; index < outputLength; index += 1) {
+    const sourceIndex = index * ratio;
+    const leftIndex = Math.floor(sourceIndex);
+    const rightIndex = Math.min(samples.length - 1, leftIndex + 1);
+    const interpolationWeight = sourceIndex - leftIndex;
+    const leftValue = samples[leftIndex] ?? 0;
+    const rightValue = samples[rightIndex] ?? leftValue;
+    output[index] = leftValue + (rightValue - leftValue) * interpolationWeight;
+  }
+
+  return output;
+}
+
+function encodeMono16BitWav(samples: Float32Array, sampleRateHz: number): ArrayBuffer {
+  const dataView = new DataView(new ArrayBuffer(44 + samples.length * 2));
+
+  writeAscii(dataView, 0, "RIFF");
+  dataView.setUint32(4, 36 + samples.length * 2, true);
+  writeAscii(dataView, 8, "WAVE");
+  writeAscii(dataView, 12, "fmt ");
+  dataView.setUint32(16, 16, true);
+  dataView.setUint16(20, 1, true);
+  dataView.setUint16(22, 1, true);
+  dataView.setUint32(24, sampleRateHz, true);
+  dataView.setUint32(28, sampleRateHz * 2, true);
+  dataView.setUint16(32, 2, true);
+  dataView.setUint16(34, 16, true);
+  writeAscii(dataView, 36, "data");
+  dataView.setUint32(40, samples.length * 2, true);
+
+  let offset = 44;
+  for (const sample of samples) {
+    const clamped = Math.max(-1, Math.min(1, sample));
+    const pcm = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+    dataView.setInt16(offset, Math.round(pcm), true);
+    offset += 2;
+  }
+
+  return dataView.buffer;
+}
+
+function writeAscii(view: DataView, offset: number, value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    view.setUint8(offset + index, value.charCodeAt(index));
+  }
+}
+
+async function blobToBase64(blob: Blob): Promise<string> {
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+        return;
+      }
+      reject(new Error("Failed to read recorded audio."));
+    });
+    reader.addEventListener("error", () => {
+      reject(reader.error ?? new Error("Failed to read recorded audio."));
+    });
+    reader.readAsDataURL(blob);
+  });
+  const commaIndex = dataUrl.indexOf(",");
+  return commaIndex >= 0 ? dataUrl.slice(commaIndex + 1) : dataUrl;
+}

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -295,6 +295,7 @@ export function createWsNativeApi(): NativeApi {
     },
     server: {
       getConfig: () => transport.request(WS_METHODS.serverGetConfig),
+      transcribeVoice: (input) => transport.request(WS_METHODS.serverTranscribeVoice, input),
       upsertKeybinding: (input) => transport.request(WS_METHODS.serverUpsertKeybinding, input),
     },
     provider: {

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -33,7 +33,13 @@ import type {
   ProjectWriteFileInput,
   ProjectWriteFileResult,
 } from "./project";
-import type { ServerConfig } from "./server";
+import type {
+  ServerConfig,
+  ServerUpsertKeybindingInput,
+  ServerUpsertKeybindingResult,
+  ServerVoiceTranscriptionInput,
+  ServerVoiceTranscriptionResult,
+} from "./server";
 import type {
   TerminalClearInput,
   TerminalCloseInput,
@@ -44,7 +50,6 @@ import type {
   TerminalSessionSnapshot,
   TerminalWriteInput,
 } from "./terminal";
-import type { ServerUpsertKeybindingInput, ServerUpsertKeybindingResult } from "./server";
 import type {
   ClientOrchestrationCommand,
   OrchestrationGetFullThreadDiffInput,
@@ -283,6 +288,9 @@ export interface NativeApi {
   };
   server: {
     getConfig: () => Promise<ServerConfig>;
+    transcribeVoice: (
+      input: ServerVoiceTranscriptionInput,
+    ) => Promise<ServerVoiceTranscriptionResult>;
     upsertKeybinding: (input: ServerUpsertKeybindingInput) => Promise<ServerUpsertKeybindingResult>;
   };
   provider: {

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -1,8 +1,10 @@
 import { Schema } from "effect";
-import { IsoDateTime, TrimmedNonEmptyString } from "./baseSchemas";
+import { IsoDateTime, NonNegativeInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas";
 import { KeybindingRule, ResolvedKeybindingsConfig } from "./keybindings";
 import { EditorId } from "./editor";
 import { ProviderKind } from "./orchestration";
+
+const SERVER_VOICE_TRANSCRIPTION_MAX_AUDIO_BASE64_CHARS = 14_000_000;
 
 const KeybindingsMalformedConfigIssue = Schema.Struct({
   kind: Schema.Literal("keybindings.malformed-config"),
@@ -38,6 +40,7 @@ export const ServerProviderStatus = Schema.Struct({
   status: ServerProviderStatusState,
   available: Schema.Boolean,
   authStatus: ServerProviderAuthStatus,
+  voiceTranscriptionAvailable: Schema.optional(Schema.Boolean),
   checkedAt: IsoDateTime,
   message: Schema.optional(TrimmedNonEmptyString),
 });
@@ -55,6 +58,24 @@ export const ServerConfig = Schema.Struct({
   availableEditors: Schema.Array(EditorId),
 });
 export type ServerConfig = typeof ServerConfig.Type;
+
+export const ServerVoiceTranscriptionInput = Schema.Struct({
+  provider: ProviderKind,
+  cwd: TrimmedNonEmptyString,
+  threadId: Schema.optional(ThreadId),
+  mimeType: TrimmedNonEmptyString.check(Schema.isMaxLength(100)),
+  sampleRateHz: NonNegativeInt,
+  durationMs: NonNegativeInt,
+  audioBase64: TrimmedNonEmptyString.check(
+    Schema.isMaxLength(SERVER_VOICE_TRANSCRIPTION_MAX_AUDIO_BASE64_CHARS),
+  ),
+});
+export type ServerVoiceTranscriptionInput = typeof ServerVoiceTranscriptionInput.Type;
+
+export const ServerVoiceTranscriptionResult = Schema.Struct({
+  text: TrimmedNonEmptyString,
+});
+export type ServerVoiceTranscriptionResult = typeof ServerVoiceTranscriptionResult.Type;
 
 export const ServerUpsertKeybindingInput = KeybindingRule;
 export type ServerUpsertKeybindingInput = typeof ServerUpsertKeybindingInput.Type;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -42,7 +42,7 @@ import {
 import { KeybindingRule } from "./keybindings";
 import { ProjectSearchEntriesInput, ProjectWriteFileInput } from "./project";
 import { OpenInEditorInput } from "./editor";
-import { ServerConfigUpdatedPayload } from "./server";
+import { ServerConfigUpdatedPayload, ServerVoiceTranscriptionInput } from "./server";
 import {
   ProviderListCommandsInput,
   ProviderGetComposerCapabilitiesInput,
@@ -92,6 +92,7 @@ export const WS_METHODS = {
 
   // Server meta
   serverGetConfig: "server.getConfig",
+  serverTranscribeVoice: "server.transcribeVoice",
   serverUpsertKeybinding: "server.upsertKeybinding",
 
   // Provider discovery
@@ -170,6 +171,7 @@ const WebSocketRequestBody = Schema.Union([
 
   // Server meta
   tagRequestBody(WS_METHODS.serverGetConfig, Schema.Struct({})),
+  tagRequestBody(WS_METHODS.serverTranscribeVoice, ServerVoiceTranscriptionInput),
   tagRequestBody(WS_METHODS.serverUpsertKeybinding, KeybindingRule),
 
   // Provider discovery


### PR DESCRIPTION
## Summary
- add a new `server.transcribeVoice` contract and WebSocket route for voice transcription
- proxy recorded WAV clips through the Codex ChatGPT session to the private transcription endpoint
- add composer voice recording UI, local WAV normalization, and transcript insertion into the draft
- expose voice transcription availability in provider health and harden stale request/auth retry handling

## Testing
- Not run (not requested)