### PR TITLE
Improve desktop update button states and progress feedback

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -88,6 +88,7 @@ import { toastManager } from "./ui/toast";
 import {
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
+  getDesktopUpdateButtonPresentation,
   getDesktopUpdateButtonTooltip,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
@@ -733,6 +734,7 @@ export default function Sidebar() {
   const [desktopUpdateState, setDesktopUpdateState] = useState<DesktopUpdateState | null>(null);
   const [renamingWorkspaceId, setRenamingWorkspaceId] = useState<string | null>(null);
   const [renamingWorkspaceTitle, setRenamingWorkspaceTitle] = useState("");
+  const [installingDesktopUpdate, setInstallingDesktopUpdate] = useState(false);
   const selectedThreadIds = useThreadSelectionStore((s) => s.selectedThreadIds);
   const toggleThreadSelection = useThreadSelectionStore((s) => s.toggleThread);
   const rangeSelectTo = useThreadSelectionStore((s) => s.rangeSelectTo);
@@ -2928,13 +2930,19 @@ export default function Sidebar() {
   const showDesktopUpdateButton = isElectron && shouldShowDesktopUpdateButton(desktopUpdateState);
 
   const desktopUpdateTooltip = desktopUpdateState
-    ? getDesktopUpdateButtonTooltip(desktopUpdateState)
+    ? getDesktopUpdateButtonTooltip(desktopUpdateState, {
+        installing: installingDesktopUpdate,
+      })
     : "Update available";
 
-  const desktopUpdateButtonDisabled = isDesktopUpdateButtonDisabled(desktopUpdateState);
+  const desktopUpdateButtonDisabled =
+    isDesktopUpdateButtonDisabled(desktopUpdateState) || installingDesktopUpdate;
   const desktopUpdateButtonAction = desktopUpdateState
     ? resolveDesktopUpdateButtonAction(desktopUpdateState)
     : "none";
+  const desktopUpdateButtonPresentation = getDesktopUpdateButtonPresentation(desktopUpdateState, {
+    installing: installingDesktopUpdate,
+  });
   const showArm64IntelBuildWarning =
     isElectron && shouldShowArm64IntelBuildWarning(desktopUpdateState);
   const arm64IntelBuildWarningDescription =
@@ -2944,8 +2952,9 @@ export default function Sidebar() {
   const desktopUpdateButtonInteractivityClasses = desktopUpdateButtonDisabled
     ? "cursor-not-allowed opacity-60"
     : "hover:brightness-110";
-  const desktopUpdateButtonClasses =
-    desktopUpdateState?.status === "downloaded"
+  const desktopUpdateButtonClasses = installingDesktopUpdate
+    ? "bg-sky-500 hover:bg-sky-600"
+    : desktopUpdateState?.status === "downloaded"
       ? "bg-emerald-500 hover:bg-emerald-600"
       : desktopUpdateState?.status === "downloading"
         ? "bg-sky-500 hover:bg-sky-600"
@@ -2953,7 +2962,7 @@ export default function Sidebar() {
           ? "bg-rose-500 hover:bg-rose-600"
           : "bg-[var(--info-foreground)] hover:brightness-110";
   const desktopUpdateRowButtonClasses = cn(
-    "inline-flex h-7 shrink-0 items-center justify-center rounded-full pl-2.5 pr-[12px] text-[10px] font-medium text-white transition-colors",
+    "inline-flex min-h-8 shrink-0 items-center justify-between gap-2 rounded-full px-2.5 py-1 text-left text-white transition-colors",
     desktopUpdateButtonInteractivityClasses,
     desktopUpdateButtonClasses,
   );
@@ -3030,6 +3039,8 @@ export default function Sidebar() {
       void bridge
         .checkForUpdates()
         .then((nextState) => {
+          setInstallingDesktopUpdate(false);
+          setDesktopUpdateState(nextState);
           if (nextState.status === "available") {
             toastManager.add({
               type: "success",
@@ -3070,6 +3081,8 @@ export default function Sidebar() {
       void bridge
         .downloadUpdate()
         .then((result) => {
+          setInstallingDesktopUpdate(false);
+          setDesktopUpdateState(result.state);
           if (result.completed) {
             toastManager.add({
               type: "success",
@@ -3097,9 +3110,12 @@ export default function Sidebar() {
     }
 
     if (desktopUpdateButtonAction === "install") {
+      setInstallingDesktopUpdate(true);
       void bridge
         .installUpdate()
         .then((result) => {
+          setDesktopUpdateState(result.state);
+          setInstallingDesktopUpdate(false);
           if (!shouldToastDesktopUpdateActionResult(result)) return;
           const actionError = getDesktopUpdateActionError(result);
           if (!actionError) return;
@@ -3110,6 +3126,7 @@ export default function Sidebar() {
           });
         })
         .catch((error) => {
+          setInstallingDesktopUpdate(false);
           toastManager.add({
             type: "error",
             title: "Could not install update",
@@ -3674,7 +3691,21 @@ export default function Sidebar() {
                         className={desktopUpdateRowButtonClasses}
                         onClick={handleDesktopUpdateButtonClick}
                       >
-                        Update
+                        <span className="flex min-w-0 flex-1 flex-col leading-tight">
+                          <span className="truncate text-[10px] font-semibold">
+                            {desktopUpdateButtonPresentation.label}
+                          </span>
+                          {desktopUpdateButtonPresentation.detail ? (
+                            <span className="truncate text-[8.5px] font-normal text-white/86">
+                              {desktopUpdateButtonPresentation.detail}
+                            </span>
+                          ) : null}
+                        </span>
+                        {desktopUpdateButtonPresentation.progressPercent !== null ? (
+                          <span className="rounded-full bg-white/20 px-1.5 py-0.5 text-[9px] font-semibold tabular-nums text-white/95">
+                            {desktopUpdateButtonPresentation.progressPercent}%
+                          </span>
+                        ) : null}
                       </button>
                     }
                   />

--- a/apps/web/src/components/desktopUpdate.buttonPresentation.test.ts
+++ b/apps/web/src/components/desktopUpdate.buttonPresentation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { DesktopUpdateState } from "@t3tools/contracts";
+
+import { getDesktopUpdateButtonPresentation } from "./desktopUpdate.logic";
+
+const baseState: DesktopUpdateState = {
+  enabled: true,
+  status: "idle",
+  currentVersion: "1.0.0",
+  hostArch: "x64",
+  appArch: "x64",
+  runningUnderArm64Translation: false,
+  availableVersion: null,
+  downloadedVersion: null,
+  downloadPercent: null,
+  checkedAt: null,
+  message: null,
+  errorContext: null,
+  canRetry: false,
+};
+
+describe("desktop update button presentation timeline", () => {
+  it("surfaces checking, downloading and ready-to-install states with details", () => {
+    const checking = getDesktopUpdateButtonPresentation({
+      ...baseState,
+      status: "checking",
+    });
+    expect(checking.label).toBe("Checking...");
+    expect(checking.detail).toBe("Looking for updates");
+    expect(checking.progressPercent).toBeNull();
+
+    const downloading = getDesktopUpdateButtonPresentation({
+      ...baseState,
+      status: "downloading",
+      availableVersion: "1.2.0",
+      downloadPercent: 37.9,
+    });
+    expect(downloading.label).toBe("Downloading...");
+    expect(downloading.detail).toBe("Progress 37%");
+    expect(downloading.progressPercent).toBe(37);
+
+    const downloaded = getDesktopUpdateButtonPresentation({
+      ...baseState,
+      status: "downloaded",
+      availableVersion: "1.2.0",
+      downloadedVersion: "1.2.0",
+    });
+    expect(downloaded.label).toBe("Ready to update");
+    expect(downloaded.detail).toBe("Restart to install");
+    expect(downloaded.progressPercent).toBeNull();
+  });
+
+  it("shows a stable fallback when download progress is unavailable", () => {
+    const downloading = getDesktopUpdateButtonPresentation({
+      ...baseState,
+      status: "downloading",
+      availableVersion: "1.2.0",
+      downloadPercent: null,
+    });
+
+    expect(downloading.label).toBe("Downloading...");
+    expect(downloading.detail).toBe("Preparing download");
+    expect(downloading.progressPercent).toBeNull();
+  });
+
+  it("clamps percentage output to avoid invalid UI values", () => {
+    const over = getDesktopUpdateButtonPresentation({
+      ...baseState,
+      status: "downloading",
+      availableVersion: "1.2.0",
+      downloadPercent: 126.9,
+    });
+    expect(over.detail).toBe("Progress 100%");
+    expect(over.progressPercent).toBe(100);
+
+    const below = getDesktopUpdateButtonPresentation({
+      ...baseState,
+      status: "downloading",
+      availableVersion: "1.2.0",
+      downloadPercent: -8,
+    });
+    expect(below.detail).toBe("Progress 0%");
+    expect(below.progressPercent).toBe(0);
+  });
+});

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -4,6 +4,8 @@ import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/con
 import {
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
+  getDesktopUpdateButtonLabel,
+  getDesktopUpdateButtonPresentation,
   getDesktopUpdateButtonTooltip,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
@@ -98,6 +100,9 @@ describe("desktop update button state", () => {
     expect(shouldShowDesktopUpdateButton(state)).toBe(true);
     expect(isDesktopUpdateButtonDisabled(state)).toBe(true);
     expect(getDesktopUpdateButtonTooltip(state)).toContain("42%");
+    expect(getDesktopUpdateButtonLabel(state)).toBe("Downloading...");
+    expect(getDesktopUpdateButtonPresentation(state).detail).toBe("Progress 42%");
+    expect(getDesktopUpdateButtonPresentation(state).progressPercent).toBe(42);
   });
 
   it("disables the button while a check is in flight", () => {
@@ -106,9 +111,49 @@ describe("desktop update button state", () => {
       status: "checking",
     };
 
+    expect(shouldShowDesktopUpdateButton(state)).toBe(true);
     expect(resolveDesktopUpdateButtonAction(state)).toBe("check");
     expect(isDesktopUpdateButtonDisabled(state)).toBe(true);
     expect(getDesktopUpdateButtonTooltip(state)).toContain("Checking for updates");
+    expect(getDesktopUpdateButtonLabel(state)).toBe("Checking...");
+  });
+
+  it("shows retry labels for actionable update errors", () => {
+    expect(
+      getDesktopUpdateButtonLabel({
+        ...baseState,
+        status: "error",
+        availableVersion: "1.1.0",
+        errorContext: "download",
+        canRetry: true,
+      }),
+    ).toBe("Download failed");
+
+    expect(
+      getDesktopUpdateButtonLabel({
+        ...baseState,
+        status: "error",
+        downloadedVersion: "1.1.0",
+        availableVersion: "1.1.0",
+        errorContext: "install",
+        canRetry: true,
+      }),
+    ).toBe("Install failed");
+  });
+
+  it("shows explicit updating state when install is in progress", () => {
+    const installingState: DesktopUpdateState = {
+      ...baseState,
+      status: "downloaded",
+      downloadedVersion: "1.1.0",
+      availableVersion: "1.1.0",
+    };
+    const presentation = getDesktopUpdateButtonPresentation(installingState, { installing: true });
+    expect(presentation.label).toBe("Updating...");
+    expect(presentation.detail).toBe("Applying update");
+    expect(getDesktopUpdateButtonTooltip(installingState, { installing: true })).toBe(
+      "Applying update...",
+    );
   });
 });
 

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -35,6 +35,7 @@ export function shouldShowDesktopUpdateButton(state: DesktopUpdateState | null):
   // Only show the button when there's actually something to do:
   // a new version to download, a downloaded update to install, or a retryable error
   return (
+    state.status === "checking" ||
     state.status === "available" ||
     state.status === "downloading" ||
     state.status === "downloaded" ||
@@ -48,6 +49,104 @@ export function shouldShowArm64IntelBuildWarning(state: DesktopUpdateState | nul
 
 export function isDesktopUpdateButtonDisabled(state: DesktopUpdateState | null): boolean {
   return state?.status === "downloading" || state?.status === "checking";
+}
+
+function formatDesktopUpdateDownloadPercent(percent: number | null): string | null {
+  if (typeof percent !== "number" || !Number.isFinite(percent)) {
+    return null;
+  }
+  const normalized = Math.max(0, Math.min(100, Math.floor(percent)));
+  return `${normalized}%`;
+}
+
+export interface DesktopUpdateButtonPresentation {
+  label: string;
+  detail: string | null;
+  progressPercent: number | null;
+}
+
+export function getDesktopUpdateButtonPresentation(
+  state: DesktopUpdateState | null,
+  options?: { installing?: boolean },
+): DesktopUpdateButtonPresentation {
+  if (options?.installing) {
+    return {
+      label: "Updating...",
+      detail: "Applying update",
+      progressPercent: null,
+    };
+  }
+
+  if (!state) {
+    return {
+      label: "Update",
+      detail: null,
+      progressPercent: null,
+    };
+  }
+
+  if (state.status === "checking") {
+    return {
+      label: "Checking...",
+      detail: "Looking for updates",
+      progressPercent: null,
+    };
+  }
+
+  if (state.status === "downloading") {
+    const percentText = formatDesktopUpdateDownloadPercent(state.downloadPercent);
+    return {
+      label: "Downloading...",
+      detail: percentText ? `Progress ${percentText}` : "Preparing download",
+      progressPercent: percentText ? Number.parseInt(percentText, 10) : null,
+    };
+  }
+
+  const action = resolveDesktopUpdateButtonAction(state);
+  if (action === "download") {
+    if (state.status === "error" && state.errorContext === "download") {
+      return {
+        label: "Download failed",
+        detail: "Click to retry",
+        progressPercent: null,
+      };
+    }
+    return {
+      label: "Update available",
+      detail: state.availableVersion ? `Version ${state.availableVersion}` : "Ready to download",
+      progressPercent: null,
+    };
+  }
+  if (action === "install") {
+    if (state.status === "error" && state.errorContext === "install") {
+      return {
+        label: "Install failed",
+        detail: "Click to retry",
+        progressPercent: null,
+      };
+    }
+    return {
+      label: "Ready to update",
+      detail: "Restart to install",
+      progressPercent: null,
+    };
+  }
+  if (action === "check") {
+    return {
+      label: "Check updates",
+      detail: null,
+      progressPercent: null,
+    };
+  }
+  return {
+    label: "Update",
+    detail: null,
+    progressPercent: null,
+  };
+}
+
+export function getDesktopUpdateButtonLabel(state: DesktopUpdateState | null): string {
+  return getDesktopUpdateButtonPresentation(state).label;
 }
 
 export function getArm64IntelBuildWarningDescription(state: DesktopUpdateState): string {
@@ -65,7 +164,13 @@ export function getArm64IntelBuildWarningDescription(state: DesktopUpdateState):
   return "This Mac has Apple Silicon, but DP Code is still running the Intel build under Rosetta. The next app update will replace it with the native Apple Silicon build.";
 }
 
-export function getDesktopUpdateButtonTooltip(state: DesktopUpdateState): string {
+export function getDesktopUpdateButtonTooltip(
+  state: DesktopUpdateState,
+  options?: { installing?: boolean },
+): string {
+  if (options?.installing) {
+    return "Applying update...";
+  }
   if (state.status === "idle") {
     return "Check for updates";
   }


### PR DESCRIPTION
## Summary
- Add richer update button presentation states (`Checking`, `Downloading`, `Ready to update`, `Updating`) with detail text and progress percent support.
- Keep the sidebar update button disabled while install is in progress and synchronize local UI state from update action results.
- Update tooltip behavior to reflect install-in-progress state.
- Expand updater logic tests and add a dedicated presentation timeline test for progress formatting and bounds.

## Testing
- Not run (not requested)