### PR TITLE
Fix project sidebar sync fallback

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -198,8 +198,6 @@ const SIDEBAR_LIST_ANIMATION_OPTIONS = {
 } as const;
 const ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS = 6;
 const ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS = 50;
-const ADD_PROJECT_CREATE_SYNC_ERROR =
-  "Project was created, but it has not appeared in the sidebar yet. Try again in a moment.";
 const ADD_PROJECT_EXISTING_SYNC_ERROR =
   "This folder is already linked, but the existing project has not synced into the sidebar yet. Try again in a moment.";
 
@@ -1344,8 +1342,15 @@ export default function Sidebar() {
           finishAddingProject();
           return;
         }
-        setIsAddingProject(false);
-        setAddProjectError(ADD_PROJECT_CREATE_SYNC_ERROR);
+
+        // The command already committed successfully at this point. If the projection
+        // snapshot is just slow to catch up, continue with the local new-thread flow
+        // instead of surfacing a false-negative sidebar sync error.
+        setProjectExpanded(projectId, true);
+        await handleNewThread(projectId, {
+          envMode: appSettings.defaultThreadEnvMode,
+        }).catch(() => undefined);
+        finishAddingProject();
         return;
       } catch (error) {
         const description =
@@ -1370,12 +1375,15 @@ export default function Sidebar() {
       }
     },
     [
+      appSettings.defaultThreadEnvMode,
+      handleNewThread,
       isAddingProject,
       openExistingProjectLocally,
       projects,
       recoverExistingProjectFromServer,
       recoverExistingProjectByWorkspaceRootFromServer,
       recoverProjectThreadFromServer,
+      setProjectExpanded,
     ],
   );
 

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -367,6 +367,132 @@ describe("store pure functions", () => {
     });
   });
 
+  it("adds projects immediately from live project.created events", () => {
+    const next = applyOrchestrationEvents(
+      {
+        projects: [],
+        threads: [],
+        sidebarThreadSummaryById: {},
+        threadsHydrated: false,
+      },
+      [
+        makeDomainEvent(
+          "project.created",
+          {
+            projectId: ProjectId.makeUnsafe("project-live"),
+            title: "Live Project",
+            workspaceRoot: "/tmp/live-project",
+            defaultModelSelection: {
+              provider: "codex",
+              model: "gpt-5-codex",
+            },
+            scripts: [],
+            createdAt: "2026-02-27T00:00:00.000Z",
+            updatedAt: "2026-02-27T00:00:00.000Z",
+          },
+          { aggregateKind: "project" },
+        ),
+      ],
+    );
+
+    expect(next.projects).toHaveLength(1);
+    expect(next.projects[0]).toMatchObject({
+      id: ProjectId.makeUnsafe("project-live"),
+      name: "Live Project",
+      remoteName: "Live Project",
+      folderName: "live-project",
+      cwd: "/tmp/live-project",
+      createdAt: "2026-02-27T00:00:00.000Z",
+      updatedAt: "2026-02-27T00:00:00.000Z",
+    });
+  });
+
+  it("updates existing projects immediately from live project.meta-updated events", () => {
+    const initialState: AppState = {
+      projects: [
+        makeProject({
+          id: ProjectId.makeUnsafe("project-live"),
+          name: "Local Name",
+          remoteName: "Original Name",
+          localName: "Local Name",
+          folderName: "original-project",
+          cwd: "/tmp/original-project",
+          createdAt: "2026-02-27T00:00:00.000Z",
+          updatedAt: "2026-02-27T00:00:00.000Z",
+        }),
+      ],
+      threads: [],
+      sidebarThreadSummaryById: {},
+      threadsHydrated: true,
+    };
+
+    const next = applyOrchestrationEvents(initialState, [
+      makeDomainEvent(
+        "project.meta-updated",
+        {
+          projectId: ProjectId.makeUnsafe("project-live"),
+          title: "Renamed Remotely",
+          workspaceRoot: "/tmp/renamed-project",
+          defaultModelSelection: null,
+          scripts: [
+            {
+              id: "lint",
+              name: "Lint",
+              command: "bun lint",
+              icon: "lint",
+              runOnWorktreeCreate: false,
+            },
+          ],
+          updatedAt: "2026-02-27T00:05:00.000Z",
+        },
+        { aggregateKind: "project" },
+      ),
+    ]);
+
+    expect(next.projects[0]).toMatchObject({
+      id: ProjectId.makeUnsafe("project-live"),
+      name: "Local Name",
+      remoteName: "Renamed Remotely",
+      folderName: "renamed-project",
+      localName: "Local Name",
+      cwd: "/tmp/renamed-project",
+      defaultModelSelection: null,
+      updatedAt: "2026-02-27T00:05:00.000Z",
+      scripts: [
+        {
+          id: "lint",
+          name: "Lint",
+          command: "bun lint",
+          icon: "lint",
+          runOnWorktreeCreate: false,
+        },
+      ],
+    });
+  });
+
+  it("removes projects immediately from live project.deleted events", () => {
+    const next = applyOrchestrationEvents(
+      {
+        projects: [makeProject({ id: ProjectId.makeUnsafe("project-live") })],
+        threads: [],
+        sidebarThreadSummaryById: {},
+        threadsHydrated: true,
+      },
+      [
+        makeDomainEvent(
+          "project.deleted",
+          {
+            projectId: ProjectId.makeUnsafe("project-live"),
+            deletedAt: "2026-02-27T00:06:00.000Z",
+          },
+          { aggregateKind: "project" },
+        ),
+      ],
+    );
+
+    expect(next.projects).toEqual([]);
+  });
+
   it("settles a running latest turn immediately when session stop is requested", () => {
     const initialState = makeState(
       makeThread({

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -280,9 +280,10 @@ function normalizeProjectFromReadModel(
   const workspaceRootKey = projectCwdKey(incoming.workspaceRoot);
   const folderName = basenameOfPath(incoming.workspaceRoot) ?? incoming.title;
   const localName = previous?.localName ?? persistedProjectNamesByCwd.get(workspaceRootKey) ?? null;
-  const defaultModelSelection = incoming.defaultModelSelection
-    ? normalizeModelSelection(incoming.defaultModelSelection, previous?.defaultModelSelection)
-    : (previous?.defaultModelSelection ?? null);
+  const defaultModelSelection =
+    incoming.defaultModelSelection === null
+      ? null
+      : normalizeModelSelection(incoming.defaultModelSelection, previous?.defaultModelSelection);
   const scripts = normalizeProjectScripts(incoming.scripts, previous?.scripts);
   const expanded =
     previous?.expanded ??
@@ -320,6 +321,28 @@ function normalizeProjectFromReadModel(
     updatedAt: incoming.updatedAt,
     scripts,
   } satisfies Project;
+}
+
+function upsertProjectFromReadModel(state: AppState, incoming: ReadModelProject): AppState {
+  const existingProject = state.projects.find((project) => project.id === incoming.id);
+  const nextProject = normalizeProjectFromReadModel(incoming, existingProject);
+
+  if (existingProject) {
+    if (existingProject === nextProject) {
+      return state;
+    }
+    return {
+      ...state,
+      projects: state.projects.map((project) =>
+        project.id === incoming.id ? nextProject : project,
+      ),
+    };
+  }
+
+  return {
+    ...state,
+    projects: [...state.projects, nextProject],
+  };
 }
 
 function normalizeChatAttachments(
@@ -1416,6 +1439,45 @@ function applyThreadMessageSentEvent(thread: Thread, event: ThreadMessageSentEve
 
 function applyOrchestrationEvent(state: AppState, event: OrchestrationEvent): AppState {
   switch (event.type) {
+    case "project.created":
+      return upsertProjectFromReadModel(state, {
+        id: event.payload.projectId,
+        title: event.payload.title,
+        workspaceRoot: event.payload.workspaceRoot,
+        defaultModelSelection: event.payload.defaultModelSelection,
+        scripts: event.payload.scripts,
+        createdAt: event.payload.createdAt,
+        updatedAt: event.payload.updatedAt,
+        deletedAt: null,
+      });
+
+    case "project.meta-updated": {
+      const existingProject = state.projects.find(
+        (project) => project.id === event.payload.projectId,
+      );
+      if (!existingProject) {
+        return state;
+      }
+      return upsertProjectFromReadModel(state, {
+        id: existingProject.id,
+        title: event.payload.title ?? existingProject.remoteName,
+        workspaceRoot: event.payload.workspaceRoot ?? existingProject.cwd,
+        defaultModelSelection:
+          event.payload.defaultModelSelection !== undefined
+            ? event.payload.defaultModelSelection
+            : existingProject.defaultModelSelection,
+        scripts: event.payload.scripts ?? existingProject.scripts,
+        createdAt: existingProject.createdAt ?? event.payload.updatedAt,
+        updatedAt: event.payload.updatedAt,
+        deletedAt: null,
+      });
+    }
+
+    case "project.deleted": {
+      const projects = state.projects.filter((project) => project.id !== event.payload.projectId);
+      return projects === state.projects ? state : { ...state, projects };
+    }
+
     case "thread.message-sent":
       return applyThreadUpdate(state, event.payload.threadId, (thread) =>
         applyThreadMessageSentEvent(thread, event),


### PR DESCRIPTION
## Summary
- apply live project events to the web store so newly created projects show up immediately
- avoid showing a false sidebar sync error after a successful `project.create`
- add store tests for live project create, update, and delete events

## Testing
- bun fmt
- bun lint
- bun typecheck