### PR TITLE
 UX Fix: Hide settings button when actively viewing settings

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4345,16 +4345,7 @@ export default function Sidebar() {
         <SidebarMenu>
           <SidebarMenuItem>
             <div className="flex items-center gap-2">
-              {isOnSettings ? (
-                <SidebarMenuButton
-                  size="default"
-                  className="h-8 flex-1 gap-2.5 rounded-lg px-2 text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/72 hover:bg-accent/55 hover:text-foreground"
-                  isActive
-                >
-                  <SettingsIcon className="size-[15px]" />
-                  <span>Settings</span>
-                </SidebarMenuButton>
-              ) : (
+              {!isOnSettings && (
                 <SidebarMenuButton
                   size="default"
                   className="h-8 flex-1 gap-2.5 rounded-lg px-2 text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/72 hover:bg-accent/55 hover:text-foreground"


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->
Updated `Sidebar.tsx` to conditionally render the Settings button in the sidebar footer as `null` when `isOnSettings` evaluates to true.

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->
The settings button previously remained visible even when the user was already actively viewing the Settings page. This change tightens the sidebar layout to clearly reflect the active context and avoids offering an action that the user has already taken.

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
If the change involves motion or interaction, include a short video.
Delete this section if not applicable. -->

<table align="center">
  <tr>
    <th align="center">Before</th>
    <th align="center">After</th>
  </tr>
  <tr>
    <td align="center">
      <video src="https://github.com/user-attachments/assets/40e1f9c2-5c9b-4300-8a8d-d19051aa81af" width="100%" controls autoplay loop></video>
    </td>
    <td align="center">
      <video src="https://github.com/user-attachments/assets/aa905873-b38b-40db-8bc5-f7878e5244cd" width="100%" controls autoplay loop></video>
    </td>
  </tr>
</table>


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes
