### PR TITLE
Add agent mentions to the composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5332,10 +5332,32 @@ export default function ChatView({
         if (applied) {
           setComposerHighlightedItemId(null);
         }
+        return;
+      }
+      if (item.type === "agent") {
+        // Insert @alias() and position cursor inside parentheses
+        const replacement = `@${item.alias}()`;
+        const applied = applyPromptReplacement(
+          trigger.rangeStart,
+          trigger.rangeEnd,
+          replacement,
+          { expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd) },
+        );
+        if (applied) {
+          setComposerHighlightedItemId(null);
+          // Move cursor back one position to be inside the parentheses
+          window.requestAnimationFrame(() => {
+            const currentCursor = composerCursor;
+            const newCursor = Math.max(0, currentCursor - 1);
+            setComposerCursor(newCursor);
+            composerEditorRef.current?.focusAt(newCursor);
+          });
+        }
       }
     },
     [
       applyPromptReplacement,
+      composerCursor,
       handleForkTargetSelection,
       handleReviewTargetSelection,
       handleSlashCommandSelection,

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -6,7 +6,6 @@ import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
 import {
-  $applyNodeReplacement,
   $createRangeSelection,
   $getSelection,
   $setSelection,
@@ -26,16 +25,9 @@ import {
   COMMAND_PRIORITY_HIGH,
   KEY_BACKSPACE_COMMAND,
   $getRoot,
-  DecoratorNode,
   type ElementNode,
   type LexicalNode,
-  type SerializedLexicalNode,
-  TextNode,
-  type EditorConfig,
   type EditorState,
-  type NodeKey,
-  type SerializedTextNode,
-  type Spread,
 } from "lexical";
 import {
   createContext,
@@ -48,7 +40,6 @@ import {
   useMemo,
   useRef,
   type ClipboardEventHandler,
-  type ReactElement,
   type Ref,
 } from "react";
 
@@ -64,46 +55,21 @@ import {
   type TerminalContextDraft,
 } from "~/lib/terminalContext";
 import { cn } from "~/lib/utils";
-import { basenameOfPath, getVscodeIconUrlForEntry, inferEntryKindFromPath } from "~/vscode-icons";
 import {
-  COMPOSER_INLINE_CHIP_CLASS_NAME,
-  COMPOSER_INLINE_CHIP_ICON_CLASS_NAME,
-  COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME,
-  COMPOSER_INLINE_SKILL_CHIP_ICON_SVG,
-  COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME,
-  COMPOSER_INLINE_SKILL_CHIP_ICON_CLASS_NAME,
-  formatComposerSkillChipLabel,
-} from "./composerInlineChip";
-import { ComposerPendingTerminalContextChip } from "./chat/ComposerPendingTerminalContexts";
+  ComposerMentionNode,
+  ComposerSkillNode,
+  ComposerAgentMentionNode,
+  ComposerTerminalContextNode,
+  $createComposerMentionNode,
+  $createComposerSkillNode,
+  $createComposerAgentMentionNode,
+  $createComposerTerminalContextNode,
+  isComposerInlineTokenNode,
+  COMPOSER_NODE_CLASSES,
+  type ComposerInlineTokenNode,
+} from "./composer-nodes";
 
 const COMPOSER_EDITOR_HMR_KEY = `composer-editor-${Math.random().toString(36).slice(2)}`;
-
-type SerializedComposerMentionNode = Spread<
-  {
-    path: string;
-    type: "composer-mention";
-    version: 1;
-  },
-  SerializedTextNode
->;
-
-type SerializedComposerSkillNode = Spread<
-  {
-    skillName: string;
-    type: "composer-skill";
-    version: 1;
-  },
-  SerializedTextNode
->;
-
-type SerializedComposerTerminalContextNode = Spread<
-  {
-    context: TerminalContextDraft;
-    type: "composer-terminal-context";
-    version: 1;
-  },
-  SerializedLexicalNode
->;
 
 const ComposerTerminalContextActionsContext = createContext<{
   onRemoveTerminalContext: (contextId: string) => void;
@@ -111,268 +77,7 @@ const ComposerTerminalContextActionsContext = createContext<{
   onRemoveTerminalContext: () => {},
 });
 
-class ComposerMentionNode extends TextNode {
-  __path: string;
-
-  static override getType(): string {
-    return "composer-mention";
-  }
-
-  static override clone(node: ComposerMentionNode): ComposerMentionNode {
-    return new ComposerMentionNode(node.__path, node.__key);
-  }
-
-  static override importJSON(serializedNode: SerializedComposerMentionNode): ComposerMentionNode {
-    return $createComposerMentionNode(serializedNode.path);
-  }
-
-  constructor(path: string, key?: NodeKey) {
-    const normalizedPath = path.startsWith("@") ? path.slice(1) : path;
-    super(`@${normalizedPath}`, key);
-    this.__path = normalizedPath;
-  }
-
-  override exportJSON(): SerializedComposerMentionNode {
-    return {
-      ...super.exportJSON(),
-      path: this.__path,
-      type: "composer-mention",
-      version: 1,
-    };
-  }
-
-  override createDOM(_config: EditorConfig): HTMLElement {
-    const dom = document.createElement("span");
-    dom.className = COMPOSER_INLINE_CHIP_CLASS_NAME;
-    dom.contentEditable = "false";
-    dom.setAttribute("spellcheck", "false");
-    renderMentionChipDom(dom, this.__path);
-    return dom;
-  }
-
-  override updateDOM(
-    prevNode: ComposerMentionNode,
-    dom: HTMLElement,
-    _config: EditorConfig,
-  ): boolean {
-    dom.contentEditable = "false";
-    if (prevNode.__text !== this.__text || prevNode.__path !== this.__path) {
-      renderMentionChipDom(dom, this.__path);
-    }
-    return false;
-  }
-
-  override canInsertTextBefore(): false {
-    return false;
-  }
-
-  override canInsertTextAfter(): false {
-    return false;
-  }
-
-  override isTextEntity(): true {
-    return true;
-  }
-
-  override isToken(): true {
-    return true;
-  }
-}
-
-function $createComposerMentionNode(path: string): ComposerMentionNode {
-  return $applyNodeReplacement(new ComposerMentionNode(path));
-}
-
-function renderSkillChipDom(container: HTMLElement, name: string): void {
-  container.textContent = "";
-  container.style.setProperty("user-select", "none");
-  container.style.setProperty("-webkit-user-select", "none");
-
-  const icon = document.createElement("span");
-  icon.ariaHidden = "true";
-  icon.className = COMPOSER_INLINE_SKILL_CHIP_ICON_CLASS_NAME;
-  icon.innerHTML = COMPOSER_INLINE_SKILL_CHIP_ICON_SVG;
-
-  const label = document.createElement("span");
-  label.className = COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME;
-  label.textContent = formatComposerSkillChipLabel(name);
-
-  container.append(icon, label);
-}
-
-class ComposerSkillNode extends TextNode {
-  __skillName: string;
-
-  static override getType(): string {
-    return "composer-skill";
-  }
-
-  static override clone(node: ComposerSkillNode): ComposerSkillNode {
-    return new ComposerSkillNode(node.__skillName, node.__key);
-  }
-
-  static override importJSON(serializedNode: SerializedComposerSkillNode): ComposerSkillNode {
-    return $createComposerSkillNode(serializedNode.skillName);
-  }
-
-  constructor(name: string, key?: NodeKey) {
-    const normalizedName = name.startsWith("$") || name.startsWith("/") ? name.slice(1) : name;
-    const prefix = name.startsWith("/") ? "/" : "$";
-    super(`${prefix}${normalizedName}`, key);
-    this.__skillName = normalizedName;
-  }
-
-  override exportJSON(): SerializedComposerSkillNode {
-    return {
-      ...super.exportJSON(),
-      skillName: this.__skillName,
-      type: "composer-skill",
-      version: 1,
-    };
-  }
-
-  override createDOM(_config: EditorConfig): HTMLElement {
-    const dom = document.createElement("span");
-    dom.className = COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME;
-    dom.contentEditable = "false";
-    dom.setAttribute("spellcheck", "false");
-    renderSkillChipDom(dom, this.__skillName);
-    return dom;
-  }
-
-  override updateDOM(
-    prevNode: ComposerSkillNode,
-    dom: HTMLElement,
-    _config: EditorConfig,
-  ): boolean {
-    dom.contentEditable = "false";
-    if (prevNode.__text !== this.__text || prevNode.__skillName !== this.__skillName) {
-      renderSkillChipDom(dom, this.__skillName);
-    }
-    return false;
-  }
-
-  override canInsertTextBefore(): false {
-    return false;
-  }
-
-  override canInsertTextAfter(): false {
-    return false;
-  }
-
-  override isTextEntity(): true {
-    return true;
-  }
-
-  override isToken(): true {
-    return true;
-  }
-}
-
-function $createComposerSkillNode(name: string): ComposerSkillNode {
-  return $applyNodeReplacement(new ComposerSkillNode(name));
-}
-
-function ComposerTerminalContextDecorator(props: { context: TerminalContextDraft }) {
-  return <ComposerPendingTerminalContextChip context={props.context} />;
-}
-
-class ComposerTerminalContextNode extends DecoratorNode<ReactElement> {
-  __context: TerminalContextDraft;
-
-  static override getType(): string {
-    return "composer-terminal-context";
-  }
-
-  static override clone(node: ComposerTerminalContextNode): ComposerTerminalContextNode {
-    return new ComposerTerminalContextNode(node.__context, node.__key);
-  }
-
-  static override importJSON(
-    serializedNode: SerializedComposerTerminalContextNode,
-  ): ComposerTerminalContextNode {
-    return $createComposerTerminalContextNode(serializedNode.context);
-  }
-
-  constructor(context: TerminalContextDraft, key?: NodeKey) {
-    super(key);
-    this.__context = context;
-  }
-
-  override exportJSON(): SerializedComposerTerminalContextNode {
-    return {
-      ...super.exportJSON(),
-      context: this.__context,
-      type: "composer-terminal-context",
-      version: 1,
-    };
-  }
-
-  override createDOM(): HTMLElement {
-    const dom = document.createElement("span");
-    dom.className = "inline-flex align-middle leading-none";
-    return dom;
-  }
-
-  override updateDOM(): false {
-    return false;
-  }
-
-  override getTextContent(): string {
-    return INLINE_TERMINAL_CONTEXT_PLACEHOLDER;
-  }
-
-  override isInline(): true {
-    return true;
-  }
-
-  override decorate(): ReactElement {
-    return <ComposerTerminalContextDecorator context={this.__context} />;
-  }
-}
-
-function $createComposerTerminalContextNode(
-  context: TerminalContextDraft,
-): ComposerTerminalContextNode {
-  return $applyNodeReplacement(new ComposerTerminalContextNode(context));
-}
-
-type ComposerInlineTokenNode =
-  | ComposerMentionNode
-  | ComposerSkillNode
-  | ComposerTerminalContextNode;
-
-function isComposerInlineTokenNode(candidate: unknown): candidate is ComposerInlineTokenNode {
-  return (
-    candidate instanceof ComposerMentionNode ||
-    candidate instanceof ComposerSkillNode ||
-    candidate instanceof ComposerTerminalContextNode
-  );
-}
-
-function resolvedThemeFromDocument(): "light" | "dark" {
-  return document.documentElement.classList.contains("dark") ? "dark" : "light";
-}
-
-function renderMentionChipDom(container: HTMLElement, pathValue: string): void {
-  container.textContent = "";
-  container.style.setProperty("user-select", "none");
-  container.style.setProperty("-webkit-user-select", "none");
-
-  const theme = resolvedThemeFromDocument();
-  const icon = document.createElement("img");
-  icon.alt = "";
-  icon.ariaHidden = "true";
-  icon.className = COMPOSER_INLINE_CHIP_ICON_CLASS_NAME;
-  icon.loading = "lazy";
-  icon.src = getVscodeIconUrlForEntry(pathValue, inferEntryKindFromPath(pathValue), theme);
-
-  const label = document.createElement("span");
-  label.className = COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME;
-  label.textContent = basenameOfPath(pathValue);
-
-  container.append(icon, label);
-}
+// Node classes imported from ./composer-nodes
 
 function terminalContextSignature(contexts: ReadonlyArray<TerminalContextDraft>): string {
   return contexts
@@ -499,7 +204,7 @@ function getAbsoluteOffsetForPoint(node: LexicalNode, pointOffset: number): numb
   }
 
   if ($isTextNode(node)) {
-    if (node instanceof ComposerMentionNode || node instanceof ComposerSkillNode) {
+    if (node instanceof ComposerMentionNode || node instanceof ComposerSkillNode || node instanceof ComposerAgentMentionNode) {
       return getAbsoluteOffsetForInlineTokenPoint(node, offset, pointOffset);
     }
     return offset + Math.min(pointOffset, node.getTextContentSize());
@@ -546,7 +251,7 @@ function getExpandedAbsoluteOffsetForPoint(node: LexicalNode, pointOffset: numbe
   }
 
   if ($isTextNode(node)) {
-    if (node instanceof ComposerMentionNode || node instanceof ComposerSkillNode) {
+    if (node instanceof ComposerMentionNode || node instanceof ComposerSkillNode || node instanceof ComposerAgentMentionNode) {
       return getExpandedAbsoluteOffsetForInlineTokenPoint(node, offset, pointOffset);
     }
     return offset + Math.min(pointOffset, node.getTextContentSize());
@@ -577,7 +282,7 @@ function findSelectionPointAtOffset(
   node: LexicalNode,
   remainingRef: { value: number },
 ): { key: string; offset: number; type: "text" | "element" } | null {
-  if (node instanceof ComposerMentionNode || node instanceof ComposerSkillNode) {
+  if (node instanceof ComposerMentionNode || node instanceof ComposerSkillNode || node instanceof ComposerAgentMentionNode) {
     return findSelectionPointForInlineToken(node, remainingRef);
   }
   if (node instanceof ComposerTerminalContextNode) {
@@ -720,6 +425,10 @@ function $setComposerEditorPrompt(
       if (segment.context) {
         paragraph.append($createComposerTerminalContextNode(segment.context));
       }
+      continue;
+    }
+    if (segment.type === "agent-mention") {
+      paragraph.append($createComposerAgentMentionNode(segment.alias, segment.task));
       continue;
     }
     $appendTextWithLineBreaks(paragraph, segment.text);
@@ -1259,7 +968,7 @@ export const ComposerPromptEditor = forwardRef<
     () => ({
       namespace: "t3tools-composer-editor",
       editable: true,
-      nodes: [ComposerMentionNode, ComposerSkillNode, ComposerTerminalContextNode],
+      nodes: [ComposerMentionNode, ComposerSkillNode, ComposerTerminalContextNode, ComposerAgentMentionNode],
       editorState: () => {
         $setComposerEditorPrompt(initialValueRef.current, initialTerminalContextsRef.current);
       },

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -161,6 +161,14 @@ export type ComposerCommandItem =
       skill: ProviderSkillDescriptor;
       label: string;
       description: string;
+    }
+  | {
+      id: string;
+      type: "agent";
+      alias: string;
+      model: string;
+      label: string;
+      description: string;
     };
 
 type ComposerCommandGroupModel = {
@@ -408,6 +416,9 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
         <Badge variant="outline" className="px-1 py-0 text-[9px]">
           model
         </Badge>
+      ) : null}
+      {props.item.type === "agent" ? (
+        <TbUsers className="size-3.5 text-muted-foreground/60" />
       ) : null}
       <div className="min-w-0 flex flex-1 items-center gap-2">
         <div className="min-w-0 flex flex-1 items-center gap-1.5 overflow-hidden">

--- a/apps/web/src/components/composer-nodes/index.tsx
+++ b/apps/web/src/components/composer-nodes/index.tsx
@@ -1,0 +1,465 @@
+/**
+ * Composer Lexical Nodes
+ *
+ * Custom nodes for the composer editor:
+ * - ComposerMentionNode: File/path mentions (@path)
+ * - ComposerSkillNode: Skill mentions ($skill or /skill)
+ * - ComposerAgentMentionNode: Agent mentions (@alias(task))
+ * - ComposerTerminalContextNode: Terminal context blocks
+ */
+
+import {
+  $applyNodeReplacement,
+  DecoratorNode,
+  TextNode,
+  type EditorConfig,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type SerializedTextNode,
+  type Spread,
+} from "lexical";
+import type { ReactElement } from "react";
+
+import {
+  INLINE_TERMINAL_CONTEXT_PLACEHOLDER,
+  type TerminalContextDraft,
+} from "~/lib/terminalContext";
+import { basenameOfPath, getVscodeIconUrlForEntry, inferEntryKindFromPath } from "~/vscode-icons";
+import {
+  COMPOSER_INLINE_CHIP_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_ICON_CLASS_NAME,
+  COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME,
+  COMPOSER_INLINE_SKILL_CHIP_ICON_SVG,
+  COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME,
+  COMPOSER_INLINE_SKILL_CHIP_ICON_CLASS_NAME,
+  COMPOSER_INLINE_AGENT_CHIP_CLASS_NAME,
+  COMPOSER_INLINE_AGENT_CHIP_ICON_CLASS_NAME,
+  COMPOSER_INLINE_AGENT_CHIP_ICON_SVG,
+  formatComposerSkillChipLabel,
+} from "../composerInlineChip";
+import { ComposerPendingTerminalContextChip } from "../chat/ComposerPendingTerminalContexts";
+
+// ── Serialized Types ──────────────────────────────────────────────────
+
+export type SerializedComposerMentionNode = Spread<
+  {
+    path: string;
+    type: "composer-mention";
+    version: 1;
+  },
+  SerializedTextNode
+>;
+
+export type SerializedComposerSkillNode = Spread<
+  {
+    skillName: string;
+    type: "composer-skill";
+    version: 1;
+  },
+  SerializedTextNode
+>;
+
+export type SerializedComposerAgentMentionNode = Spread<
+  {
+    alias: string;
+    task: string;
+    type: "composer-agent-mention";
+    version: 1;
+  },
+  SerializedTextNode
+>;
+
+export type SerializedComposerTerminalContextNode = Spread<
+  {
+    context: TerminalContextDraft;
+    type: "composer-terminal-context";
+    version: 1;
+  },
+  SerializedLexicalNode
+>;
+
+// ── Helper Functions ──────────────────────────────────────────────────
+
+function resolvedThemeFromDocument(): "light" | "dark" {
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+function renderMentionChipDom(container: HTMLElement, pathValue: string): void {
+  container.textContent = "";
+  container.style.setProperty("user-select", "none");
+  container.style.setProperty("-webkit-user-select", "none");
+
+  const theme = resolvedThemeFromDocument();
+  const icon = document.createElement("img");
+  icon.alt = "";
+  icon.ariaHidden = "true";
+  icon.className = COMPOSER_INLINE_CHIP_ICON_CLASS_NAME;
+  icon.loading = "lazy";
+  icon.src = getVscodeIconUrlForEntry(pathValue, inferEntryKindFromPath(pathValue), theme);
+
+  const label = document.createElement("span");
+  label.className = COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME;
+  label.textContent = basenameOfPath(pathValue);
+
+  container.append(icon, label);
+}
+
+function renderSkillChipDom(container: HTMLElement, name: string): void {
+  container.textContent = "";
+  container.style.setProperty("user-select", "none");
+  container.style.setProperty("-webkit-user-select", "none");
+
+  const icon = document.createElement("span");
+  icon.ariaHidden = "true";
+  icon.className = COMPOSER_INLINE_SKILL_CHIP_ICON_CLASS_NAME;
+  icon.innerHTML = COMPOSER_INLINE_SKILL_CHIP_ICON_SVG;
+
+  const label = document.createElement("span");
+  label.className = COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME;
+  label.textContent = formatComposerSkillChipLabel(name);
+
+  container.append(icon, label);
+}
+
+function renderAgentMentionChipDom(container: HTMLElement, alias: string, task: string): void {
+  container.textContent = "";
+  container.style.setProperty("user-select", "none");
+  container.style.setProperty("-webkit-user-select", "none");
+
+  const icon = document.createElement("span");
+  icon.ariaHidden = "true";
+  icon.className = COMPOSER_INLINE_AGENT_CHIP_ICON_CLASS_NAME;
+  icon.innerHTML = COMPOSER_INLINE_AGENT_CHIP_ICON_SVG;
+
+  const label = document.createElement("span");
+  label.className = COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME;
+  // Show @alias with truncated task preview
+  const taskPreview = task.length > 20 ? `${task.slice(0, 20)}...` : task;
+  label.textContent = `@${alias}(${taskPreview})`;
+
+  container.append(icon, label);
+}
+
+// ── ComposerMentionNode ───────────────────────────────────────────────
+
+export class ComposerMentionNode extends TextNode {
+  __path: string;
+
+  static override getType(): string {
+    return "composer-mention";
+  }
+
+  static override clone(node: ComposerMentionNode): ComposerMentionNode {
+    return new ComposerMentionNode(node.__path, node.__key);
+  }
+
+  static override importJSON(serializedNode: SerializedComposerMentionNode): ComposerMentionNode {
+    return $createComposerMentionNode(serializedNode.path);
+  }
+
+  constructor(path: string, key?: NodeKey) {
+    const normalizedPath = path.startsWith("@") ? path.slice(1) : path;
+    super(`@${normalizedPath}`, key);
+    this.__path = normalizedPath;
+  }
+
+  override exportJSON(): SerializedComposerMentionNode {
+    return {
+      ...super.exportJSON(),
+      path: this.__path,
+      type: "composer-mention",
+      version: 1,
+    };
+  }
+
+  override createDOM(_config: EditorConfig): HTMLElement {
+    const dom = document.createElement("span");
+    dom.className = COMPOSER_INLINE_CHIP_CLASS_NAME;
+    dom.contentEditable = "false";
+    dom.setAttribute("spellcheck", "false");
+    renderMentionChipDom(dom, this.__path);
+    return dom;
+  }
+
+  override updateDOM(
+    prevNode: ComposerMentionNode,
+    dom: HTMLElement,
+    _config: EditorConfig,
+  ): boolean {
+    dom.contentEditable = "false";
+    if (prevNode.__text !== this.__text || prevNode.__path !== this.__path) {
+      renderMentionChipDom(dom, this.__path);
+    }
+    return false;
+  }
+
+  override canInsertTextBefore(): false {
+    return false;
+  }
+
+  override canInsertTextAfter(): false {
+    return false;
+  }
+
+  override isTextEntity(): true {
+    return true;
+  }
+
+  override isToken(): true {
+    return true;
+  }
+}
+
+export function $createComposerMentionNode(path: string): ComposerMentionNode {
+  return $applyNodeReplacement(new ComposerMentionNode(path));
+}
+
+// ── ComposerSkillNode ─────────────────────────────────────────────────
+
+export class ComposerSkillNode extends TextNode {
+  __skillName: string;
+
+  static override getType(): string {
+    return "composer-skill";
+  }
+
+  static override clone(node: ComposerSkillNode): ComposerSkillNode {
+    return new ComposerSkillNode(node.__skillName, node.__key);
+  }
+
+  static override importJSON(serializedNode: SerializedComposerSkillNode): ComposerSkillNode {
+    return $createComposerSkillNode(serializedNode.skillName);
+  }
+
+  constructor(name: string, key?: NodeKey) {
+    const normalizedName = name.startsWith("$") || name.startsWith("/") ? name.slice(1) : name;
+    const prefix = name.startsWith("/") ? "/" : "$";
+    super(`${prefix}${normalizedName}`, key);
+    this.__skillName = normalizedName;
+  }
+
+  override exportJSON(): SerializedComposerSkillNode {
+    return {
+      ...super.exportJSON(),
+      skillName: this.__skillName,
+      type: "composer-skill",
+      version: 1,
+    };
+  }
+
+  override createDOM(_config: EditorConfig): HTMLElement {
+    const dom = document.createElement("span");
+    dom.className = COMPOSER_INLINE_SKILL_CHIP_CLASS_NAME;
+    dom.contentEditable = "false";
+    dom.setAttribute("spellcheck", "false");
+    renderSkillChipDom(dom, this.__skillName);
+    return dom;
+  }
+
+  override updateDOM(
+    prevNode: ComposerSkillNode,
+    dom: HTMLElement,
+    _config: EditorConfig,
+  ): boolean {
+    dom.contentEditable = "false";
+    if (prevNode.__text !== this.__text || prevNode.__skillName !== this.__skillName) {
+      renderSkillChipDom(dom, this.__skillName);
+    }
+    return false;
+  }
+
+  override canInsertTextBefore(): false {
+    return false;
+  }
+
+  override canInsertTextAfter(): false {
+    return false;
+  }
+
+  override isTextEntity(): true {
+    return true;
+  }
+
+  override isToken(): true {
+    return true;
+  }
+}
+
+export function $createComposerSkillNode(name: string): ComposerSkillNode {
+  return $applyNodeReplacement(new ComposerSkillNode(name));
+}
+
+// ── ComposerAgentMentionNode ──────────────────────────────────────────
+
+export class ComposerAgentMentionNode extends TextNode {
+  __alias: string;
+  __task: string;
+
+  static override getType(): string {
+    return "composer-agent-mention";
+  }
+
+  static override clone(node: ComposerAgentMentionNode): ComposerAgentMentionNode {
+    return new ComposerAgentMentionNode(node.__alias, node.__task, node.__key);
+  }
+
+  static override importJSON(
+    serializedNode: SerializedComposerAgentMentionNode,
+  ): ComposerAgentMentionNode {
+    return $createComposerAgentMentionNode(serializedNode.alias, serializedNode.task);
+  }
+
+  constructor(alias: string, task: string, key?: NodeKey) {
+    // The text content is the full @alias(task) for proper serialization
+    super(`@${alias}(${task})`, key);
+    this.__alias = alias;
+    this.__task = task;
+  }
+
+  override exportJSON(): SerializedComposerAgentMentionNode {
+    return {
+      ...super.exportJSON(),
+      alias: this.__alias,
+      task: this.__task,
+      type: "composer-agent-mention",
+      version: 1,
+    };
+  }
+
+  override createDOM(_config: EditorConfig): HTMLElement {
+    const dom = document.createElement("span");
+    dom.className = COMPOSER_INLINE_AGENT_CHIP_CLASS_NAME;
+    dom.contentEditable = "false";
+    dom.setAttribute("spellcheck", "false");
+    renderAgentMentionChipDom(dom, this.__alias, this.__task);
+    return dom;
+  }
+
+  override updateDOM(
+    prevNode: ComposerAgentMentionNode,
+    dom: HTMLElement,
+    _config: EditorConfig,
+  ): boolean {
+    dom.contentEditable = "false";
+    if (prevNode.__alias !== this.__alias || prevNode.__task !== this.__task) {
+      renderAgentMentionChipDom(dom, this.__alias, this.__task);
+    }
+    return false;
+  }
+
+  override canInsertTextBefore(): false {
+    return false;
+  }
+
+  override canInsertTextAfter(): false {
+    return false;
+  }
+
+  override isTextEntity(): true {
+    return true;
+  }
+
+  override isToken(): true {
+    return true;
+  }
+}
+
+export function $createComposerAgentMentionNode(
+  alias: string,
+  task: string,
+): ComposerAgentMentionNode {
+  return $applyNodeReplacement(new ComposerAgentMentionNode(alias, task));
+}
+
+// ── ComposerTerminalContextNode ───────────────────────────────────────
+
+function ComposerTerminalContextDecorator(props: { context: TerminalContextDraft }) {
+  return <ComposerPendingTerminalContextChip context={props.context} />;
+}
+
+export class ComposerTerminalContextNode extends DecoratorNode<ReactElement> {
+  __context: TerminalContextDraft;
+
+  static override getType(): string {
+    return "composer-terminal-context";
+  }
+
+  static override clone(node: ComposerTerminalContextNode): ComposerTerminalContextNode {
+    return new ComposerTerminalContextNode(node.__context, node.__key);
+  }
+
+  static override importJSON(
+    serializedNode: SerializedComposerTerminalContextNode,
+  ): ComposerTerminalContextNode {
+    return $createComposerTerminalContextNode(serializedNode.context);
+  }
+
+  constructor(context: TerminalContextDraft, key?: NodeKey) {
+    super(key);
+    this.__context = context;
+  }
+
+  override exportJSON(): SerializedComposerTerminalContextNode {
+    return {
+      ...super.exportJSON(),
+      context: this.__context,
+      type: "composer-terminal-context",
+      version: 1,
+    };
+  }
+
+  override createDOM(): HTMLElement {
+    const dom = document.createElement("span");
+    dom.className = "inline-flex align-middle leading-none";
+    return dom;
+  }
+
+  override updateDOM(): false {
+    return false;
+  }
+
+  override getTextContent(): string {
+    return INLINE_TERMINAL_CONTEXT_PLACEHOLDER;
+  }
+
+  override isInline(): true {
+    return true;
+  }
+
+  override decorate(): ReactElement {
+    return <ComposerTerminalContextDecorator context={this.__context} />;
+  }
+}
+
+export function $createComposerTerminalContextNode(
+  context: TerminalContextDraft,
+): ComposerTerminalContextNode {
+  return $applyNodeReplacement(new ComposerTerminalContextNode(context));
+}
+
+// ── Type Guards & Utilities ───────────────────────────────────────────
+
+export type ComposerInlineTokenNode =
+  | ComposerMentionNode
+  | ComposerSkillNode
+  | ComposerTerminalContextNode
+  | ComposerAgentMentionNode;
+
+export function isComposerInlineTokenNode(
+  candidate: unknown,
+): candidate is ComposerInlineTokenNode {
+  return (
+    candidate instanceof ComposerMentionNode ||
+    candidate instanceof ComposerSkillNode ||
+    candidate instanceof ComposerTerminalContextNode ||
+    candidate instanceof ComposerAgentMentionNode
+  );
+}
+
+/** All node classes for Lexical registration */
+export const COMPOSER_NODE_CLASSES = [
+  ComposerMentionNode,
+  ComposerSkillNode,
+  ComposerTerminalContextNode,
+  ComposerAgentMentionNode,
+] as const;

--- a/apps/web/src/components/composerInlineChip.ts
+++ b/apps/web/src/components/composerInlineChip.ts
@@ -20,6 +20,15 @@ export const COMPOSER_INLINE_CHIP_DISMISS_BUTTON_CLASS_NAME =
 
 export const COMPOSER_INLINE_SKILL_CHIP_ICON_SVG = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>`;
 
+// Agent mention chip styling (for @alias(task) syntax)
+export const COMPOSER_INLINE_AGENT_CHIP_CLASS_NAME =
+  "inline-flex max-w-full select-none items-center gap-1 rounded-md bg-[var(--warning-foreground)]/15 px-2 py-1 text-[var(--warning-foreground)] align-middle -translate-y-0.5";
+
+export const COMPOSER_INLINE_AGENT_CHIP_ICON_CLASS_NAME = "size-3.5 shrink-0";
+
+// Users icon SVG for agent mentions
+export const COMPOSER_INLINE_AGENT_CHIP_ICON_SVG = `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>`;
+
 // Formats raw skill ids like `check-code` into the label used by inline skill chips.
 export function formatComposerSkillChipLabel(name: string): string {
   return name

--- a/apps/web/src/composer-editor-mentions.ts
+++ b/apps/web/src/composer-editor-mentions.ts
@@ -3,6 +3,7 @@ import {
   INLINE_TERMINAL_CONTEXT_PLACEHOLDER,
   type TerminalContextDraft,
 } from "./lib/terminalContext";
+import { resolveAgentAlias, type ModelSlug } from "@t3tools/contracts";
 
 export type ComposerPromptSegment =
   | {
@@ -21,12 +22,25 @@ export type ComposerPromptSegment =
   | {
       type: "terminal-context";
       context: TerminalContextDraft | null;
+    }
+  | {
+      /** Agent mention: @alias(task) - delegates task to a subagent */
+      type: "agent-mention";
+      alias: string;
+      model: ModelSlug;
+      displayName: string;
+      task: string;
     };
 
 const MENTION_TOKEN_REGEX = /(^|\s)@([^\s@]+)(?=\s)/g;
 const SKILL_TOKEN_REGEX = /(^|\s)([$/])([a-zA-Z][a-zA-Z0-9_:-]*)(?=\s)/g;
 const DISPLAY_MENTION_TOKEN_REGEX = /(^|\s)@([^\s@]+)(?=\s|$)/g;
 const DISPLAY_SKILL_TOKEN_REGEX = /(^|\s)([$/])([a-zA-Z][a-zA-Z0-9_:-]*)(?=\s|$)/g;
+
+// Agent mention: @alias(task content here)
+// Matches @alias followed by parentheses with task content
+// Supports nested parentheses by counting open/close parens
+const AGENT_MENTION_TOKEN_REGEX = /(^|\s)@([a-zA-Z0-9._-]+)\(/g;
 
 function pushTextSegment(segments: ComposerPromptSegment[], text: string): void {
   if (!text) return;
@@ -38,13 +52,51 @@ function pushTextSegment(segments: ComposerPromptSegment[], text: string): void 
   segments.push({ type: "text", text });
 }
 
-type InlineTokenMatch = {
-  kind: "mention" | "skill";
-  value: string;
-  skillPrefix?: string;
-  start: number;
-  end: number;
-};
+type InlineTokenMatch =
+  | {
+      kind: "mention" | "skill";
+      value: string;
+      skillPrefix?: string;
+      start: number;
+      end: number;
+    }
+  | {
+      kind: "agent-mention";
+      alias: string;
+      model: ModelSlug;
+      displayName: string;
+      task: string;
+      start: number;
+      end: number;
+    };
+
+/**
+ * Extract the content inside parentheses, handling nested parens.
+ * Returns the task content and the end position (after closing paren).
+ */
+function extractParenContent(text: string, startIndex: number): { task: string; endIndex: number } | null {
+  let depth = 1;
+  let index = startIndex;
+
+  while (index < text.length && depth > 0) {
+    const char = text[index];
+    if (char === "(") {
+      depth++;
+    } else if (char === ")") {
+      depth--;
+    }
+    index++;
+  }
+
+  if (depth !== 0) {
+    // Unclosed parenthesis
+    return null;
+  }
+
+  // Extract content between opening and closing parens
+  const task = text.slice(startIndex, index - 1);
+  return { task, endIndex: index };
+}
 
 function collectInlineTokenMatches(
   text: string,
@@ -60,6 +112,49 @@ function collectInlineTokenMatches(
     ? DISPLAY_SKILL_TOKEN_REGEX
     : SKILL_TOKEN_REGEX;
 
+  // Track positions covered by agent mentions to avoid double-matching
+  const agentMentionRanges: Array<{ start: number; end: number }> = [];
+
+  // First, match agent mentions: @alias(task)
+  for (const match of text.matchAll(AGENT_MENTION_TOKEN_REGEX)) {
+    const whitespace = match[1] ?? "";
+    const alias = match[2] ?? "";
+    const matchIndex = match.index ?? 0;
+    const start = matchIndex + whitespace.length;
+    const parenStart = matchIndex + match[0].length; // position after "("
+
+    // Try to resolve the alias
+    const resolved = resolveAgentAlias(alias);
+    if (!resolved) {
+      // Not a valid agent alias, skip - will be handled as regular mention
+      continue;
+    }
+
+    // Extract content inside parentheses
+    const parenContent = extractParenContent(text, parenStart);
+    if (!parenContent) {
+      // Unclosed parenthesis, skip
+      continue;
+    }
+
+    const end = parenContent.endIndex;
+    agentMentionRanges.push({ start, end });
+
+    matches.push({
+      kind: "agent-mention",
+      alias,
+      model: resolved.model,
+      displayName: resolved.displayName,
+      task: parenContent.task,
+      start,
+      end,
+    });
+  }
+
+  // Helper to check if a position is inside an agent mention
+  const isInsideAgentMention = (pos: number): boolean =>
+    agentMentionRanges.some((range) => pos >= range.start && pos < range.end);
+
   for (const match of text.matchAll(mentionRegex)) {
     const fullMatch = match[0];
     const prefix = match[1] ?? "";
@@ -67,6 +162,10 @@ function collectInlineTokenMatches(
     const matchIndex = match.index ?? 0;
     const start = matchIndex + prefix.length;
     const end = start + fullMatch.length - prefix.length;
+
+    // Skip if this overlaps with an agent mention
+    if (isInsideAgentMention(start)) continue;
+
     if (path.length > 0) {
       matches.push({ kind: "mention", value: path, start, end });
     }
@@ -80,6 +179,10 @@ function collectInlineTokenMatches(
     const matchIndex = match.index ?? 0;
     const start = matchIndex + whitespace.length;
     const end = start + fullMatch.length - whitespace.length;
+
+    // Skip if this overlaps with an agent mention
+    if (isInsideAgentMention(start)) continue;
+
     // Skip built-in slash commands so `/clear`, `/plan` etc. stay as plain text.
     if (name.length > 0 && !(skillPrefix === "/" && isBuiltInComposerSlashCommand(name))) {
       matches.push({ kind: "skill", value: name, skillPrefix, start, end });
@@ -111,7 +214,15 @@ function splitTextIntoPromptSegments(
       pushTextSegment(segments, text.slice(cursor, match.start));
     }
 
-    if (match.kind === "mention") {
+    if (match.kind === "agent-mention") {
+      segments.push({
+        type: "agent-mention",
+        alias: match.alias,
+        model: match.model,
+        displayName: match.displayName,
+        task: match.task,
+      });
+    } else if (match.kind === "mention") {
       segments.push({ type: "mention", path: match.value });
     } else {
       const skillSegment: ComposerPromptSegment = match.skillPrefix

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -27,7 +27,8 @@ type ComposerSegmentLike =
   | { type: "text"; text: string }
   | { type: "mention" }
   | { type: "skill" }
-  | { type: "terminal-context" };
+  | { type: "terminal-context" }
+  | { type: "agent-mention"; alias: string; task: string };
 
 const isInlineTokenSegment = (segment: ComposerSegmentLike): boolean => segment.type !== "text";
 
@@ -76,6 +77,16 @@ export function expandCollapsedComposerCursor(text: string, cursorInput: number)
     }
     if (segment.type === "skill") {
       const expandedLength = segment.name.length + 1;
+      if (remaining <= 1) {
+        return expandedCursor + (remaining === 0 ? 0 : expandedLength);
+      }
+      remaining -= 1;
+      expandedCursor += expandedLength;
+      continue;
+    }
+    if (segment.type === "agent-mention") {
+      // @alias(task) = 1 + alias.length + 1 + task.length + 1
+      const expandedLength = segment.alias.length + segment.task.length + 3;
       if (remaining <= 1) {
         return expandedCursor + (remaining === 0 ? 0 : expandedLength);
       }
@@ -156,6 +167,19 @@ export function collapseExpandedComposerCursor(text: string, cursorInput: number
     }
     if (segment.type === "skill") {
       const expandedLength = segment.name.length + 1;
+      if (remaining === 0) {
+        return collapsedCursor;
+      }
+      if (remaining <= expandedLength) {
+        return collapsedCursor + 1;
+      }
+      remaining -= expandedLength;
+      collapsedCursor += 1;
+      continue;
+    }
+    if (segment.type === "agent-mention") {
+      // @alias(task) = 1 + alias.length + 1 + task.length + 1
+      const expandedLength = segment.alias.length + segment.task.length + 3;
       if (remaining === 0) {
         return collapsedCursor;
       }

--- a/apps/web/src/hooks/useComposerCommandMenuItems.ts
+++ b/apps/web/src/hooks/useComposerCommandMenuItems.ts
@@ -6,6 +6,7 @@ import type {
   ProviderPluginDescriptor,
   ProviderSkillDescriptor,
 } from "@t3tools/contracts";
+import { getAgentMentionAliases } from "@t3tools/contracts";
 import { useMemo } from "react";
 import {
   buildCommandSearchBlob,
@@ -68,6 +69,26 @@ export function useComposerCommandMenuItems(input: {
     // Keep trigger-specific discovery outside ChatView so the view mostly orchestrates state.
     if (composerTrigger.kind === "mention") {
       const query = normalizeProviderDiscoveryText(composerTrigger.query);
+
+      // Agent items for @alias(task) syntax - only show for Codex provider
+      const agentItems: ComposerCommandItem[] =
+        provider === "codex"
+          ? getAgentMentionAliases()
+              .filter(({ alias, displayName }) => {
+                if (!query) return true;
+                const searchBlob = `${alias} ${displayName}`.toLowerCase();
+                return searchBlob.includes(query);
+              })
+              .map(({ alias, model, displayName }) => ({
+                id: `agent:${alias}`,
+                type: "agent" as const,
+                alias,
+                model,
+                label: `@${alias}`,
+                description: `${displayName} · delegate task to subagent`,
+              }))
+          : [];
+
       const pluginItems = providerPlugins
         .filter(({ plugin }) => {
           if (!query) return true;
@@ -89,7 +110,8 @@ export function useComposerCommandMenuItems(input: {
         label: basenameOfPath(entry.path),
         description: entry.parentPath ?? "",
       }));
-      return [...pluginItems, ...pathItems];
+      // Show agents first, then plugins, then paths
+      return [...agentItems, ...pluginItems, ...pathItems];
     }
 
     if (composerTrigger.kind === "slash-command") {

--- a/packages/contracts/src/agentMentions.ts
+++ b/packages/contracts/src/agentMentions.ts
@@ -1,0 +1,82 @@
+/**
+ * Agent Mentions - @alias(task) syntax for subagent delegation
+ *
+ * Provides aliases for calling subagents with specific models.
+ * Usage: @spark(do this task) or @mini(handle this)
+ */
+
+import type { ModelSlug } from "./model";
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export interface AgentAliasDefinition {
+  readonly model: ModelSlug;
+  readonly displayName: string;
+}
+
+export interface ResolvedAgentAlias {
+  readonly alias: string;
+  readonly model: ModelSlug;
+  readonly displayName: string;
+}
+
+// ── Alias Definitions ─────────────────────────────────────────────────
+
+/**
+ * Agent aliases for the @agent(task) mention syntax.
+ * Maps short names to model slugs for subagent delegation.
+ */
+export const AGENT_MENTION_ALIASES: Record<string, AgentAliasDefinition> = {
+  // GPT-5.4 family
+  "5.4": { model: "gpt-5.4", displayName: "GPT-5.4" },
+  "mini": { model: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" },
+  "5.4-mini": { model: "gpt-5.4-mini", displayName: "GPT-5.4 Mini" },
+  // GPT-5.3 family
+  "codex": { model: "gpt-5.3-codex", displayName: "GPT-5.3 Codex" },
+  "5.3": { model: "gpt-5.3-codex", displayName: "GPT-5.3 Codex" },
+  "spark": { model: "gpt-5.3-codex-spark", displayName: "GPT-5.3 Spark" },
+  "5.3-spark": { model: "gpt-5.3-codex-spark", displayName: "GPT-5.3 Spark" },
+  // GPT-5.2 family
+  "5.2": { model: "gpt-5.2", displayName: "GPT-5.2" },
+  "5.2-codex": { model: "gpt-5.2-codex", displayName: "GPT-5.2 Codex" },
+} as const;
+
+// ── Helper Functions ──────────────────────────────────────────────────
+
+/**
+ * Get all available agent aliases for autocomplete.
+ * Returns array sorted by alias name.
+ */
+export function getAgentMentionAliases(): ResolvedAgentAlias[] {
+  return Object.entries(AGENT_MENTION_ALIASES)
+    .map(([alias, { model, displayName }]) => ({
+      alias,
+      model,
+      displayName,
+    }))
+    .sort((a, b) => a.alias.localeCompare(b.alias));
+}
+
+/**
+ * Resolve an agent alias to its model slug.
+ * Case-insensitive lookup.
+ * @returns Resolved alias info or null if not found
+ */
+export function resolveAgentAlias(alias: string): AgentAliasDefinition | null {
+  const normalized = alias.toLowerCase();
+  return AGENT_MENTION_ALIASES[normalized] ?? null;
+}
+
+/**
+ * Check if a string is a valid agent alias.
+ */
+export function isValidAgentAlias(alias: string): boolean {
+  return resolveAgentAlias(alias) !== null;
+}
+
+/**
+ * Get the list of all alias names (for validation/autocomplete).
+ */
+export function getAgentAliasNames(): string[] {
+  return Object.keys(AGENT_MENTION_ALIASES);
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,6 +5,7 @@ export * from "./provider";
 export * from "./providerDiscovery";
 export * from "./providerRuntime";
 export * from "./model";
+export * from "./agentMentions";
 export * from "./ws";
 export * from "./keybindings";
 export * from "./server";

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -243,6 +243,18 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
   },
 };
 
+// ── Agent mention aliases ─────────────────────────────────────────────
+// Re-exported from agentMentions.ts for backward compatibility
+export {
+  AGENT_MENTION_ALIASES,
+  getAgentMentionAliases,
+  resolveAgentAlias,
+  isValidAgentAlias,
+  getAgentAliasNames,
+  type AgentAliasDefinition,
+  type ResolvedAgentAlias,
+} from "./agentMentions";
+
 // ── Model capabilities index ──────────────────────────────────────────
 
 export const MODEL_CAPABILITIES_INDEX = Object.fromEntries(


### PR DESCRIPTION
## Summary
- Add support for `@alias(task)` agent mentions in the composer, including parsing, serialization, cursor handling, and inline chip rendering.
- Extend the command menu to surface available agent aliases for Codex and insert the new mention format into the prompt editor.
- Move composer Lexical node implementations into a shared module and update shared contracts for agent mention metadata.

## Testing
- Not run (not requested).
- Expected checks for this change: `bun fmt`, `bun lint`, `bun typecheck`.