### PR TITLE
desktop: auto-detect Codex in Linux AppImages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,24 @@ We are not accepting contributions yet.
 
 Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening an issue or PR.
 
+## Linux AppImage Builds
+
+Linux AppImage packaging is supported from the workspace root:
+
+```bash
+bun run dist:desktop:linux
+```
+
+If `bun install` fails while rebuilding native dependencies such as `node-pty`, make sure Bun is using the `node-gyp` from the same Node toolchain as your active `node` and `npm` binaries:
+
+```bash
+sudo apt update
+sudo apt install -y build-essential python3 make g++ pkg-config libx11-dev libxkbfile-dev
+npm install -g node-gyp
+npm_config_node_gyp="$(npm config get prefix)/bin/node-gyp" bun install
+bun run dist:desktop:linux
+```
+
+The desktop app auto-detects common Codex CLI installs on Linux, including NVM-managed installs, so packaged builds do not need a separate wrapper script just to launch Codex.
+
 Need support? Join the [Discord](https://discord.gg/jn4EGJjrvv).

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -56,8 +56,6 @@ import {
 import { isArm64HostRunningIntelBuild, resolveDesktopRuntimeInfo } from "./runtimeArch";
 import { DesktopBrowserManager } from "./browserManager";
 
-syncShellEnvironment();
-
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const SET_THEME_CHANNEL = "desktop:set-theme";
@@ -91,6 +89,9 @@ const STATE_DIR = Path.join(BASE_DIR, "userdata");
 const DESKTOP_SCHEME = "t3";
 const ROOT_DIR = Path.resolve(__dirname, "../../..");
 const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
+syncShellEnvironment(process.env, {
+  preferInheritedEnvironmentOnLinux: !isDevelopment,
+});
 const APP_DISPLAY_NAME = isDevelopment ? "DP Code (Dev)" : "DP Code (Alpha)";
 const APP_USER_MODEL_ID = isDevelopment ? "com.t3tools.dpcode.dev" : "com.t3tools.dpcode";
 const USER_DATA_DIR_NAME = isDevelopment ? "t3code-dev" : "t3code";
@@ -1679,29 +1680,26 @@ async function bootstrap(): Promise<void> {
   startBackend();
   writeDesktopLogHeader("bootstrap backend start requested");
 
-  if (isDevelopment) {
-    mainWindow = createWindow();
-    writeDesktopLogHeader("bootstrap main window created");
-    void waitForBackendHttpReady(backendHttpUrl)
-      .then(() => {
-        writeDesktopLogHeader("bootstrap backend ready");
-      })
-      .catch((error) => {
-        if (isBackendReadinessAborted(error)) {
-          return;
-        }
-        writeDesktopLogHeader(
-          `bootstrap backend readiness warning message=${formatErrorMessage(error)}`,
-        );
-        console.warn("[desktop] backend readiness check timed out during dev bootstrap", error);
-      });
-    return;
-  }
-
-  await waitForBackendHttpReady(backendHttpUrl);
-  writeDesktopLogHeader("bootstrap backend ready");
   mainWindow = createWindow();
   writeDesktopLogHeader("bootstrap main window created");
+  void waitForBackendHttpReady(backendHttpUrl)
+    .then(() => {
+      writeDesktopLogHeader("bootstrap backend ready");
+    })
+    .catch((error) => {
+      if (isBackendReadinessAborted(error)) {
+        return;
+      }
+      writeDesktopLogHeader(
+        `bootstrap backend readiness warning message=${formatErrorMessage(error)}`,
+      );
+      console.warn(
+        isDevelopment
+          ? "[desktop] backend readiness check timed out during dev bootstrap"
+          : "[desktop] backend readiness check timed out during packaged bootstrap",
+        error,
+      );
+    });
 }
 
 app.on("before-quit", () => {

--- a/apps/desktop/src/syncShellEnvironment.test.ts
+++ b/apps/desktop/src/syncShellEnvironment.test.ts
@@ -100,6 +100,25 @@ describe("syncShellEnvironment", () => {
     expect(env.SSH_AUTH_SOCK).toBe("/tmp/ssh.sock");
   });
 
+  it("can prefer the inherited Linux environment to avoid blocking startup", () => {
+    const env: NodeJS.ProcessEnv = {
+      SHELL: "/bin/zsh",
+      PATH: "/usr/bin",
+      SSH_AUTH_SOCK: "/tmp/inherited.sock",
+    };
+    const readEnvironment = vi.fn();
+
+    syncShellEnvironment(env, {
+      platform: "linux",
+      preferInheritedEnvironmentOnLinux: true,
+      readEnvironment,
+    });
+
+    expect(readEnvironment).not.toHaveBeenCalled();
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.SSH_AUTH_SOCK).toBe("/tmp/inherited.sock");
+  });
+
   it("falls back to a user login shell when SHELL is missing", () => {
     const env: NodeJS.ProcessEnv = {
       PATH: "/usr/bin",

--- a/apps/desktop/src/syncShellEnvironment.ts
+++ b/apps/desktop/src/syncShellEnvironment.ts
@@ -28,6 +28,7 @@ export function syncShellEnvironment(
   env: NodeJS.ProcessEnv = process.env,
   options: {
     platform?: NodeJS.Platform;
+    preferInheritedEnvironmentOnLinux?: boolean;
     readEnvironment?: ShellEnvironmentReader;
     readLaunchctlPath?: typeof readPathFromLaunchctl;
     userShell?: string;
@@ -36,6 +37,9 @@ export function syncShellEnvironment(
 ): void {
   const platform = options.platform ?? process.platform;
   if (platform !== "darwin" && platform !== "linux") return;
+  if (platform === "linux" && options.preferInheritedEnvironmentOnLinux && env.PATH?.trim()) {
+    return;
+  }
 
   const logWarning = options.logWarning ?? logShellEnvironmentWarning;
   const readEnvironment = options.readEnvironment ?? readEnvironmentFromLoginShell;

--- a/apps/desktop/src/voiceTranscription.ts
+++ b/apps/desktop/src/voiceTranscription.ts
@@ -11,6 +11,11 @@ import type {
   ServerVoiceTranscriptionInput,
   ServerVoiceTranscriptionResult,
 } from "@t3tools/contracts";
+import {
+  applyCodexBinaryToPath,
+  readConfiguredCodexHomePath,
+  resolveCodexBinaryPath,
+} from "@t3tools/shared/codexConfig";
 
 export const SERVER_TRANSCRIBE_VOICE_CHANNEL = "desktop:server-transcribe-voice";
 
@@ -81,9 +86,12 @@ async function resolveDesktopVoiceAuth(
   cwd: string,
 ): Promise<{ token: string; transcriptionUrl: string }> {
   return new Promise((resolve, reject) => {
-    const child = ChildProcess.spawn("codex", ["app-server"], {
+    const codexBinaryPath = resolveCodexBinaryPath(process.env);
+    const codexHomePath = readConfiguredCodexHomePath(process.env);
+    const envWithCodexPath = applyCodexBinaryToPath(process.env, codexBinaryPath);
+    const child = ChildProcess.spawn(codexBinaryPath, ["app-server"], {
       cwd,
-      env: process.env,
+      env: codexHomePath ? { ...envWithCodexPath, CODEX_HOME: codexHomePath } : envWithCodexPath,
       stdio: ["pipe", "pipe", "pipe"],
       shell: process.platform === "win32",
     });
@@ -111,7 +119,9 @@ async function resolveDesktopVoiceAuth(
     };
 
     child.once("error", (error) => {
-      rejectOnce(new Error(`Could not start Codex auth discovery: ${error.message}`));
+      rejectOnce(
+        new Error(`Could not start Codex auth discovery (${codexBinaryPath}): ${error.message}`),
+      );
     });
     child.stderr.on("data", () => {
       // Ignore stderr noise from the discovery process; the JSON-RPC result is authoritative.

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -306,6 +306,18 @@ describe("buildCodexProcessEnv", () => {
     expect(readEnvironment).not.toHaveBeenCalled();
     expect(env.AZURE_OPENAI_API_KEY).toBe("existing-secret");
   });
+
+  it("prepends an absolute codex binary directory to PATH", () => {
+    const env = buildCodexProcessEnv({
+      env: {
+        PATH: "/usr/bin",
+      },
+      binaryPath: "/home/test/.nvm/versions/node/v22.22.2/bin/codex",
+      platform: "linux",
+    });
+
+    expect(env.PATH).toBe("/home/test/.nvm/versions/node/v22.22.2/bin:/usr/bin");
+  });
 });
 
 describe("handleStdoutLine", () => {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -37,7 +37,12 @@ import {
   type ServerVoiceTranscriptionInput,
   type ServerVoiceTranscriptionResult,
 } from "@t3tools/contracts";
-import { readActiveCodexProviderEnvKey } from "@t3tools/shared/codexConfig";
+import {
+  applyCodexBinaryToPath,
+  readActiveCodexProviderEnvKey,
+  readConfiguredCodexHomePath,
+  resolveCodexBinaryPath,
+} from "@t3tools/shared/codexConfig";
 import { normalizeModelSlug } from "@t3tools/shared/model";
 import {
   readEnvironmentFromLoginShell,
@@ -242,13 +247,19 @@ function asString(value: unknown): string | undefined {
 export function buildCodexProcessEnv(
   input: {
     readonly env?: NodeJS.ProcessEnv;
+    readonly binaryPath?: string;
     readonly homePath?: string;
     readonly platform?: NodeJS.Platform;
     readonly readEnvironment?: ShellEnvironmentReader;
   } = {},
 ): NodeJS.ProcessEnv {
   const baseEnv = { ...(input.env ?? process.env) };
-  const effectiveEnv = input.homePath ? { ...baseEnv, CODEX_HOME: input.homePath } : baseEnv;
+  const codexBinaryPath = input.binaryPath ?? resolveCodexBinaryPath(baseEnv);
+  const configuredHomePath = input.homePath ?? readConfiguredCodexHomePath(baseEnv);
+  const envWithCodexPath = applyCodexBinaryToPath(baseEnv, codexBinaryPath);
+  const effectiveEnv = configuredHomePath
+    ? { ...envWithCodexPath, CODEX_HOME: configuredHomePath }
+    : envWithCodexPath;
   const platform = input.platform ?? process.platform;
 
   if (platform === "darwin" || platform === "linux") {
@@ -275,6 +286,8 @@ export function buildCodexProcessEnv(
       // Keep inherited environment if shell lookup fails.
     }
   }
+
+  Object.assign(effectiveEnv, applyCodexBinaryToPath(effectiveEnv, codexBinaryPath));
 
   return effectiveEnv;
 }
@@ -685,6 +698,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       const child = spawn(codexBinaryPath, ["app-server"], {
         cwd: resolvedCwd,
         env: buildCodexProcessEnv({
+          binaryPath: codexBinaryPath,
           ...(codexHomePath ? { homePath: codexHomePath } : {}),
         }),
         stdio: ["pipe", "pipe", "pipe"],
@@ -1202,6 +1216,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       const child = spawn(codexBinaryPath, ["app-server"], {
         cwd: resolvedCwd,
         env: buildCodexProcessEnv({
+          binaryPath: codexBinaryPath,
           ...(codexHomePath ? { homePath: codexHomePath } : {}),
         }),
         stdio: ["pipe", "pipe", "pipe"],
@@ -1681,13 +1696,19 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
 
     const now = new Date().toISOString();
+    const codexBinaryPath = resolveCodexBinaryPath(process.env);
+    const codexHomePath = readConfiguredCodexHomePath(process.env);
     this.assertSupportedCodexCliVersion({
-      binaryPath: "codex",
+      binaryPath: codexBinaryPath,
       cwd: normalizedCwd,
+      ...(codexHomePath ? { homePath: codexHomePath } : {}),
     });
-    const child = spawn("codex", ["app-server"], {
+    const child = spawn(codexBinaryPath, ["app-server"], {
       cwd: normalizedCwd,
-      env: buildCodexProcessEnv(),
+      env: buildCodexProcessEnv({
+        binaryPath: codexBinaryPath,
+        ...(codexHomePath ? { homePath: codexHomePath } : {}),
+      }),
       stdio: ["pipe", "pipe", "pipe"],
       shell: process.platform === "win32",
     });
@@ -2675,12 +2696,14 @@ function readCodexProviderOptions(input: CodexAppServerStartSessionInput): {
   readonly homePath?: string;
 } {
   const options = input.providerOptions?.codex;
-  if (!options) {
-    return {};
-  }
+  const configuredCodexHomePath = readConfiguredCodexHomePath(process.env);
   return {
-    ...(options.binaryPath ? { binaryPath: options.binaryPath } : {}),
-    ...(options.homePath ? { homePath: options.homePath } : {}),
+    binaryPath: options?.binaryPath ?? resolveCodexBinaryPath(process.env),
+    ...(options?.homePath
+      ? { homePath: options.homePath }
+      : configuredCodexHomePath
+        ? { homePath: configuredCodexHomePath }
+        : {}),
   };
 }
 
@@ -2692,6 +2715,7 @@ function assertSupportedCodexCliVersion(input: {
   const result = spawnSync(input.binaryPath, ["--version"], {
     cwd: input.cwd,
     env: buildCodexProcessEnv({
+      binaryPath: input.binaryPath,
       ...(input.homePath ? { homePath: input.homePath } : {}),
     }),
     encoding: "utf8",

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -5,7 +5,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { DEFAULT_GIT_TEXT_GENERATION_MODEL } from "@t3tools/contracts";
 import { sanitizeGeneratedThreadTitle } from "@t3tools/shared/chatThreads";
-import { resolveCodexHome } from "@t3tools/shared/codexConfig";
+import { resolveCodexBinaryPath, resolveCodexHome } from "@t3tools/shared/codexConfig";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
@@ -342,10 +342,11 @@ const makeCodexTextGeneration = Effect.gen(function* () {
       );
       const outputPath = yield* writeTempFile(operation, "codex-output", "");
       const isolatedCodexHome = yield* prepareIsolatedCodexHome(operation, codexHomePath);
+      const codexBinaryPath = resolveCodexBinaryPath(process.env);
 
       const runCodexCommand = Effect.gen(function* () {
         const command = ChildProcess.make(
-          "codex",
+          codexBinaryPath,
           [
             "exec",
             "--ephemeral",
@@ -364,7 +365,10 @@ const makeCodexTextGeneration = Effect.gen(function* () {
           ],
           {
             cwd,
-            env: buildCodexProcessEnv({ homePath: isolatedCodexHome.homePath }),
+            env: buildCodexProcessEnv({
+              binaryPath: codexBinaryPath,
+              homePath: isolatedCodexHome.homePath,
+            }),
             shell: process.platform === "win32",
             stdin: {
               stream: Stream.make(new TextEncoder().encode(prompt)),

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -8,13 +8,18 @@
  *
  * @module ProviderHealthLive
  */
-import * as OS from "node:os";
 import type {
   ServerProviderAuthStatus,
   ServerProviderStatus,
   ServerProviderStatusState,
 } from "@t3tools/contracts";
-import { parseCodexConfigModelProvider } from "@t3tools/shared/codexConfig";
+import {
+  applyCodexBinaryToPath,
+  parseCodexConfigModelProvider,
+  readConfiguredCodexHomePath,
+  resolveCodexBinaryPath,
+  resolveCodexHome,
+} from "@t3tools/shared/codexConfig";
 import {
   Array,
   Effect,
@@ -265,7 +270,7 @@ const OPENAI_AUTH_PROVIDERS = new Set(["openai"]);
 export const readCodexConfigModelProvider = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const codexHome = process.env.CODEX_HOME || path.join(OS.homedir(), ".codex");
+  const codexHome = resolveCodexHome(process.env);
   const configPath = path.join(codexHome, "config.toml");
 
   const content = yield* fileSystem
@@ -301,7 +306,11 @@ const collectStreamAsString = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.
 const runCodexCommand = (args: ReadonlyArray<string>) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const command = ChildProcess.make("codex", [...args], {
+    const codexBinaryPath = resolveCodexBinaryPath(process.env);
+    const codexHomePath = readConfiguredCodexHomePath(process.env);
+    const envWithCodexPath = applyCodexBinaryToPath(process.env, codexBinaryPath);
+    const command = ChildProcess.make(codexBinaryPath, [...args], {
+      env: codexHomePath ? { ...envWithCodexPath, CODEX_HOME: codexHomePath } : envWithCodexPath,
       shell: process.platform === "win32",
     });
 
@@ -348,6 +357,7 @@ export const checkCodexProviderStatus: Effect.Effect<
   ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
 > = Effect.gen(function* () {
   const checkedAt = new Date().toISOString();
+  const codexBinaryPath = resolveCodexBinaryPath(process.env);
 
   // Probe 1: `codex --version` — is the CLI reachable?
   const versionProbe = yield* runCodexCommand(["--version"]).pipe(
@@ -364,7 +374,7 @@ export const checkCodexProviderStatus: Effect.Effect<
       authStatus: "unknown" as const,
       checkedAt,
       message: isCommandMissingCause(error)
-        ? "Codex CLI (`codex`) is not installed or not on PATH."
+        ? `Codex CLI (\`${codexBinaryPath}\`) is not installed or not on PATH.`
         : `Failed to execute Codex CLI health check: ${error instanceof Error ? error.message : String(error)}.`,
     };
   }

--- a/packages/shared/src/codexConfig.test.ts
+++ b/packages/shared/src/codexConfig.test.ts
@@ -128,8 +128,8 @@ describe("readActiveCodexProviderEnvKey", () => {
 
 describe("resolveCodexBinaryPath", () => {
   it("reads CODEX_BINARY_PATH when configured", () => {
-    expect(resolveCodexBinaryPath({ CODEX_BINARY_PATH: "/home/harrjyot/codex-wrapper.sh" })).toBe(
-      "/home/harrjyot/codex-wrapper.sh",
+    expect(resolveCodexBinaryPath({ CODEX_BINARY_PATH: "/opt/custom/bin/codex" })).toBe(
+      "/opt/custom/bin/codex",
     );
   });
 

--- a/packages/shared/src/codexConfig.test.ts
+++ b/packages/shared/src/codexConfig.test.ts
@@ -1,13 +1,19 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import OS from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  applyCodexBinaryToPath,
+  findCodexBinaryPath,
   parseCodexConfigActiveProviderEnvKey,
   parseCodexConfigModelProvider,
   parseCodexConfigProviderEnvKey,
+  readConfiguredCodexBinaryPath,
+  readConfiguredCodexHomePath,
   readActiveCodexProviderEnvKey,
+  resolveCodexBinaryPath,
+  resolveCodexHome,
 } from "./codexConfig";
 
 const tempDirs: string[] = [];
@@ -21,6 +27,12 @@ function makeTempCodexHome(configContent?: string): string {
   }
 
   return tempDir;
+}
+
+function writeExecutable(filePath: string, content = "#!/bin/sh\nexit 0\n"): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, "utf8");
+  chmodSync(filePath, 0o755);
 }
 
 afterEach(() => {
@@ -111,5 +123,78 @@ describe("readActiveCodexProviderEnvKey", () => {
   it("returns undefined when config.toml is missing", () => {
     const codexHome = makeTempCodexHome();
     expect(readActiveCodexProviderEnvKey({ CODEX_HOME: codexHome })).toBeUndefined();
+  });
+});
+
+describe("resolveCodexBinaryPath", () => {
+  it("reads CODEX_BINARY_PATH when configured", () => {
+    expect(resolveCodexBinaryPath({ CODEX_BINARY_PATH: "/home/harrjyot/codex-wrapper.sh" })).toBe(
+      "/home/harrjyot/codex-wrapper.sh",
+    );
+  });
+
+  it("falls back to codex when no override is configured", () => {
+    expect(resolveCodexBinaryPath({})).toBe("codex");
+  });
+
+  it("finds codex on PATH before scanning toolchain directories", () => {
+    const home = makeTempCodexHome();
+    const codexPath = join(home, "bin", "codex");
+    writeExecutable(codexPath);
+
+    expect(resolveCodexBinaryPath({ HOME: home, PATH: join(home, "bin") })).toBe(codexPath);
+  });
+
+  it("finds codex in the newest installed nvm node version", () => {
+    const home = makeTempCodexHome();
+    const olderCodexPath = join(home, ".nvm", "versions", "node", "v20.18.0", "bin", "codex");
+    const newerCodexPath = join(home, ".nvm", "versions", "node", "v22.22.2", "bin", "codex");
+    writeExecutable(olderCodexPath);
+    writeExecutable(newerCodexPath);
+
+    expect(findCodexBinaryPath({ HOME: home, PATH: "/usr/bin" })).toBe(newerCodexPath);
+  });
+
+  it("exposes the raw configured override", () => {
+    expect(readConfiguredCodexBinaryPath({ CODEX_BINARY_PATH: " /tmp/custom-codex " })).toBe(
+      "/tmp/custom-codex",
+    );
+  });
+});
+
+describe("applyCodexBinaryToPath", () => {
+  it("prepends the codex binary directory when an absolute path is used", () => {
+    expect(
+      applyCodexBinaryToPath(
+        { PATH: "/usr/bin" },
+        "/home/test/.nvm/versions/node/v22.22.2/bin/codex",
+      ),
+    ).toEqual({
+      PATH: "/home/test/.nvm/versions/node/v22.22.2/bin:/usr/bin",
+    });
+  });
+
+  it("leaves PATH unchanged for bare command names", () => {
+    expect(applyCodexBinaryToPath({ PATH: "/usr/bin" }, "codex")).toEqual({ PATH: "/usr/bin" });
+  });
+});
+
+describe("resolveCodexHome", () => {
+  it("prefers CODEX_HOME when it is configured", () => {
+    expect(
+      resolveCodexHome({ CODEX_HOME: "/tmp/codex-home", CODEX_HOME_PATH: "/tmp/ignored" }),
+    ).toBe("/tmp/codex-home");
+  });
+
+  it("falls back to CODEX_HOME_PATH for desktop/server overrides", () => {
+    expect(resolveCodexHome({ CODEX_HOME_PATH: "/tmp/codex-home-path" })).toBe(
+      "/tmp/codex-home-path",
+    );
+  });
+
+  it("exposes the configured home override without defaulting", () => {
+    expect(readConfiguredCodexHomePath({ CODEX_HOME_PATH: " /tmp/codex-home-path " })).toBe(
+      "/tmp/codex-home-path",
+    );
   });
 });

--- a/packages/shared/src/codexConfig.ts
+++ b/packages/shared/src/codexConfig.ts
@@ -5,8 +5,8 @@
  * discovery without pulling in a full TOML dependency.
  */
 import OS from "node:os";
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { accessSync, constants, existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, isAbsolute, join } from "node:path";
 
 function readQuotedAssignmentValue(trimmedLine: string, key: string): string | undefined {
   const match = trimmedLine.match(new RegExp(`^${key}\\s*=\\s*(?:"([^"]+)"|'([^']+)')`));
@@ -18,6 +18,118 @@ function readModelProviderSectionName(trimmedLine: string): string | undefined {
     /^\[\s*model_providers\.(?:"([^"]+)"|'([^']+)'|([A-Za-z0-9_-]+))\s*\]$/,
   );
   return match?.[1] ?? match?.[2] ?? match?.[3];
+}
+
+function readConfiguredEnvPath(
+  env: NodeJS.ProcessEnv,
+  keys: ReadonlyArray<string>,
+): string | undefined {
+  for (const key of keys) {
+    const configured = env[key]?.trim();
+    if (configured) {
+      return configured;
+    }
+  }
+
+  return undefined;
+}
+
+function isExecutableFile(filePath: string): boolean {
+  try {
+    accessSync(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function envPathKeyFor(env: NodeJS.ProcessEnv): "PATH" | "Path" | "path" {
+  if ("PATH" in env) return "PATH";
+  if ("Path" in env) return "Path";
+  return "path";
+}
+
+function compareVersionSegments(a: string, b: string): number {
+  const aSegments = a
+    .replace(/^v/i, "")
+    .split(".")
+    .map((segment) => Number.parseInt(segment, 10) || 0);
+  const bSegments = b
+    .replace(/^v/i, "")
+    .split(".")
+    .map((segment) => Number.parseInt(segment, 10) || 0);
+  const segmentCount = Math.max(aSegments.length, bSegments.length);
+
+  for (let index = 0; index < segmentCount; index += 1) {
+    const difference = (bSegments[index] ?? 0) - (aSegments[index] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+function listInstalledNodeVersions(baseDirectory: string): ReadonlyArray<string> {
+  if (!existsSync(baseDirectory)) {
+    return [];
+  }
+
+  return readdirSync(baseDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .toSorted(compareVersionSegments);
+}
+
+function resolveExecutableOnPath(commandName: string, env: NodeJS.ProcessEnv): string | undefined {
+  const envPath = env[envPathKeyFor(env)]?.trim();
+  if (!envPath) {
+    return undefined;
+  }
+
+  for (const entry of envPath.split(process.platform === "win32" ? ";" : ":")) {
+    const directory = entry.trim();
+    if (!directory) {
+      continue;
+    }
+
+    const candidatePath = join(directory, commandName);
+    if (isExecutableFile(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  return undefined;
+}
+
+function listCodexBinaryCandidates(env: NodeJS.ProcessEnv): ReadonlyArray<string> {
+  const home = env.HOME?.trim() || OS.homedir();
+  const xdgDataHome = env.XDG_DATA_HOME?.trim() || join(home, ".local", "share");
+  const nvmVersions = listInstalledNodeVersions(join(home, ".nvm", "versions", "node"));
+  const fnmVersions = listInstalledNodeVersions(join(home, ".fnm", "node-versions"));
+
+  return [
+    join(home, ".local", "bin", "codex"),
+    join(home, ".volta", "bin", "codex"),
+    join(home, ".asdf", "shims", "codex"),
+    join(xdgDataHome, "mise", "shims", "codex"),
+    ...nvmVersions.map((version) =>
+      join(home, ".nvm", "versions", "node", version, "bin", "codex"),
+    ),
+    ...fnmVersions.map((version) =>
+      join(home, ".fnm", "node-versions", version, "installation", "bin", "codex"),
+    ),
+  ];
+}
+
+function prependPathEntry(env: NodeJS.ProcessEnv, directory: string): NodeJS.ProcessEnv {
+  const envPathKey = envPathKeyFor(env);
+  const inheritedPath = env[envPathKey]?.trim();
+  const delimiter = process.platform === "win32" ? ";" : ":";
+  return {
+    ...env,
+    [envPathKey]: inheritedPath ? `${directory}${delimiter}${inheritedPath}` : directory,
+  };
 }
 
 export function parseCodexConfigModelProvider(content: string): string | undefined {
@@ -71,9 +183,50 @@ export function parseCodexConfigActiveProviderEnvKey(content: string): string | 
   return parseCodexConfigProviderEnvKey(content, provider);
 }
 
+export function readConfiguredCodexBinaryPath(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return readConfiguredEnvPath(env, ["CODEX_BINARY_PATH"]);
+}
+
+export function findCodexBinaryPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const binaryOnPath = resolveExecutableOnPath("codex", env);
+  if (binaryOnPath) {
+    return binaryOnPath;
+  }
+
+  for (const candidatePath of listCodexBinaryCandidates(env)) {
+    if (isExecutableFile(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  return undefined;
+}
+
+export function resolveCodexBinaryPath(env: NodeJS.ProcessEnv = process.env): string {
+  return readConfiguredCodexBinaryPath(env) ?? findCodexBinaryPath(env) ?? "codex";
+}
+
+export function applyCodexBinaryToPath(
+  env: NodeJS.ProcessEnv,
+  binaryPath: string | undefined,
+): NodeJS.ProcessEnv {
+  if (!binaryPath || !isAbsolute(binaryPath)) {
+    return env;
+  }
+
+  return prependPathEntry(env, dirname(binaryPath));
+}
+
+export function readConfiguredCodexHomePath(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return readConfiguredEnvPath(env, ["CODEX_HOME", "CODEX_HOME_PATH"]);
+}
+
 export function resolveCodexHome(env: NodeJS.ProcessEnv = process.env): string {
-  const configured = env.CODEX_HOME?.trim();
-  return configured && configured.length > 0 ? configured : join(OS.homedir(), ".codex");
+  return readConfiguredCodexHomePath(env) ?? join(OS.homedir(), ".codex");
 }
 
 export function readCodexConfigContent(env: NodeJS.ProcessEnv = process.env): string | undefined {

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export npm_config_node_gyp="${npm_config_node_gyp:-$(npm config get prefix)/bin/node-gyp}"
+
+bun install
+bun run build:desktop
+bun run dist:desktop:linux


### PR DESCRIPTION
## Summary
- auto-detect common Linux Codex installs, including NVM-managed installs, and prepend the matching bin dir so packaged desktop builds can launch Codex without an external wrapper
- reuse the resolved Codex binary across desktop voice auth, provider health checks, discovery sessions, and Codex text generation, while honoring configured `CODEX_HOME_PATH`
- reduce packaged Linux startup latency by preferring the inherited environment and showing the window before backend readiness finishes, then document Linux AppImage build setup and add a helper script

## Verification
- `bun fmt`
- `bun lint` (existing workspace warnings only)
- `bun typecheck`
- `bun run dist:desktop:linux` via `T3CODE_DESKTOP_OUTPUT_DIR=release-next`