### PR TITLE
[codex] fix(web): keep sidebar summaries fresh on hot path

### DIFF
--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   applyShellEvent,
   applyOrchestrationEvents,
+  applyOrchestrationEventsHotPath,
   collapseProjectsExcept,
   markThreadUnread,
   renameProjectLocally,
@@ -23,6 +24,7 @@ import {
   setThreadWorkspace,
   setAllProjectsExpanded,
   syncServerReadModel,
+  syncServerThreadDetailHotPath,
   type AppState,
 } from "./store";
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type Thread } from "./types";
@@ -1102,6 +1104,66 @@ describe("store read model sync", () => {
     expect(next.threads[0]?.archivedAt).toBe("2026-02-27T00:05:00.000Z");
     expect(next.sidebarThreadSummaryById["thread-archived"]?.archivedAt).toBe(
       "2026-02-27T00:05:00.000Z",
+    );
+  });
+
+  it("updates sidebar summaries during hot-path thread detail syncs", () => {
+    // Seed the hydrated store with the original thread metadata that the sidebar already shows.
+    const initialState = syncServerReadModel(
+      makeState(makeThread({ title: "Original title" })),
+      makeReadModel(
+        makeReadModelThread({
+          title: "Original title",
+          updatedAt: "2026-02-27T00:00:00.000Z",
+        }),
+      ),
+    );
+
+    // Apply the live detail snapshot that renames and archives the same thread.
+    const next = syncServerThreadDetailHotPath(
+      initialState,
+      makeReadModelThread({
+        title: "Renamed title",
+        archivedAt: "2026-02-27T00:05:00.000Z",
+        updatedAt: "2026-02-27T00:05:00.000Z",
+      }),
+    );
+
+    // The sidebar row must reflect the latest title and archive state immediately.
+    expect(next.sidebarThreadSummaryById["thread-1"]).toMatchObject({
+      title: "Renamed title",
+      archivedAt: "2026-02-27T00:05:00.000Z",
+    });
+  });
+
+  it("updates sidebar summaries for hot-path archive events", () => {
+    // Start from a hydrated unarchived thread so the event must flip the sidebar summary.
+    const initialState = syncServerReadModel(
+      makeState(makeThread({ title: "Archivable thread" })),
+      makeReadModel(
+        makeReadModelThread({
+          title: "Archivable thread",
+          updatedAt: "2026-02-27T00:00:00.000Z",
+        }),
+      ),
+    );
+
+    // Replay the live archive event through the hot path used by the event router.
+    const next = applyOrchestrationEventsHotPath(
+      initialState,
+      [
+        makeDomainEvent("thread.archived", {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          archivedAt: "2026-02-27T00:07:00.000Z",
+          updatedAt: "2026-02-27T00:07:00.000Z",
+        }),
+      ],
+      { updateThreadArray: false },
+    );
+
+    // The sidebar summary must expose the new archive timestamp without waiting for a full refresh.
+    expect(next.sidebarThreadSummaryById["thread-1"]?.archivedAt).toBe(
+      "2026-02-27T00:07:00.000Z",
     );
   });
 

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -1652,6 +1652,7 @@ function commitThreadProjection(
   state: AppState,
   threadId: ThreadId,
   options?: {
+    updateThreadArray?: boolean;
     updateSidebarSummary?: boolean;
   },
 ): AppState {
@@ -1661,20 +1662,23 @@ function commitThreadProjection(
     return state;
   }
 
+  // Let hot-path detail syncs skip array churn without suppressing sidebar freshness.
+  const shouldUpdateThreadArray = options?.updateThreadArray ?? true;
+  // Sidebar summaries still need the latest title/archive signals for navigation.
   const shouldUpdateSidebarSummary = options?.updateSidebarSummary ?? true;
   const threadExists = previousThread !== undefined;
-  const threads = threadExists
-    ? updateThread(state.threads, threadId, (thread) =>
-        nextThread === thread ? thread : nextThread,
-      )
-    : [...state.threads, nextThread];
-
-  if (!shouldUpdateSidebarSummary) {
-    return state;
-  }
+  const threads = shouldUpdateThreadArray
+    ? threadExists
+      ? updateThread(state.threads, threadId, (thread) =>
+          nextThread === thread ? thread : nextThread,
+        )
+      : [...state.threads, nextThread]
+    : state.threads;
 
   const previousSummary = state.sidebarThreadSummaryById[threadId];
-  const nextSummary = buildSidebarThreadSummary(nextThread, previousSummary);
+  const nextSummary = shouldUpdateSidebarSummary
+    ? buildSidebarThreadSummary(nextThread, previousSummary)
+    : previousSummary;
 
   if (threads === state.threads && nextSummary === previousSummary) {
     return state;
@@ -2017,7 +2021,7 @@ function applyThreadUpdate(
     return state;
   }
   return commitThreadProjection(writeThreadState(state, updatedThread, currentThread), threadId, {
-    updateSidebarSummary: options?.updateThreadArray ?? true,
+    updateThreadArray: options?.updateThreadArray ?? true,
   });
 }
 
@@ -2614,7 +2618,7 @@ function syncServerThreadDetailWithOptions(
     writeThreadState(state, normalizeThreadFromReadModel(thread, previousThread), previousThread),
     thread.id,
     {
-      updateSidebarSummary: options?.updateThreadArray ?? true,
+      updateThreadArray: options?.updateThreadArray ?? true,
     },
   );
 }


### PR DESCRIPTION
## Summary
This PR fixes a stale-sidebar regression in the web app. Live hot-path thread updates could refresh thread detail state without refreshing the sidebar summary, which left renamed or archived threads showing outdated metadata in the primary navigation until a fuller refresh happened.

## What changed
- updated the thread projection path so hot-path updates can skip thread-array churn without skipping sidebar summary refresh
- passed the new `updateThreadArray` intent through the hot-path thread and event update call sites
- added regression tests for hot-path detail syncs and hot-path archive events

## Why this change
The event router uses a hot path for live thread updates to reduce unnecessary render work. That path was effectively disabling sidebar summary updates as well, so the app could have correct thread detail state internally while the main sidebar still displayed stale title or archive status.

## Impact
- keeps the primary navigation in sync with live thread rename/archive updates
- preserves the original goal of avoiding unnecessary thread-array churn on the hot path
- keeps the fix small and limited to the store layer

## Validation
- `bun x vitest run src/store.test.ts` (34/34 passing)

## Notes
This change is limited to sidebar state synchronization. It does not intentionally change layout, styling, or motion.
