### PR TITLE
Fix thread panel deep links and preserve worktree associations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ apps/web/src/components/__screenshots__
 .vitest-*
 __screenshots__/
 .tanstack
+/.pi/
+/.tmp/
+/~/

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -56,6 +56,50 @@ function withEventBase(
   };
 }
 
+function deriveCommandAssociatedWorktreeMetadata(input: {
+  readonly branch: string | null;
+  readonly worktreePath: string | null;
+  readonly associatedWorktreePath?: string | null;
+  readonly associatedWorktreeBranch?: string | null;
+  readonly associatedWorktreeRef?: string | null;
+}) {
+  return deriveAssociatedWorktreeMetadata({
+    branch: input.branch,
+    worktreePath: input.worktreePath,
+    ...(input.associatedWorktreePath !== undefined
+      ? { associatedWorktreePath: input.associatedWorktreePath }
+      : {}),
+    ...(input.associatedWorktreeBranch !== undefined
+      ? { associatedWorktreeBranch: input.associatedWorktreeBranch }
+      : {}),
+    ...(input.associatedWorktreeRef !== undefined
+      ? { associatedWorktreeRef: input.associatedWorktreeRef }
+      : {}),
+  });
+}
+
+function deriveCommandAssociatedWorktreeMetadataPatch(input: {
+  readonly branch?: string | null;
+  readonly worktreePath?: string | null;
+  readonly associatedWorktreePath?: string | null;
+  readonly associatedWorktreeBranch?: string | null;
+  readonly associatedWorktreeRef?: string | null;
+}) {
+  return deriveAssociatedWorktreeMetadataPatch({
+    ...(input.branch !== undefined ? { branch: input.branch } : {}),
+    ...(input.worktreePath !== undefined ? { worktreePath: input.worktreePath } : {}),
+    ...(input.associatedWorktreePath !== undefined
+      ? { associatedWorktreePath: input.associatedWorktreePath }
+      : {}),
+    ...(input.associatedWorktreeBranch !== undefined
+      ? { associatedWorktreeBranch: input.associatedWorktreeBranch }
+      : {}),
+    ...(input.associatedWorktreeRef !== undefined
+      ? { associatedWorktreeRef: input.associatedWorktreeRef }
+      : {}),
+  });
+}
+
 export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand")(function* ({
   command,
   readModel,
@@ -191,12 +235,18 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           envMode: command.envMode,
           branch: command.branch,
           worktreePath: command.worktreePath,
-          ...deriveAssociatedWorktreeMetadata({
+          ...deriveCommandAssociatedWorktreeMetadata({
             branch: command.branch,
             worktreePath: command.worktreePath,
-            associatedWorktreePath: command.associatedWorktreePath ?? null,
-            associatedWorktreeBranch: command.associatedWorktreeBranch ?? null,
-            associatedWorktreeRef: command.associatedWorktreeRef ?? null,
+            ...(command.associatedWorktreePath !== undefined
+              ? { associatedWorktreePath: command.associatedWorktreePath }
+              : {}),
+            ...(command.associatedWorktreeBranch !== undefined
+              ? { associatedWorktreeBranch: command.associatedWorktreeBranch }
+              : {}),
+            ...(command.associatedWorktreeRef !== undefined
+              ? { associatedWorktreeRef: command.associatedWorktreeRef }
+              : {}),
           }),
           parentThreadId: command.parentThreadId,
           subagentAgentId: command.subagentAgentId,
@@ -263,12 +313,18 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           envMode: command.envMode,
           branch: command.branch,
           worktreePath: command.worktreePath,
-          ...deriveAssociatedWorktreeMetadata({
+          ...deriveCommandAssociatedWorktreeMetadata({
             branch: command.branch,
             worktreePath: command.worktreePath,
-            associatedWorktreePath: command.associatedWorktreePath ?? null,
-            associatedWorktreeBranch: command.associatedWorktreeBranch ?? null,
-            associatedWorktreeRef: command.associatedWorktreeRef ?? null,
+            ...(command.associatedWorktreePath !== undefined
+              ? { associatedWorktreePath: command.associatedWorktreePath }
+              : {}),
+            ...(command.associatedWorktreeBranch !== undefined
+              ? { associatedWorktreeBranch: command.associatedWorktreeBranch }
+              : {}),
+            ...(command.associatedWorktreeRef !== undefined
+              ? { associatedWorktreeRef: command.associatedWorktreeRef }
+              : {}),
           }),
           parentThreadId: null,
           subagentAgentId: null,
@@ -359,12 +415,18 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           envMode: command.envMode,
           branch: command.branch,
           worktreePath: command.worktreePath,
-          ...deriveAssociatedWorktreeMetadata({
+          ...deriveCommandAssociatedWorktreeMetadata({
             branch: command.branch,
             worktreePath: command.worktreePath,
-            associatedWorktreePath: command.associatedWorktreePath ?? null,
-            associatedWorktreeBranch: command.associatedWorktreeBranch ?? null,
-            associatedWorktreeRef: command.associatedWorktreeRef ?? null,
+            ...(command.associatedWorktreePath !== undefined
+              ? { associatedWorktreePath: command.associatedWorktreePath }
+              : {}),
+            ...(command.associatedWorktreeBranch !== undefined
+              ? { associatedWorktreeBranch: command.associatedWorktreeBranch }
+              : {}),
+            ...(command.associatedWorktreeRef !== undefined
+              ? { associatedWorktreeRef: command.associatedWorktreeRef }
+              : {}),
           }),
           parentThreadId: null,
           subagentAgentId: null,
@@ -494,12 +556,18 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           ...(command.envMode !== undefined ? { envMode: command.envMode } : {}),
           ...(command.branch !== undefined ? { branch: command.branch } : {}),
           ...(command.worktreePath !== undefined ? { worktreePath: command.worktreePath } : {}),
-          ...deriveAssociatedWorktreeMetadataPatch({
-            branch: command.branch ?? null,
-            worktreePath: command.worktreePath ?? null,
-            associatedWorktreePath: command.associatedWorktreePath ?? null,
-            associatedWorktreeBranch: command.associatedWorktreeBranch ?? null,
-            associatedWorktreeRef: command.associatedWorktreeRef ?? null,
+          ...deriveCommandAssociatedWorktreeMetadataPatch({
+            ...(command.branch !== undefined ? { branch: command.branch } : {}),
+            ...(command.worktreePath !== undefined ? { worktreePath: command.worktreePath } : {}),
+            ...(command.associatedWorktreePath !== undefined
+              ? { associatedWorktreePath: command.associatedWorktreePath }
+              : {}),
+            ...(command.associatedWorktreeBranch !== undefined
+              ? { associatedWorktreeBranch: command.associatedWorktreeBranch }
+              : {}),
+            ...(command.associatedWorktreeRef !== undefined
+              ? { associatedWorktreeRef: command.associatedWorktreeRef }
+              : {}),
           }),
           ...(command.parentThreadId !== undefined
             ? { parentThreadId: command.parentThreadId }

--- a/apps/server/src/orchestration/decider.worktreeMetadata.test.ts
+++ b/apps/server/src/orchestration/decider.worktreeMetadata.test.ts
@@ -203,6 +203,55 @@ describe("decider worktree metadata", () => {
     expect(event.payload).not.toHaveProperty("associatedWorktreeRef");
   });
 
+  it("keeps associated worktree metadata when switching back to local without an explicit clear", async () => {
+    const now = new Date().toISOString();
+    const readModel = await createWorktreeThreadReadModel(now);
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.meta.update",
+          commandId: CommandId.makeUnsafe("cmd-thread-meta-detach-to-local"),
+          threadId: THREAD_ID,
+          envMode: "local",
+          worktreePath: null,
+        },
+        readModel,
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event?.type).toBe("thread.meta-updated");
+    if (!event || event.type !== "thread.meta-updated") {
+      return;
+    }
+
+    expect(event.payload).toMatchObject({
+      threadId: THREAD_ID,
+      envMode: "local",
+      worktreePath: null,
+    });
+    expect(event.payload).not.toHaveProperty("associatedWorktreePath");
+    expect(event.payload).not.toHaveProperty("associatedWorktreeBranch");
+    expect(event.payload).not.toHaveProperty("associatedWorktreeRef");
+
+    const nextReadModel = await Effect.runPromise(
+      projectEvent(readModel, {
+        ...event,
+        sequence: 3,
+      }),
+    );
+    const thread = nextReadModel.threads.find((candidate) => candidate.id === THREAD_ID);
+
+    expect(thread).toMatchObject({
+      envMode: "local",
+      worktreePath: null,
+      associatedWorktreePath: WORKTREE_PATH,
+      associatedWorktreeBranch: WORKTREE_BRANCH,
+      associatedWorktreeRef: WORKTREE_BRANCH,
+    });
+  });
+
   it("still forwards explicit associated worktree clears during thread.meta.update", async () => {
     const now = new Date().toISOString();
     const readModel = await createWorktreeThreadReadModel(now);

--- a/apps/server/src/orchestration/decider.worktreeMetadata.test.ts
+++ b/apps/server/src/orchestration/decider.worktreeMetadata.test.ts
@@ -1,0 +1,236 @@
+import {
+  CommandId,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  EventId,
+  ProjectId,
+  ThreadId,
+} from "@t3tools/contracts";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+import { createEmptyReadModel, projectEvent } from "./projector.ts";
+
+const PROJECT_ID = ProjectId.makeUnsafe("project-1");
+const THREAD_ID = ThreadId.makeUnsafe("thread-1");
+const FORK_THREAD_ID = ThreadId.makeUnsafe("thread-fork-1");
+const WORKTREE_BRANCH = "feature/worktree";
+const WORKTREE_PATH = "/tmp/worktrees/feature-worktree";
+
+const asEventId = (value: string) => EventId.makeUnsafe(value);
+
+async function createProjectReadModel(now: string) {
+  return Effect.runPromise(
+    projectEvent(createEmptyReadModel(now), {
+      sequence: 1,
+      eventId: asEventId("evt-project-create"),
+      aggregateKind: "project",
+      aggregateId: PROJECT_ID,
+      type: "project.created",
+      occurredAt: now,
+      commandId: CommandId.makeUnsafe("cmd-project-create"),
+      causationEventId: null,
+      correlationId: CommandId.makeUnsafe("cmd-project-create"),
+      metadata: {},
+      payload: {
+        projectId: PROJECT_ID,
+        title: "Project",
+        workspaceRoot: "/tmp/project",
+        defaultModelSelection: null,
+        scripts: [],
+        createdAt: now,
+        updatedAt: now,
+      },
+    }),
+  );
+}
+
+async function createWorktreeThreadReadModel(now: string) {
+  const withProject = await createProjectReadModel(now);
+
+  return Effect.runPromise(
+    projectEvent(withProject, {
+      sequence: 2,
+      eventId: asEventId("evt-thread-create"),
+      aggregateKind: "thread",
+      aggregateId: THREAD_ID,
+      type: "thread.created",
+      occurredAt: now,
+      commandId: CommandId.makeUnsafe("cmd-thread-create"),
+      causationEventId: null,
+      correlationId: CommandId.makeUnsafe("cmd-thread-create"),
+      metadata: {},
+      payload: {
+        threadId: THREAD_ID,
+        projectId: PROJECT_ID,
+        title: "Worktree thread",
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "full-access",
+        envMode: "worktree",
+        branch: WORKTREE_BRANCH,
+        worktreePath: WORKTREE_PATH,
+        associatedWorktreePath: WORKTREE_PATH,
+        associatedWorktreeBranch: WORKTREE_BRANCH,
+        associatedWorktreeRef: WORKTREE_BRANCH,
+        parentThreadId: null,
+        subagentAgentId: null,
+        subagentNickname: null,
+        subagentRole: null,
+        forkSourceThreadId: null,
+        handoff: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    }),
+  );
+}
+
+describe("decider worktree metadata", () => {
+  it("derives associated worktree metadata during thread.create when only branch and worktreePath are provided", async () => {
+    const now = new Date().toISOString();
+    const readModel = await createProjectReadModel(now);
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.create",
+          commandId: CommandId.makeUnsafe("cmd-thread-create-derived-worktree"),
+          threadId: THREAD_ID,
+          projectId: PROJECT_ID,
+          title: "Worktree thread",
+          modelSelection: {
+            provider: "codex",
+            model: "gpt-5-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "full-access",
+          envMode: "worktree",
+          branch: WORKTREE_BRANCH,
+          worktreePath: WORKTREE_PATH,
+          createdAt: now,
+        },
+        readModel,
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event?.type).toBe("thread.created");
+    if (!event || event.type !== "thread.created") {
+      return;
+    }
+
+    expect(event.payload).toMatchObject({
+      associatedWorktreePath: WORKTREE_PATH,
+      associatedWorktreeBranch: WORKTREE_BRANCH,
+      associatedWorktreeRef: WORKTREE_BRANCH,
+    });
+  });
+
+  it("derives associated worktree metadata for thread.fork.create as well", async () => {
+    const now = new Date().toISOString();
+    const readModel = await createWorktreeThreadReadModel(now);
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.fork.create",
+          commandId: CommandId.makeUnsafe("cmd-thread-fork-derived-worktree"),
+          threadId: FORK_THREAD_ID,
+          sourceThreadId: THREAD_ID,
+          projectId: PROJECT_ID,
+          title: "Forked thread",
+          modelSelection: {
+            provider: "codex",
+            model: "gpt-5-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "full-access",
+          envMode: "worktree",
+          branch: WORKTREE_BRANCH,
+          worktreePath: WORKTREE_PATH,
+          importedMessages: [],
+          createdAt: now,
+        },
+        readModel,
+      }),
+    );
+
+    const createdEvent = (Array.isArray(result) ? result : [result])[0];
+    expect(createdEvent?.type).toBe("thread.created");
+    if (!createdEvent || createdEvent.type !== "thread.created") {
+      return;
+    }
+
+    expect(createdEvent.payload).toMatchObject({
+      associatedWorktreePath: WORKTREE_PATH,
+      associatedWorktreeBranch: WORKTREE_BRANCH,
+      associatedWorktreeRef: WORKTREE_BRANCH,
+    });
+  });
+
+  it("does not emit associated worktree clears for unrelated thread.meta.update commands", async () => {
+    const now = new Date().toISOString();
+    const readModel = await createWorktreeThreadReadModel(now);
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.meta.update",
+          commandId: CommandId.makeUnsafe("cmd-thread-meta-update-title-only"),
+          threadId: THREAD_ID,
+          title: "Renamed worktree thread",
+        },
+        readModel,
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event?.type).toBe("thread.meta-updated");
+    if (!event || event.type !== "thread.meta-updated") {
+      return;
+    }
+
+    expect(event.payload).toMatchObject({
+      threadId: THREAD_ID,
+      title: "Renamed worktree thread",
+    });
+    expect(event.payload).not.toHaveProperty("associatedWorktreePath");
+    expect(event.payload).not.toHaveProperty("associatedWorktreeBranch");
+    expect(event.payload).not.toHaveProperty("associatedWorktreeRef");
+  });
+
+  it("still forwards explicit associated worktree clears during thread.meta.update", async () => {
+    const now = new Date().toISOString();
+    const readModel = await createWorktreeThreadReadModel(now);
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.meta.update",
+          commandId: CommandId.makeUnsafe("cmd-thread-meta-clear-associated-worktree"),
+          threadId: THREAD_ID,
+          associatedWorktreePath: null,
+          associatedWorktreeBranch: null,
+          associatedWorktreeRef: null,
+        },
+        readModel,
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event?.type).toBe("thread.meta-updated");
+    if (!event || event.type !== "thread.meta-updated") {
+      return;
+    }
+
+    expect(event.payload).toMatchObject({
+      associatedWorktreePath: null,
+      associatedWorktreeBranch: null,
+      associatedWorktreeRef: null,
+    });
+  });
+});

--- a/apps/web/src/routes/-chatThreadRoute.logic.test.ts
+++ b/apps/web/src/routes/-chatThreadRoute.logic.test.ts
@@ -1,0 +1,165 @@
+import { TurnId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveRoutePanelBootstrap,
+  resolveThreadPickerTitle,
+  resolveToggledChatPanelPatch,
+} from "./-chatThreadRoute.logic";
+
+const TURN_ID = TurnId.makeUnsafe("turn-1");
+const OTHER_TURN_ID = TurnId.makeUnsafe("turn-2");
+
+describe("resolveThreadPickerTitle", () => {
+  it("falls back to a stable untitled label", () => {
+    expect(resolveThreadPickerTitle(null)).toBe("New chat");
+    expect(resolveThreadPickerTitle("")).toBe("New chat");
+  });
+
+  it("preserves non-empty thread titles", () => {
+    expect(resolveThreadPickerTitle("Bug bash")).toBe("Bug bash");
+  });
+});
+
+describe("resolveRoutePanelBootstrap", () => {
+  it("hydrates diff deep links exactly once per scope and search payload", () => {
+    const first = resolveRoutePanelBootstrap({
+      scopeId: "thread-1",
+      search: {
+        panel: "diff",
+        diff: "1",
+        diffTurnId: TURN_ID,
+        diffFilePath: "src/chat.tsx",
+      },
+      lastAppliedSearchKey: null,
+    });
+
+    expect(first.panelPatch).toEqual({
+      panel: "diff",
+      diffTurnId: TURN_ID,
+      diffFilePath: "src/chat.tsx",
+    });
+    expect(first.nextAppliedSearchKey).toEqual(expect.any(String));
+
+    const duplicate = resolveRoutePanelBootstrap({
+      scopeId: "thread-1",
+      search: {
+        panel: "diff",
+        diff: "1",
+        diffTurnId: TURN_ID,
+        diffFilePath: "src/chat.tsx",
+      },
+      lastAppliedSearchKey: first.nextAppliedSearchKey,
+    });
+
+    expect(duplicate).toEqual({
+      nextAppliedSearchKey: first.nextAppliedSearchKey,
+      panelPatch: null,
+    });
+  });
+
+  it("resets once route search params are stripped so the same deep link can replay", () => {
+    const first = resolveRoutePanelBootstrap({
+      scopeId: "thread-1",
+      search: {
+        panel: "diff",
+        diff: "1",
+        diffTurnId: TURN_ID,
+        diffFilePath: "src/chat.tsx",
+      },
+      lastAppliedSearchKey: null,
+    });
+
+    const cleared = resolveRoutePanelBootstrap({
+      scopeId: "thread-1",
+      search: {},
+      lastAppliedSearchKey: first.nextAppliedSearchKey,
+    });
+
+    expect(cleared).toEqual({
+      nextAppliedSearchKey: null,
+      panelPatch: null,
+    });
+
+    const replay = resolveRoutePanelBootstrap({
+      scopeId: "thread-1",
+      search: {
+        panel: "diff",
+        diff: "1",
+        diffTurnId: TURN_ID,
+        diffFilePath: "src/chat.tsx",
+      },
+      lastAppliedSearchKey: cleared.nextAppliedSearchKey,
+    });
+
+    expect(replay.panelPatch).toEqual({
+      panel: "diff",
+      diffTurnId: TURN_ID,
+      diffFilePath: "src/chat.tsx",
+    });
+  });
+
+  it("reapplies the same deep link when the mounted thread scope changes", () => {
+    const first = resolveRoutePanelBootstrap({
+      scopeId: "thread-1",
+      search: {
+        panel: "diff",
+        diff: "1",
+        diffTurnId: TURN_ID,
+      },
+      lastAppliedSearchKey: null,
+    });
+
+    const nextThread = resolveRoutePanelBootstrap({
+      scopeId: "thread-2",
+      search: {
+        panel: "diff",
+        diff: "1",
+        diffTurnId: TURN_ID,
+      },
+      lastAppliedSearchKey: first.nextAppliedSearchKey,
+    });
+
+    expect(nextThread.panelPatch).toEqual({
+      panel: "diff",
+      diffTurnId: TURN_ID,
+      diffFilePath: null,
+    });
+  });
+});
+
+describe("resolveToggledChatPanelPatch", () => {
+  it("preserves the last diff target when switching from diff to browser", () => {
+    expect(
+      resolveToggledChatPanelPatch(
+        {
+          panel: "diff",
+          diffTurnId: TURN_ID,
+          diffFilePath: "src/chat.tsx",
+        },
+        "browser",
+      ),
+    ).toEqual({
+      panel: "browser",
+      diffTurnId: TURN_ID,
+      diffFilePath: "src/chat.tsx",
+    });
+  });
+
+  it("keeps diff context even when closing the browser panel", () => {
+    expect(
+      resolveToggledChatPanelPatch(
+        {
+          panel: "browser",
+          diffTurnId: OTHER_TURN_ID,
+          diffFilePath: "src/browser.tsx",
+        },
+        "browser",
+      ),
+    ).toEqual({
+      panel: null,
+      diffTurnId: OTHER_TURN_ID,
+      diffFilePath: "src/browser.tsx",
+    });
+  });
+});

--- a/apps/web/src/routes/-chatThreadRoute.logic.ts
+++ b/apps/web/src/routes/-chatThreadRoute.logic.ts
@@ -1,0 +1,96 @@
+// FILE: chatThreadRoute.logic.ts
+// Purpose: Keep route-level chat panel state transitions and fallbacks deterministic.
+// Layer: Route UI logic helpers.
+// Exports: thread title fallback, deep-link bootstrap replay handling, and panel toggle helpers.
+
+import type { TurnId } from "@t3tools/contracts";
+
+import type { ChatRightPanel, DiffRouteSearch } from "../diffRouteSearch";
+
+export interface ChatPanelStateSnapshot {
+  panel: ChatRightPanel | null;
+  diffTurnId: TurnId | null;
+  diffFilePath: string | null;
+}
+
+export interface ChatPanelStatePatch {
+  panel?: ChatRightPanel | null;
+  diffTurnId?: TurnId | null;
+  diffFilePath?: string | null;
+}
+
+export interface RoutePanelBootstrapResult {
+  nextAppliedSearchKey: string | null;
+  panelPatch: ChatPanelStatePatch | null;
+}
+
+export function resolveThreadPickerTitle(title: string | null): string {
+  return title || "New chat";
+}
+
+function createRoutePanelSearchKey(input: {
+  scopeId: string;
+  search: DiffRouteSearch;
+}): string | null {
+  const { scopeId, search } = input;
+  if (
+    search.panel === undefined &&
+    search.diff === undefined &&
+    search.diffTurnId === undefined &&
+    search.diffFilePath === undefined
+  ) {
+    return null;
+  }
+
+  return JSON.stringify({
+    scopeId,
+    panel: search.panel ?? (search.diff ? "diff" : null),
+    diffTurnId: search.diffTurnId ?? null,
+    diffFilePath: search.diffFilePath ?? null,
+  });
+}
+
+export function resolveRoutePanelBootstrap(input: {
+  scopeId: string;
+  search: DiffRouteSearch;
+  lastAppliedSearchKey: string | null;
+}): RoutePanelBootstrapResult {
+  const nextAppliedSearchKey = createRoutePanelSearchKey({
+    scopeId: input.scopeId,
+    search: input.search,
+  });
+
+  if (nextAppliedSearchKey === null) {
+    return {
+      nextAppliedSearchKey: null,
+      panelPatch: null,
+    };
+  }
+
+  if (input.lastAppliedSearchKey === nextAppliedSearchKey) {
+    return {
+      nextAppliedSearchKey,
+      panelPatch: null,
+    };
+  }
+
+  return {
+    nextAppliedSearchKey,
+    panelPatch: {
+      panel: input.search.panel ?? (input.search.diff ? "diff" : null),
+      diffTurnId: input.search.diffTurnId ?? null,
+      diffFilePath: input.search.diffFilePath ?? null,
+    },
+  };
+}
+
+export function resolveToggledChatPanelPatch(
+  previousState: ChatPanelStateSnapshot,
+  panel: ChatRightPanel,
+): ChatPanelStatePatch {
+  return {
+    panel: previousState.panel === panel ? null : panel,
+    diffTurnId: previousState.diffTurnId,
+    diffFilePath: previousState.diffFilePath,
+  };
+}

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -66,6 +66,11 @@ import {
   DialogTitle,
 } from "../components/ui/dialog";
 import { Sheet, SheetPopup } from "../components/ui/sheet";
+import {
+  resolveRoutePanelBootstrap,
+  resolveThreadPickerTitle,
+  resolveToggledChatPanelPatch,
+} from "./-chatThreadRoute.logic";
 import { getLocalStorageItem, setLocalStorageItem } from "~/hooks/useLocalStorage";
 import { cn } from "~/lib/utils";
 import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
@@ -462,7 +467,7 @@ function SplitPaneEmptyState(props: {
                 />
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm font-medium text-foreground">
-                    {thread.title || "New chat"}
+                    {resolveThreadPickerTitle(thread.title)}
                   </div>
                   <div className="truncate text-xs text-muted-foreground">{projectName}</div>
                 </div>
@@ -710,11 +715,7 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
       }
       const previousState =
         pane === "left" ? activeSplitView.leftPanel : activeSplitView.rightPanel;
-      updatePanePanelState(pane, {
-        panel: previousState.panel === panel ? null : panel,
-        diffTurnId: panel === "diff" ? previousState.diffTurnId : null,
-        diffFilePath: panel === "diff" ? previousState.diffFilePath : null,
-      });
+      updatePanePanelState(pane, resolveToggledChatPanelPatch(previousState, panel));
     },
     [activeSplitView, updatePanePanelState],
   );
@@ -965,7 +966,7 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
                     />
                     <div className="min-w-0 flex-1">
                       <div className="truncate text-sm font-medium text-foreground">
-                        {thread.title}
+                        {resolveThreadPickerTitle(thread.title)}
                       </div>
                       <div className="truncate text-xs text-muted-foreground">{projectName}</div>
                     </div>
@@ -997,7 +998,7 @@ function SingleChatSurface(props: {
   const setThreadPanelState = useSingleChatPanelStore((store) => store.setThreadPanelState);
   const activePanel = panelState.panel;
   const panelOpen = activePanel !== null;
-  const hasBootstrappedRoutePanelRef = useRef(false);
+  const lastAppliedRoutePanelSearchKeyRef = useRef<string | null>(null);
   const updatePanelState = useCallback(
     (patch: Partial<Pick<SplitViewPanePanelState, "panel" | "diffTurnId" | "diffFilePath">>) => {
       const nextPanel = patch.panel ?? panelState.panel;
@@ -1043,36 +1044,25 @@ function SingleChatSurface(props: {
   }, [createSplitView, navigate, props.projectId, props.threadId]);
 
   useEffect(() => {
-    if (
-      hasBootstrappedRoutePanelRef.current ||
-      (props.search.panel === undefined &&
-        props.search.diffTurnId === undefined &&
-        props.search.diffFilePath === undefined)
-    ) {
+    const { nextAppliedSearchKey, panelPatch } = resolveRoutePanelBootstrap({
+      scopeId: props.threadId,
+      search: props.search,
+      lastAppliedSearchKey: lastAppliedRoutePanelSearchKeyRef.current,
+    });
+
+    lastAppliedRoutePanelSearchKeyRef.current = nextAppliedSearchKey;
+    if (!panelPatch) {
       return;
     }
 
-    hasBootstrappedRoutePanelRef.current = true;
-    updatePanelState({
-      panel: props.search.panel ?? (props.search.diff ? "diff" : null),
-      diffTurnId: props.search.diffTurnId ?? null,
-      diffFilePath: props.search.diffFilePath ?? null,
-    });
+    updatePanelState(panelPatch);
     void navigate({
       to: "/$threadId",
       params: { threadId: props.threadId },
       replace: true,
       search: (previous) => stripDiffSearchParams(previous),
     });
-  }, [
-    navigate,
-    props.search.diff,
-    props.search.diffFilePath,
-    props.search.diffTurnId,
-    props.search.panel,
-    props.threadId,
-    updatePanelState,
-  ]);
+  }, [navigate, props.search, props.threadId, updatePanelState]);
 
   useEffect(() => {
     const onMenuAction = window.desktopBridge?.onMenuAction;
@@ -1082,17 +1072,13 @@ function SingleChatSurface(props: {
 
     const unsubscribe = onMenuAction((action) => {
       if (action !== "toggle-browser") return;
-      updatePanelState({
-        panel: activePanel === "browser" ? null : "browser",
-        diffTurnId: null,
-        diffFilePath: null,
-      });
+      updatePanelState(resolveToggledChatPanelPatch(panelState, "browser"));
     });
 
     return () => {
       unsubscribe?.();
     };
-  }, [activePanel, props.threadId, updatePanelState]);
+  }, [panelState, updatePanelState]);
 
   const shouldRenderPanelContent = activePanel !== null && (panelOpen || panelState.hasOpenedPanel);
 
@@ -1105,16 +1091,10 @@ function SingleChatSurface(props: {
             threadId={props.threadId}
             panelState={panelState}
             onToggleDiffPanel={() =>
-              updatePanelState({
-                panel: activePanel === "diff" ? null : "diff",
-              })
+              updatePanelState(resolveToggledChatPanelPatch(panelState, "diff"))
             }
             onToggleBrowserPanel={() =>
-              updatePanelState({
-                panel: activePanel === "browser" ? null : "browser",
-                diffTurnId: null,
-                diffFilePath: null,
-              })
+              updatePanelState(resolveToggledChatPanelPatch(panelState, "browser"))
             }
             onOpenTurnDiffPanel={(turnId, filePath) =>
               updatePanelState({
@@ -1148,16 +1128,10 @@ function SingleChatSurface(props: {
           threadId={props.threadId}
           panelState={panelState}
           onToggleDiffPanel={() =>
-            updatePanelState({
-              panel: activePanel === "diff" ? null : "diff",
-            })
+            updatePanelState(resolveToggledChatPanelPatch(panelState, "diff"))
           }
           onToggleBrowserPanel={() =>
-            updatePanelState({
-              panel: activePanel === "browser" ? null : "browser",
-              diffTurnId: null,
-              diffFilePath: null,
-            })
+            updatePanelState(resolveToggledChatPanelPatch(panelState, "browser"))
           }
           onOpenTurnDiffPanel={(turnId, filePath) =>
             updatePanelState({


### PR DESCRIPTION
## Summary

This keeps the change set small and focused around thread-state regressions and one cleanup to avoid accidental local tool artifacts in future diffs.

## What changed

### Web
- fix untitled split-pane chooser rows so they render `New chat` instead of a blank title
- replay right-panel deep links from route search params correctly instead of only bootstrapping once
- preserve the last selected diff target when switching between the Browser and Diff panels

### Server
- stop coercing omitted `associatedWorktree*` fields to `null` during:
  - `thread.create`
  - `thread.handoff.create`
  - `thread.fork.create`
  - `thread.meta.update`
- keep explicit clears working as before
- add regression coverage for derived worktree association behavior

### Repo hygiene
- ignore local Pi harness artifacts (`/.pi/`, `/.tmp/`, `/~/`) so accidental local files do not dirty the repo

## Why

These were small but user-visible / state-visible regressions:
- split-pane chooser rows could render blank for untitled threads
- route-driven diff/browser panel state could go stale on same-thread revisits
- switching to Browser discarded the current diff target
- worktree-associated threads could lose or incorrectly overwrite associated worktree metadata because omitted fields were treated like explicit clears

## Before / after

### Before
- untitled split-pane chooser rows were blank
- same-thread diff deep links could be ignored after the first bootstrap
- switching from Diff -> Browser cleared the stored diff target
- omitted `associatedWorktree*` command fields could be treated like `null`

### After
- untitled split-pane chooser rows show `New chat`
- same-thread diff deep links replay reliably
- switching Diff <-> Browser preserves the last diff target
- omitted `associatedWorktree*` fields stay omitted, while explicit clears still clear

> Note: the UI impact here is text/state behavior only; there are no layout or styling changes.

## Verification

Ran locally:
- `bun run --cwd apps/web test -- src/routes/-chatThreadRoute.logic.test.ts`
- `bun run --cwd apps/server test -- src/orchestration/decider.worktreeMetadata.test.ts`
- `bun run typecheck`
- `bun run lint` *(warnings only, no errors)*
- `bunx oxfmt --check apps/web/src/routes/_chat.$threadId.tsx apps/web/src/routes/-chatThreadRoute.logic.ts apps/web/src/routes/-chatThreadRoute.logic.test.ts apps/server/src/orchestration/decider.ts apps/server/src/orchestration/decider.worktreeMetadata.test.ts .gitignore`

## Commits
- `fix(web): preserve chat panel deep links and titles`
- `fix(server): preserve derived worktree associations`
- `test(server): document local worktree detach semantics`
- `chore(repo): ignore local pi artifacts`
