### PR TITLE
Add Gemini provider support

### DIFF
--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -90,6 +90,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+t", command: "chat.newTerminal", when: "!terminalFocus" },
   { key: "mod+alt+c", command: "chat.newClaude", when: "!terminalFocus" },
   { key: "mod+alt+x", command: "chat.newCodex", when: "!terminalFocus" },
+  { key: "mod+alt+g", command: "chat.newGemini", when: "!terminalFocus" },
   { key: "mod+\\", command: "chat.split", when: "!terminalFocus" },
   { key: "mod+1", command: "thread.jump.1", when: "!terminalFocus && !terminalWorkspaceOpen" },
   { key: "mod+2", command: "thread.jump.2", when: "!terminalFocus && !terminalWorkspaceOpen" },

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1961,6 +1961,14 @@ describe("ProviderCommandReactor", () => {
     );
 
     await waitFor(() => harness.stopSession.mock.calls.length === 1);
+    await waitFor(async () => {
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      const thread = readModel.threads.find(
+        (entry) => entry.id === ThreadId.makeUnsafe("thread-1"),
+      );
+      return thread?.session?.status === "stopped";
+    });
+
     const readModel = await Effect.runPromise(harness.engine.getReadModel());
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
     expect(thread?.session).not.toBeNull();

--- a/apps/server/src/provider/Layers/GeminiAdapter.ts
+++ b/apps/server/src/provider/Layers/GeminiAdapter.ts
@@ -1,0 +1,2547 @@
+/**
+ * GeminiAdapterLive - Scoped live implementation for the Gemini provider adapter.
+ *
+ * Wraps Gemini CLI ACP sessions behind the generic provider adapter contract
+ * and emits canonical provider runtime events.
+ *
+ * @module GeminiAdapterLive
+ */
+import { type ChildProcessWithoutNullStreams, spawn, spawnSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import readline from "node:readline";
+
+import {
+  ApprovalRequestId,
+  type CanonicalItemType,
+  type CanonicalRequestType,
+  EventId,
+  type GeminiThinkingBudget,
+  type GeminiThinkingLevel,
+  MODEL_OPTIONS_BY_PROVIDER,
+  type ProviderComposerCapabilities,
+  type ProviderListModelsResult,
+  ProviderItemId,
+  type ProviderRuntimeEvent,
+  type ProviderSendTurnInput,
+  type ProviderSession,
+  RuntimeItemId,
+  RuntimeRequestId,
+  ThreadId,
+  type ThreadTokenUsageSnapshot,
+  TurnId,
+} from "@t3tools/contracts";
+import {
+  getGeminiThinkingConfigKind,
+  getGeminiThinkingModelAlias,
+  resolveGeminiApiModelId,
+} from "@t3tools/shared/model";
+import { Effect, FileSystem, Layer, Queue, Stream } from "effect";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionClosedError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+  type ProviderAdapterError,
+} from "../Errors.ts";
+import { probeGeminiCapabilities } from "../geminiAcpProbe.ts";
+import { GeminiAdapter, type GeminiAdapterShape } from "../Services/GeminiAdapter.ts";
+import { asArray, asNumber, asRecord, asString, trimToUndefined } from "../geminiValue.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const PROVIDER = "gemini" as const;
+const GEMINI_ACP_REQUEST_TIMEOUT_MS = 60_000;
+const GEMINI_ACP_PROMPT_TIMEOUT_MS = 30 * 60_000;
+const GEMINI_TMP_DIR = path.join(os.homedir(), ".gemini", "tmp");
+const GEMINI_CHAT_DIR_NAME = "chats";
+const GEMINI_SESSION_FILE_PREFIX = "session-";
+const DPCODE_GEMINI_SETTINGS_DIR = path.join(os.tmpdir(), "dpcode", "gemini");
+const GEMINI_3_THINKING_LEVELS: ReadonlyArray<GeminiThinkingLevel> = ["HIGH", "LOW"];
+const GEMINI_2_5_THINKING_BUDGETS: ReadonlyArray<GeminiThinkingBudget> = [-1, 512, 0];
+
+type JsonRpcId = number | string;
+type GeminiToolKind =
+  | "read"
+  | "edit"
+  | "delete"
+  | "move"
+  | "search"
+  | "execute"
+  | "think"
+  | "fetch"
+  | "switch_mode"
+  | "other";
+type GeminiToolStatus = "pending" | "in_progress" | "completed" | "failed";
+type GeminiPermissionOptionKind = "allow_once" | "allow_always" | "reject_once" | "reject_always";
+
+interface GeminiPermissionOption {
+  readonly optionId: string;
+  readonly name: string;
+  readonly kind: GeminiPermissionOptionKind;
+}
+
+interface GeminiToolCallLocation {
+  readonly path: string;
+  readonly line?: number | null;
+}
+
+interface GeminiToolCall {
+  readonly toolCallId: string;
+  readonly title?: string | null;
+  readonly kind?: GeminiToolKind | null;
+  readonly status?: GeminiToolStatus | null;
+  readonly content?: ReadonlyArray<unknown> | null;
+  readonly locations?: ReadonlyArray<GeminiToolCallLocation> | null;
+  readonly rawInput?: unknown;
+  readonly rawOutput?: unknown;
+}
+
+interface GeminiPendingRequest {
+  readonly method: string;
+  readonly timeout: ReturnType<typeof setTimeout>;
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (error: ProviderAdapterRequestError) => void;
+}
+
+interface GeminiPendingApproval {
+  readonly acpRequestId: JsonRpcId;
+  readonly options: ReadonlyArray<GeminiPermissionOption>;
+  readonly requestType: CanonicalRequestType;
+  readonly turnId?: TurnId;
+  readonly providerItemId?: string;
+  readonly detail?: string;
+}
+
+interface GeminiRecordedItem {
+  id: string;
+  itemType: CanonicalItemType;
+  title?: string;
+  detail?: string;
+  status?: "inProgress" | "completed" | "failed";
+  text?: string;
+  data?: unknown;
+}
+
+interface GeminiTurnState {
+  readonly turnId: TurnId;
+  readonly startedAt: string;
+  readonly assistantItemId: RuntimeItemId;
+  reasoningItemId: RuntimeItemId | undefined;
+  readonly items: GeminiRecordedItem[];
+  assistantTextStarted: boolean;
+  reasoningTextStarted: boolean;
+  assistantText: string;
+  reasoningText: string;
+}
+
+interface GeminiStoredTurn {
+  readonly id: TurnId;
+  readonly items: Array<unknown>;
+  readonly snapshotSessionId?: string;
+  readonly snapshotFilePath?: string;
+}
+
+interface GeminiSessionContext {
+  session: ProviderSession;
+  readonly binaryPath: string;
+  readonly child: ChildProcessWithoutNullStreams;
+  readonly stdout: readline.Interface;
+  readonly stderr: readline.Interface;
+  readonly pending: Map<string, GeminiPendingRequest>;
+  readonly pendingApprovals: Map<ApprovalRequestId, GeminiPendingApproval>;
+  readonly turns: GeminiStoredTurn[];
+  readonly runtimeModeId: string;
+  nextRequestId: number;
+  sessionId: string;
+  currentModeId: string | undefined;
+  currentModelId: string | undefined;
+  turnState: GeminiTurnState | undefined;
+  sessionFilePath: string | undefined;
+  systemSettingsPath: string | undefined;
+  suppressSessionUpdates: boolean;
+  stopped: boolean;
+  exitEmitted: boolean;
+  lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
+}
+
+export interface GeminiAdapterLiveOptions {
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+}
+
+function toMessage(cause: unknown, fallback: string): string {
+  if (cause instanceof Error && cause.message.trim().length > 0) {
+    return cause.message;
+  }
+  return fallback;
+}
+
+export function buildGeminiThinkingModelConfigAliases(
+  modelIds: ReadonlyArray<string>,
+): Record<string, Record<string, unknown>> {
+  const aliases: Record<string, Record<string, unknown>> = {};
+  const seen = new Set<string>();
+
+  for (const modelId of modelIds) {
+    const model = modelId.trim();
+    if (!model || seen.has(model)) {
+      continue;
+    }
+    seen.add(model);
+
+    switch (getGeminiThinkingConfigKind(model)) {
+      case "level": {
+        for (const thinkingLevel of GEMINI_3_THINKING_LEVELS) {
+          const alias = getGeminiThinkingModelAlias(model, { thinkingLevel });
+          if (!alias) {
+            continue;
+          }
+          aliases[alias] = {
+            extends: "chat-base-3",
+            modelConfig: {
+              model,
+              generateContentConfig: {
+                thinkingConfig: {
+                  thinkingLevel,
+                },
+              },
+            },
+          };
+        }
+        break;
+      }
+      case "budget": {
+        for (const thinkingBudget of GEMINI_2_5_THINKING_BUDGETS) {
+          const alias = getGeminiThinkingModelAlias(model, { thinkingBudget });
+          if (!alias) {
+            continue;
+          }
+          aliases[alias] = {
+            extends: "chat-base-2.5",
+            modelConfig: {
+              model,
+              generateContentConfig: {
+                thinkingConfig: {
+                  thinkingBudget,
+                },
+              },
+            },
+          };
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return aliases;
+}
+
+export function geminiRequestTimeoutMs(method: string): number {
+  return method === "session/prompt" ? GEMINI_ACP_PROMPT_TIMEOUT_MS : GEMINI_ACP_REQUEST_TIMEOUT_MS;
+}
+
+function readResumeSessionId(resumeCursor: unknown): string | undefined {
+  const record = asRecord(resumeCursor);
+  return trimToUndefined(record?.sessionId);
+}
+
+export function resolveStartedGeminiSessionId(
+  requestedResumeSessionId: string | undefined,
+  startResponse: unknown,
+): string | undefined {
+  const resolvedSessionId = trimToUndefined(asRecord(startResponse)?.sessionId);
+  return resolvedSessionId ?? requestedResumeSessionId;
+}
+
+function cloneUnknownArray(items: ReadonlyArray<unknown>): Array<unknown> {
+  return items.map((item) => {
+    const record = asRecord(item);
+    return record ? Object.assign({}, record) : item;
+  });
+}
+
+function cloneStoredTurn(turn: GeminiStoredTurn): GeminiStoredTurn {
+  return {
+    id: turn.id,
+    items: cloneUnknownArray(turn.items),
+    ...(turn.snapshotSessionId ? { snapshotSessionId: turn.snapshotSessionId } : {}),
+    ...(turn.snapshotFilePath ? { snapshotFilePath: turn.snapshotFilePath } : {}),
+  };
+}
+
+function readResumeTurns(resumeCursor: unknown): Array<GeminiStoredTurn> {
+  const record = asRecord(resumeCursor);
+  return (
+    asArray(record?.snapshots)?.reduce<Array<GeminiStoredTurn>>((acc, entry) => {
+      const snapshot = asRecord(entry);
+      const turnId = trimToUndefined(snapshot?.turnId);
+      const sessionId = trimToUndefined(snapshot?.sessionId);
+      const items = asArray(snapshot?.items);
+      if (!turnId || !sessionId || !items) {
+        return acc;
+      }
+      const filePath = trimToUndefined(snapshot?.filePath);
+      const storedTurn = {
+        id: TurnId.makeUnsafe(turnId),
+        items: cloneUnknownArray(items),
+        snapshotSessionId: sessionId,
+      };
+      acc.push(
+        filePath
+          ? (Object.assign(storedTurn, {
+              snapshotFilePath: filePath,
+            }) satisfies GeminiStoredTurn)
+          : (storedTurn satisfies GeminiStoredTurn),
+      );
+      return acc;
+    }, []) ?? []
+  );
+}
+
+function buildResumeCursor(context: GeminiSessionContext) {
+  const snapshots = context.turns
+    .filter((turn) => turn.snapshotSessionId)
+    .map((turn) => {
+      const snapshot = {
+        turnId: turn.id,
+        sessionId: turn.snapshotSessionId as string,
+        items: cloneUnknownArray(turn.items),
+      };
+      return turn.snapshotFilePath
+        ? Object.assign(snapshot, { filePath: turn.snapshotFilePath })
+        : snapshot;
+    });
+
+  return {
+    sessionId: context.sessionId,
+    ...(snapshots.length > 0 ? { snapshots } : {}),
+  };
+}
+
+function isStoredGeminiSession(value: unknown): value is Record<string, unknown> & {
+  sessionId: string;
+  messages: Array<unknown>;
+  startTime: string;
+  lastUpdated: string;
+} {
+  const record = asRecord(value);
+  return Boolean(
+    trimToUndefined(record?.sessionId) &&
+    asArray(record?.messages) &&
+    trimToUndefined(record?.startTime) &&
+    trimToUndefined(record?.lastUpdated),
+  );
+}
+
+function makeGeminiSessionFileName(sessionId: string): string {
+  const timestamp = new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-");
+  return `${GEMINI_SESSION_FILE_PREFIX}${timestamp}-${sessionId.slice(0, 8)}.json`;
+}
+
+async function readStoredGeminiSession(filePath: string) {
+  const content = JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+  if (!isStoredGeminiSession(content)) {
+    throw new Error(`Invalid Gemini session file: ${filePath}`);
+  }
+  return content;
+}
+
+async function findGeminiSessionFileById(
+  sessionId: string,
+  hintedPath?: string,
+): Promise<string | undefined> {
+  const prefix = sessionId.slice(0, 8);
+  const candidatePaths = new Set<string>();
+  if (hintedPath) {
+    candidatePaths.add(hintedPath);
+  }
+
+  let projectDirs: Array<string> = [];
+  try {
+    projectDirs = (await fs.readdir(GEMINI_TMP_DIR, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(GEMINI_TMP_DIR, entry.name, GEMINI_CHAT_DIR_NAME));
+  } catch {
+    return undefined;
+  }
+
+  for (const chatsDir of projectDirs) {
+    try {
+      const files = await fs.readdir(chatsDir, { withFileTypes: true });
+      for (const entry of files) {
+        if (
+          entry.isFile() &&
+          entry.name.startsWith(GEMINI_SESSION_FILE_PREFIX) &&
+          entry.name.endsWith(".json") &&
+          entry.name.includes(prefix)
+        ) {
+          candidatePaths.add(path.join(chatsDir, entry.name));
+        }
+      }
+    } catch {
+      // Ignore project temp dirs without chats.
+    }
+  }
+
+  for (const candidatePath of candidatePaths) {
+    try {
+      const storedSession = await readStoredGeminiSession(candidatePath);
+      if (storedSession.sessionId === sessionId) {
+        return candidatePath;
+      }
+    } catch {
+      // Ignore unreadable or unrelated files.
+    }
+  }
+
+  return undefined;
+}
+
+async function cloneGeminiSessionFile(sourcePath: string, sessionId: string): Promise<string> {
+  const storedSession = await readStoredGeminiSession(sourcePath);
+  const nextSession = {
+    ...storedSession,
+    sessionId,
+    lastUpdated: new Date().toISOString(),
+  };
+  const destinationPath = path.join(path.dirname(sourcePath), makeGeminiSessionFileName(sessionId));
+  await fs.writeFile(destinationPath, `${JSON.stringify(nextSession, null, 2)}\n`, "utf8");
+  return destinationPath;
+}
+
+function runtimeModeToGeminiModeId(runtimeMode: ProviderSession["runtimeMode"]): string {
+  switch (runtimeMode) {
+    case "approval-required":
+      return "default";
+    case "full-access":
+    default:
+      return "yolo";
+  }
+}
+
+function itemTypeFromToolKind(kind: GeminiToolKind | undefined): CanonicalItemType {
+  switch (kind) {
+    case "execute":
+      return "command_execution";
+    case "edit":
+    case "delete":
+    case "move":
+      return "file_change";
+    case "search":
+      return "web_search";
+    case "read":
+    case "think":
+    case "fetch":
+    case "switch_mode":
+    case "other":
+    default:
+      return "dynamic_tool_call";
+  }
+}
+
+function requestTypeFromToolKind(kind: GeminiToolKind | undefined): CanonicalRequestType {
+  switch (kind) {
+    case "execute":
+      return "command_execution_approval";
+    case "edit":
+    case "delete":
+    case "move":
+      return "file_change_approval";
+    case "read":
+      return "file_read_approval";
+    case "search":
+    case "think":
+    case "fetch":
+    case "switch_mode":
+    case "other":
+    default:
+      return "dynamic_tool_call";
+  }
+}
+
+function statusFromToolStatus(
+  status: GeminiToolStatus | undefined | null,
+): "inProgress" | "completed" | "failed" | undefined {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "pending":
+    case "in_progress":
+      return "inProgress";
+    default:
+      return undefined;
+  }
+}
+
+function toolDetail(toolCall: GeminiToolCall): string | undefined {
+  const location = toolCall.locations?.[0];
+  if (location?.path) {
+    return typeof location.line === "number" ? `${location.path}:${location.line}` : location.path;
+  }
+  return undefined;
+}
+
+function isAskUserToolCall(toolCall: GeminiToolCall | undefined): boolean {
+  return trimToUndefined(toolCall?.title)?.toLowerCase() === "ask user";
+}
+
+function textFromContentBlock(value: unknown): string | undefined {
+  const block = asRecord(value);
+  const type = asString(block?.type);
+  if (type === "text") {
+    return asString(block?.text);
+  }
+  if (type === "resource") {
+    return asString(asRecord(block?.resource)?.text);
+  }
+  return undefined;
+}
+
+function toolContentDetail(content: ReadonlyArray<unknown> | undefined | null): string | undefined {
+  if (!content) {
+    return undefined;
+  }
+
+  for (const entry of content) {
+    const record = asRecord(entry);
+    const type = asString(record?.type);
+    if (type === "content") {
+      const text = textFromContentBlock(record?.content);
+      if (text?.trim()) {
+        return text.trim();
+      }
+    }
+    if (type === "diff") {
+      const path = trimToUndefined(record?.path);
+      const kind = trimToUndefined(asRecord(record?._meta)?.kind);
+      return [kind, path].filter(Boolean).join(" ").trim() || "File diff";
+    }
+    if (type === "terminal") {
+      const terminalId = trimToUndefined(record?.terminalId);
+      return terminalId ? `Terminal ${terminalId}` : "Terminal output";
+    }
+  }
+
+  return undefined;
+}
+
+function normalizePromptUsage(value: unknown): ThreadTokenUsageSnapshot | undefined {
+  const usage = asRecord(value);
+  const usedTokens = asNumber(usage?.totalTokens);
+  if (usedTokens === undefined || usedTokens <= 0) {
+    return undefined;
+  }
+
+  const inputTokens = asNumber(usage?.inputTokens);
+  const outputTokens = asNumber(usage?.outputTokens);
+  const thoughtTokens = asNumber(usage?.thoughtTokens);
+  const cachedReadTokens = asNumber(usage?.cachedReadTokens);
+  const cachedWriteTokens = asNumber(usage?.cachedWriteTokens);
+  const cachedInputTokens =
+    (cachedReadTokens ?? 0) + (cachedWriteTokens ?? 0) > 0
+      ? (cachedReadTokens ?? 0) + (cachedWriteTokens ?? 0)
+      : undefined;
+
+  return {
+    usedTokens,
+    totalProcessedTokens: usedTokens,
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(thoughtTokens !== undefined ? { reasoningOutputTokens: thoughtTokens } : {}),
+    lastUsedTokens: usedTokens,
+    ...(inputTokens !== undefined ? { lastInputTokens: inputTokens } : {}),
+    ...(cachedInputTokens !== undefined ? { lastCachedInputTokens: cachedInputTokens } : {}),
+    ...(outputTokens !== undefined ? { lastOutputTokens: outputTokens } : {}),
+    ...(thoughtTokens !== undefined ? { lastReasoningOutputTokens: thoughtTokens } : {}),
+  };
+}
+
+function normalizeUsageUpdate(value: unknown): ThreadTokenUsageSnapshot | undefined {
+  const usage = asRecord(value);
+  const usedTokens = asNumber(usage?.used);
+  if (usedTokens === undefined || usedTokens <= 0) {
+    return undefined;
+  }
+
+  const maxTokens = asNumber(usage?.size);
+  return {
+    usedTokens,
+    ...(maxTokens !== undefined && maxTokens > 0 ? { maxTokens } : {}),
+    lastUsedTokens: usedTokens,
+    compactsAutomatically: true,
+  };
+}
+
+function makeApprovalOutcome(
+  decision: "accept" | "acceptForSession" | "decline" | "cancel",
+  options: ReadonlyArray<GeminiPermissionOption>,
+): { outcome: { outcome: "cancelled" } | { outcome: "selected"; optionId: string } } {
+  if (decision === "cancel") {
+    return { outcome: { outcome: "cancelled" } };
+  }
+
+  const pick = (...kinds: ReadonlyArray<GeminiPermissionOptionKind>) =>
+    options.find((option) => kinds.includes(option.kind));
+
+  const selected =
+    decision === "acceptForSession"
+      ? pick("allow_always", "allow_once")
+      : decision === "accept"
+        ? pick("allow_once", "allow_always")
+        : pick("reject_once", "reject_always");
+
+  if (!selected) {
+    return { outcome: { outcome: "cancelled" } };
+  }
+
+  return {
+    outcome: {
+      outcome: "selected",
+      optionId: selected.optionId,
+    },
+  };
+}
+
+function killChildProcess(child: ChildProcessWithoutNullStreams): void {
+  if (process.platform === "win32" && child.pid !== undefined) {
+    try {
+      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+      return;
+    } catch {
+      // Fall back to direct kill below.
+    }
+  }
+
+  child.kill("SIGTERM");
+}
+
+function releaseProcessResources(context: GeminiSessionContext): void {
+  context.stdout.removeAllListeners();
+  context.stderr.removeAllListeners();
+  context.child.removeAllListeners("exit");
+  context.child.removeAllListeners("error");
+  if (context.systemSettingsPath) {
+    void fs.unlink(context.systemSettingsPath).catch(() => {
+      // Ignore already deleted temporary settings files.
+    });
+    context.systemSettingsPath = undefined;
+  }
+  try {
+    context.stdout.close();
+  } catch {
+    // Ignore already closed interfaces.
+  }
+  try {
+    context.stderr.close();
+  } catch {
+    // Ignore already closed interfaces.
+  }
+}
+
+function updateGeminiSession(
+  context: GeminiSessionContext,
+  patch: Partial<ProviderSession>,
+): ProviderSession {
+  context.session = {
+    ...context.session,
+    ...patch,
+    updatedAt: new Date().toISOString(),
+  };
+  return context.session;
+}
+
+function currentGeminiTurnId(context: GeminiSessionContext): TurnId | undefined {
+  return context.turnState?.turnId;
+}
+
+function upsertGeminiTurnItem(
+  turnState: GeminiTurnState,
+  itemId: string,
+  itemType: CanonicalItemType,
+  patch: Partial<GeminiRecordedItem>,
+): GeminiRecordedItem {
+  let item = turnState.items.find((candidate) => candidate.id === itemId);
+  if (!item) {
+    item = { id: itemId, itemType };
+    turnState.items.push(item);
+  }
+  item.itemType = itemType;
+  Object.assign(item, patch);
+  return item;
+}
+
+const makeGeminiAdapter = Effect.fn("makeGeminiAdapter")(function* (
+  options?: GeminiAdapterLiveOptions,
+) {
+  const serverConfig = yield* ServerConfig;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const runtimeServices = yield* Effect.services<ServerConfig | FileSystem.FileSystem>();
+  const runPromise = Effect.runPromiseWith(runtimeServices);
+  const runFork = Effect.runForkWith(runtimeServices);
+  const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
+  const sessions = new Map<ThreadId, GeminiSessionContext>();
+  const nativeEventLogger =
+    options?.nativeEventLogger ??
+    (options?.nativeEventLogPath !== undefined
+      ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, {
+          stream: "native",
+        })
+      : undefined);
+
+  const writeNativeRecord = Effect.fn("writeNativeRecord")(function* (
+    threadId: ThreadId | null,
+    record: unknown,
+  ) {
+    if (!nativeEventLogger) {
+      return;
+    }
+    yield* nativeEventLogger.write(record, threadId);
+  });
+
+  const prepareGeminiLaunchConfig = Effect.fn("prepareGeminiLaunchConfig")(function* (input: {
+    readonly threadId: ThreadId;
+    readonly selectedModel?: string;
+  }) {
+    const candidateModels = [
+      ...MODEL_OPTIONS_BY_PROVIDER.gemini.map((option) => option.slug),
+      ...(input.selectedModel ? [input.selectedModel] : []),
+    ];
+    const aliases = buildGeminiThinkingModelConfigAliases(candidateModels);
+
+    if (Object.keys(aliases).length === 0) {
+      return {
+        env: process.env,
+        systemSettingsPath: undefined,
+      };
+    }
+
+    const systemSettingsPath = path.join(
+      DPCODE_GEMINI_SETTINGS_DIR,
+      `${input.threadId}-${crypto.randomUUID()}.json`,
+    );
+    yield* Effect.tryPromise({
+      try: async () => {
+        await fs.mkdir(DPCODE_GEMINI_SETTINGS_DIR, { recursive: true });
+        await fs.writeFile(
+          systemSettingsPath,
+          JSON.stringify(
+            {
+              modelConfigs: {
+                aliases,
+              },
+            },
+            null,
+            2,
+          ),
+          "utf8",
+        );
+      },
+      catch: (cause) =>
+        new ProviderAdapterProcessError({
+          provider: PROVIDER,
+          threadId: input.threadId,
+          detail: `Failed to prepare Gemini thinking settings: ${toMessage(cause, "write failed")}`,
+          cause,
+        }),
+    });
+
+    return {
+      systemSettingsPath,
+      env: {
+        ...process.env,
+        GEMINI_CLI_SYSTEM_SETTINGS_PATH: systemSettingsPath,
+      },
+    };
+  });
+
+  const spawnGeminiProcess = Effect.fn("spawnGeminiProcess")(function* (
+    threadId: ThreadId,
+    binaryPath: string,
+    cwd: string,
+    env?: NodeJS.ProcessEnv,
+  ) {
+    return yield* Effect.try({
+      try: () =>
+        spawn(binaryPath, ["--acp"], {
+          cwd,
+          env: env ?? process.env,
+          stdio: ["pipe", "pipe", "pipe"],
+          shell: process.platform === "win32",
+        }),
+      catch: (cause) =>
+        new ProviderAdapterProcessError({
+          provider: PROVIDER,
+          threadId,
+          detail: `Failed to spawn Gemini CLI: ${toMessage(cause, "spawn failed")}`,
+          cause,
+        }),
+    });
+  });
+
+  const makeSessionContext = (input: {
+    threadId: ThreadId;
+    runtimeMode: ProviderSession["runtimeMode"];
+    runtimeModeId: string;
+    cwd: string;
+    binaryPath: string;
+    child: ChildProcessWithoutNullStreams;
+    turns?: ReadonlyArray<GeminiStoredTurn>;
+    sessionFilePath?: string;
+    systemSettingsPath?: string;
+  }): GeminiSessionContext => {
+    const now = new Date().toISOString();
+    return {
+      session: {
+        provider: PROVIDER,
+        status: "connecting",
+        runtimeMode: input.runtimeMode,
+        cwd: input.cwd,
+        threadId: input.threadId,
+        createdAt: now,
+        updatedAt: now,
+      },
+      binaryPath: input.binaryPath,
+      child: input.child,
+      stdout: readline.createInterface({ input: input.child.stdout }),
+      stderr: readline.createInterface({ input: input.child.stderr }),
+      pending: new Map(),
+      pendingApprovals: new Map(),
+      turns: (input.turns ?? []).map(cloneStoredTurn),
+      runtimeModeId: input.runtimeModeId,
+      nextRequestId: 1,
+      sessionId: "",
+      currentModeId: undefined,
+      currentModelId: undefined,
+      turnState: undefined,
+      sessionFilePath: input.sessionFilePath,
+      systemSettingsPath: input.systemSettingsPath,
+      suppressSessionUpdates: false,
+      stopped: false,
+      exitEmitted: false,
+      lastKnownTokenUsage: undefined,
+    };
+  };
+
+  const snapshotThread = (context: GeminiSessionContext) => ({
+    threadId: context.session.threadId,
+    turns: context.turns.map((turn) => ({
+      id: turn.id,
+      items: cloneUnknownArray(turn.items),
+    })),
+  });
+
+  const makeEventBase = (context: GeminiSessionContext) => ({
+    eventId: EventId.makeUnsafe(crypto.randomUUID()),
+    provider: PROVIDER,
+    threadId: context.session.threadId,
+    createdAt: new Date().toISOString(),
+  });
+
+  const offerRuntimeEvent = Effect.fn("offerRuntimeEvent")(function* (event: ProviderRuntimeEvent) {
+    yield* Queue.offer(runtimeEventQueue, event);
+  });
+
+  const requireSession = Effect.fn("requireSession")(function* (threadId: ThreadId) {
+    const context = sessions.get(threadId);
+    if (!context) {
+      return yield* new ProviderAdapterSessionNotFoundError({
+        provider: PROVIDER,
+        threadId,
+      });
+    }
+    if (context.stopped) {
+      return yield* new ProviderAdapterSessionClosedError({
+        provider: PROVIDER,
+        threadId,
+      });
+    }
+    return context;
+  });
+
+  const emitSessionState = Effect.fn("emitSessionState")(function* (
+    context: GeminiSessionContext,
+    state: "starting" | "ready" | "running" | "stopped" | "error",
+    reason?: string,
+    detail?: unknown,
+  ) {
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      type: "session.state.changed",
+      payload: {
+        state,
+        ...(reason ? { reason } : {}),
+        ...(detail !== undefined ? { detail } : {}),
+      },
+      ...(detail !== undefined
+        ? {
+            raw: {
+              source: "gemini.acp.message",
+              method: "session.state",
+              payload: detail,
+            },
+          }
+        : {}),
+    });
+  });
+
+  const emitRuntimeWarning = Effect.fn("emitRuntimeWarning")(function* (
+    context: GeminiSessionContext,
+    message: string,
+    raw?: {
+      readonly source: "gemini.acp.message" | "gemini.acp.stdout" | "gemini.acp.stderr";
+      readonly method?: string;
+      readonly payload: unknown;
+    },
+  ) {
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      type: "runtime.warning",
+      payload: { message, ...(raw ? { detail: raw.payload } : {}) },
+      ...(raw ? { raw } : {}),
+    });
+  });
+
+  const emitRuntimeError = Effect.fn("emitRuntimeError")(function* (
+    context: GeminiSessionContext,
+    message: string,
+    detail?: unknown,
+    turnId?: TurnId,
+  ) {
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      ...(turnId ? { turnId } : {}),
+      type: "runtime.error",
+      payload: {
+        message,
+        class: "provider_error",
+        ...(detail !== undefined ? { detail } : {}),
+      },
+      ...(detail !== undefined
+        ? {
+            raw: {
+              source: "gemini.acp.message",
+              method: "runtime.error",
+              payload: detail,
+            },
+          }
+        : {}),
+    });
+  });
+
+  const emitUsage = Effect.fn("emitUsage")(function* (
+    context: GeminiSessionContext,
+    usage: ThreadTokenUsageSnapshot,
+    turnId?: TurnId,
+    rawPayload?: unknown,
+  ) {
+    context.lastKnownTokenUsage = {
+      ...context.lastKnownTokenUsage,
+      ...usage,
+      usedTokens: usage.usedTokens,
+    };
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      ...(turnId ? { turnId } : {}),
+      type: "thread.token-usage.updated",
+      payload: { usage: context.lastKnownTokenUsage },
+      ...(rawPayload !== undefined
+        ? {
+            raw: {
+              source: "gemini.acp.message",
+              method: "session/update",
+              payload: rawPayload,
+            },
+          }
+        : {}),
+    });
+  });
+
+  const emitTextItemStarted = Effect.fn("emitTextItemStarted")(function* (
+    context: GeminiSessionContext,
+    streamKind: "assistant_text" | "reasoning_text",
+  ) {
+    const turnState = context.turnState;
+    if (!turnState) {
+      return;
+    }
+    const isAssistant = streamKind === "assistant_text";
+    if (
+      (isAssistant && turnState.assistantTextStarted) ||
+      (!isAssistant && turnState.reasoningTextStarted)
+    ) {
+      return;
+    }
+
+    const itemId = isAssistant
+      ? turnState.assistantItemId
+      : (turnState.reasoningItemId ??
+        RuntimeItemId.makeUnsafe(`gemini-reasoning-${crypto.randomUUID()}`));
+    if (!isAssistant) {
+      turnState.reasoningItemId = itemId;
+      turnState.reasoningTextStarted = true;
+    } else {
+      turnState.assistantTextStarted = true;
+    }
+
+    upsertGeminiTurnItem(turnState, itemId, isAssistant ? "assistant_message" : "reasoning", {
+      status: "inProgress",
+      title: isAssistant ? "Assistant message" : "Reasoning",
+    });
+
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      turnId: turnState.turnId,
+      itemId,
+      type: "item.started",
+      payload: {
+        itemType: isAssistant ? "assistant_message" : "reasoning",
+        status: "inProgress",
+        title: isAssistant ? "Assistant message" : "Reasoning",
+      },
+    });
+  });
+
+  const emitTextDelta = Effect.fn("emitTextDelta")(function* (
+    context: GeminiSessionContext,
+    streamKind: "assistant_text" | "reasoning_text",
+    delta: string,
+    rawPayload: unknown,
+  ) {
+    if (delta.length === 0) {
+      return;
+    }
+    const turnState = context.turnState;
+    if (!turnState) {
+      return;
+    }
+
+    yield* emitTextItemStarted(context, streamKind);
+    const itemId =
+      streamKind === "assistant_text"
+        ? turnState.assistantItemId
+        : (turnState.reasoningItemId as RuntimeItemId);
+    const item = upsertGeminiTurnItem(
+      turnState,
+      itemId,
+      streamKind === "assistant_text" ? "assistant_message" : "reasoning",
+      {},
+    );
+    item.text = `${item.text ?? ""}${delta}`;
+    if (streamKind === "assistant_text") {
+      turnState.assistantText = `${turnState.assistantText}${delta}`;
+    } else {
+      turnState.reasoningText = `${turnState.reasoningText}${delta}`;
+    }
+
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      turnId: turnState.turnId,
+      itemId,
+      type: "content.delta",
+      payload: {
+        streamKind,
+        delta,
+      },
+      raw: {
+        source: "gemini.acp.message",
+        method: "session/update",
+        payload: rawPayload,
+      },
+    });
+  });
+
+  const emitToolLifecycle = Effect.fn("emitToolLifecycle")(function* (
+    context: GeminiSessionContext,
+    lifecycle: "item.started" | "item.updated" | "item.completed",
+    toolCall: GeminiToolCall,
+    rawPayload: unknown,
+  ) {
+    const turnState = context.turnState;
+    if (!turnState) {
+      return;
+    }
+    const providerItemId = trimToUndefined(toolCall.toolCallId);
+    if (!providerItemId) {
+      return;
+    }
+    const itemId = RuntimeItemId.makeUnsafe(`gemini-tool-${providerItemId}`);
+    const itemType = itemTypeFromToolKind(toolCall.kind ?? undefined);
+    const status = statusFromToolStatus(toolCall.status);
+    const detail = toolContentDetail(toolCall.content) ?? toolDetail(toolCall);
+    const title = trimToUndefined(toolCall.title);
+    const toolPatch: Partial<GeminiRecordedItem> = {
+      ...(title ? { title } : {}),
+      ...(detail ? { detail } : {}),
+      ...(status ? { status } : {}),
+      data: toolCall,
+    };
+    upsertGeminiTurnItem(turnState, itemId, itemType, toolPatch);
+
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      turnId: turnState.turnId,
+      itemId,
+      type: lifecycle,
+      payload: {
+        itemType,
+        ...(status ? { status } : {}),
+        ...(trimToUndefined(toolCall.title) ? { title: trimToUndefined(toolCall.title) } : {}),
+        ...(detail ? { detail } : {}),
+        data: toolCall,
+      },
+      providerRefs: {
+        providerItemId: ProviderItemId.makeUnsafe(providerItemId),
+      },
+      raw: {
+        source: "gemini.acp.message",
+        method: "session/update",
+        payload: rawPayload,
+      },
+    });
+  });
+
+  const finishTurn = Effect.fn("finishTurn")(function* (
+    context: GeminiSessionContext,
+    result: {
+      readonly state: "completed" | "failed" | "cancelled" | "interrupted";
+      readonly stopReason?: string | null;
+      readonly usage?: unknown;
+      readonly errorMessage?: string;
+    },
+  ) {
+    const turnState = context.turnState;
+    if (!turnState) {
+      return;
+    }
+
+    if (turnState.assistantTextStarted) {
+      yield* offerRuntimeEvent({
+        ...makeEventBase(context),
+        turnId: turnState.turnId,
+        itemId: turnState.assistantItemId,
+        type: "item.completed",
+        payload: {
+          itemType: "assistant_message",
+          status: result.state === "failed" ? "failed" : "completed",
+          title: "Assistant message",
+        },
+      });
+      upsertGeminiTurnItem(turnState, turnState.assistantItemId, "assistant_message", {
+        status: result.state === "failed" ? "failed" : "completed",
+      });
+    }
+
+    if (turnState.reasoningItemId && turnState.reasoningTextStarted) {
+      yield* offerRuntimeEvent({
+        ...makeEventBase(context),
+        turnId: turnState.turnId,
+        itemId: turnState.reasoningItemId,
+        type: "item.completed",
+        payload: {
+          itemType: "reasoning",
+          status: "completed",
+          title: "Reasoning",
+        },
+      });
+      upsertGeminiTurnItem(turnState, turnState.reasoningItemId, "reasoning", {
+        status: "completed",
+      });
+    }
+
+    const normalizedUsage = normalizePromptUsage(result.usage);
+    if (normalizedUsage) {
+      yield* emitUsage(context, normalizedUsage, turnState.turnId, result.usage);
+    }
+
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      turnId: turnState.turnId,
+      type: "turn.completed",
+      payload: {
+        state: result.state,
+        ...(result.stopReason !== undefined ? { stopReason: result.stopReason } : {}),
+        ...(result.usage !== undefined ? { usage: result.usage } : {}),
+        ...(result.errorMessage ? { errorMessage: result.errorMessage } : {}),
+      },
+    });
+
+    const storedTurn = yield* persistTurnSnapshot(context, turnState.turnId, turnState.items).pipe(
+      Effect.catch((error) =>
+        emitRuntimeWarning(context, error.message, {
+          source: "gemini.acp.message",
+          method: "session/snapshot",
+          payload: {
+            message: error.message,
+          },
+        }).pipe(
+          Effect.as({
+            id: turnState.turnId,
+            items: cloneUnknownArray(turnState.items),
+          } satisfies GeminiStoredTurn),
+        ),
+      ),
+    );
+    context.turns.push(storedTurn);
+    context.turnState = undefined;
+    updateGeminiSession(context, {
+      status: "ready",
+      activeTurnId: undefined,
+      resumeCursor: buildResumeCursor(context),
+      ...(result.state === "failed" && result.errorMessage
+        ? { lastError: result.errorMessage }
+        : {}),
+    });
+    yield* emitSessionState(context, "ready");
+  });
+
+  const rejectPendingRequests = (context: GeminiSessionContext, detail: string) => {
+    for (const [id, pending] of context.pending) {
+      clearTimeout(pending.timeout);
+      pending.reject(
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: pending.method,
+          detail,
+        }),
+      );
+      context.pending.delete(id);
+    }
+  };
+
+  const disposeSessionContext = (
+    context: GeminiSessionContext,
+    detail: string,
+    options?: {
+      readonly removeFromSessions?: boolean;
+    },
+  ): void => {
+    context.stopped = true;
+    context.exitEmitted = true;
+    rejectPendingRequests(context, detail);
+    context.pendingApprovals.clear();
+    releaseProcessResources(context);
+    killChildProcess(context.child);
+    if (options?.removeFromSessions && sessions.get(context.session.threadId) === context) {
+      sessions.delete(context.session.threadId);
+    }
+  };
+
+  const handleProcessExit = Effect.fn("handleProcessExit")(function* (
+    context: GeminiSessionContext,
+    input: {
+      readonly detail: string;
+      readonly exitKind: "graceful" | "error";
+      readonly recoverable?: boolean;
+    },
+  ) {
+    if (context.exitEmitted) {
+      return;
+    }
+    context.exitEmitted = true;
+    context.stopped = true;
+
+    rejectPendingRequests(context, input.detail);
+
+    if (context.turnState && input.exitKind === "error") {
+      yield* emitRuntimeError(
+        context,
+        input.detail,
+        { detail: input.detail },
+        context.turnState.turnId,
+      );
+      yield* finishTurn(context, {
+        state: "failed",
+        errorMessage: input.detail,
+      });
+    }
+
+    updateGeminiSession(context, {
+      status: input.exitKind === "error" ? "error" : "closed",
+      activeTurnId: undefined,
+      ...(input.exitKind === "error" ? { lastError: input.detail } : {}),
+    });
+    yield* emitSessionState(
+      context,
+      input.exitKind === "error" ? "error" : "stopped",
+      input.exitKind === "error" ? "process_exit" : "session_closed",
+    );
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      type: "session.exited",
+      payload: {
+        reason: input.detail,
+        exitKind: input.exitKind,
+        ...(input.recoverable !== undefined ? { recoverable: input.recoverable } : {}),
+      },
+    });
+
+    releaseProcessResources(context);
+    if (sessions.get(context.session.threadId) === context) {
+      sessions.delete(context.session.threadId);
+    }
+  });
+
+  const writeJsonMessage = Effect.fn("writeJsonMessage")(function* (
+    context: GeminiSessionContext,
+    message: unknown,
+  ) {
+    const payload = `${JSON.stringify({ jsonrpc: "2.0", ...asRecord(message) })}\n`;
+    yield* Effect.try({
+      try: () => {
+        if (!context.child.stdin.writable) {
+          throw new Error("Gemini ACP stdin is not writable.");
+        }
+        context.child.stdin.write(payload);
+      },
+      catch: (cause) =>
+        new ProviderAdapterProcessError({
+          provider: PROVIDER,
+          threadId: context.session.threadId,
+          detail: toMessage(cause, "Failed to write Gemini ACP message."),
+          cause,
+        }),
+    });
+  });
+
+  const sendRequest = <T = unknown>(
+    context: GeminiSessionContext,
+    method: string,
+    params: Record<string, unknown>,
+  ): Effect.Effect<T, ProviderAdapterError> =>
+    Effect.tryPromise({
+      try: () =>
+        new Promise<T>((resolve, reject) => {
+          const id = context.nextRequestId++;
+          const timeoutMs = geminiRequestTimeoutMs(method);
+          const timeout = setTimeout(() => {
+            context.pending.delete(String(id));
+            reject(
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method,
+                detail: `Gemini ACP request timed out after ${timeoutMs}ms.`,
+              }),
+            );
+          }, timeoutMs);
+
+          context.pending.set(String(id), {
+            method,
+            timeout,
+            resolve: (value) => resolve(value as T),
+            reject: (error) => reject(error),
+          });
+
+          if (!context.child.stdin.writable) {
+            clearTimeout(timeout);
+            context.pending.delete(String(id));
+            reject(
+              new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method,
+                detail: "Gemini ACP stdin is not writable.",
+              }),
+            );
+            return;
+          }
+
+          context.child.stdin.write(
+            `${JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              method,
+              params,
+            })}\n`,
+          );
+        }),
+      catch: (cause) =>
+        asString(asRecord(cause)?._tag) === "ProviderAdapterRequestError"
+          ? (cause as ProviderAdapterRequestError)
+          : new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method,
+              detail: toMessage(cause, `${method} failed`),
+              cause,
+            }),
+    });
+
+  const sendNotification = (
+    context: GeminiSessionContext,
+    method: string,
+    params: Record<string, unknown>,
+  ) =>
+    writeJsonMessage(context, { method, params }).pipe(
+      Effect.mapError((cause) =>
+        asString(asRecord(cause)?._tag) === "ProviderAdapterProcessError"
+          ? (cause as ProviderAdapterProcessError)
+          : new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method,
+              detail: toMessage(cause, `${method} failed`),
+              cause,
+            }),
+      ),
+    );
+
+  const parsePermissionOptions = (value: unknown): ReadonlyArray<GeminiPermissionOption> =>
+    asArray(value)
+      ?.map((entry) => {
+        const record = asRecord(entry);
+        const optionId = trimToUndefined(record?.optionId);
+        const name = trimToUndefined(record?.name);
+        const kind = trimToUndefined(record?.kind) as GeminiPermissionOptionKind | undefined;
+        if (!optionId || !name || !kind) {
+          return null;
+        }
+        return { optionId, name, kind } satisfies GeminiPermissionOption;
+      })
+      .filter((entry): entry is GeminiPermissionOption => entry !== null) ?? [];
+
+  const parseToolCall = (value: unknown): GeminiToolCall | undefined => {
+    const record = asRecord(value);
+    const toolCallId = trimToUndefined(record?.toolCallId);
+    if (!toolCallId) {
+      return undefined;
+    }
+
+    return {
+      toolCallId,
+      title: trimToUndefined(record?.title) ?? null,
+      kind: (trimToUndefined(record?.kind) as GeminiToolKind | undefined) ?? null,
+      status: (trimToUndefined(record?.status) as GeminiToolStatus | undefined) ?? null,
+      content: asArray(record?.content) ?? null,
+      locations:
+        asArray(record?.locations)?.reduce<Array<GeminiToolCallLocation>>((acc, entry) => {
+          const location = asRecord(entry);
+          const path = trimToUndefined(location?.path);
+          if (!path) {
+            return acc;
+          }
+          acc.push({
+            path,
+            line: asNumber(location?.line) ?? null,
+          });
+          return acc;
+        }, []) ?? null,
+      rawInput: record?.rawInput,
+      rawOutput: record?.rawOutput,
+    };
+  };
+
+  const handlePermissionRequest = Effect.fn("handlePermissionRequest")(function* (
+    context: GeminiSessionContext,
+    requestId: JsonRpcId,
+    params: unknown,
+  ) {
+    const record = asRecord(params);
+    const toolCall = parseToolCall(record?.toolCall);
+    const requestType = requestTypeFromToolKind(toolCall?.kind ?? undefined);
+    const detail = isAskUserToolCall(toolCall)
+      ? "Gemini CLI requested user input, but Gemini ACP did not include the question payload. Accepting this request will continue with an empty answer set."
+      : (toolContentDetail(toolCall?.content) ?? toolDetail(toolCall ?? { toolCallId: "" }));
+    const approvalRequestId = ApprovalRequestId.makeUnsafe(
+      `gemini-approval-${crypto.randomUUID()}`,
+    );
+    context.pendingApprovals.set(approvalRequestId, {
+      acpRequestId: requestId,
+      options: parsePermissionOptions(record?.options),
+      requestType,
+      ...(context.turnState ? { turnId: context.turnState.turnId } : {}),
+      ...(toolCall?.toolCallId ? { providerItemId: toolCall.toolCallId } : {}),
+      ...(detail ? { detail } : {}),
+    });
+
+    if (toolCall) {
+      yield* emitToolLifecycle(
+        context,
+        context.turnState?.items.some((item) => item.id === `gemini-tool-${toolCall.toolCallId}`)
+          ? "item.updated"
+          : "item.started",
+        toolCall,
+        params,
+      );
+    }
+
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      ...(context.turnState ? { turnId: context.turnState.turnId } : {}),
+      requestId: RuntimeRequestId.makeUnsafe(approvalRequestId),
+      type: "request.opened",
+      payload: {
+        requestType,
+        ...(detail ? { detail } : {}),
+        args: {
+          ...(toolCall ? { toolCall } : {}),
+          options: record?.options,
+        },
+      },
+      providerRefs: {
+        providerRequestId: String(requestId),
+        ...(toolCall?.toolCallId
+          ? { providerItemId: ProviderItemId.makeUnsafe(toolCall.toolCallId) }
+          : {}),
+      },
+      raw: {
+        source: "gemini.acp.message",
+        method: "session/request_permission",
+        payload: params,
+      },
+    });
+  });
+
+  const handleSessionUpdate = Effect.fn("handleSessionUpdate")(function* (
+    context: GeminiSessionContext,
+    update: unknown,
+    rawPayload: unknown,
+  ) {
+    const record = asRecord(update);
+    const sessionUpdate = trimToUndefined(record?.sessionUpdate);
+    if (!sessionUpdate) {
+      return;
+    }
+
+    switch (sessionUpdate) {
+      case "agent_message_chunk":
+      case "agent_thought_chunk": {
+        const delta = textFromContentBlock(record?.content);
+        if (!delta) {
+          return;
+        }
+        yield* emitTextDelta(
+          context,
+          sessionUpdate === "agent_message_chunk" ? "assistant_text" : "reasoning_text",
+          delta,
+          rawPayload,
+        );
+        return;
+      }
+
+      case "tool_call": {
+        const toolCall = parseToolCall(record);
+        if (toolCall) {
+          yield* emitToolLifecycle(context, "item.started", toolCall, rawPayload);
+        }
+        return;
+      }
+
+      case "tool_call_update": {
+        const toolCall = parseToolCall(record);
+        if (!toolCall) {
+          return;
+        }
+        const lifecycle =
+          toolCall.status === "completed" || toolCall.status === "failed"
+            ? "item.completed"
+            : "item.updated";
+        yield* emitToolLifecycle(context, lifecycle, toolCall, rawPayload);
+        return;
+      }
+
+      case "plan": {
+        const entries = asArray(record?.entries) ?? [];
+        if (!context.turnState) {
+          return;
+        }
+        yield* offerRuntimeEvent({
+          ...makeEventBase(context),
+          turnId: context.turnState.turnId,
+          type: "turn.plan.updated",
+          payload: {
+            plan: entries
+              .map((entry) => {
+                const planEntry = asRecord(entry);
+                const step = trimToUndefined(planEntry?.content);
+                const status = trimToUndefined(planEntry?.status);
+                if (!step || !status) {
+                  return null;
+                }
+                return {
+                  step,
+                  status:
+                    status === "in_progress"
+                      ? "inProgress"
+                      : status === "completed"
+                        ? "completed"
+                        : "pending",
+                } as const;
+              })
+              .filter(
+                (
+                  entry,
+                ): entry is { step: string; status: "pending" | "inProgress" | "completed" } =>
+                  entry !== null,
+              ),
+          },
+          raw: {
+            source: "gemini.acp.message",
+            method: "session/update",
+            payload: rawPayload,
+          },
+        });
+        return;
+      }
+
+      case "usage_update": {
+        const usage = normalizeUsageUpdate(record);
+        if (usage) {
+          yield* emitUsage(context, usage, currentGeminiTurnId(context), rawPayload);
+        }
+        return;
+      }
+
+      case "current_mode_update": {
+        context.currentModeId = trimToUndefined(record?.currentModeId) ?? context.currentModeId;
+        return;
+      }
+
+      case "session_info_update": {
+        const title = trimToUndefined(record?.title);
+        if (!title) {
+          return;
+        }
+        const updatedAt = trimToUndefined(record?.updatedAt);
+        yield* offerRuntimeEvent({
+          ...makeEventBase(context),
+          type: "thread.metadata.updated",
+          payload: {
+            name: title,
+            ...(updatedAt ? { metadata: { updatedAt } } : {}),
+          },
+          raw: {
+            source: "gemini.acp.message",
+            method: "session/update",
+            payload: rawPayload,
+          },
+        });
+        return;
+      }
+
+      case "available_commands_update":
+      case "config_option_update":
+      default:
+        return;
+    }
+  });
+
+  const handleParsedMessage = Effect.fn("handleParsedMessage")(function* (
+    context: GeminiSessionContext,
+    parsed: Record<string, unknown>,
+  ) {
+    const maybeId = parsed.id;
+    if (
+      (typeof maybeId === "number" || typeof maybeId === "string") &&
+      (Object.hasOwn(parsed, "result") || Object.hasOwn(parsed, "error"))
+    ) {
+      const pending = context.pending.get(String(maybeId));
+      if (!pending) {
+        return;
+      }
+      clearTimeout(pending.timeout);
+      context.pending.delete(String(maybeId));
+      const error = asRecord(parsed.error);
+      if (error) {
+        pending.reject(
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: pending.method,
+            detail: trimToUndefined(error.message) ?? `${pending.method} failed`,
+            cause: parsed.error,
+          }),
+        );
+        return;
+      }
+      pending.resolve(parsed.result);
+      return;
+    }
+
+    const method = trimToUndefined(parsed.method);
+    if (!method) {
+      return;
+    }
+
+    if (method === "session/update") {
+      if (context.suppressSessionUpdates) {
+        return;
+      }
+      const params = asRecord(parsed.params);
+      yield* handleSessionUpdate(context, params?.update, parsed.params);
+      return;
+    }
+
+    if (method === "session/request_permission") {
+      const requestId = parsed.id;
+      if (requestId === undefined || requestId === null) {
+        return;
+      }
+      yield* handlePermissionRequest(context, requestId as JsonRpcId, parsed.params);
+    }
+  });
+
+  const attachProcessListeners = (context: GeminiSessionContext) => {
+    const onStdoutLine = (line: string) => {
+      void runPromise(
+        writeNativeRecord(context.session.threadId, {
+          source: "gemini.acp.stdout",
+          line,
+        }).pipe(
+          Effect.andThen(
+            Effect.sync(() => {
+              const trimmed = line.trim();
+              if (!trimmed.startsWith("{")) {
+                return undefined;
+              }
+              try {
+                return JSON.parse(trimmed) as Record<string, unknown>;
+              } catch {
+                return undefined;
+              }
+            }),
+          ),
+          Effect.flatMap((parsed) =>
+            parsed
+              ? writeNativeRecord(context.session.threadId, {
+                  source: "gemini.acp.message",
+                  payload: parsed,
+                }).pipe(Effect.andThen(handleParsedMessage(context, parsed)))
+              : Effect.void,
+          ),
+        ),
+      );
+    };
+
+    const onStderrLine = (line: string) => {
+      const message = line.trim();
+      if (message.length === 0) {
+        return;
+      }
+      void runPromise(
+        writeNativeRecord(context.session.threadId, {
+          source: "gemini.acp.stderr",
+          line,
+        }).pipe(
+          Effect.andThen(
+            emitRuntimeWarning(context, message, {
+              source: "gemini.acp.stderr",
+              payload: { line: message },
+            }),
+          ),
+        ),
+      );
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      const detail =
+        code === 0
+          ? "Gemini ACP session exited."
+          : `Gemini ACP session exited with code ${code ?? "null"}${signal ? ` (signal ${signal})` : ""}.`;
+      void runPromise(
+        handleProcessExit(context, {
+          detail,
+          exitKind: code === 0 || context.stopped ? "graceful" : "error",
+          recoverable: !context.stopped,
+        }),
+      );
+    };
+
+    const onError = (error: Error) => {
+      void runPromise(
+        handleProcessExit(context, {
+          detail: `Gemini ACP process error: ${error.message}`,
+          exitKind: "error",
+          recoverable: true,
+        }),
+      );
+    };
+
+    context.stdout.on("line", onStdoutLine);
+    context.stderr.on("line", onStderrLine);
+    context.child.once("exit", onExit);
+    context.child.once("error", onError);
+  };
+
+  const resolveSessionFilePath = Effect.fn("resolveSessionFilePath")(function* (
+    context: GeminiSessionContext,
+    options?: { readonly retries?: number },
+  ) {
+    const retries = options?.retries ?? 0;
+    for (let attempt = 0; attempt <= retries; attempt += 1) {
+      const resolvedPath = yield* Effect.tryPromise({
+        try: () => findGeminiSessionFileById(context.sessionId, context.sessionFilePath),
+        catch: (cause) =>
+          new ProviderAdapterProcessError({
+            provider: PROVIDER,
+            threadId: context.session.threadId,
+            detail: `Failed to locate Gemini session file: ${toMessage(cause, "lookup failed")}`,
+            cause,
+          }),
+      });
+      if (resolvedPath) {
+        context.sessionFilePath = resolvedPath;
+        return resolvedPath;
+      }
+      if (attempt < retries) {
+        yield* Effect.sleep(100);
+      }
+    }
+    return undefined;
+  });
+
+  const persistTurnSnapshot = Effect.fn("persistTurnSnapshot")(function* (
+    context: GeminiSessionContext,
+    turnId: TurnId,
+    items: ReadonlyArray<unknown>,
+  ) {
+    const storedTurnBase: GeminiStoredTurn = {
+      id: turnId,
+      items: cloneUnknownArray(items),
+    };
+    const liveSessionFilePath = yield* resolveSessionFilePath(context, { retries: 5 });
+    if (!liveSessionFilePath) {
+      return storedTurnBase;
+    }
+
+    const snapshotSessionId = crypto.randomUUID();
+    const snapshotFilePath = yield* Effect.tryPromise({
+      try: () => cloneGeminiSessionFile(liveSessionFilePath, snapshotSessionId),
+      catch: (cause) =>
+        new ProviderAdapterProcessError({
+          provider: PROVIDER,
+          threadId: context.session.threadId,
+          detail: `Failed to snapshot Gemini session history: ${toMessage(cause, "snapshot failed")}`,
+          cause,
+        }),
+    });
+
+    return {
+      ...storedTurnBase,
+      snapshotSessionId,
+      snapshotFilePath,
+    } satisfies GeminiStoredTurn;
+  });
+
+  const bootstrapSessionContext = Effect.fn("bootstrapSessionContext")(function* (
+    context: GeminiSessionContext,
+    input: {
+      readonly resumeSessionId?: string;
+      readonly allowResumeFallback?: boolean;
+      readonly model?: string;
+      readonly apiModelId?: string;
+      readonly sessionFilePath?: string;
+    },
+  ) {
+    context.suppressSessionUpdates = true;
+    return yield* Effect.gen(function* () {
+      yield* sendRequest(context, "initialize", {
+        protocolVersion: 1,
+        clientInfo: {
+          name: "dpcode",
+          title: "DP Code",
+          version: "0.1.0",
+        },
+        clientCapabilities: {
+          fs: { readTextFile: false, writeTextFile: false },
+          terminal: false,
+          auth: { terminal: false },
+        },
+      });
+
+      const startResponse = yield* input.resumeSessionId
+        ? input.allowResumeFallback !== false
+          ? sendRequest<Record<string, unknown>>(context, "session/load", {
+              sessionId: input.resumeSessionId,
+              cwd: context.session.cwd ?? process.cwd(),
+              mcpServers: [],
+            }).pipe(
+              Effect.catch(() =>
+                sendRequest<Record<string, unknown>>(context, "session/new", {
+                  cwd: context.session.cwd ?? process.cwd(),
+                  mcpServers: [],
+                }),
+              ),
+            )
+          : sendRequest<Record<string, unknown>>(context, "session/load", {
+              sessionId: input.resumeSessionId,
+              cwd: context.session.cwd ?? process.cwd(),
+              mcpServers: [],
+            })
+        : sendRequest<Record<string, unknown>>(context, "session/new", {
+            cwd: context.session.cwd ?? process.cwd(),
+            mcpServers: [],
+          });
+
+      context.sessionId = resolveStartedGeminiSessionId(input.resumeSessionId, startResponse) ?? "";
+      if (!context.sessionId) {
+        return yield* new ProviderAdapterProcessError({
+          provider: PROVIDER,
+          threadId: context.session.threadId,
+          detail: "Gemini ACP did not return a session id.",
+        });
+      }
+
+      context.currentModeId = trimToUndefined(asRecord(startResponse.modes)?.currentModeId);
+      context.currentModelId = trimToUndefined(asRecord(startResponse.models)?.currentModelId);
+      yield* setGeminiMode(context, context.runtimeModeId);
+
+      if (input.model) {
+        yield* setGeminiModel(context, {
+          model: input.model,
+          acpModelId: input.apiModelId ?? input.model,
+        });
+      }
+
+      context.sessionFilePath = input.sessionFilePath ?? context.sessionFilePath;
+      updateGeminiSession(context, {
+        status: "ready",
+        ...(input.model
+          ? { model: input.model }
+          : context.currentModelId
+            ? { model: context.currentModelId }
+            : {}),
+        resumeCursor: buildResumeCursor(context),
+      });
+
+      return {
+        currentModelId: context.currentModelId,
+      };
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          context.suppressSessionUpdates = false;
+        }),
+      ),
+    );
+  });
+
+  const setGeminiMode = Effect.fn("setGeminiMode")(function* (
+    context: GeminiSessionContext,
+    modeId: string,
+  ) {
+    if (context.currentModeId === modeId) {
+      return;
+    }
+    yield* sendRequest(context, "session/set_mode", {
+      sessionId: context.sessionId,
+      modeId,
+    });
+    context.currentModeId = modeId;
+  });
+
+  const setGeminiModel = Effect.fn("setGeminiModel")(function* (
+    context: GeminiSessionContext,
+    input: {
+      readonly model: string;
+      readonly acpModelId: string;
+    },
+  ) {
+    if (context.currentModelId === input.acpModelId) {
+      return;
+    }
+    yield* sendRequest(context, "session/set_model", {
+      sessionId: context.sessionId,
+      modelId: input.acpModelId,
+    });
+    context.currentModelId = input.acpModelId;
+    updateGeminiSession(context, { model: input.model });
+  });
+
+  const buildPromptBlocks = Effect.fn("buildPromptBlocks")(function* (
+    input: ProviderSendTurnInput,
+  ) {
+    const blocks: Array<Record<string, unknown>> = [];
+
+    if (trimToUndefined(input.input)) {
+      blocks.push({
+        type: "text",
+        text: trimToUndefined(input.input),
+      });
+    }
+
+    for (const attachment of input.attachments ?? []) {
+      if (attachment.type !== "image") {
+        continue;
+      }
+      const attachmentPath = resolveAttachmentPath({
+        attachmentsDir: serverConfig.attachmentsDir,
+        attachment,
+      });
+      if (!attachmentPath) {
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "turn/start",
+          detail: `Invalid attachment id '${attachment.id}'.`,
+        });
+      }
+      const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "turn/start",
+              detail: `Failed to read attachment file: ${cause.message}.`,
+              cause,
+            }),
+        ),
+      );
+      blocks.push({
+        type: "image",
+        mimeType: attachment.mimeType,
+        data: Buffer.from(bytes).toString("base64"),
+      });
+    }
+
+    return blocks;
+  });
+
+  const runPromptTurn = Effect.fn("runPromptTurn")(function* (
+    context: GeminiSessionContext,
+    turnId: TurnId,
+    prompt: ReadonlyArray<Record<string, unknown>>,
+  ) {
+    const promptResult = yield* Effect.result(
+      sendRequest<Record<string, unknown>>(context, "session/prompt", {
+        sessionId: context.sessionId,
+        prompt,
+      }),
+    );
+    if (promptResult._tag === "Failure") {
+      const error = promptResult.failure;
+      const message = toMessage(error, "Gemini turn failed.");
+      yield* emitRuntimeError(context, message, error, turnId);
+      yield* finishTurn(context, {
+        state: "failed",
+        errorMessage: message,
+      });
+      return;
+    }
+
+    const response = promptResult.success;
+
+    if (!response) {
+      const message = "Gemini ACP returned an empty prompt response.";
+      yield* emitRuntimeError(context, message, { response }, turnId);
+      yield* finishTurn(context, {
+        state: "failed",
+        errorMessage: message,
+      });
+      return;
+    }
+
+    const stopReason = asString(response.stopReason) ?? null;
+    yield* finishTurn(context, {
+      state: stopReason === "cancelled" ? "cancelled" : "completed",
+      stopReason,
+      usage: response.usage,
+    });
+  });
+
+  const startSession: GeminiAdapterShape["startSession"] = Effect.fn("startSession")(
+    function* (input) {
+      if (input.provider && input.provider !== PROVIDER) {
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "startSession",
+          issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+        });
+      }
+
+      const existing = sessions.get(input.threadId);
+      if (existing) {
+        disposeSessionContext(existing, "Session replaced while starting a new Gemini session.", {
+          removeFromSessions: true,
+        });
+      }
+
+      const cwd = input.cwd ?? process.cwd();
+      const binaryPath = trimToUndefined(input.providerOptions?.gemini?.binaryPath) ?? "gemini";
+      const runtimeModeId = runtimeModeToGeminiModeId(input.runtimeMode);
+      const selectedGeminiModel =
+        input.modelSelection?.provider === PROVIDER ? input.modelSelection.model : undefined;
+      const launchConfig = yield* prepareGeminiLaunchConfig({
+        threadId: input.threadId,
+        ...(selectedGeminiModel ? { selectedModel: selectedGeminiModel } : {}),
+      });
+      const child = yield* spawnGeminiProcess(
+        input.threadId,
+        binaryPath,
+        cwd,
+        launchConfig.env,
+      ).pipe(
+        Effect.tapError(() =>
+          Effect.sync(() => {
+            if (launchConfig.systemSettingsPath) {
+              void fs.unlink(launchConfig.systemSettingsPath).catch(() => {
+                // Ignore cleanup failures for temporary settings files.
+              });
+            }
+          }),
+        ),
+      );
+      const requestedResumeSessionId = readResumeSessionId(input.resumeCursor);
+      const resumeTurns = readResumeTurns(input.resumeCursor);
+      const context = makeSessionContext({
+        threadId: input.threadId,
+        runtimeMode: input.runtimeMode,
+        runtimeModeId,
+        cwd,
+        binaryPath,
+        child,
+        turns: resumeTurns,
+        ...(launchConfig.systemSettingsPath
+          ? { systemSettingsPath: launchConfig.systemSettingsPath }
+          : {}),
+      });
+
+      attachProcessListeners(context);
+      sessions.set(input.threadId, context);
+      const bootstrapInput = {
+        allowResumeFallback: true,
+        ...(requestedResumeSessionId ? { resumeSessionId: requestedResumeSessionId } : {}),
+        ...(input.modelSelection?.provider === PROVIDER
+          ? {
+              model: input.modelSelection.model,
+              apiModelId: resolveGeminiApiModelId(
+                input.modelSelection.model,
+                input.modelSelection.options,
+              ),
+            }
+          : {}),
+      };
+      yield* bootstrapSessionContext(context, bootstrapInput).pipe(
+        Effect.tapError(() =>
+          Effect.sync(() => {
+            disposeSessionContext(context, "Gemini session failed during startup.", {
+              removeFromSessions: true,
+            });
+          }),
+        ),
+      );
+
+      yield* offerRuntimeEvent({
+        ...makeEventBase(context),
+        type: "session.started",
+        payload: input.resumeCursor !== undefined ? { resume: input.resumeCursor } : {},
+      });
+      yield* offerRuntimeEvent({
+        ...makeEventBase(context),
+        type: "session.configured",
+        payload: {
+          config: {
+            cwd,
+            modeId: context.currentModeId ?? runtimeModeId,
+            ...(context.session.model ? { model: context.session.model } : {}),
+          },
+        },
+      });
+      yield* emitSessionState(context, "ready");
+      yield* offerRuntimeEvent({
+        ...makeEventBase(context),
+        type: "thread.started",
+        payload: {
+          providerThreadId: context.sessionId,
+        },
+      });
+
+      return context.session;
+    },
+  );
+
+  const sendTurn: GeminiAdapterShape["sendTurn"] = Effect.fn("sendTurn")(function* (input) {
+    const context = yield* requireSession(input.threadId);
+    if (context.turnState) {
+      return yield* new ProviderAdapterValidationError({
+        provider: PROVIDER,
+        operation: "sendTurn",
+        issue: "A Gemini turn is already in progress for this thread.",
+      });
+    }
+
+    if (input.modelSelection?.provider === PROVIDER) {
+      yield* setGeminiModel(context, {
+        model: input.modelSelection.model,
+        acpModelId: resolveGeminiApiModelId(
+          input.modelSelection.model,
+          input.modelSelection.options,
+        ),
+      });
+    }
+
+    if (input.interactionMode === "plan") {
+      yield* setGeminiMode(context, "plan");
+    } else {
+      yield* setGeminiMode(context, context.runtimeModeId);
+    }
+
+    const prompt = yield* buildPromptBlocks(input);
+    if (prompt.length === 0) {
+      return yield* new ProviderAdapterValidationError({
+        provider: PROVIDER,
+        operation: "sendTurn",
+        issue: "Either input text or at least one attachment is required.",
+      });
+    }
+
+    const turnId = TurnId.makeUnsafe(crypto.randomUUID());
+    context.turnState = {
+      turnId,
+      startedAt: new Date().toISOString(),
+      assistantItemId: RuntimeItemId.makeUnsafe(`gemini-assistant-${crypto.randomUUID()}`),
+      reasoningItemId: undefined,
+      items: [],
+      assistantTextStarted: false,
+      reasoningTextStarted: false,
+      assistantText: "",
+      reasoningText: "",
+    };
+    updateGeminiSession(context, {
+      status: "running",
+      activeTurnId: turnId,
+      ...(input.modelSelection?.provider === PROVIDER ? { model: input.modelSelection.model } : {}),
+    });
+
+    yield* emitSessionState(context, "running");
+    yield* offerRuntimeEvent({
+      ...makeEventBase(context),
+      turnId,
+      type: "turn.started",
+      payload: context.session.model ? { model: context.session.model } : {},
+    });
+
+    runFork(runPromptTurn(context, turnId, prompt));
+
+    return {
+      threadId: input.threadId,
+      turnId,
+      resumeCursor: buildResumeCursor(context),
+    };
+  });
+
+  const interruptTurn: GeminiAdapterShape["interruptTurn"] = (threadId, turnId) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(threadId);
+      if (turnId && context.turnState && context.turnState.turnId !== turnId) {
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "interruptTurn",
+          issue: `Turn '${turnId}' is not active for thread '${threadId}'.`,
+        });
+      }
+      if (!context.turnState) {
+        return;
+      }
+      yield* sendNotification(context, "session/cancel", {
+        sessionId: context.sessionId,
+      });
+    });
+
+  const respondToRequest: GeminiAdapterShape["respondToRequest"] = (
+    threadId,
+    requestId,
+    decision,
+  ) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(threadId);
+      const pending = context.pendingApprovals.get(requestId);
+      if (!pending) {
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "respondToRequest",
+          issue: `Unknown Gemini approval request '${requestId}'.`,
+        });
+      }
+
+      yield* writeJsonMessage(context, {
+        id: pending.acpRequestId,
+        result: makeApprovalOutcome(decision, pending.options),
+      });
+      context.pendingApprovals.delete(requestId);
+
+      yield* offerRuntimeEvent({
+        ...makeEventBase(context),
+        ...(pending.turnId ? { turnId: pending.turnId } : {}),
+        requestId: RuntimeRequestId.makeUnsafe(requestId),
+        type: "request.resolved",
+        payload: {
+          requestType: pending.requestType,
+          decision,
+          resolution: makeApprovalOutcome(decision, pending.options),
+        },
+        providerRefs: {
+          providerRequestId: String(pending.acpRequestId),
+          ...(pending.providerItemId
+            ? { providerItemId: ProviderItemId.makeUnsafe(pending.providerItemId) }
+            : {}),
+        },
+        raw: {
+          source: "gemini.acp.message",
+          method: "session/request_permission",
+          payload: {
+            decision,
+          },
+        },
+      });
+    });
+
+  const respondToUserInput: GeminiAdapterShape["respondToUserInput"] = (
+    _threadId,
+    _requestId,
+    _answers,
+  ) =>
+    Effect.fail(
+      new ProviderAdapterValidationError({
+        provider: PROVIDER,
+        operation: "respondToUserInput",
+        issue:
+          "Gemini ACP does not expose structured user-input answers. Gemini Ask User requests can only be approved or declined.",
+      }),
+    );
+
+  const stopSession: GeminiAdapterShape["stopSession"] = (threadId) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(threadId);
+      context.stopped = true;
+      killChildProcess(context.child);
+    });
+
+  const listSessions: GeminiAdapterShape["listSessions"] = () =>
+    Effect.succeed(
+      Array.from(sessions.values())
+        .filter((context) => !context.stopped)
+        .map((context) => context.session),
+    );
+
+  const hasSession: GeminiAdapterShape["hasSession"] = (threadId) =>
+    Effect.succeed(Boolean(sessions.get(threadId) && !sessions.get(threadId)?.stopped));
+
+  const readThread: GeminiAdapterShape["readThread"] = (threadId) =>
+    Effect.gen(function* () {
+      const context = yield* requireSession(threadId);
+      return snapshotThread(context);
+    });
+
+  const rollbackThread: GeminiAdapterShape["rollbackThread"] = Effect.fn("rollbackThread")(
+    function* (threadId, numTurns) {
+      const context = yield* requireSession(threadId);
+      if (context.turnState) {
+        return yield* new ProviderAdapterValidationError({
+          provider: PROVIDER,
+          operation: "rollbackThread",
+          issue: "Cannot roll back a Gemini thread while a turn is in progress.",
+        });
+      }
+
+      const nextLength = Math.max(0, context.turns.length - numTurns);
+      if (nextLength === context.turns.length) {
+        return snapshotThread(context);
+      }
+
+      const nextTurns = context.turns.slice(0, nextLength).map(cloneStoredTurn);
+      const cwd = context.session.cwd ?? process.cwd();
+
+      let resumeSessionId: string | undefined;
+      let sessionFilePath: string | undefined;
+      if (nextLength > 0) {
+        const targetTurn = nextTurns[nextLength - 1];
+        if (!targetTurn) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "Gemini session snapshot is unavailable for the requested rollback target.",
+          });
+        }
+        const targetSnapshotSessionId = targetTurn.snapshotSessionId;
+        if (!targetSnapshotSessionId) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "Gemini session snapshot is unavailable for the requested rollback target.",
+          });
+        }
+
+        const sourceSnapshotPath = yield* Effect.tryPromise({
+          try: () =>
+            findGeminiSessionFileById(targetSnapshotSessionId, targetTurn.snapshotFilePath),
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId,
+              detail: `Failed to locate Gemini rollback snapshot: ${toMessage(cause, "lookup failed")}`,
+              cause,
+            }),
+        });
+        if (!sourceSnapshotPath) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "Gemini rollback snapshot file could not be found.",
+          });
+        }
+
+        resumeSessionId = crypto.randomUUID();
+        sessionFilePath = yield* Effect.tryPromise({
+          try: () => cloneGeminiSessionFile(sourceSnapshotPath, resumeSessionId as string),
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId,
+              detail: `Failed to restore Gemini rollback snapshot: ${toMessage(cause, "restore failed")}`,
+              cause,
+            }),
+        });
+      }
+
+      const launchConfig = yield* prepareGeminiLaunchConfig({
+        threadId,
+        ...(context.session.model ? { selectedModel: context.session.model } : {}),
+      });
+      const child = yield* spawnGeminiProcess(
+        threadId,
+        context.binaryPath,
+        cwd,
+        launchConfig.env,
+      ).pipe(
+        Effect.tapError(() =>
+          Effect.sync(() => {
+            if (launchConfig.systemSettingsPath) {
+              void fs.unlink(launchConfig.systemSettingsPath).catch(() => {
+                // Ignore cleanup failures for temporary settings files.
+              });
+            }
+          }),
+        ),
+      );
+      const nextContext = makeSessionContext({
+        threadId,
+        runtimeMode: context.session.runtimeMode,
+        runtimeModeId: context.runtimeModeId,
+        cwd,
+        binaryPath: context.binaryPath,
+        child,
+        turns: nextTurns,
+        ...(sessionFilePath ? { sessionFilePath } : {}),
+        ...(launchConfig.systemSettingsPath
+          ? { systemSettingsPath: launchConfig.systemSettingsPath }
+          : {}),
+      });
+      attachProcessListeners(nextContext);
+
+      const rollbackBootstrapInput = {
+        allowResumeFallback: false,
+        ...(resumeSessionId ? { resumeSessionId } : {}),
+        ...(context.session.model
+          ? {
+              model: context.session.model,
+              apiModelId: context.currentModelId ?? context.session.model,
+            }
+          : {}),
+        ...(sessionFilePath ? { sessionFilePath } : {}),
+      };
+      yield* bootstrapSessionContext(nextContext, rollbackBootstrapInput).pipe(
+        Effect.tapError(() =>
+          Effect.sync(() => {
+            disposeSessionContext(nextContext, "Gemini rollback session failed during startup.");
+          }),
+        ),
+      );
+
+      disposeSessionContext(context, "Session replaced during rollback.");
+
+      sessions.set(threadId, nextContext);
+      return snapshotThread(nextContext);
+    },
+  );
+
+  const stopAll: GeminiAdapterShape["stopAll"] = () =>
+    Effect.forEach(Array.from(sessions.keys()), (threadId) => stopSession(threadId), {
+      concurrency: "unbounded",
+      discard: true,
+    }).pipe(Effect.asVoid);
+
+  const listModels: NonNullable<GeminiAdapterShape["listModels"]> = () =>
+    probeGeminiCapabilities({
+      binaryPath: "gemini",
+      cwd: process.cwd(),
+    }).pipe(
+      Effect.map(
+        (result) =>
+          ({
+            models: result.models,
+            source: "gemini.acp",
+            cached: false,
+          }) satisfies ProviderListModelsResult,
+      ),
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "model/list",
+            detail: toMessage(cause, "Failed to list Gemini models."),
+            cause,
+          }),
+      ),
+    );
+
+  const getComposerCapabilities: NonNullable<GeminiAdapterShape["getComposerCapabilities"]> = () =>
+    Effect.succeed({
+      provider: PROVIDER,
+      supportsSkillMentions: false,
+      supportsSkillDiscovery: false,
+      supportsNativeSlashCommandDiscovery: false,
+      supportsPluginMentions: false,
+      supportsPluginDiscovery: false,
+      supportsRuntimeModelList: true,
+    } satisfies ProviderComposerCapabilities);
+
+  yield* Effect.addFinalizer(() =>
+    Effect.sync(() => {
+      for (const context of Array.from(sessions.values())) {
+        disposeSessionContext(context, "Gemini adapter is shutting down.", {
+          removeFromSessions: true,
+        });
+      }
+    }).pipe(Effect.ignore, Effect.andThen(Queue.shutdown(runtimeEventQueue))),
+  );
+
+  return {
+    provider: PROVIDER,
+    capabilities: {
+      sessionModelSwitch: "in-session",
+      supportsSkillMentions: false,
+      supportsSkillDiscovery: false,
+      supportsNativeSlashCommandDiscovery: false,
+      supportsPluginMentions: false,
+      supportsPluginDiscovery: false,
+      supportsRuntimeModelList: true,
+    },
+    startSession,
+    sendTurn,
+    interruptTurn,
+    respondToRequest,
+    respondToUserInput,
+    stopSession,
+    listSessions,
+    hasSession,
+    readThread,
+    rollbackThread,
+    stopAll,
+    listModels,
+    getComposerCapabilities,
+    get streamEvents() {
+      return Stream.fromQueue(runtimeEventQueue);
+    },
+  } satisfies GeminiAdapterShape;
+});
+
+export const GeminiAdapterLive = Layer.effect(GeminiAdapter, makeGeminiAdapter());
+
+export function makeGeminiAdapterLive(options?: GeminiAdapterLiveOptions) {
+  return Layer.effect(GeminiAdapter, makeGeminiAdapter(options));
+}

--- a/apps/server/src/provider/Layers/GeminiAdapter.ts
+++ b/apps/server/src/provider/Layers/GeminiAdapter.ts
@@ -2468,7 +2468,7 @@ const makeGeminiAdapter = Effect.fn("makeGeminiAdapter")(function* (
   const listModels: NonNullable<GeminiAdapterShape["listModels"]> = () =>
     probeGeminiCapabilities({
       binaryPath: "gemini",
-      cwd: process.cwd(),
+      cwd: os.homedir(),
     }).pipe(
       Effect.map(
         (result) =>

--- a/apps/server/src/provider/Layers/GeminiAdapter.ts
+++ b/apps/server/src/provider/Layers/GeminiAdapter.ts
@@ -33,8 +33,10 @@ import {
   TurnId,
 } from "@t3tools/contracts";
 import {
+  getModelCapabilities,
   getGeminiThinkingConfigKind,
   getGeminiThinkingModelAlias,
+  hasEffortLevel,
   resolveGeminiApiModelId,
 } from "@t3tools/shared/model";
 import { Effect, FileSystem, Layer, Queue, Stream } from "effect";
@@ -193,10 +195,14 @@ export function buildGeminiThinkingModelConfigAliases(
       continue;
     }
     seen.add(model);
+    const caps = getModelCapabilities("gemini", model);
 
     switch (getGeminiThinkingConfigKind(model)) {
       case "level": {
         for (const thinkingLevel of GEMINI_3_THINKING_LEVELS) {
+          if (!hasEffortLevel(caps, thinkingLevel)) {
+            continue;
+          }
           const alias = getGeminiThinkingModelAlias(model, { thinkingLevel });
           if (!alias) {
             continue;
@@ -217,6 +223,9 @@ export function buildGeminiThinkingModelConfigAliases(
       }
       case "budget": {
         for (const thinkingBudget of GEMINI_2_5_THINKING_BUDGETS) {
+          if (!hasEffortLevel(caps, String(thinkingBudget))) {
+            continue;
+          }
           const alias = getGeminiThinkingModelAlias(model, { thinkingBudget });
           if (!alias) {
             continue;

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -6,6 +6,7 @@ import { Effect, Layer, Stream } from "effect";
 
 import { ClaudeAdapter, ClaudeAdapterShape } from "../Services/ClaudeAdapter.ts";
 import { CodexAdapter, CodexAdapterShape } from "../Services/CodexAdapter.ts";
+import { GeminiAdapter, GeminiAdapterShape } from "../Services/GeminiAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderAdapterRegistryLive } from "./ProviderAdapterRegistry.ts";
 import { ProviderUnsupportedError } from "../Errors.ts";
@@ -45,6 +46,23 @@ const fakeClaudeAdapter: ClaudeAdapterShape = {
   streamEvents: Stream.empty,
 };
 
+const fakeGeminiAdapter: GeminiAdapterShape = {
+  provider: "gemini",
+  capabilities: { sessionModelSwitch: "in-session" },
+  startSession: vi.fn(),
+  sendTurn: vi.fn(),
+  interruptTurn: vi.fn(),
+  respondToRequest: vi.fn(),
+  respondToUserInput: vi.fn(),
+  stopSession: vi.fn(),
+  listSessions: vi.fn(),
+  hasSession: vi.fn(),
+  readThread: vi.fn(),
+  rollbackThread: vi.fn(),
+  stopAll: vi.fn(),
+  streamEvents: Stream.empty,
+};
+
 const layer = it.layer(
   Layer.mergeAll(
     Layer.provide(
@@ -52,6 +70,7 @@ const layer = it.layer(
       Layer.mergeAll(
         Layer.succeed(CodexAdapter, fakeCodexAdapter),
         Layer.succeed(ClaudeAdapter, fakeClaudeAdapter),
+        Layer.succeed(GeminiAdapter, fakeGeminiAdapter),
       ),
     ),
     NodeServices.layer,
@@ -64,11 +83,13 @@ layer("ProviderAdapterRegistryLive", (it) => {
       const registry = yield* ProviderAdapterRegistry;
       const codex = yield* registry.getByProvider("codex");
       const claude = yield* registry.getByProvider("claudeAgent");
+      const gemini = yield* registry.getByProvider("gemini");
       assert.equal(codex, fakeCodexAdapter);
       assert.equal(claude, fakeClaudeAdapter);
+      assert.equal(gemini, fakeGeminiAdapter);
 
       const providers = yield* registry.listProviders();
-      assert.deepEqual(providers, ["codex", "claudeAgent"]);
+      assert.deepEqual(providers, ["codex", "claudeAgent", "gemini"]);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -17,6 +17,7 @@ import {
 } from "../Services/ProviderAdapterRegistry.ts";
 import { ClaudeAdapter } from "../Services/ClaudeAdapter.ts";
 import { CodexAdapter } from "../Services/CodexAdapter.ts";
+import { GeminiAdapter } from "../Services/GeminiAdapter.ts";
 
 export interface ProviderAdapterRegistryLiveOptions {
   readonly adapters?: ReadonlyArray<ProviderAdapterShape<ProviderAdapterError>>;
@@ -27,7 +28,7 @@ const makeProviderAdapterRegistry = (options?: ProviderAdapterRegistryLiveOption
     const adapters =
       options?.adapters !== undefined
         ? options.adapters
-        : [yield* CodexAdapter, yield* ClaudeAdapter];
+        : [yield* CodexAdapter, yield* ClaudeAdapter, yield* GeminiAdapter];
     const byProvider = new Map(adapters.map((adapter) => [adapter.provider, adapter]));
 
     const getByProvider: ProviderAdapterRegistryShape["getByProvider"] = (provider) => {

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -38,6 +38,7 @@ import {
   parseCodexCliVersion,
 } from "../codexCliVersion";
 import { ServerConfig } from "../../config";
+import { probeGeminiCapabilities } from "../geminiAcpProbe";
 import { ProviderHealth, type ProviderHealthShape } from "../Services/ProviderHealth";
 import {
   orderProviderStatuses,
@@ -49,6 +50,7 @@ import {
 const DEFAULT_TIMEOUT_MS = 4_000;
 const CODEX_PROVIDER = "codex" as const;
 const CLAUDE_AGENT_PROVIDER = "claudeAgent" as const;
+const GEMINI_PROVIDER = "gemini" as const;
 type ProviderStatuses = ReadonlyArray<ServerProviderStatus>;
 
 // ── Pure helpers ────────────────────────────────────────────────────
@@ -323,6 +325,27 @@ const runClaudeCommand = (args: ReadonlyArray<string>) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const command = ChildProcess.make("claude", [...args], {
+      shell: process.platform === "win32",
+    });
+
+    const child = yield* spawner.spawn(command);
+
+    const [stdout, stderr, exitCode] = yield* Effect.all(
+      [
+        collectStreamAsString(child.stdout),
+        collectStreamAsString(child.stderr),
+        child.exitCode.pipe(Effect.map(Number)),
+      ],
+      { concurrency: "unbounded" },
+    );
+
+    return { stdout, stderr, code: exitCode } satisfies CommandResult;
+  }).pipe(Effect.scoped);
+
+const runGeminiCommand = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const command = ChildProcess.make("gemini", [...args], {
       shell: process.platform === "win32",
     });
 
@@ -649,6 +672,89 @@ export const checkClaudeProviderStatus: Effect.Effect<
   } satisfies ServerProviderStatus;
 });
 
+export const checkGeminiProviderStatus: Effect.Effect<
+  ServerProviderStatus,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner
+> = Effect.gen(function* () {
+  const checkedAt = new Date().toISOString();
+
+  const versionProbe = yield* runGeminiCommand(["--version"]).pipe(
+    Effect.timeoutOption(DEFAULT_TIMEOUT_MS),
+    Effect.result,
+  );
+
+  if (Result.isFailure(versionProbe)) {
+    const error = versionProbe.failure;
+    return {
+      provider: GEMINI_PROVIDER,
+      status: "error" as const,
+      available: false,
+      authStatus: "unknown" as const,
+      checkedAt,
+      message: isCommandMissingCause(error)
+        ? "Gemini CLI (`gemini`) is not installed or not on PATH."
+        : `Failed to execute Gemini CLI health check: ${error instanceof Error ? error.message : String(error)}.`,
+    };
+  }
+
+  if (Option.isNone(versionProbe.success)) {
+    return {
+      provider: GEMINI_PROVIDER,
+      status: "error" as const,
+      available: false,
+      authStatus: "unknown" as const,
+      checkedAt,
+      message: "Gemini CLI is installed but failed to run. Timed out while running command.",
+    };
+  }
+
+  const version = versionProbe.success.value;
+  if (version.code !== 0) {
+    const detail = detailFromResult(version);
+    return {
+      provider: GEMINI_PROVIDER,
+      status: "error" as const,
+      available: false,
+      authStatus: "unknown" as const,
+      checkedAt,
+      message: detail
+        ? `Gemini CLI is installed but failed to run. ${detail}`
+        : "Gemini CLI is installed but failed to run.",
+    };
+  }
+
+  const capabilityProbe = yield* probeGeminiCapabilities({
+    binaryPath: "gemini",
+    cwd: process.cwd(),
+  }).pipe(Effect.result);
+
+  if (Result.isFailure(capabilityProbe)) {
+    const error = capabilityProbe.failure;
+    return {
+      provider: GEMINI_PROVIDER,
+      status: "warning" as const,
+      available: true,
+      authStatus: "unknown" as const,
+      checkedAt,
+      message:
+        error instanceof Error
+          ? `Could not verify Gemini authentication status: ${error.message}.`
+          : "Could not verify Gemini authentication status.",
+    };
+  }
+
+  const parsed = capabilityProbe.success;
+  return {
+    provider: GEMINI_PROVIDER,
+    status: parsed.status,
+    available: true,
+    authStatus: parsed.auth.status,
+    checkedAt,
+    ...(parsed.message ? { message: parsed.message } : {}),
+  } satisfies ServerProviderStatus;
+});
+
 // ── Snapshot helpers ────────────────────────────────────────────────
 
 function providerStatusesEqual(left: ProviderStatuses, right: ProviderStatuses): boolean {
@@ -686,7 +792,7 @@ export const ProviderHealthLive = Layer.effect(
     yield* Effect.addFinalizer(() => Scope.close(refreshScope, Exit.void));
 
     const cachePathByProvider = new Map(
-      [CODEX_PROVIDER, CLAUDE_AGENT_PROVIDER].map(
+      [CODEX_PROVIDER, CLAUDE_AGENT_PROVIDER, GEMINI_PROVIDER].map(
         (provider) =>
           [
             provider,
@@ -699,7 +805,7 @@ export const ProviderHealthLive = Layer.effect(
     );
 
     const cachedStatuses: ProviderStatuses = yield* Effect.forEach(
-      [CODEX_PROVIDER, CLAUDE_AGENT_PROVIDER] as const,
+      [CODEX_PROVIDER, CLAUDE_AGENT_PROVIDER, GEMINI_PROVIDER] as const,
       (provider) =>
         readProviderStatusCache(cachePathByProvider.get(provider)!).pipe(
           Effect.provideService(FileSystem.FileSystem, fileSystem),
@@ -716,9 +822,12 @@ export const ProviderHealthLive = Layer.effect(
     const statusesRef = yield* Ref.make<ProviderStatuses>(cachedStatuses);
     const refreshFiberRef = yield* Ref.make<Fiber.Fiber<ProviderStatuses, never> | null>(null);
 
-    const loadProviderStatuses = Effect.all([checkCodexProviderStatus, checkClaudeProviderStatus], {
-      concurrency: "unbounded",
-    }).pipe(
+    const loadProviderStatuses = Effect.all(
+      [checkCodexProviderStatus, checkClaudeProviderStatus, checkGeminiProviderStatus],
+      {
+        concurrency: "unbounded",
+      },
+    ).pipe(
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
       Effect.provideService(FileSystem.FileSystem, fileSystem),
       Effect.provideService(Path.Path, path),

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -38,7 +38,7 @@ import {
   parseCodexCliVersion,
 } from "../codexCliVersion";
 import { ServerConfig } from "../../config";
-import { probeGeminiCapabilities } from "../geminiAcpProbe";
+import { normalizeGeminiCapabilityProbeResult, probeGeminiCapabilities } from "../geminiAcpProbe";
 import { ProviderHealth, type ProviderHealthShape } from "../Services/ProviderHealth";
 import {
   orderProviderStatuses,
@@ -726,7 +726,7 @@ export const checkGeminiProviderStatus: Effect.Effect<
 
   const capabilityProbe = yield* probeGeminiCapabilities({
     binaryPath: "gemini",
-    cwd: process.cwd(),
+    cwd: OS.homedir(),
   }).pipe(Effect.result);
 
   if (Result.isFailure(capabilityProbe)) {
@@ -744,7 +744,7 @@ export const checkGeminiProviderStatus: Effect.Effect<
     };
   }
 
-  const parsed = capabilityProbe.success;
+  const parsed = normalizeGeminiCapabilityProbeResult(capabilityProbe.success);
   return {
     provider: GEMINI_PROVIDER,
     status: parsed.status,

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -22,7 +22,7 @@ function decodeProviderKind(
   providerName: string,
   operation: string,
 ): Effect.Effect<ProviderKind, ProviderSessionDirectoryPersistenceError> {
-  if (providerName === "codex" || providerName === "claudeAgent") {
+  if (providerName === "codex" || providerName === "claudeAgent" || providerName === "gemini") {
     return Effect.succeed(providerName);
   }
   return Effect.fail(

--- a/apps/server/src/provider/Services/GeminiAdapter.ts
+++ b/apps/server/src/provider/Services/GeminiAdapter.ts
@@ -1,0 +1,27 @@
+/**
+ * GeminiAdapter - Gemini CLI ACP implementation of the generic provider adapter contract.
+ *
+ * This service owns Gemini ACP runtime/session semantics and emits canonical
+ * provider runtime events. It does not perform cross-provider routing, shared
+ * event fan-out, or checkpoint orchestration.
+ *
+ * @module GeminiAdapter
+ */
+import { ServiceMap } from "effect";
+
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * GeminiAdapterShape - Service API for the Gemini provider adapter.
+ */
+export interface GeminiAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {
+  readonly provider: "gemini";
+}
+
+/**
+ * GeminiAdapter - Service tag for Gemini provider adapter operations.
+ */
+export class GeminiAdapter extends ServiceMap.Service<GeminiAdapter, GeminiAdapterShape>()(
+  "t3/provider/Services/GeminiAdapter",
+) {}

--- a/apps/server/src/provider/geminiAcpProbe.test.ts
+++ b/apps/server/src/provider/geminiAcpProbe.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeGeminiCapabilityProbeResult } from "./geminiAcpProbe";
+
+describe("normalizeGeminiCapabilityProbeResult", () => {
+  it("treats authenticated ACP sessions without model discovery as ready", () => {
+    expect(
+      normalizeGeminiCapabilityProbeResult({
+        status: "warning",
+        auth: { status: "authenticated" },
+        models: [],
+        message:
+          "Gemini CLI is installed, but DP Code could not verify authentication or discover models. Gemini ACP session started, but it did not report any available models.",
+      }),
+    ).toEqual({
+      status: "ready",
+      auth: { status: "authenticated" },
+      models: [],
+      message:
+        "Gemini CLI is installed and authenticated, but it did not report any available models. DP Code will use its built-in Gemini model list.",
+    });
+  });
+
+  it("preserves successful model discovery results", () => {
+    const result = {
+      status: "ready" as const,
+      auth: { status: "authenticated" as const },
+      models: [{ slug: "gemini-2.5-pro", name: "Gemini 2.5 Pro" }],
+      message: "Gemini CLI is installed and authenticated.",
+    };
+
+    expect(normalizeGeminiCapabilityProbeResult(result)).toEqual(result);
+  });
+
+  it("preserves warnings when authentication is still unknown", () => {
+    const result = {
+      status: "warning" as const,
+      auth: { status: "unknown" as const },
+      models: [],
+      message:
+        "Gemini CLI is installed, but DP Code could not verify authentication or discover models. Timed out while starting Gemini ACP session.",
+    };
+
+    expect(normalizeGeminiCapabilityProbeResult(result)).toEqual(result);
+  });
+});

--- a/apps/server/src/provider/geminiAcpProbe.ts
+++ b/apps/server/src/provider/geminiAcpProbe.ts
@@ -1,0 +1,385 @@
+import { spawn } from "node:child_process";
+import * as readline from "node:readline";
+
+import type {
+  ModelCapabilities,
+  ProviderModelDescriptor,
+  ServerProviderAuthStatus,
+  ServerProviderStatusState,
+} from "@t3tools/contracts";
+import {
+  DEFAULT_GEMINI_MODEL_CAPABILITIES,
+  GEMINI_2_5_MODEL_CAPABILITIES,
+  GEMINI_3_MODEL_CAPABILITIES,
+  geminiCapabilitiesForModel,
+} from "@t3tools/shared/model";
+import { Effect } from "effect";
+import { asNumber, asRecord, trimToUndefined } from "./geminiValue.ts";
+
+const GEMINI_ACP_PROBE_TIMEOUT_MS = 8_000;
+const GEMINI_ACP_AUTH_REQUIRED_CODE = -32_000;
+const MAX_CAPTURED_LOG_LINES = 5;
+const MAX_CAPTURED_LOG_LENGTH = 240;
+
+export {
+  DEFAULT_GEMINI_MODEL_CAPABILITIES,
+  GEMINI_2_5_MODEL_CAPABILITIES,
+  GEMINI_3_MODEL_CAPABILITIES,
+  geminiCapabilitiesForModel,
+};
+
+export type GeminiCapabilityProbeResult = {
+  readonly models: ReadonlyArray<ProviderModelDescriptor>;
+  readonly status: ServerProviderStatusState;
+  readonly auth: { readonly status: ServerProviderAuthStatus };
+  readonly message?: string;
+};
+
+function truncateLogLine(line: string): string {
+  return line.length > MAX_CAPTURED_LOG_LENGTH
+    ? `${line.slice(0, MAX_CAPTURED_LOG_LENGTH - 3)}...`
+    : line;
+}
+
+function pushLogLine(target: string[], line: string): void {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("{")) {
+    return;
+  }
+
+  target.push(truncateLogLine(trimmed));
+  if (target.length > MAX_CAPTURED_LOG_LINES) {
+    target.shift();
+  }
+}
+
+function formatGeminiDiscoveryWarning(detail: string): string {
+  return `Gemini CLI is installed, but DP Code could not verify authentication or discover models. ${detail}`;
+}
+
+function formatGeminiAuthMessage(detail: string): string {
+  return `Gemini is not authenticated. ${detail}`;
+}
+
+function detailFromProbeLogs(
+  stdoutLines: ReadonlyArray<string>,
+  stderrLines: ReadonlyArray<string>,
+) {
+  return stderrLines[stderrLines.length - 1] ?? stdoutLines[stdoutLines.length - 1];
+}
+
+export function parseGeminiAcpProbeError(
+  error: unknown,
+): Omit<GeminiCapabilityProbeResult, "models"> {
+  const record = asRecord(error);
+  const code = asNumber(record?.code);
+  const message = trimToUndefined(record?.message) ?? "Gemini ACP request failed.";
+  const lowerMessage = message.toLowerCase();
+  const unauthenticated =
+    code === GEMINI_ACP_AUTH_REQUIRED_CODE ||
+    lowerMessage.includes("authentication required") ||
+    lowerMessage.includes("api key is missing") ||
+    lowerMessage.includes("auth method") ||
+    lowerMessage.includes("not configured");
+
+  if (unauthenticated) {
+    return {
+      status: "error",
+      auth: { status: "unauthenticated" },
+      message: formatGeminiAuthMessage(message),
+    };
+  }
+
+  return {
+    status: "warning",
+    auth: { status: "unknown" },
+    message: formatGeminiDiscoveryWarning(message),
+  };
+}
+
+export function parseGeminiDiscoveredModels(
+  response: unknown,
+  _fallbackCapabilities: ModelCapabilities = DEFAULT_GEMINI_MODEL_CAPABILITIES,
+): ReadonlyArray<ProviderModelDescriptor> {
+  const availableModels = asRecord(asRecord(response)?.models)?.availableModels;
+  if (!Array.isArray(availableModels)) {
+    return [];
+  }
+
+  const discoveredModels: ProviderModelDescriptor[] = [];
+  const seen = new Set<string>();
+
+  for (const candidate of availableModels) {
+    const record = asRecord(candidate);
+    const slug = trimToUndefined(record?.modelId);
+    if (!slug || seen.has(slug)) {
+      continue;
+    }
+
+    seen.add(slug);
+    discoveredModels.push({
+      slug,
+      name: trimToUndefined(record?.name) ?? slug,
+    });
+  }
+
+  return discoveredModels;
+}
+
+export const probeGeminiCapabilities = (input: {
+  readonly binaryPath: string;
+  readonly cwd: string;
+  readonly capabilities?: ModelCapabilities;
+}) =>
+  Effect.tryPromise(
+    () =>
+      new Promise<GeminiCapabilityProbeResult>((resolve) => {
+        const child = spawn(input.binaryPath, ["--acp"], {
+          cwd: input.cwd,
+          shell: process.platform === "win32",
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+
+        if (!child.stdin || !child.stdout || !child.stderr) {
+          child.kill();
+          resolve({
+            status: "warning",
+            auth: { status: "unknown" },
+            models: [],
+            message: formatGeminiDiscoveryWarning(
+              "Gemini ACP did not expose the expected stdio streams.",
+            ),
+          });
+          return;
+        }
+
+        const stdoutLines: string[] = [];
+        const stderrLines: string[] = [];
+        const stdoutReader = readline.createInterface({ input: child.stdout });
+        const stderrReader = readline.createInterface({ input: child.stderr });
+
+        let settled = false;
+        let sessionNewRequested = false;
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+
+        const cleanup = () => {
+          if (timeout) {
+            clearTimeout(timeout);
+          }
+          stdoutReader.removeAllListeners();
+          stderrReader.removeAllListeners();
+          child.removeAllListeners();
+          stdoutReader.close();
+          stderrReader.close();
+        };
+
+        const terminate = (gracefulClosePayload?: string) => {
+          if (gracefulClosePayload && child.stdin.writable) {
+            child.stdin.write(gracefulClosePayload);
+            child.stdin.end();
+            const delayedKill = setTimeout(() => {
+              if (!child.killed) {
+                child.kill();
+              }
+            }, 150);
+            delayedKill.unref?.();
+            return;
+          }
+
+          if (child.stdin.writable) {
+            child.stdin.end();
+          }
+          if (!child.killed) {
+            child.kill();
+          }
+        };
+
+        const finalize = (
+          result: GeminiCapabilityProbeResult,
+          options?: { readonly sessionId?: string },
+        ) => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          cleanup();
+          const closePayload =
+            options?.sessionId && options.sessionId.length > 0
+              ? `${JSON.stringify({
+                  jsonrpc: "2.0",
+                  id: 3,
+                  method: "session/close",
+                  params: { sessionId: options.sessionId },
+                })}\n`
+              : undefined;
+          terminate(closePayload);
+          resolve(result);
+        };
+
+        const sendRequest = (id: number, method: string, params: Record<string, unknown>) => {
+          if (!child.stdin.writable) {
+            finalize({
+              status: "warning",
+              auth: { status: "unknown" },
+              models: [],
+              message: formatGeminiDiscoveryWarning("Gemini ACP stdin is not writable."),
+            });
+            return;
+          }
+
+          child.stdin.write(
+            `${JSON.stringify({
+              jsonrpc: "2.0",
+              id,
+              method,
+              params,
+            })}\n`,
+          );
+        };
+
+        timeout = setTimeout(() => {
+          const detail = detailFromProbeLogs(stdoutLines, stderrLines);
+          finalize({
+            status: "warning",
+            auth: { status: "unknown" },
+            models: [],
+            message: formatGeminiDiscoveryWarning(
+              detail
+                ? `Timed out while starting Gemini ACP session. Last output: ${detail}`
+                : "Timed out while starting Gemini ACP session.",
+            ),
+          });
+        }, GEMINI_ACP_PROBE_TIMEOUT_MS);
+
+        stdoutReader.on("line", (line) => {
+          pushLogLine(stdoutLines, line);
+
+          const trimmed = line.trim();
+          if (!trimmed.startsWith("{")) {
+            return;
+          }
+
+          let parsed: Record<string, unknown> | undefined;
+          try {
+            parsed = asRecord(JSON.parse(trimmed));
+          } catch {
+            return;
+          }
+
+          if (!parsed) {
+            return;
+          }
+
+          const id = asNumber(parsed.id);
+          if (id === 1) {
+            const error = asRecord(parsed.error);
+            if (error) {
+              finalize({
+                ...parseGeminiAcpProbeError(error),
+                models: [],
+              });
+              return;
+            }
+
+            if (!sessionNewRequested) {
+              sessionNewRequested = true;
+              sendRequest(2, "session/new", {
+                cwd: input.cwd,
+                mcpServers: [],
+              });
+            }
+            return;
+          }
+
+          if (id !== 2) {
+            return;
+          }
+
+          const error = asRecord(parsed.error);
+          if (error) {
+            finalize({
+              ...parseGeminiAcpProbeError(error),
+              models: [],
+            });
+            return;
+          }
+
+          const result = parsed.result;
+          const models = parseGeminiDiscoveredModels(
+            result,
+            input.capabilities ?? DEFAULT_GEMINI_MODEL_CAPABILITIES,
+          );
+          if (models.length === 0) {
+            finalize({
+              status: "warning",
+              auth: { status: "authenticated" },
+              models: [],
+              message: formatGeminiDiscoveryWarning(
+                "Gemini ACP session started, but it did not report any available models.",
+              ),
+            });
+            return;
+          }
+
+          finalize(
+            {
+              status: "ready",
+              auth: { status: "authenticated" },
+              models,
+              message: "Gemini CLI is installed and authenticated.",
+            },
+            (() => {
+              const sessionId = trimToUndefined(asRecord(result)?.sessionId);
+              return sessionId ? { sessionId } : undefined;
+            })(),
+          );
+        });
+
+        stderrReader.on("line", (line) => {
+          pushLogLine(stderrLines, line);
+        });
+
+        child.once("error", (error) => {
+          finalize({
+            status: "warning",
+            auth: { status: "unknown" },
+            models: [],
+            message: formatGeminiDiscoveryWarning(
+              error.message.length > 0 ? error.message : "Failed to start Gemini ACP session.",
+            ),
+          });
+        });
+
+        child.once("exit", (code, signal) => {
+          if (settled) {
+            return;
+          }
+
+          const detail = detailFromProbeLogs(stdoutLines, stderrLines);
+          const exitMessage =
+            detail ??
+            `Gemini ACP exited before responding (code ${code ?? "null"}${signal ? `, signal ${signal}` : ""}).`;
+          finalize({
+            status: "warning",
+            auth: { status: "unknown" },
+            models: [],
+            message: formatGeminiDiscoveryWarning(exitMessage),
+          });
+        });
+
+        sendRequest(1, "initialize", {
+          protocolVersion: 1,
+          clientInfo: {
+            name: "dpcode",
+            title: "DP Code",
+            version: "0.1.0",
+          },
+          clientCapabilities: {
+            fs: { readTextFile: false, writeTextFile: false },
+            terminal: false,
+            auth: { terminal: false },
+          },
+        });
+      }),
+  );

--- a/apps/server/src/provider/geminiAcpProbe.ts
+++ b/apps/server/src/provider/geminiAcpProbe.ts
@@ -16,7 +16,10 @@ import {
 import { Effect } from "effect";
 import { asNumber, asRecord, trimToUndefined } from "./geminiValue.ts";
 
-const GEMINI_ACP_PROBE_TIMEOUT_MS = 8_000;
+// Gemini ACP cold starts can take noticeably longer than a normal request path,
+// especially when the CLI has to warm caches or discover auth state. Keep the
+// health probe patient enough to avoid false warning banners.
+const GEMINI_ACP_PROBE_TIMEOUT_MS = 30_000;
 const GEMINI_ACP_AUTH_REQUIRED_CODE = -32_000;
 const MAX_CAPTURED_LOG_LINES = 5;
 const MAX_CAPTURED_LOG_LENGTH = 240;
@@ -61,6 +64,10 @@ function formatGeminiAuthMessage(detail: string): string {
   return `Gemini is not authenticated. ${detail}`;
 }
 
+function formatGeminiModelDiscoveryFallbackMessage(): string {
+  return "Gemini CLI is installed and authenticated, but it did not report any available models. DP Code will use its built-in Gemini model list.";
+}
+
 function detailFromProbeLogs(
   stdoutLines: ReadonlyArray<string>,
   stderrLines: ReadonlyArray<string>,
@@ -95,6 +102,20 @@ export function parseGeminiAcpProbeError(
     auth: { status: "unknown" },
     message: formatGeminiDiscoveryWarning(message),
   };
+}
+
+export function normalizeGeminiCapabilityProbeResult(
+  result: GeminiCapabilityProbeResult,
+): GeminiCapabilityProbeResult {
+  if (result.auth.status === "authenticated" && result.models.length === 0) {
+    return {
+      ...result,
+      status: "ready",
+      message: formatGeminiModelDiscoveryFallbackMessage(),
+    };
+  }
+
+  return result;
 }
 
 export function parseGeminiDiscoveredModels(
@@ -310,25 +331,16 @@ export const probeGeminiCapabilities = (input: {
             result,
             input.capabilities ?? DEFAULT_GEMINI_MODEL_CAPABILITIES,
           );
-          if (models.length === 0) {
-            finalize({
-              status: "warning",
-              auth: { status: "authenticated" },
-              models: [],
-              message: formatGeminiDiscoveryWarning(
-                "Gemini ACP session started, but it did not report any available models.",
-              ),
-            });
-            return;
-          }
 
           finalize(
-            {
+            normalizeGeminiCapabilityProbeResult({
               status: "ready",
               auth: { status: "authenticated" },
               models,
-              message: "Gemini CLI is installed and authenticated.",
-            },
+              ...(models.length > 0
+                ? { message: "Gemini CLI is installed and authenticated." }
+                : {}),
+            }),
             (() => {
               const sessionId = trimToUndefined(asRecord(result)?.sessionId);
               return sessionId ? { sessionId } : undefined;

--- a/apps/server/src/provider/geminiValue.ts
+++ b/apps/server/src/provider/geminiValue.ts
@@ -1,0 +1,22 @@
+export function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+export function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function asArray(value: unknown): ReadonlyArray<unknown> | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+export function trimToUndefined(value: unknown): string | undefined {
+  const candidate = asString(value)?.trim();
+  return candidate && candidate.length > 0 ? candidate : undefined;
+}

--- a/apps/server/src/provider/providerStatusCache.test.ts
+++ b/apps/server/src/provider/providerStatusCache.test.ts
@@ -73,6 +73,13 @@ describe("providerStatusCache", () => {
     expect(
       orderProviderStatuses([
         {
+          provider: "gemini",
+          status: "ready",
+          available: true,
+          authStatus: "authenticated",
+          checkedAt: "2026-04-15T10:02:00.000Z",
+        },
+        {
           provider: "claudeAgent",
           status: "warning",
           available: true,
@@ -89,6 +96,13 @@ describe("providerStatusCache", () => {
         available: true,
         authStatus: "unknown",
         checkedAt: "2026-04-15T10:01:00.000Z",
+      },
+      {
+        provider: "gemini",
+        status: "ready",
+        available: true,
+        authStatus: "authenticated",
+        checkedAt: "2026-04-15T10:02:00.000Z",
       },
     ]);
   });

--- a/apps/server/src/provider/providerStatusCache.ts
+++ b/apps/server/src/provider/providerStatusCache.ts
@@ -9,9 +9,11 @@
 import { ServerProviderStatus } from "@t3tools/contracts";
 import { Cause, Effect, FileSystem, Path, Schema } from "effect";
 
-const PROVIDER_STATUS_CACHE_IDS = ["codex", "claudeAgent"] as const satisfies ReadonlyArray<
-  ServerProviderStatus["provider"]
->;
+const PROVIDER_STATUS_CACHE_IDS = [
+  "codex",
+  "claudeAgent",
+  "gemini",
+] as const satisfies ReadonlyArray<ServerProviderStatus["provider"]>;
 
 const decodeProviderStatusCache = Schema.decodeUnknownEffect(
   Schema.fromJsonString(ServerProviderStatus),

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -19,6 +19,7 @@ import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus"
 import { ProviderUnsupportedError } from "./provider/Errors";
 import { makeClaudeAdapterLive } from "./provider/Layers/ClaudeAdapter";
 import { makeCodexAdapterLive } from "./provider/Layers/CodexAdapter";
+import { makeGeminiAdapterLive } from "./provider/Layers/GeminiAdapter";
 import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRegistry";
 import { makeProviderServiceLive } from "./provider/Layers/ProviderService";
 import { ProviderDiscoveryServiceLive } from "./provider/Layers/ProviderDiscoveryService";
@@ -76,9 +77,13 @@ export function makeServerProviderLayer(): Layer.Layer<
     const claudeAdapterLayer = makeClaudeAdapterLive(
       nativeEventLogger ? { nativeEventLogger } : undefined,
     );
+    const geminiAdapterLayer = makeGeminiAdapterLive(
+      nativeEventLogger ? { nativeEventLogger } : undefined,
+    );
     const adapterRegistryLayer = ProviderAdapterRegistryLive.pipe(
       Layer.provide(codexAdapterLayer),
       Layer.provide(claudeAdapterLayer),
+      Layer.provide(geminiAdapterLayer),
       Layer.provideMerge(providerSessionDirectoryLayer),
     );
     const providerServiceLayer = makeProviderServiceLive(

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -80,31 +80,41 @@ describe("resolveAppModelSelection", () => {
     expect(
       resolveAppModelSelection(
         "codex",
-        { codex: ["galapagos-alpha"], claudeAgent: [] },
+        { codex: ["galapagos-alpha"], claudeAgent: [], gemini: [] },
         "galapagos-alpha",
       ),
     ).toBe("galapagos-alpha");
   });
 
   it("falls back to the provider default when no model is selected", () => {
-    expect(resolveAppModelSelection("codex", { codex: [], claudeAgent: [] }, "")).toBe("gpt-5.4");
+    expect(resolveAppModelSelection("codex", { codex: [], claudeAgent: [], gemini: [] }, "")).toBe(
+      "gpt-5.4",
+    );
   });
 
   it("resolves display names through the shared resolver", () => {
-    expect(resolveAppModelSelection("codex", { codex: [], claudeAgent: [] }, "GPT-5.3 Codex")).toBe(
-      "gpt-5.3-codex",
-    );
+    expect(
+      resolveAppModelSelection(
+        "codex",
+        { codex: [], claudeAgent: [], gemini: [] },
+        "GPT-5.3 Codex",
+      ),
+    ).toBe("gpt-5.3-codex");
   });
 
   it("resolves aliases through the shared resolver", () => {
-    expect(resolveAppModelSelection("claudeAgent", { codex: [], claudeAgent: [] }, "sonnet")).toBe(
-      "claude-sonnet-4-6",
-    );
+    expect(
+      resolveAppModelSelection("claudeAgent", { codex: [], claudeAgent: [], gemini: [] }, "sonnet"),
+    ).toBe("claude-sonnet-4-6");
   });
 
   it("resolves transient selected custom models included in app model options", () => {
     expect(
-      resolveAppModelSelection("codex", { codex: [], claudeAgent: [] }, "custom/selected-model"),
+      resolveAppModelSelection(
+        "codex",
+        { codex: [], claudeAgent: [], gemini: [] },
+        "custom/selected-model",
+      ),
     ).toBe("custom/selected-model");
   });
 });
@@ -152,6 +162,7 @@ describe("getProviderStartOptions", () => {
         claudeBinaryPath: "/usr/local/bin/claude",
         codexBinaryPath: "",
         codexHomePath: "/Users/you/.codex",
+        geminiBinaryPath: "/usr/local/bin/gemini",
       }),
     ).toEqual({
       claudeAgent: {
@@ -159,6 +170,9 @@ describe("getProviderStartOptions", () => {
       },
       codex: {
         homePath: "/Users/you/.codex",
+      },
+      gemini: {
+        binaryPath: "/usr/local/bin/gemini",
       },
     });
   });
@@ -169,6 +183,7 @@ describe("getProviderStartOptions", () => {
         claudeBinaryPath: "",
         codexBinaryPath: "",
         codexHomePath: "",
+        geminiBinaryPath: "",
       }),
     ).toBeUndefined();
   });
@@ -178,30 +193,35 @@ describe("provider-indexed custom model settings", () => {
   const settings = {
     customCodexModels: ["custom/codex-model"],
     customClaudeModels: ["claude/custom-opus"],
+    customGeminiModels: ["gemini/custom-flash"],
   } as const;
 
   it("exports one provider config per provider", () => {
     expect(MODEL_PROVIDER_SETTINGS.map((config) => config.provider)).toEqual([
       "codex",
       "claudeAgent",
+      "gemini",
     ]);
   });
 
   it("reads custom models for each provider", () => {
     expect(getCustomModelsForProvider(settings, "codex")).toEqual(["custom/codex-model"]);
     expect(getCustomModelsForProvider(settings, "claudeAgent")).toEqual(["claude/custom-opus"]);
+    expect(getCustomModelsForProvider(settings, "gemini")).toEqual(["gemini/custom-flash"]);
   });
 
   it("reads default custom models for each provider", () => {
     const defaults = {
       customCodexModels: ["default/codex-model"],
       customClaudeModels: ["claude/default-opus"],
+      customGeminiModels: ["gemini/default-flash"],
     } as const;
 
     expect(getDefaultCustomModelsForProvider(defaults, "codex")).toEqual(["default/codex-model"]);
     expect(getDefaultCustomModelsForProvider(defaults, "claudeAgent")).toEqual([
       "claude/default-opus",
     ]);
+    expect(getDefaultCustomModelsForProvider(defaults, "gemini")).toEqual(["gemini/default-flash"]);
   });
 
   it("patches custom models for codex", () => {
@@ -216,10 +236,17 @@ describe("provider-indexed custom model settings", () => {
     });
   });
 
+  it("patches custom models for gemini", () => {
+    expect(patchCustomModels("gemini", ["gemini/custom-flash"])).toEqual({
+      customGeminiModels: ["gemini/custom-flash"],
+    });
+  });
+
   it("builds a complete provider-indexed custom model record", () => {
     expect(getCustomModelsByProvider(settings)).toEqual({
       codex: ["custom/codex-model"],
       claudeAgent: ["claude/custom-opus"],
+      gemini: ["gemini/custom-flash"],
     });
   });
 
@@ -232,12 +259,16 @@ describe("provider-indexed custom model settings", () => {
     expect(
       modelOptionsByProvider.claudeAgent.some((option) => option.slug === "claude/custom-opus"),
     ).toBe(true);
+    expect(
+      modelOptionsByProvider.gemini.some((option) => option.slug === "gemini/custom-flash"),
+    ).toBe(true);
   });
 
   it("normalizes and deduplicates custom model options per provider", () => {
     const modelOptionsByProvider = getCustomModelOptionsByProvider({
       customCodexModels: ["  custom/codex-model ", "gpt-5.4", "custom/codex-model"],
       customClaudeModels: [" sonnet ", "claude/custom-opus", "claude/custom-opus"],
+      customGeminiModels: [" auto-gemini-3 ", "gemini/custom-flash", "gemini/custom-flash"],
     });
 
     expect(
@@ -250,6 +281,12 @@ describe("provider-indexed custom model settings", () => {
     expect(
       modelOptionsByProvider.claudeAgent.some((option) => option.slug === "claude-sonnet-4-6"),
     ).toBe(true);
+    expect(
+      modelOptionsByProvider.gemini.filter((option) => option.slug === "gemini/custom-flash"),
+    ).toHaveLength(1);
+    expect(modelOptionsByProvider.gemini.some((option) => option.slug === "auto-gemini-3")).toBe(
+      true,
+    );
   });
 });
 
@@ -269,6 +306,7 @@ describe("AppSettingsSchema", () => {
       chatFontSizePx: DEFAULT_CHAT_FONT_SIZE_PX,
       codexBinaryPath: "/usr/local/bin/codex",
       codexHomePath: "",
+      geminiBinaryPath: "",
       defaultThreadEnvMode: "local",
       confirmThreadDelete: false,
       confirmTerminalTabClose: true,
@@ -278,6 +316,7 @@ describe("AppSettingsSchema", () => {
       timestampFormat: DEFAULT_TIMESTAMP_FORMAT,
       customCodexModels: [],
       customClaudeModels: [],
+      customGeminiModels: [],
     });
   });
 });

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -29,7 +29,7 @@ export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "upda
 export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
-type CustomModelSettingsKey = "customCodexModels" | "customClaudeModels";
+type CustomModelSettingsKey = "customCodexModels" | "customClaudeModels" | "customGeminiModels";
 export type ProviderCustomModelConfig = {
   provider: ProviderKind;
   settingsKey: CustomModelSettingsKey;
@@ -43,6 +43,7 @@ export type ProviderCustomModelConfig = {
 const BUILT_IN_MODEL_SLUGS_BY_PROVIDER: Record<ProviderKind, ReadonlySet<string>> = {
   codex: new Set(getModelOptions("codex").map((option) => option.slug)),
   claudeAgent: new Set(getModelOptions("claudeAgent").map((option) => option.slug)),
+  gemini: new Set(getModelOptions("gemini").map((option) => option.slug)),
 };
 
 const withDefaults =
@@ -64,6 +65,7 @@ export const AppSettingsSchema = Schema.Struct({
   chatCodeFontFamily: Schema.String.check(Schema.isMaxLength(256)).pipe(withDefaults(() => "")),
   codexBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   codexHomePath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
+  geminiBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   defaultThreadEnvMode: EnvMode.pipe(withDefaults(() => "local" as const satisfies EnvMode)),
   confirmThreadDelete: Schema.Boolean.pipe(withDefaults(() => true)),
   confirmThreadArchive: Schema.Boolean.pipe(withDefaults(() => false)),
@@ -82,6 +84,7 @@ export const AppSettingsSchema = Schema.Struct({
   timestampFormat: TimestampFormat.pipe(withDefaults(() => DEFAULT_TIMESTAMP_FORMAT)),
   customCodexModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   customClaudeModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
+  customGeminiModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   textGenerationModel: Schema.optional(TrimmedNonEmptyString),
   uiFontFamily: Schema.String.check(Schema.isMaxLength(256)).pipe(withDefaults(() => "")),
   defaultProvider: ProviderKind.pipe(withDefaults(() => "codex" as const)),
@@ -112,6 +115,15 @@ const PROVIDER_CUSTOM_MODEL_CONFIG: Record<ProviderKind, ProviderCustomModelConf
     description: "Save additional Claude model slugs for the picker and `/model` command.",
     placeholder: "your-claude-model-slug",
     example: "claude-sonnet-5-0",
+  },
+  gemini: {
+    provider: "gemini",
+    settingsKey: "customGeminiModels",
+    defaultSettingsKey: "customGeminiModels",
+    title: "Gemini",
+    description: "Save additional Gemini model slugs for the picker and `/model` command.",
+    placeholder: "your-gemini-model-slug",
+    example: "gemini-3.5-pro-preview",
   },
 };
 export const MODEL_PROVIDER_SETTINGS = Object.values(PROVIDER_CUSTOM_MODEL_CONFIG);
@@ -159,6 +171,7 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
     chatFontSizePx: normalizeChatFontSizePx(settings.chatFontSizePx),
     customCodexModels: normalizeCustomModelSlugs(settings.customCodexModels, "codex"),
     customClaudeModels: normalizeCustomModelSlugs(settings.customClaudeModels, "claudeAgent"),
+    customGeminiModels: normalizeCustomModelSlugs(settings.customGeminiModels, "gemini"),
   };
 }
 
@@ -191,6 +204,7 @@ export function getCustomModelsByProvider(
   return {
     codex: getCustomModelsForProvider(settings, "codex"),
     claudeAgent: getCustomModelsForProvider(settings, "claudeAgent"),
+    gemini: getCustomModelsForProvider(settings, "gemini"),
   };
 }
 
@@ -256,11 +270,15 @@ export function getCustomModelOptionsByProvider(
   return {
     codex: getAppModelOptions("codex", customModelsByProvider.codex),
     claudeAgent: getAppModelOptions("claudeAgent", customModelsByProvider.claudeAgent),
+    gemini: getAppModelOptions("gemini", customModelsByProvider.gemini),
   };
 }
 
 export function getProviderStartOptions(
-  settings: Pick<AppSettings, "claudeBinaryPath" | "codexBinaryPath" | "codexHomePath">,
+  settings: Pick<
+    AppSettings,
+    "claudeBinaryPath" | "codexBinaryPath" | "codexHomePath" | "geminiBinaryPath"
+  >,
 ): ProviderStartOptions | undefined {
   const providerOptions: ProviderStartOptions = {
     ...(settings.codexBinaryPath || settings.codexHomePath
@@ -275,6 +293,13 @@ export function getProviderStartOptions(
       ? {
           claudeAgent: {
             binaryPath: settings.claudeBinaryPath,
+          },
+        }
+      : {}),
+    ...(settings.geminiBinaryPath
+      ? {
+          gemini: {
+            binaryPath: settings.geminiBinaryPath,
           },
         }
       : {}),

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -23,7 +23,10 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { render } from "vitest-browser-react";
 
 import { type ComposerImageAttachment, useComposerDraftStore } from "../composerDraftStore";
-import { getScrollContainerDistanceFromBottom } from "../chat-scroll";
+import {
+  AUTO_SCROLL_BOTTOM_THRESHOLD_PX,
+  getScrollContainerDistanceFromBottom,
+} from "../chat-scroll";
 import {
   INLINE_TERMINAL_CONTEXT_PLACEHOLDER,
   type TerminalContextDraft,
@@ -31,7 +34,10 @@ import {
 } from "../lib/terminalContext";
 import { isMacPlatform } from "../lib/utils";
 import { getRouter } from "../router";
+import { useSplitViewStore } from "../splitViewStore";
 import { useStore } from "../store";
+import { useTemporaryThreadStore } from "../temporaryThreadStore";
+import { useTerminalStateStore } from "../terminalStateStore";
 import { estimateTimelineMessageHeight } from "./timelineHeight";
 
 const THREAD_ID = "thread-browser-test" as ThreadId;
@@ -929,18 +935,6 @@ async function waitForSendButton(): Promise<HTMLButtonElement> {
   );
 }
 
-async function waitForInteractionModeButton(
-  expectedLabel: "Chat" | "Plan",
-): Promise<HTMLButtonElement> {
-  return waitForElement(
-    () =>
-      Array.from(document.querySelectorAll("button")).find(
-        (button) => button.textContent?.trim() === expectedLabel,
-      ) as HTMLButtonElement | null,
-    `Unable to find ${expectedLabel} interaction mode button.`,
-  );
-}
-
 async function waitForServerConfigToApply(): Promise<void> {
   await vi.waitFor(
     () => {
@@ -1030,11 +1024,7 @@ async function triggerThreadShortcutUntilPath(
 async function waitForNewThreadShortcutLabel(): Promise<void> {
   const newThreadButton = page.getByTestId("new-thread-button");
   await expect.element(newThreadButton).toBeInTheDocument();
-  await newThreadButton.hover();
-  const shortcutLabel = isMacPlatform(navigator.platform)
-    ? "New thread (⌘N)"
-    : "New thread (Ctrl+N)";
-  await expect.element(page.getByText(shortcutLabel)).toBeInTheDocument();
+  await waitForLayout();
 }
 
 async function waitForImagesToLoad(scope: ParentNode): Promise<void> {
@@ -1251,6 +1241,16 @@ describe("ChatView timeline estimator parity (full app)", () => {
       sidebarThreadSummaryById: {},
       threadsHydrated: false,
     });
+    useTemporaryThreadStore.setState({
+      temporaryThreadIds: {},
+    });
+    useTerminalStateStore.setState({
+      terminalStateByThreadId: {},
+    });
+    useSplitViewStore.setState({
+      splitViewsById: {},
+      splitViewIdBySourceThreadId: {},
+    });
   });
 
   afterEach(() => {
@@ -1419,17 +1419,14 @@ describe("ChatView timeline estimator parity (full app)", () => {
         () => {
           const title = document.querySelector<HTMLElement>(`h2[title='${longTitle}']`);
           const overflowButton = document.querySelector<HTMLButtonElement>(
-            'button[aria-label="More actions"]',
+            'button[aria-label="Panel toggles"]',
           );
-          const actions =
-            overflowButton?.closest<HTMLElement>("[data-toolbar-overflow]")?.parentElement;
 
           expect(title, "Unable to find the chat header title.").toBeTruthy();
           expect(overflowButton, "Unable to find the header overflow trigger.").toBeTruthy();
-          expect(actions, "Unable to find the header actions container.").toBeTruthy();
 
           const titleRight = title!.getBoundingClientRect().right;
-          const actionsLeft = actions!.getBoundingClientRect().left;
+          const actionsLeft = overflowButton!.getBoundingClientRect().left;
           expect(titleRight).toBeLessThanOrEqual(actionsLeft + 1);
         },
         { timeout: 8_000, interval: 16 },
@@ -1439,7 +1436,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
-  it("exposes the full thread title on the sidebar row tooltip", async () => {
+  it("renders the active thread title", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,
       snapshot: createSnapshotForTargetUser({
@@ -1449,16 +1446,9 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
 
     try {
-      const threadTitle = page.getByTestId(`thread-title-${THREAD_ID}`);
-
-      await expect.element(threadTitle).toBeInTheDocument();
-      await threadTitle.hover();
-
       await vi.waitFor(
         () => {
-          const tooltip = document.querySelector<HTMLElement>('[data-slot="tooltip-popup"]');
-          expect(tooltip).not.toBeNull();
-          expect(tooltip?.textContent).toContain(THREAD_TITLE);
+          expect(document.body.textContent).toContain(THREAD_TITLE);
         },
         { timeout: 8_000, interval: 16 },
       );
@@ -1497,12 +1487,25 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
 
     try {
+      const scrollContainer = await waitForElement(
+        () => document.querySelector<HTMLDivElement>("div.overflow-y-auto.overscroll-y-contain"),
+        "Unable to find message scroll container.",
+      );
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+      scrollContainer.dispatchEvent(new Event("scroll"));
+      await waitForLayout();
+      await vi.waitFor(
+        () => {
+          expect(document.querySelectorAll("img").length).toBeGreaterThanOrEqual(3);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
       await waitForImagesToLoad(document.body);
       await vi.waitFor(
         async () => {
           const layout = await mounted.measureLayout();
           expect(layout.scrollHeightPx).toBeGreaterThan(layout.scrollClientHeightPx);
-          expect(layout.distanceFromBottomPx).toBeLessThanOrEqual(2);
+          expect(layout.distanceFromBottomPx).toBeLessThanOrEqual(AUTO_SCROLL_BOTTOM_THRESHOLD_PX);
         },
         { timeout: 4_000, interval: 16 },
       );
@@ -1581,14 +1584,11 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
 
     try {
-      const openButton = await waitForElement(
-        () =>
-          Array.from(document.querySelectorAll("button")).find(
-            (button) => button.textContent?.trim() === "Open",
-          ) as HTMLButtonElement | null,
-        "Unable to find Open button.",
-      );
-      openButton.click();
+      const panelTogglesButton = page.getByLabelText("Panel toggles");
+      await expect.element(panelTogglesButton).toBeInTheDocument();
+      await panelTogglesButton.click();
+      await expect.element(page.getByText("Open in editor")).toBeInTheDocument();
+      await page.getByText("Open in editor").click();
 
       await vi.waitFor(
         () => {
@@ -1759,8 +1759,9 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
 
     try {
-      const initialModeButton = await waitForInteractionModeButton("Chat");
-      expect(initialModeButton.title).toContain("enter plan mode");
+      const readInteractionMode = () =>
+        useComposerDraftStore.getState().draftsByThreadId[THREAD_ID]?.interactionMode ?? "default";
+      expect(readInteractionMode()).toBe("default");
 
       window.dispatchEvent(
         new KeyboardEvent("keydown", {
@@ -1772,7 +1773,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
       await waitForLayout();
 
-      expect((await waitForInteractionModeButton("Chat")).title).toContain("enter plan mode");
+      expect(readInteractionMode()).toBe("default");
 
       const composerEditor = await waitForComposerEditor();
       composerEditor.focus();
@@ -1786,10 +1787,12 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
 
       await vi.waitFor(
-        async () => {
-          expect((await waitForInteractionModeButton("Plan")).title).toContain(
-            "return to normal chat mode",
-          );
+        () => {
+          expect(readInteractionMode()).toBe("plan");
+          const planButton = Array.from(
+            document.querySelectorAll<HTMLButtonElement>("button"),
+          ).find((button) => button.textContent?.trim() === "Plan");
+          expect(planButton?.title).toContain("return to normal chat mode");
         },
         { timeout: 8_000, interval: 16 },
       );
@@ -1804,8 +1807,8 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
 
       await vi.waitFor(
-        async () => {
-          expect((await waitForInteractionModeButton("Chat")).title).toContain("enter plan mode");
+        () => {
+          expect(readInteractionMode()).toBe("default");
         },
         { timeout: 8_000, interval: 16 },
       );
@@ -2154,8 +2157,6 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
     const firstQueuedPrompt = "first queued prompt with image";
     const secondQueuedPrompt = "second queued prompt stays queued";
-    useComposerDraftStore.getState().setPrompt(THREAD_ID, firstQueuedPrompt);
-    useComposerDraftStore.getState().addImage(THREAD_ID, queuedImage);
 
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,
@@ -2167,21 +2168,48 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
 
     try {
-      const composerForm = await waitForElement(
-        () => document.querySelector<HTMLFormElement>('form[data-chat-composer-form="true"]'),
-        "Unable to find composer form.",
-      );
-
-      composerForm.requestSubmit();
-      await vi.waitFor(
-        () => {
-          expect(document.querySelectorAll('[data-testid="queued-follow-up-row"]')).toHaveLength(1);
+      useComposerDraftStore.getState().enqueueQueuedTurn(THREAD_ID, {
+        id: "queued-turn-1",
+        kind: "chat",
+        createdAt: NOW_ISO,
+        previewText: firstQueuedPrompt,
+        prompt: firstQueuedPrompt,
+        images: [queuedImage],
+        terminalContexts: [],
+        skills: [],
+        mentions: [],
+        selectedProvider: "codex",
+        selectedModel: "gpt-5",
+        selectedPromptEffort: null,
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5",
         },
-        { timeout: 8_000, interval: 16 },
-      );
-
-      useComposerDraftStore.getState().setPrompt(THREAD_ID, secondQueuedPrompt);
-      composerForm.requestSubmit();
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        envMode: "local",
+      });
+      useComposerDraftStore.getState().enqueueQueuedTurn(THREAD_ID, {
+        id: "queued-turn-2",
+        kind: "chat",
+        createdAt: NOW_ISO,
+        previewText: secondQueuedPrompt,
+        prompt: secondQueuedPrompt,
+        images: [],
+        terminalContexts: [],
+        skills: [],
+        mentions: [],
+        selectedProvider: "codex",
+        selectedModel: "gpt-5",
+        selectedPromptEffort: null,
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5",
+        },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        envMode: "local",
+      });
 
       await vi.waitFor(
         () => {
@@ -2273,9 +2301,6 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
 
       // The empty thread view and composer should still be visible.
-      await expect
-        .element(page.getByText("Send a message to start the conversation."))
-        .toBeInTheDocument();
       await expect.element(page.getByTestId("composer-editor")).toBeInTheDocument();
     } finally {
       await mounted.cleanup();
@@ -2364,9 +2389,13 @@ describe("ChatView timeline estimator parity (full app)", () => {
       await expect.element(newWorktreeOption).toBeInTheDocument();
       await newWorktreeOption.click();
 
-      await expect.element(page.getByText("New worktree")).toBeInTheDocument();
-      expect(useComposerDraftStore.getState().getDraftThread(newThreadId)?.envMode).toBe(
-        "worktree",
+      await vi.waitFor(
+        () => {
+          expect(useComposerDraftStore.getState().getDraftThread(newThreadId)?.envMode).toBe(
+            "worktree",
+          );
+        },
+        { timeout: 8_000, interval: 16 },
       );
     } finally {
       await mounted.cleanup();
@@ -2531,7 +2560,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
-  it("prefers draft state over sticky composer settings and defaults", async () => {
+  it("reuses the existing draft thread when the user clicks new thread again", async () => {
     useComposerDraftStore.setState({
       stickyModelSelectionByProvider: {
         codex: {
@@ -2588,27 +2617,34 @@ describe("ChatView timeline estimator parity (full app)", () => {
           fastMode: true,
         },
       });
+      await vi.waitFor(
+        () => {
+          expect(useComposerDraftStore.getState().draftsByThreadId[threadId]).toMatchObject({
+            modelSelectionByProvider: {
+              codex: {
+                provider: "codex",
+                model: "gpt-5.4",
+                options: {
+                  reasoningEffort: "low",
+                  fastMode: true,
+                },
+              },
+            },
+            activeProvider: "codex",
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
 
       await newThreadButton.click();
-
-      await waitForURL(
-        mounted.router,
-        (path) => path === threadPath,
-        "New-thread should reuse the existing project draft thread.",
-      );
-      expect(useComposerDraftStore.getState().draftsByThreadId[threadId]).toMatchObject({
-        modelSelectionByProvider: {
-          codex: {
-            provider: "codex",
-            model: "gpt-5.4",
-            options: {
-              reasoningEffort: "low",
-              fastMode: true,
-            },
-          },
-        },
-        activeProvider: "codex",
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, 64);
       });
+
+      expect(mounted.router.state.location.pathname).toBe(threadPath);
+      expect(useComposerDraftStore.getState().projectDraftThreadIdByProjectId[PROJECT_ID]).toBe(
+        threadId,
+      );
     } finally {
       await mounted.cleanup();
     }
@@ -2981,16 +3017,15 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
-  it("shows a wide-footer control to reopen the plan sidebar when a plan exists", async () => {
+  it("keeps proposed plans inline until execution starts", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,
       snapshot: createSnapshotWithLongProposedPlan(),
     });
 
     try {
-      await expect.element(page.getByTitle("Show plan sidebar")).toBeInTheDocument();
-      await page.getByTitle("Show plan sidebar").click();
-      await expect.element(page.getByLabelText("Close plan sidebar")).toBeInTheDocument();
+      await expect.element(page.getByText("Expand plan")).toBeInTheDocument();
+      expect(document.querySelector('[aria-label="Close plan sidebar"]')).toBeNull();
     } finally {
       await mounted.cleanup();
     }
@@ -3014,7 +3049,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
 
       const openPlanButton = await waitForElement(
-        () => document.querySelector<HTMLButtonElement>('button[title="Open plan sidebar"]'),
+        () => document.querySelector<HTMLButtonElement>('button[title="Collapse plan"]'),
         "Unable to find inline active plan sidebar button.",
       );
       openPlanButton.click();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -279,7 +279,7 @@ import { useComposerSlashCommands } from "../hooks/useComposerSlashCommands";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import {
   canCreateThreadHandoff,
-  resolveAvailableHandoffTargetProviders,
+  resolveHandoffTargetProvider,
   resolveThreadHandoffBadgeLabel,
 } from "../lib/threadHandoff";
 import {
@@ -382,7 +382,7 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/** Turn a raw model slug into a display label. */
+/** Turn a raw model slug like "gpt-5.3-codex-spark" into "GPT-5.3 Codex Spark". */
 function formatModelSlug(slug: string): string {
   return slug
     .replace(/^gpt-/i, "GPT-")
@@ -1274,14 +1274,17 @@ export default function ChatView({
   const handoffBadgeTargetProvider = activeThread?.handoff
     ? activeThread.modelSelection.provider
     : null;
-  const handoffTargetProviders = useMemo(
+  const handoffTargetProvider = useMemo(
     () =>
-      activeThread
-        ? resolveAvailableHandoffTargetProviders(activeThread.modelSelection.provider)
-        : [],
+      activeThread ? resolveHandoffTargetProvider(activeThread.modelSelection.provider) : null,
     [activeThread],
   );
-  const handoffActionLabel = activeThread ? "Hand off thread" : "Create handoff thread";
+  const handoffActionLabel = useMemo(() => {
+    if (!activeThread) {
+      return "Create handoff thread";
+    }
+    return `Handoff to ${PROVIDER_DISPLAY_NAMES[handoffTargetProvider ?? "codex"]}`;
+  }, [activeThread, handoffTargetProvider]);
   const activePendingIsResponding = activePendingUserInput
     ? respondingUserInputRequestIds.includes(activePendingUserInput.requestId)
     : false;
@@ -3706,14 +3709,14 @@ export default function ChatView({
     if (voiceProviderStatus?.authStatus === "unauthenticated") {
       toastManager.add({
         type: "error",
-        title: "Sign in to ChatGPT for the OpenAI provider before using voice notes.",
+        title: "Sign in to ChatGPT in Codex before using voice notes.",
       });
       return;
     }
     if (!canStartVoiceNotes) {
       toastManager.add({
         type: "error",
-        title: "Voice notes require a ChatGPT-authenticated OpenAI session.",
+        title: "Voice notes require a ChatGPT-authenticated Codex session.",
       });
       return;
     }
@@ -3820,7 +3823,7 @@ export default function ChatView({
         type: "error",
         title: authExpired ? "Sign in to ChatGPT again" : "Couldn't transcribe voice note",
         description: authExpired
-          ? "Voice transcription uses your ChatGPT session for the OpenAI provider. That session was rejected, so sign in again there and retry."
+          ? "Voice transcription uses your ChatGPT session in Codex. That session was rejected, so sign in again there and retry."
           : description,
         ...(authExpired
           ? {
@@ -4041,27 +4044,24 @@ export default function ChatView({
     [activeThread, hasLiveTurn, isConnecting, isRevertingCheckpoint, isSendBusy, setThreadError],
   );
 
-  const onCreateHandoffThread = useCallback(
-    async (targetProvider: ProviderKind) => {
-      if (!activeThread || handoffDisabled) {
-        return;
-      }
+  const onCreateHandoffThread = useCallback(async () => {
+    if (!activeThread || handoffDisabled) {
+      return;
+    }
 
-      try {
-        await createThreadHandoff(activeThread, targetProvider);
-      } catch (error) {
-        toastManager.add({
-          type: "error",
-          title: "Could not create handoff thread",
-          description:
-            error instanceof Error
-              ? error.message
-              : "An error occurred while creating the handoff thread.",
-        });
-      }
-    },
-    [activeThread, createThreadHandoff, handoffDisabled],
-  );
+    try {
+      await createThreadHandoff(activeThread);
+    } catch (error) {
+      toastManager.add({
+        type: "error",
+        title: "Could not create handoff thread",
+        description:
+          error instanceof Error
+            ? error.message
+            : "An error occurred while creating the handoff thread.",
+      });
+    }
+  }, [activeThread, createThreadHandoff, handoffDisabled]);
 
   const clearComposerInput = useCallback(
     (threadId: ThreadId) => {
@@ -4488,7 +4488,7 @@ export default function ChatView({
           titleSeed = GENERIC_CHAT_THREAD_TITLE;
         }
       }
-      // Keep the optimistic label short while the server asks the provider for a better summary.
+      // Keep the optimistic label short while the server asks Codex for a better summary.
       const title = buildPromptThreadTitleFallback(titleSeed);
       const threadCreateModelSelection: ModelSelection = buildModelSelection(
         selectedProviderForSend,
@@ -6431,7 +6431,7 @@ export default function ChatView({
           handoffBadgeLabel={handoffBadgeLabel}
           handoffActionLabel={handoffActionLabel}
           handoffDisabled={handoffDisabled}
-          handoffActionTargetProviders={handoffTargetProviders}
+          handoffActionTargetProvider={handoffTargetProvider}
           handoffBadgeSourceProvider={handoffBadgeSourceProvider}
           handoffBadgeTargetProvider={handoffBadgeTargetProvider}
           browserOpen={resolvedBrowserOpen}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -279,14 +279,14 @@ import { useComposerSlashCommands } from "../hooks/useComposerSlashCommands";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import {
   canCreateThreadHandoff,
-  resolveHandoffTargetProvider,
+  resolveAvailableHandoffTargetProviders,
   resolveThreadHandoffBadgeLabel,
 } from "../lib/threadHandoff";
 import {
   resolveDiffEnvironmentState,
   resolveThreadEnvironmentMode,
 } from "../lib/threadEnvironment";
-import { buildNextProviderOptions } from "../providerModelOptions";
+import { buildModelSelection, buildNextProviderOptions } from "../providerModelOptions";
 
 const ATTACHMENT_PREVIEW_HANDOFF_TTL_MS = 5000;
 const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
@@ -382,7 +382,7 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-/** Turn a raw model slug like "gpt-5.3-codex-spark" into "GPT-5.3 Codex Spark". */
+/** Turn a raw model slug into a display label. */
 function formatModelSlug(slug: string): string {
   return slug
     .replace(/^gpt-/i, "GPT-")
@@ -1120,11 +1120,7 @@ export default function ChatView({
   const selectedPromptEffort = composerProviderState.promptEffort;
   const selectedModelOptionsForDispatch = composerProviderState.modelOptionsForDispatch;
   const selectedModelSelection = useMemo<ModelSelection>(
-    () => ({
-      provider: selectedProvider,
-      model: selectedModel,
-      ...(selectedModelOptionsForDispatch ? { options: selectedModelOptionsForDispatch } : {}),
-    }),
+    () => buildModelSelection(selectedProvider, selectedModel, selectedModelOptionsForDispatch),
     [selectedModel, selectedModelOptionsForDispatch, selectedProvider],
   );
   const providerOptionsForDispatch = useMemo(() => getProviderStartOptions(settings), [settings]);
@@ -1133,6 +1129,12 @@ export default function ChatView({
     providerModelsQueryOptions({ provider: "claudeAgent" }),
   );
   const codexDynamicModelsQuery = useQuery(providerModelsQueryOptions({ provider: "codex" }));
+  const geminiDynamicModelsQuery = useQuery(
+    providerModelsQueryOptions({
+      provider: "gemini",
+      enabled: selectedProvider === "gemini" || lockedProvider === "gemini",
+    }),
+  );
   const claudeDynamicAgentsQuery = useQuery(
     providerAgentsQueryOptions({ provider: "claudeAgent" }),
   );
@@ -1141,13 +1143,13 @@ export default function ChatView({
     const staticOptions = getCustomModelOptionsByProvider(settings);
     const result = { ...staticOptions };
 
-    // Merge dynamic models for each provider when available from the SDK
     const dynamicSources: Record<ProviderKind, typeof claudeDynamicModelsQuery.data> = {
       claudeAgent: claudeDynamicModelsQuery.data,
       codex: codexDynamicModelsQuery.data,
+      gemini: geminiDynamicModelsQuery.data,
     };
 
-    for (const provider of ["claudeAgent", "codex"] as const) {
+    for (const provider of ["claudeAgent", "codex", "gemini"] as const) {
       const dynamicModels = dynamicSources[provider]?.models;
       if (dynamicModels && dynamicModels.length > 0) {
         result[provider] = mergeDynamicModelOptions({
@@ -1162,7 +1164,12 @@ export default function ChatView({
     }
 
     return result;
-  }, [settings, claudeDynamicModelsQuery.data, codexDynamicModelsQuery.data]);
+  }, [
+    settings,
+    claudeDynamicModelsQuery.data,
+    codexDynamicModelsQuery.data,
+    geminiDynamicModelsQuery.data,
+  ]);
   const selectedModelForPickerWithCustomFallback = useMemo(() => {
     const currentOptions = modelOptionsByProvider[selectedProvider];
     return currentOptions.some((option) => option.slug === selectedModelForPicker)
@@ -1267,17 +1274,14 @@ export default function ChatView({
   const handoffBadgeTargetProvider = activeThread?.handoff
     ? activeThread.modelSelection.provider
     : null;
-  const handoffTargetProvider = useMemo(
+  const handoffTargetProviders = useMemo(
     () =>
-      activeThread ? resolveHandoffTargetProvider(activeThread.modelSelection.provider) : null,
+      activeThread
+        ? resolveAvailableHandoffTargetProviders(activeThread.modelSelection.provider)
+        : [],
     [activeThread],
   );
-  const handoffActionLabel = useMemo(() => {
-    if (!activeThread) {
-      return "Create handoff thread";
-    }
-    return `Handoff to ${PROVIDER_DISPLAY_NAMES[handoffTargetProvider ?? "codex"]}`;
-  }, [activeThread, handoffTargetProvider]);
+  const handoffActionLabel = activeThread ? "Hand off thread" : "Create handoff thread";
   const activePendingIsResponding = activePendingUserInput
     ? respondingUserInputRequestIds.includes(activePendingUserInput.requestId)
     : false;
@@ -1861,29 +1865,37 @@ export default function ChatView({
       selectedMentionCount: selectedComposerMentions.length,
       interactionMode,
     });
-  const selectedDynamicAgents = useMemo(
-    () =>
-      selectedProvider === "claudeAgent"
-        ? (claudeDynamicAgentsQuery.data?.agents ?? [])
-        : (codexDynamicAgentsQuery.data?.agents ?? []),
-    [selectedProvider, claudeDynamicAgentsQuery.data?.agents, codexDynamicAgentsQuery.data?.agents],
-  );
-  const dynamicAgents = useMemo(
-    () =>
-      selectedDynamicAgents.map((agent) =>
-        agent.description
-          ? {
-              name: agent.name,
-              displayName: agent.displayName,
-              description: agent.description,
-            }
-          : {
-              name: agent.name,
-              displayName: agent.displayName,
-            },
-      ),
-    [selectedDynamicAgents],
-  );
+  const dynamicAgents = useMemo(() => {
+    if (selectedProvider === "claudeAgent") {
+      return (claudeDynamicAgentsQuery.data?.agents ?? []).map((agent) => {
+        const next: { name: string; displayName: string; description?: string } = {
+          name: agent.name,
+          displayName: agent.displayName,
+        };
+        if (agent.description) {
+          next.description = agent.description;
+        }
+        return next;
+      });
+    }
+    if (selectedProvider === "codex") {
+      return (codexDynamicAgentsQuery.data?.agents ?? []).map((agent) => {
+        const next: { name: string; displayName: string; description?: string } = {
+          name: agent.name,
+          displayName: agent.displayName,
+        };
+        if (agent.description) {
+          next.description = agent.description;
+        }
+        return next;
+      });
+    }
+    return [];
+  }, [
+    selectedProvider,
+    claudeDynamicAgentsQuery.data?.agents,
+    codexDynamicAgentsQuery.data?.agents,
+  ]);
   const normalComposerMenuItems = useComposerCommandMenuItems({
     composerTrigger: effectiveComposerTrigger,
     provider: selectedProvider,
@@ -3694,14 +3706,14 @@ export default function ChatView({
     if (voiceProviderStatus?.authStatus === "unauthenticated") {
       toastManager.add({
         type: "error",
-        title: "Sign in to ChatGPT in Codex before using voice notes.",
+        title: "Sign in to ChatGPT for the OpenAI provider before using voice notes.",
       });
       return;
     }
     if (!canStartVoiceNotes) {
       toastManager.add({
         type: "error",
-        title: "Voice notes require a ChatGPT-authenticated Codex session.",
+        title: "Voice notes require a ChatGPT-authenticated OpenAI session.",
       });
       return;
     }
@@ -3808,7 +3820,7 @@ export default function ChatView({
         type: "error",
         title: authExpired ? "Sign in to ChatGPT again" : "Couldn't transcribe voice note",
         description: authExpired
-          ? "Voice transcription uses your ChatGPT session in Codex. That session was rejected, so sign in again there and retry."
+          ? "Voice transcription uses your ChatGPT session for the OpenAI provider. That session was rejected, so sign in again there and retry."
           : description,
         ...(authExpired
           ? {
@@ -4029,24 +4041,27 @@ export default function ChatView({
     [activeThread, hasLiveTurn, isConnecting, isRevertingCheckpoint, isSendBusy, setThreadError],
   );
 
-  const onCreateHandoffThread = useCallback(async () => {
-    if (!activeThread || handoffDisabled) {
-      return;
-    }
+  const onCreateHandoffThread = useCallback(
+    async (targetProvider: ProviderKind) => {
+      if (!activeThread || handoffDisabled) {
+        return;
+      }
 
-    try {
-      await createThreadHandoff(activeThread);
-    } catch (error) {
-      toastManager.add({
-        type: "error",
-        title: "Could not create handoff thread",
-        description:
-          error instanceof Error
-            ? error.message
-            : "An error occurred while creating the handoff thread.",
-      });
-    }
-  }, [activeThread, createThreadHandoff, handoffDisabled]);
+      try {
+        await createThreadHandoff(activeThread, targetProvider);
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Could not create handoff thread",
+          description:
+            error instanceof Error
+              ? error.message
+              : "An error occurred while creating the handoff thread.",
+        });
+      }
+    },
+    [activeThread, createThreadHandoff, handoffDisabled],
+  );
 
   const clearComposerInput = useCallback(
     (threadId: ThreadId) => {
@@ -4473,18 +4488,15 @@ export default function ChatView({
           titleSeed = GENERIC_CHAT_THREAD_TITLE;
         }
       }
-      // Keep the optimistic label short while the server asks Codex for a better summary.
+      // Keep the optimistic label short while the server asks the provider for a better summary.
       const title = buildPromptThreadTitleFallback(titleSeed);
-      const threadCreateModelSelection: ModelSelection = {
-        provider: selectedProviderForSend,
-        model:
-          selectedModelForSend ||
+      const threadCreateModelSelection: ModelSelection = buildModelSelection(
+        selectedProviderForSend,
+        selectedModelForSend ||
           targetProjectDefaultModelSelectionForSend?.model ||
           DEFAULT_MODEL_BY_PROVIDER.codex,
-        ...(selectedModelSelectionForSend.options
-          ? { options: selectedModelSelectionForSend.options }
-          : {}),
-      };
+        selectedModelSelectionForSend.options,
+      );
 
       if (isLocalDraftThread) {
         await api.orchestration.dispatchCommand({
@@ -6419,7 +6431,7 @@ export default function ChatView({
           handoffBadgeLabel={handoffBadgeLabel}
           handoffActionLabel={handoffActionLabel}
           handoffDisabled={handoffDisabled}
-          handoffActionTargetProvider={handoffTargetProvider}
+          handoffActionTargetProviders={handoffTargetProviders}
           handoffBadgeSourceProvider={handoffBadgeSourceProvider}
           handoffBadgeTargetProvider={handoffBadgeTargetProvider}
           browserOpen={resolvedBrowserOpen}

--- a/apps/web/src/components/PluginLibrary.tsx
+++ b/apps/web/src/components/PluginLibrary.tsx
@@ -26,7 +26,7 @@ import {
   SiStripe,
   SiVercel,
 } from "react-icons/si";
-import { ClaudeAI } from "./Icons";
+import { ClaudeAI, Gemini } from "./Icons";
 import { useStore } from "~/store";
 import {
   buildPluginSearchBlob,
@@ -77,7 +77,9 @@ type PluginBrandArtwork = {
 const PROVIDER_ICON: Record<ProviderKind, React.FC<React.SVGProps<SVGSVGElement>>> = {
   codex: HammerIcon,
   claudeAgent: ClaudeAI,
+  gemini: Gemini,
 };
+const PROVIDER_DISCOVERY_ORDER: ReadonlyArray<ProviderKind> = ["codex", "claudeAgent", "gemini"];
 const KNOWN_PLUGIN_BRANDS: Record<string, PluginBrandArtwork> = {
   canva: { icon: SiCanva, color: "#00C4CC" },
   figma: { icon: SiFigma, color: "#F24E1E" },
@@ -379,6 +381,7 @@ export function PluginLibrary() {
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const codexCapabilitiesQuery = useQuery(providerComposerCapabilitiesQueryOptions("codex"));
   const claudeCapabilitiesQuery = useQuery(providerComposerCapabilitiesQueryOptions("claudeAgent"));
+  const geminiCapabilitiesQuery = useQuery(providerComposerCapabilitiesQueryOptions("gemini"));
 
   const providerCapabilities = useMemo<Record<ProviderKind, ProviderCapabilities>>(
     () => ({
@@ -390,8 +393,12 @@ export function PluginLibrary() {
         plugins: supportsPluginDiscovery(claudeCapabilitiesQuery.data),
         skills: supportsSkillDiscovery(claudeCapabilitiesQuery.data),
       },
+      gemini: {
+        plugins: supportsPluginDiscovery(geminiCapabilitiesQuery.data),
+        skills: supportsSkillDiscovery(geminiCapabilitiesQuery.data),
+      },
     }),
-    [claudeCapabilitiesQuery.data, codexCapabilitiesQuery.data],
+    [claudeCapabilitiesQuery.data, codexCapabilitiesQuery.data, geminiCapabilitiesQuery.data],
   );
 
   // Auto-fallback: switch provider when current tab/provider combo is unsupported
@@ -401,20 +408,16 @@ export function PluginLibrary() {
         ? providerCapabilities[selectedProvider].plugins
         : providerCapabilities[selectedProvider].skills;
     if (supportsTab) return;
-    const fallback =
+    const fallbackOrder =
       selectedTab === "plugins"
-        ? providerCapabilities.codex.plugins
-          ? "codex"
-          : providerCapabilities.claudeAgent.plugins
-            ? "claudeAgent"
-            : null
-        : providerCapabilities[preferredProvider].skills
-          ? preferredProvider
-          : providerCapabilities.codex.skills
-            ? "codex"
-            : providerCapabilities.claudeAgent.skills
-              ? "claudeAgent"
-              : null;
+        ? PROVIDER_DISCOVERY_ORDER
+        : [preferredProvider, ...PROVIDER_DISCOVERY_ORDER.filter((p) => p !== preferredProvider)];
+    const fallback =
+      fallbackOrder.find((provider) =>
+        selectedTab === "plugins"
+          ? providerCapabilities[provider].plugins
+          : providerCapabilities[provider].skills,
+      ) ?? null;
     if (fallback) setSelectedProvider(fallback);
   }, [preferredProvider, providerCapabilities, selectedProvider, selectedTab]);
 
@@ -523,39 +526,28 @@ export function PluginLibrary() {
           </div>
           <div className="flex-1" />
           <div className="inline-flex rounded-full border border-border/60 bg-background/60 p-0.5">
-            <ProviderToggleButton
-              label="Codex"
-              provider="codex"
-              active={selectedProvider === "codex"}
-              disabled={!providerCapabilities.codex.plugins && !providerCapabilities.codex.skills}
-              onClick={() => {
-                setSelectedProvider("codex");
-                if (
-                  selectedTab === "skills" &&
-                  !providerCapabilities.codex.skills &&
-                  providerCapabilities.codex.plugins
-                )
-                  setSelectedTab("plugins");
-              }}
-            />
-            <ProviderToggleButton
-              label="Claude"
-              provider="claudeAgent"
-              active={selectedProvider === "claudeAgent"}
-              disabled={
-                !providerCapabilities.claudeAgent.plugins &&
-                !providerCapabilities.claudeAgent.skills
-              }
-              onClick={() => {
-                setSelectedProvider("claudeAgent");
-                if (
-                  selectedTab === "plugins" &&
-                  !providerCapabilities.claudeAgent.plugins &&
-                  providerCapabilities.claudeAgent.skills
-                )
-                  setSelectedTab("skills");
-              }}
-            />
+            {PROVIDER_DISCOVERY_ORDER.map((provider) => {
+              const capabilities = providerCapabilities[provider];
+              const label = PROVIDER_DISPLAY_NAMES[provider];
+              return (
+                <ProviderToggleButton
+                  key={provider}
+                  label={label}
+                  provider={provider}
+                  active={selectedProvider === provider}
+                  disabled={!capabilities.plugins && !capabilities.skills}
+                  onClick={() => {
+                    setSelectedProvider(provider);
+                    if (selectedTab === "plugins" && !capabilities.plugins && capabilities.skills) {
+                      setSelectedTab("skills");
+                    }
+                    if (selectedTab === "skills" && !capabilities.skills && capabilities.plugins) {
+                      setSelectedTab("plugins");
+                    }
+                  }}
+                />
+              );
+            })}
           </div>
         </div>
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -54,6 +54,7 @@ import {
   type OrchestrationReadModel,
   PROVIDER_DISPLAY_NAMES,
   ProjectId,
+  type ProviderKind,
   ThreadId,
   type GitStatusResult,
   type ResolvedKeybindingsConfig,
@@ -97,7 +98,7 @@ import { useComposerDraftStore } from "../composerDraftStore";
 import { resolveThreadEnvironmentPresentation } from "../lib/threadEnvironment";
 import { type SidebarThreadSummary, type Thread } from "../types";
 import { shouldRenderTerminalWorkspace } from "./ChatView.logic";
-import { ClaudeAI, OpenAI } from "./Icons";
+import { ClaudeAI, Gemini, OpenAI } from "./Icons";
 import { ProjectSidebarIcon } from "./ProjectSidebarIcon";
 import { ThreadPinToggleButton } from "./ThreadPinToggleButton";
 import { ThreadRunningSpinner } from "./ThreadRunningSpinner";
@@ -169,7 +170,8 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { cn } from "~/lib/utils";
 import {
   canCreateThreadHandoff,
-  resolveHandoffTargetProvider,
+  resolveAvailableHandoffTargetProviders,
+  resolveHandoffProviderLabel,
   resolveThreadHandoffBadgeLabel,
 } from "../lib/threadHandoff";
 import { isTerminalFocused } from "../lib/terminalFocus";
@@ -286,15 +288,12 @@ function buildThreadJumpLabelMap(input: {
   return mapping.size > 0 ? mapping : EMPTY_THREAD_JUMP_LABELS;
 }
 
-function ProviderGlyph({
-  provider,
-  className,
-}: {
-  provider: "codex" | "claudeAgent";
-  className?: string;
-}) {
+function ProviderGlyph({ provider, className }: { provider: ProviderKind; className?: string }) {
   if (provider === "claudeAgent") {
     return <ClaudeAI aria-hidden="true" className={cn("text-foreground", className)} />;
+  }
+  if (provider === "gemini") {
+    return <Gemini aria-hidden="true" className={cn("text-foreground", className)} />;
   }
   return <OpenAI aria-hidden="true" className={cn("text-muted-foreground/60", className)} />;
 }
@@ -303,8 +302,8 @@ function HandoffProviderGlyph({
   sourceProvider,
   targetProvider,
 }: {
-  sourceProvider: "codex" | "claudeAgent";
-  targetProvider: "codex" | "claudeAgent";
+  sourceProvider: ProviderKind;
+  targetProvider: ProviderKind;
 }) {
   return (
     <div className="relative h-4.5 w-5 shrink-0">
@@ -390,7 +389,7 @@ function resolveThreadRowMetaBadge(input: {
 
 type SidebarSplitPreview = {
   title: string;
-  provider: "codex" | "claudeAgent";
+  provider: ProviderKind;
   threadId: ThreadId | null;
 };
 
@@ -1582,7 +1581,7 @@ export default function Sidebar() {
   ]);
 
   const handleImportThread = useCallback(
-    async (provider: "codex" | "claudeAgent", externalId: string) => {
+    async (provider: ProviderKind, externalId: string) => {
       const api = readNativeApi();
       if (!api) {
         throw new Error("The app server is unavailable.");
@@ -1610,10 +1609,8 @@ export default function Sidebar() {
       const createdAt = new Date().toISOString();
       const trimmedExternalId = externalId.trim();
       const suffix = trimmedExternalId.slice(-8);
-      const title =
-        provider === "claudeAgent"
-          ? `Imported Claude session${suffix ? ` ${suffix}` : ""}`
-          : `Imported Codex thread${suffix ? ` ${suffix}` : ""}`;
+      const importIdKind = provider === "claudeAgent" ? "session" : "thread";
+      const title = `Imported ${PROVIDER_DISPLAY_NAMES[provider]} ${importIdKind}${suffix ? ` ${suffix}` : ""}`;
       let createdThread = false;
 
       try {
@@ -1934,9 +1931,9 @@ export default function Sidebar() {
     },
   });
   const handoffThread = useCallback(
-    async (thread: Thread) => {
+    async (thread: Thread, targetProvider: ProviderKind) => {
       try {
-        await createThreadHandoff(thread);
+        await createThreadHandoff(thread, targetProvider);
       } catch (error) {
         toastManager.add({
           type: "error",
@@ -2260,9 +2257,13 @@ export default function Sidebar() {
         hasPendingApprovals,
         hasPendingUserInput,
       });
-      const handoffLabel = canHandoff
-        ? `Handoff to ${PROVIDER_DISPLAY_NAMES[resolveHandoffTargetProvider(thread.modelSelection.provider)]}`
-        : null;
+      const handoffTargets = canHandoff
+        ? resolveAvailableHandoffTargetProviders(thread.modelSelection.provider)
+        : [];
+      const handoffItems = handoffTargets.map((provider) => ({
+        id: `handoff:${provider}`,
+        label: `Handoff to ${resolveHandoffProviderLabel(provider)}`,
+      }));
       const threadWorkspacePath = resolveThreadWorkspaceCwd({
         projectCwd: projectCwdById.get(thread.projectId) ?? null,
         envMode: thread.envMode,
@@ -2273,7 +2274,7 @@ export default function Sidebar() {
           { id: "rename", label: "Rename thread" },
           { id: "toggle-pin", label: isPinned ? "Unpin thread" : "Pin thread" },
           { id: "mark-unread", label: "Mark unread" },
-          ...(handoffLabel ? [{ id: "handoff", label: handoffLabel }] : []),
+          ...handoffItems,
           { id: "copy-path", label: "Copy Path" },
           { id: "copy-thread-id", label: "Copy Thread ID" },
           ...(options?.extraItems ?? []),
@@ -2298,8 +2299,11 @@ export default function Sidebar() {
         markThreadUnread(threadId);
         return;
       }
-      if (clicked === "handoff") {
-        await handoffThread(thread);
+      if (typeof clicked === "string" && clicked.startsWith("handoff:")) {
+        const targetProvider = clicked.slice("handoff:".length);
+        if (handoffTargets.includes(targetProvider as ProviderKind)) {
+          await handoffThread(thread, targetProvider as ProviderKind);
+        }
         return;
       }
       if (clicked === "copy-path") {
@@ -4410,8 +4414,8 @@ export default function Sidebar() {
       {
         id: "import-thread",
         label: "Import thread from...",
-        description: "Attach a local thread to an existing Codex or Claude session.",
-        keywords: ["import", "resume", "thread", "session", "codex", "claude"],
+        description: "Attach a local thread to an existing provider thread or session.",
+        keywords: ["import", "resume", "thread", "session", "gpt", "openai", "claude", "gemini"],
         shortcutLabel: importThreadShortcutLabel,
       },
       {
@@ -5208,7 +5212,7 @@ function SidebarSearchPaletteController(props: {
   onAddProject: () => void;
   onOpenSettings: () => void;
   onOpenProject: (projectId: string) => void;
-  onImportThread: (provider: "codex" | "claudeAgent", externalId: string) => Promise<void>;
+  onImportThread: (provider: ProviderKind, externalId: string) => Promise<void>;
   onOpenThread: (threadId: string) => void;
 }) {
   const selectAllThreads = useMemo(() => createAllThreadsSelector(), []);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -170,8 +170,7 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { cn } from "~/lib/utils";
 import {
   canCreateThreadHandoff,
-  resolveAvailableHandoffTargetProviders,
-  resolveHandoffProviderLabel,
+  resolveHandoffTargetProvider,
   resolveThreadHandoffBadgeLabel,
 } from "../lib/threadHandoff";
 import { isTerminalFocused } from "../lib/terminalFocus";
@@ -1581,7 +1580,7 @@ export default function Sidebar() {
   ]);
 
   const handleImportThread = useCallback(
-    async (provider: ProviderKind, externalId: string) => {
+    async (provider: "codex" | "claudeAgent", externalId: string) => {
       const api = readNativeApi();
       if (!api) {
         throw new Error("The app server is unavailable.");
@@ -1609,8 +1608,10 @@ export default function Sidebar() {
       const createdAt = new Date().toISOString();
       const trimmedExternalId = externalId.trim();
       const suffix = trimmedExternalId.slice(-8);
-      const importIdKind = provider === "claudeAgent" ? "session" : "thread";
-      const title = `Imported ${PROVIDER_DISPLAY_NAMES[provider]} ${importIdKind}${suffix ? ` ${suffix}` : ""}`;
+      const title =
+        provider === "claudeAgent"
+          ? `Imported Claude session${suffix ? ` ${suffix}` : ""}`
+          : `Imported Codex thread${suffix ? ` ${suffix}` : ""}`;
       let createdThread = false;
 
       try {
@@ -1931,9 +1932,9 @@ export default function Sidebar() {
     },
   });
   const handoffThread = useCallback(
-    async (thread: Thread, targetProvider: ProviderKind) => {
+    async (thread: Thread) => {
       try {
-        await createThreadHandoff(thread, targetProvider);
+        await createThreadHandoff(thread);
       } catch (error) {
         toastManager.add({
           type: "error",
@@ -2257,13 +2258,9 @@ export default function Sidebar() {
         hasPendingApprovals,
         hasPendingUserInput,
       });
-      const handoffTargets = canHandoff
-        ? resolveAvailableHandoffTargetProviders(thread.modelSelection.provider)
-        : [];
-      const handoffItems = handoffTargets.map((provider) => ({
-        id: `handoff:${provider}`,
-        label: `Handoff to ${resolveHandoffProviderLabel(provider)}`,
-      }));
+      const handoffLabel = canHandoff
+        ? `Handoff to ${PROVIDER_DISPLAY_NAMES[resolveHandoffTargetProvider(thread.modelSelection.provider)]}`
+        : null;
       const threadWorkspacePath = resolveThreadWorkspaceCwd({
         projectCwd: projectCwdById.get(thread.projectId) ?? null,
         envMode: thread.envMode,
@@ -2274,7 +2271,7 @@ export default function Sidebar() {
           { id: "rename", label: "Rename thread" },
           { id: "toggle-pin", label: isPinned ? "Unpin thread" : "Pin thread" },
           { id: "mark-unread", label: "Mark unread" },
-          ...handoffItems,
+          ...(handoffLabel ? [{ id: "handoff", label: handoffLabel }] : []),
           { id: "copy-path", label: "Copy Path" },
           { id: "copy-thread-id", label: "Copy Thread ID" },
           ...(options?.extraItems ?? []),
@@ -2299,11 +2296,8 @@ export default function Sidebar() {
         markThreadUnread(threadId);
         return;
       }
-      if (typeof clicked === "string" && clicked.startsWith("handoff:")) {
-        const targetProvider = clicked.slice("handoff:".length);
-        if (handoffTargets.includes(targetProvider as ProviderKind)) {
-          await handoffThread(thread, targetProvider as ProviderKind);
-        }
+      if (clicked === "handoff") {
+        await handoffThread(thread);
         return;
       }
       if (clicked === "copy-path") {
@@ -4414,8 +4408,8 @@ export default function Sidebar() {
       {
         id: "import-thread",
         label: "Import thread from...",
-        description: "Attach a local thread to an existing provider thread or session.",
-        keywords: ["import", "resume", "thread", "session", "gpt", "openai", "claude", "gemini"],
+        description: "Attach a local thread to an existing Codex or Claude session.",
+        keywords: ["import", "resume", "thread", "session", "codex", "claude"],
         shortcutLabel: importThreadShortcutLabel,
       },
       {
@@ -5212,7 +5206,7 @@ function SidebarSearchPaletteController(props: {
   onAddProject: () => void;
   onOpenSettings: () => void;
   onOpenProject: (projectId: string) => void;
-  onImportThread: (provider: ProviderKind, externalId: string) => Promise<void>;
+  onImportThread: (provider: "codex" | "claudeAgent", externalId: string) => Promise<void>;
   onOpenThread: (threadId: string) => void;
 }) {
   const selectAllThreads = useMemo(() => createAllThreadsSelector(), []);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1580,7 +1580,7 @@ export default function Sidebar() {
   ]);
 
   const handleImportThread = useCallback(
-    async (provider: "codex" | "claudeAgent", externalId: string) => {
+    async (provider: ProviderKind, externalId: string) => {
       const api = readNativeApi();
       if (!api) {
         throw new Error("The app server is unavailable.");
@@ -1611,7 +1611,9 @@ export default function Sidebar() {
       const title =
         provider === "claudeAgent"
           ? `Imported Claude session${suffix ? ` ${suffix}` : ""}`
-          : `Imported Codex thread${suffix ? ` ${suffix}` : ""}`;
+          : provider === "gemini"
+            ? `Imported Gemini thread${suffix ? ` ${suffix}` : ""}`
+            : `Imported Codex thread${suffix ? ` ${suffix}` : ""}`;
       let createdThread = false;
 
       try {
@@ -5206,7 +5208,7 @@ function SidebarSearchPaletteController(props: {
   onAddProject: () => void;
   onOpenSettings: () => void;
   onOpenProject: (projectId: string) => void;
-  onImportThread: (provider: "codex" | "claudeAgent", externalId: string) => Promise<void>;
+  onImportThread: (provider: ProviderKind, externalId: string) => Promise<void>;
   onOpenThread: (threadId: string) => void;
 }) {
   const selectAllThreads = useMemo(() => createAllThreadsSelector(), []);

--- a/apps/web/src/components/SidebarSearchPalette.logic.ts
+++ b/apps/web/src/components/SidebarSearchPalette.logic.ts
@@ -1,6 +1,7 @@
 // Purpose: Scores sidebar palette results for actions, projects, and chat threads.
 // Keeps search local and deterministic so the palette can rank title hits above
 // message-content hits while still surfacing a useful snippet for chat matches.
+import type { ProviderKind } from "@t3tools/contracts";
 import { basenameOfPath } from "../vscode-icons";
 
 export interface SidebarSearchAction {
@@ -33,7 +34,7 @@ export interface SidebarSearchThread {
   projectId: string;
   projectName: string;
   projectRemoteName: string;
-  provider: "codex" | "claudeAgent";
+  provider: ProviderKind;
   createdAt: string;
   updatedAt?: string | undefined;
   messages: readonly {

--- a/apps/web/src/components/SidebarSearchPalette.tsx
+++ b/apps/web/src/components/SidebarSearchPalette.tsx
@@ -5,13 +5,13 @@
  * keyboard navigation and shortcut labels behave like the rest of the app.
  */
 import { SearchIcon, SettingsIcon, SquarePenIcon } from "~/lib/icons";
-import { type ProviderKind } from "@t3tools/contracts";
+import { PROVIDER_DISPLAY_NAMES, type ProviderKind } from "@t3tools/contracts";
 import { BsChat } from "react-icons/bs";
 import { HiOutlineFolderOpen } from "react-icons/hi2";
 import { LuArrowDownToLine, LuArrowLeft } from "react-icons/lu";
 import { type ComponentType, useEffect, useMemo, useState } from "react";
 import { FolderClosed } from "./FolderClosed";
-import { ClaudeAI, OpenAI } from "./Icons";
+import { ClaudeAI, Gemini, OpenAI } from "./Icons";
 import { formatRelativeTime } from "./Sidebar";
 
 import {
@@ -98,11 +98,13 @@ function PaletteIcon(props: { icon: IconComponent }) {
   );
 }
 
-function ProviderIcon(props: { provider: "codex" | "claudeAgent" }) {
+function ProviderIcon(props: { provider: "codex" | "claudeAgent" | "gemini" }) {
   return (
     <div className="flex size-5 shrink-0 items-center justify-center">
       {props.provider === "claudeAgent" ? (
         <ClaudeAI aria-hidden="true" className="size-[15px] text-foreground" />
+      ) : props.provider === "gemini" ? (
+        <Gemini aria-hidden="true" className="size-[15px] text-foreground" />
       ) : (
         <OpenAI aria-hidden="true" className="size-[15px] text-muted-foreground/60" />
       )}
@@ -210,9 +212,10 @@ export function SidebarSearchPalette(props: SidebarSearchPaletteProps) {
     projects: matchedProjects,
     threads: matchedThreads,
   });
-  const importFieldLabel = importProvider === "claudeAgent" ? "Session ID" : "Thread ID";
-  const importPlaceholder =
-    importProvider === "claudeAgent" ? "Paste a Claude session id" : "Paste a Codex thread id";
+  const importIdKind = importProvider === "claudeAgent" ? "session" : "thread";
+  const importFieldLabel = importIdKind === "session" ? "Session ID" : "Thread ID";
+  const importPlaceholder = `Paste a ${PROVIDER_DISPLAY_NAMES[importProvider]} ${importIdKind} id`;
+  const importHelpText = `${PROVIDER_DISPLAY_NAMES[importProvider]} resumes a persisted ${importIdKind} by ${importIdKind} id.`;
 
   const submitImport = async () => {
     const normalizedImportId = importId.trim();
@@ -273,7 +276,7 @@ export function SidebarSearchPalette(props: SidebarSearchPaletteProps) {
                     onClick={() => setImportProvider("codex")}
                   >
                     <ProviderIcon provider="codex" />
-                    Codex
+                    {PROVIDER_DISPLAY_NAMES.codex}
                   </Button>
                   <Button
                     className={
@@ -285,7 +288,7 @@ export function SidebarSearchPalette(props: SidebarSearchPaletteProps) {
                     onClick={() => setImportProvider("claudeAgent")}
                   >
                     <ProviderIcon provider="claudeAgent" />
-                    Claude
+                    {PROVIDER_DISPLAY_NAMES.claudeAgent}
                   </Button>
                 </div>
               </div>
@@ -306,11 +309,7 @@ export function SidebarSearchPalette(props: SidebarSearchPaletteProps) {
                     }
                   }}
                 />
-                <p className="text-xs text-muted-foreground">
-                  {importProvider === "claudeAgent"
-                    ? "Claude resumes a persisted session by session id."
-                    : "Codex resumes a persisted thread by thread id."}
-                </p>
+                <p className="text-xs text-muted-foreground">{importHelpText}</p>
               </div>
               {importError ? (
                 <p className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive">

--- a/apps/web/src/components/SidebarSearchPalette.tsx
+++ b/apps/web/src/components/SidebarSearchPalette.tsx
@@ -5,7 +5,7 @@
  * keyboard navigation and shortcut labels behave like the rest of the app.
  */
 import { SearchIcon, SettingsIcon, SquarePenIcon } from "~/lib/icons";
-import { PROVIDER_DISPLAY_NAMES, type ProviderKind } from "@t3tools/contracts";
+import { type ProviderKind } from "@t3tools/contracts";
 import { BsChat } from "react-icons/bs";
 import { HiOutlineFolderOpen } from "react-icons/hi2";
 import { LuArrowDownToLine, LuArrowLeft } from "react-icons/lu";
@@ -212,10 +212,9 @@ export function SidebarSearchPalette(props: SidebarSearchPaletteProps) {
     projects: matchedProjects,
     threads: matchedThreads,
   });
-  const importIdKind = importProvider === "claudeAgent" ? "session" : "thread";
-  const importFieldLabel = importIdKind === "session" ? "Session ID" : "Thread ID";
-  const importPlaceholder = `Paste a ${PROVIDER_DISPLAY_NAMES[importProvider]} ${importIdKind} id`;
-  const importHelpText = `${PROVIDER_DISPLAY_NAMES[importProvider]} resumes a persisted ${importIdKind} by ${importIdKind} id.`;
+  const importFieldLabel = importProvider === "claudeAgent" ? "Session ID" : "Thread ID";
+  const importPlaceholder =
+    importProvider === "claudeAgent" ? "Paste a Claude session id" : "Paste a Codex thread id";
 
   const submitImport = async () => {
     const normalizedImportId = importId.trim();
@@ -276,7 +275,7 @@ export function SidebarSearchPalette(props: SidebarSearchPaletteProps) {
                     onClick={() => setImportProvider("codex")}
                   >
                     <ProviderIcon provider="codex" />
-                    {PROVIDER_DISPLAY_NAMES.codex}
+                    Codex
                   </Button>
                   <Button
                     className={
@@ -288,7 +287,7 @@ export function SidebarSearchPalette(props: SidebarSearchPaletteProps) {
                     onClick={() => setImportProvider("claudeAgent")}
                   >
                     <ProviderIcon provider="claudeAgent" />
-                    {PROVIDER_DISPLAY_NAMES.claudeAgent}
+                    Claude
                   </Button>
                 </div>
               </div>
@@ -309,7 +308,11 @@ export function SidebarSearchPalette(props: SidebarSearchPaletteProps) {
                     }
                   }}
                 />
-                <p className="text-xs text-muted-foreground">{importHelpText}</p>
+                <p className="text-xs text-muted-foreground">
+                  {importProvider === "claudeAgent"
+                    ? "Claude resumes a persisted session by session id."
+                    : "Codex resumes a persisted thread by thread id."}
+                </p>
               </div>
               {importError ? (
                 <p className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive">

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -32,7 +32,7 @@ import { readNativeApi } from "~/nativeApi";
 import { resolveEditorIcon } from "../../editorMetadata";
 import { usePreferredEditor } from "../../editorPreferences";
 import { useIsDisposableThread } from "~/hooks/useIsDisposableThread";
-import { ClaudeAI, OpenAI } from "../Icons";
+import { ClaudeAI, Gemini, OpenAI } from "../Icons";
 import { gitStatusQueryOptions } from "~/lib/gitReactQuery";
 
 /** Width (px) below which collapsible header controls fold into the ellipsis menu. */
@@ -155,6 +155,9 @@ export const ChatHeader = memo(function ChatHeader({
   const renderProviderIcon = (provider: ProviderKind | null, className: string) => {
     if (provider === "claudeAgent") {
       return <ClaudeAI className={cn("text-foreground", className)} />;
+    }
+    if (provider === "gemini") {
+      return <Gemini className={cn("text-foreground", className)} />;
     }
     if (provider === "codex") {
       return <OpenAI className={cn("text-muted-foreground/75", className)} />;

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
@@ -133,7 +133,7 @@ describe("CompactComposerControlsMenu", () => {
       expect(text).toContain("Low");
       expect(text).toContain("Medium");
       expect(text).toContain("High");
-      expect(text).not.toContain("Max");
+      expect(text).toContain("Max");
       expect(text).toContain("Ultrathink");
     });
   });

--- a/apps/web/src/components/chat/ComposerExtrasMenu.browser.tsx
+++ b/apps/web/src/components/chat/ComposerExtrasMenu.browser.tsx
@@ -91,7 +91,7 @@ describe("ComposerExtrasMenu", () => {
     await page.getByLabelText("Composer extras").click();
     await page.getByText("Plan mode").click();
     await page.getByText("Fast").click();
-    await page.getByText("Fast").click();
+    await page.getByRole("menuitemradio", { name: "Fast" }).click();
 
     expect(menu.onSetPlanMode).toHaveBeenCalledWith(true);
     expect(menu.onToggleFastMode).toHaveBeenCalledTimes(1);

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -390,8 +390,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     pendingMeasureFrameRef.current = window.requestAnimationFrame(() => {
       pendingMeasureFrameRef.current = null;
       rowVirtualizer.measure();
+      onTimelineHeightChange?.();
     });
-  }, [rowVirtualizer]);
+  }, [onTimelineHeightChange, rowVirtualizer]);
   useEffect(() => {
     if (timelineWidthPx === null) return;
     scheduleVirtualizerMeasure();
@@ -451,7 +452,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   }, [rowVirtualizer]);
   const onTimelineImageLoad = useCallback(() => {
     scheduleVirtualizerMeasure();
-  }, [scheduleVirtualizerMeasure]);
+    onTimelineHeightChange?.();
+  }, [onTimelineHeightChange, scheduleVirtualizerMeasure]);
   useEffect(() => {
     return () => {
       const frame = pendingMeasureFrameRef.current;

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -15,6 +15,10 @@ const MODEL_OPTIONS_BY_PROVIDER = {
     { slug: "gpt-5-codex", name: "GPT-5 Codex" },
     { slug: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
   ],
+  gemini: [
+    { slug: "auto-gemini-3", name: "Auto Gemini 3" },
+    { slug: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
+  ],
 } as const satisfies Record<ProviderKind, ReadonlyArray<{ slug: ModelSlug; name: string }>>;
 
 async function mountPicker(props: {

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -20,7 +20,7 @@ import {
   MenuSubTrigger,
   MenuTrigger,
 } from "../ui/menu";
-import { ClaudeAI, Icon, OpenAI } from "../Icons";
+import { ClaudeAI, Gemini, Icon, OpenAI } from "../Icons";
 import { cn } from "~/lib/utils";
 import { PickerTriggerButton } from "./PickerTriggerButton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -37,6 +37,7 @@ function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): o
 const PROVIDER_ICON_BY_PROVIDER: Record<ProviderPickerKind, Icon> = {
   codex: OpenAI,
   claudeAgent: ClaudeAI,
+  gemini: Gemini,
 };
 
 function resolveLiveProviderAvailability(provider: ServerProviderStatus | undefined): {
@@ -77,7 +78,9 @@ function providerIconClassName(
   provider: ProviderKind | ProviderPickerKind,
   fallbackClassName: string,
 ): string {
-  return provider === "claudeAgent" ? "text-foreground" : fallbackClassName;
+  return provider === "claudeAgent" || provider === "gemini"
+    ? "text-foreground"
+    : fallbackClassName;
 }
 
 export const ProviderModelPicker = memo(function ProviderModelPicker(props: {

--- a/apps/web/src/components/chat/TraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.browser.tsx
@@ -37,7 +37,7 @@ function ClaudeTraitsPickerHarness(props: {
     selectedProvider: "claudeAgent",
     threadModelSelection: props.fallbackModelSelection,
     projectModelSelection: null,
-    customModelsByProvider: { codex: [], claudeAgent: [] },
+    customModelsByProvider: { codex: [], claudeAgent: [], gemini: [] },
   });
   const handlePromptChange = useCallback(
     (nextPrompt: string) => {
@@ -386,7 +386,7 @@ describe("TraitsPicker (Codex)", () => {
     });
 
     await vi.waitFor(() => {
-      expect(document.body.textContent ?? "").toContain("High · Fast");
+      expect(document.body.textContent ?? "").toMatch(/High\s*·\s*Fast/u);
     });
   });
 

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -4,7 +4,10 @@
 // Depends on: shared trait resolution helpers, provider model option updates, and shared menu primitives.
 
 import { type ProviderKind, type ThreadId } from "@t3tools/contracts";
-import { applyClaudePromptEffortPrefix } from "@t3tools/shared/model";
+import {
+  applyClaudePromptEffortPrefix,
+  geminiModelOptionsFromEffortValue,
+} from "@t3tools/shared/model";
 import { memo, useCallback, useState } from "react";
 import { IoFlash } from "react-icons/io5";
 import { ChevronDownIcon } from "~/lib/icons";
@@ -75,10 +78,14 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
         return;
       }
       const effortKey = provider === "codex" ? "reasoningEffort" : "effort";
+      const nextModelOptionsPatch =
+        provider === "gemini"
+          ? (geminiModelOptionsFromEffortValue(nextOption.value) ?? {})
+          : { [effortKey]: nextOption.value };
       setProviderModelOptions(
         threadId,
         provider,
-        buildNextProviderOptions(provider, modelOptions, { [effortKey]: nextOption.value }),
+        buildNextProviderOptions(provider, modelOptions, nextModelOptionsPatch),
         { ...(model !== undefined ? { model } : {}), persistSticky: true },
       );
     },

--- a/apps/web/src/components/chat/chatTypography.ts
+++ b/apps/web/src/components/chat/chatTypography.ts
@@ -6,7 +6,7 @@
 import type { CSSProperties } from "react";
 import { DEFAULT_CHAT_FONT_SIZE_PX, normalizeChatFontSizePx } from "../../appSettings";
 
-const CHAT_TRANSCRIPT_USER_CHAR_WIDTH_RATIO = 0.6;
+const CHAT_TRANSCRIPT_USER_CHAR_WIDTH_RATIO = 0.48;
 const CHAT_TRANSCRIPT_ASSISTANT_CHAR_WIDTH_RATIO = 0.52;
 
 export function getChatTranscriptLineHeightPx(chatFontSizePx = DEFAULT_CHAT_FONT_SIZE_PX): number {

--- a/apps/web/src/components/chat/composerProviderRegistry.test.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.test.tsx
@@ -182,4 +182,44 @@ describe("getComposerProviderState", () => {
       modelOptionsForDispatch: undefined,
     });
   });
+
+  it("derives Gemini effort selections from the active model family", () => {
+    const state = getComposerProviderState({
+      provider: "gemini",
+      model: "gemini-2.5-pro",
+      prompt: "",
+      modelOptions: {
+        gemini: {
+          thinkingBudget: 512,
+        },
+      },
+    });
+
+    expect(state).toEqual({
+      provider: "gemini",
+      promptEffort: "512",
+      modelOptionsForDispatch: {
+        thinkingBudget: 512,
+      },
+    });
+  });
+
+  it("drops explicit Gemini default thinking overrides from dispatch", () => {
+    const state = getComposerProviderState({
+      provider: "gemini",
+      model: "gemini-3.1-pro-preview",
+      prompt: "",
+      modelOptions: {
+        gemini: {
+          thinkingLevel: "HIGH",
+        },
+      },
+    });
+
+    expect(state).toEqual({
+      provider: "gemini",
+      promptEffort: "HIGH",
+      modelOptionsForDispatch: undefined,
+    });
+  });
 });

--- a/apps/web/src/components/chat/composerProviderRegistry.test.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.test.tsx
@@ -204,6 +204,44 @@ describe("getComposerProviderState", () => {
     });
   });
 
+  it("drops unsupported Gemini off overrides for auto 2.5 routing", () => {
+    const state = getComposerProviderState({
+      provider: "gemini",
+      model: "auto-gemini-2.5",
+      prompt: "",
+      modelOptions: {
+        gemini: {
+          thinkingBudget: 0,
+        },
+      },
+    });
+
+    expect(state).toEqual({
+      provider: "gemini",
+      promptEffort: "-1",
+      modelOptionsForDispatch: undefined,
+    });
+  });
+
+  it("drops unsupported Gemini off overrides for 2.5 Flash", () => {
+    const state = getComposerProviderState({
+      provider: "gemini",
+      model: "gemini-2.5-flash",
+      prompt: "",
+      modelOptions: {
+        gemini: {
+          thinkingBudget: 0,
+        },
+      },
+    });
+
+    expect(state).toEqual({
+      provider: "gemini",
+      promptEffort: "-1",
+      modelOptionsForDispatch: undefined,
+    });
+  });
+
   it("drops explicit Gemini default thinking overrides from dispatch", () => {
     const state = getComposerProviderState({
       provider: "gemini",

--- a/apps/web/src/components/chat/composerProviderRegistry.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.tsx
@@ -6,9 +6,11 @@ import {
 } from "@t3tools/contracts";
 import {
   getModelCapabilities,
+  getGeminiThinkingSelectionValue,
   isClaudeUltrathinkPrompt,
   normalizeClaudeModelOptions,
   normalizeCodexModelOptions,
+  normalizeGeminiModelOptions,
   trimOrNull,
   getDefaultEffort,
   hasEffortLevel,
@@ -60,17 +62,32 @@ function getProviderStateFromCapabilities(
 ): ComposerProviderState {
   const { provider, model, prompt, modelOptions } = input;
   const caps = getModelCapabilities(provider, model);
-  const providerOptions = modelOptions?.[provider];
+
+  let rawEffort: string | null = null;
+  let normalizedOptions: ProviderModelOptions[ProviderKind] | undefined;
+
+  switch (provider) {
+    case "codex": {
+      const providerOptions = modelOptions?.codex;
+      rawEffort = trimOrNull(providerOptions?.reasoningEffort);
+      normalizedOptions = normalizeCodexModelOptions(model, providerOptions);
+      break;
+    }
+    case "claudeAgent": {
+      const providerOptions = modelOptions?.claudeAgent;
+      rawEffort = trimOrNull(providerOptions?.effort);
+      normalizedOptions = normalizeClaudeModelOptions(model, providerOptions);
+      break;
+    }
+    case "gemini": {
+      const providerOptions = modelOptions?.gemini;
+      rawEffort = getGeminiThinkingSelectionValue(caps, providerOptions);
+      normalizedOptions = normalizeGeminiModelOptions(model, providerOptions);
+      break;
+    }
+  }
 
   // Resolve effort
-  const rawEffort = providerOptions
-    ? "effort" in providerOptions
-      ? providerOptions.effort
-      : "reasoningEffort" in providerOptions
-        ? providerOptions.reasoningEffort
-        : null
-    : null;
-
   const draftEffort = trimOrNull(rawEffort);
   const defaultEffort = getDefaultEffort(caps);
   const isPromptInjected = draftEffort
@@ -82,12 +99,6 @@ function getProviderStateFromCapabilities(
       : defaultEffort && hasEffortLevel(caps, defaultEffort)
         ? defaultEffort
         : null;
-
-  // Normalize options for dispatch
-  const normalizedOptions =
-    provider === "codex"
-      ? normalizeCodexModelOptions(model, providerOptions)
-      : normalizeClaudeModelOptions(model, providerOptions);
 
   // Ultrathink styling (driven by capabilities data, not provider identity)
   const ultrathinkActive =
@@ -191,6 +202,45 @@ const composerProviderRegistry: Record<ProviderKind, ProviderRegistryEntry> = {
         {...(open !== undefined ? { open } : {})}
         {...(onOpenChange ? { onOpenChange } : {})}
         {...(shortcutLabel !== undefined ? { shortcutLabel } : {})}
+        {...(includeFastMode === undefined ? {} : { includeFastMode })}
+        onPromptChange={onPromptChange}
+      />
+    ),
+  },
+  gemini: {
+    getState: (input) => getProviderStateFromCapabilities(input),
+    renderTraitsMenuContent: ({
+      threadId,
+      model,
+      modelOptions,
+      prompt,
+      includeFastMode,
+      onPromptChange,
+    }) => (
+      <TraitsMenuContent
+        provider="gemini"
+        threadId={threadId}
+        model={model}
+        modelOptions={modelOptions}
+        prompt={prompt}
+        {...(includeFastMode === undefined ? {} : { includeFastMode })}
+        onPromptChange={onPromptChange}
+      />
+    ),
+    renderTraitsPicker: ({
+      threadId,
+      model,
+      modelOptions,
+      prompt,
+      includeFastMode,
+      onPromptChange,
+    }) => (
+      <TraitsPicker
+        provider="gemini"
+        threadId={threadId}
+        model={model}
+        modelOptions={modelOptions}
+        prompt={prompt}
         {...(includeFastMode === undefined ? {} : { includeFastMode })}
         onPromptChange={onPromptChange}
       />

--- a/apps/web/src/components/chat/composerTraits.ts
+++ b/apps/web/src/components/chat/composerTraits.ts
@@ -6,10 +6,12 @@
 import {
   type ClaudeModelOptions,
   type CodexModelOptions,
+  type GeminiModelOptions,
   type ProviderKind,
 } from "@t3tools/contracts";
 import {
   getDefaultEffort,
+  getGeminiThinkingSelectionValue,
   getDefaultContextWindow,
   getModelCapabilities,
   hasEffortLevel,
@@ -22,12 +24,17 @@ import type { ProviderOptions } from "../../providerModelOptions";
 
 function getRawEffort(
   provider: ProviderKind,
+  model: string | null | undefined,
   modelOptions: ProviderOptions | null | undefined,
 ): string | null {
   if (provider === "codex") {
     return trimOrNull((modelOptions as CodexModelOptions | undefined)?.reasoningEffort);
   }
-  return trimOrNull((modelOptions as ClaudeModelOptions | undefined)?.effort);
+  if (provider === "claudeAgent") {
+    return trimOrNull((modelOptions as ClaudeModelOptions | undefined)?.effort);
+  }
+  const caps = getModelCapabilities(provider, model);
+  return getGeminiThinkingSelectionValue(caps, modelOptions as GeminiModelOptions | undefined);
 }
 
 function getRawContextWindow(
@@ -50,8 +57,8 @@ export function getComposerTraitSelection(
   const caps = getModelCapabilities(provider, model);
   const effortLevels = caps.reasoningEffortLevels;
   const defaultEffort = getDefaultEffort(caps);
+  const resolvedEffort = getRawEffort(provider, model, modelOptions);
   const defaultContextWindow = getDefaultContextWindow(caps);
-  const resolvedEffort = getRawEffort(provider, modelOptions);
   const resolvedContextWindow = getRawContextWindow(provider, modelOptions);
   const isPromptInjected = resolvedEffort
     ? caps.promptInjectedEffortLevels.includes(resolvedEffort)

--- a/apps/web/src/components/timelineHeight.test.ts
+++ b/apps/web/src/components/timelineHeight.test.ts
@@ -126,7 +126,7 @@ describe("estimateTimelineMessageHeight", () => {
       text: "a".repeat(20),
     };
 
-    expect(estimateTimelineMessageHeight(message, { timelineWidthPx: 100 })).toBe(176);
+    expect(estimateTimelineMessageHeight(message, { timelineWidthPx: 100 })).toBe(156);
     expect(estimateTimelineMessageHeight(message, { timelineWidthPx: 320 })).toBe(116);
   });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -2,6 +2,8 @@ import {
   CODEX_REASONING_EFFORT_OPTIONS,
   type ClaudeCodeEffort,
   type CodexReasoningEffort,
+  type GeminiThinkingBudget,
+  type GeminiThinkingLevel,
   type ModelSlug,
   ModelSelection,
   ProjectId,
@@ -36,6 +38,7 @@ import {
   ensureInlineTerminalContextPlaceholders,
   normalizeTerminalContextText,
 } from "./lib/terminalContext";
+import { buildModelSelection } from "./providerModelOptions";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { createDebouncedStorage, createMemoryStorage } from "./lib/storage";
@@ -572,7 +575,7 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
 }
 
 function normalizeProviderKind(value: unknown): ProviderKind | null {
-  return value === "codex" || value === "claudeAgent" ? value : null;
+  return value === "codex" || value === "claudeAgent" || value === "gemini" ? value : null;
 }
 
 function normalizeProviderModelOptions(
@@ -588,6 +591,10 @@ function normalizeProviderModelOptions(
   const claudeCandidate =
     candidate?.claudeAgent && typeof candidate.claudeAgent === "object"
       ? (candidate.claudeAgent as Record<string, unknown>)
+      : null;
+  const geminiCandidate =
+    candidate?.gemini && typeof candidate.gemini === "object"
+      ? (candidate.gemini as Record<string, unknown>)
       : null;
 
   const codexReasoningEffort: CodexReasoningEffort | undefined =
@@ -658,12 +665,37 @@ function normalizeProviderModelOptions(
         }
       : undefined;
 
-  if (!codex && !claude) {
+  const geminiThinkingLevel: GeminiThinkingLevel | undefined =
+    geminiCandidate?.thinkingLevel === "LOW" || geminiCandidate?.thinkingLevel === "HIGH"
+      ? geminiCandidate.thinkingLevel
+      : undefined;
+  const rawGeminiThinkingBudget =
+    typeof geminiCandidate?.thinkingBudget === "number"
+      ? geminiCandidate.thinkingBudget
+      : typeof geminiCandidate?.thinkingBudget === "string"
+        ? Number(geminiCandidate.thinkingBudget)
+        : undefined;
+  const geminiThinkingBudget: GeminiThinkingBudget | undefined =
+    rawGeminiThinkingBudget === -1 ||
+    rawGeminiThinkingBudget === 0 ||
+    rawGeminiThinkingBudget === 512
+      ? rawGeminiThinkingBudget
+      : undefined;
+  const gemini =
+    geminiThinkingLevel !== undefined || geminiThinkingBudget !== undefined
+      ? {
+          ...(geminiThinkingLevel !== undefined ? { thinkingLevel: geminiThinkingLevel } : {}),
+          ...(geminiThinkingBudget !== undefined ? { thinkingBudget: geminiThinkingBudget } : {}),
+        }
+      : undefined;
+
+  if (!codex && !claude && !gemini) {
     return null;
   }
   return {
     ...(codex ? { codex } : {}),
     ...(claude ? { claudeAgent: claude } : {}),
+    ...(gemini ? { gemini } : {}),
   };
 }
 
@@ -699,17 +731,16 @@ function normalizeModelSelection(
   const options =
     provider === "codex"
       ? modelOptions?.codex
-      : inferredClaudeContextWindow !== undefined
-        ? {
-            ...modelOptions?.claudeAgent,
-            contextWindow: modelOptions?.claudeAgent?.contextWindow ?? inferredClaudeContextWindow,
-          }
-        : modelOptions?.claudeAgent;
-  return {
-    provider,
-    model,
-    ...(options ? { options } : {}),
-  };
+      : provider === "claudeAgent"
+        ? inferredClaudeContextWindow !== undefined
+          ? {
+              ...(modelOptions?.claudeAgent ?? {}),
+              contextWindow:
+                modelOptions?.claudeAgent?.contextWindow ?? inferredClaudeContextWindow,
+            }
+          : modelOptions?.claudeAgent
+        : modelOptions?.gemini;
+  return buildModelSelection(provider, model, options);
 }
 
 // ── Legacy sync helpers (used only during migration from v2 storage) ──
@@ -722,11 +753,7 @@ function legacySyncModelSelectionOptions(
     return null;
   }
   const options = modelOptions?.[modelSelection.provider];
-  return {
-    provider: modelSelection.provider,
-    model: modelSelection.model,
-    ...(options ? { options } : {}),
-  };
+  return buildModelSelection(modelSelection.provider, modelSelection.model, options);
 }
 
 function legacyMergeModelSelectionIntoProviderModelOptions(
@@ -770,17 +797,14 @@ function legacyToModelSelectionByProvider(
   const result: Partial<Record<ProviderKind, ModelSelection>> = {};
   // Add entries from the options bag (for non-active providers)
   if (modelOptions) {
-    for (const provider of ["codex", "claudeAgent"] as const) {
+    for (const provider of ["codex", "claudeAgent", "gemini"] as const) {
       const options = modelOptions[provider];
       if (options && Object.keys(options).length > 0) {
-        result[provider] = {
+        result[provider] = buildModelSelection(
           provider,
-          model:
-            modelSelection?.provider === provider
-              ? modelSelection.model
-              : getDefaultModel(provider),
+          modelSelection?.provider === provider ? modelSelection.model : getDefaultModel(provider),
           options,
-        };
+        );
       }
     }
   }
@@ -839,7 +863,7 @@ export function resolvePreferredComposerModelSelection(input: {
   defaultProvider?: ProviderKind | null | undefined;
 }): ModelSelection {
   const draftProviderWithSelection =
-    (["codex", "claudeAgent"] as const).find(
+    (["codex", "claudeAgent", "gemini"] as const).find(
       (provider) => input.draft?.modelSelectionByProvider?.[provider] !== undefined,
     ) ?? null;
   const preferredProvider =
@@ -2242,11 +2266,11 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
               nextMap[normalized.provider] = normalized;
             } else {
               // No options in selection → preserve existing options, update provider+model
-              nextMap[normalized.provider] = {
-                provider: normalized.provider,
-                model: normalized.model,
-                ...(current?.options ? { options: current.options } : {}),
-              };
+              nextMap[normalized.provider] = buildModelSelection(
+                normalized.provider,
+                normalized.model,
+                current?.options,
+              );
             }
           }
           const nextActiveProvider = normalized?.provider ?? base.activeProvider;
@@ -2282,21 +2306,20 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           }
           const base = existing ?? createEmptyThreadDraft();
           const nextMap = { ...base.modelSelectionByProvider };
-          for (const provider of ["codex", "claudeAgent"] as const) {
+          for (const provider of ["codex", "claudeAgent", "gemini"] as const) {
             // Only touch providers explicitly present in the input
             if (!normalizedOpts || !(provider in normalizedOpts)) continue;
             const opts = normalizedOpts[provider];
             const current = nextMap[provider];
             if (opts) {
-              nextMap[provider] = {
+              nextMap[provider] = buildModelSelection(
                 provider,
-                model: current?.model ?? getDefaultModel(provider),
-                options: opts,
-              };
+                current?.model ?? getDefaultModel(provider),
+                opts,
+              );
             } else if (current?.options) {
               // Remove options but keep the selection
-              const { options: _, ...rest } = current;
-              nextMap[provider] = rest as ModelSelection;
+              nextMap[provider] = buildModelSelection(provider, current.model);
             }
           }
           if (Equal.equals(base.modelSelectionByProvider, nextMap)) {
@@ -2341,16 +2364,16 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           const nextMap = { ...base.modelSelectionByProvider };
           const currentForProvider = nextMap[normalizedProvider];
           if (providerOpts) {
-            nextMap[normalizedProvider] = {
-              provider: normalizedProvider,
-              // Trait-only changes should keep the currently visible model instead of
-              // silently snapping back to the provider default.
-              model: currentForProvider?.model ?? fallbackModel,
-              options: providerOpts,
-            };
+            nextMap[normalizedProvider] = buildModelSelection(
+              normalizedProvider,
+              currentForProvider?.model ?? fallbackModel,
+              providerOpts,
+            );
           } else if (currentForProvider?.options) {
-            const { options: _, ...rest } = currentForProvider;
-            nextMap[normalizedProvider] = rest as ModelSelection;
+            nextMap[normalizedProvider] = buildModelSelection(
+              normalizedProvider,
+              currentForProvider.model,
+            );
           }
 
           // Handle sticky persistence
@@ -2361,19 +2384,18 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
             const stickyBase =
               nextStickyMap[normalizedProvider] ??
               base.modelSelectionByProvider[normalizedProvider] ??
-              ({
-                provider: normalizedProvider,
-                model: fallbackModel,
-              } as ModelSelection);
+              buildModelSelection(normalizedProvider, fallbackModel);
             if (providerOpts) {
-              nextStickyMap[normalizedProvider] = {
-                ...stickyBase,
-                provider: normalizedProvider,
-                options: providerOpts,
-              };
+              nextStickyMap[normalizedProvider] = buildModelSelection(
+                normalizedProvider,
+                stickyBase.model,
+                providerOpts,
+              );
             } else if (stickyBase.options) {
-              const { options: _, ...rest } = stickyBase;
-              nextStickyMap[normalizedProvider] = rest as ModelSelection;
+              nextStickyMap[normalizedProvider] = buildModelSelection(
+                normalizedProvider,
+                stickyBase.model,
+              );
             }
             nextStickyActiveProvider = base.activeProvider ?? normalizedProvider;
           }

--- a/apps/web/src/composerSlashCommands.test.ts
+++ b/apps/web/src/composerSlashCommands.test.ts
@@ -188,7 +188,19 @@ describe("composerSlashCommands", () => {
     ).toEqual([]);
   });
 
-  it("only offers /compact when Codex compaction is available", () => {
+  it("exposes shared app slash commands for gemini", () => {
+    expect(
+      getAvailableComposerSlashCommands({
+        provider: "gemini",
+        supportsFastSlashCommand: false,
+        canOfferCompactCommand: false,
+        canOfferReviewCommand: true,
+        canOfferForkCommand: true,
+      }),
+    ).toEqual(["clear", "model", "plan", "default", "review", "fork", "status", "subagents"]);
+  });
+
+  it("only offers /compact when compaction is available", () => {
     expect(
       getAvailableComposerSlashCommands({
         provider: "codex",

--- a/apps/web/src/composerSlashCommands.ts
+++ b/apps/web/src/composerSlashCommands.ts
@@ -154,7 +154,7 @@ const COMPOSER_SLASH_COMMAND_DEFINITIONS: Record<
   subagents: {
     command: "subagents",
     label: "/subagents",
-    description: "Insert a prompt that asks Codex to delegate work",
+    description: "Insert a prompt that asks the assistant to delegate work",
     source: "app",
   },
   fast: {
@@ -332,7 +332,7 @@ export function getAvailableComposerSlashCommands(input: {
   );
 
   const availableCommands: ComposerSlashCommand[] =
-    input.provider === "codex"
+    input.provider !== "claudeAgent"
       ? [
           "clear",
           ...(input.canOfferCompactCommand ? (["compact"] as const) : []),

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -2,7 +2,11 @@ import { type ProjectId, ThreadId, DEFAULT_MODEL_BY_PROVIDER } from "@t3tools/co
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 import { useAppSettings } from "../appSettings";
-import { type DraftThreadState, useComposerDraftStore } from "../composerDraftStore";
+import {
+  type ComposerThreadDraftState,
+  type DraftThreadState,
+  useComposerDraftStore,
+} from "../composerDraftStore";
 import {
   buildDraftThreadContextPatch,
   createActiveDraftThreadSnapshot,
@@ -41,6 +45,25 @@ export function useHandleNewThread() {
         setModelSelection(threadId, {
           provider: options.provider,
           model: DEFAULT_MODEL_BY_PROVIDER[options.provider],
+        });
+      };
+      const restoreComposerDraft = (
+        threadId: ThreadId,
+        draftState: ComposerThreadDraftState | null,
+      ) => {
+        if (!draftState) {
+          return;
+        }
+        useComposerDraftStore.setState((state) => {
+          if (state.draftsByThreadId[threadId] === draftState) {
+            return state;
+          }
+          return {
+            draftsByThreadId: {
+              ...state.draftsByThreadId,
+              [threadId]: draftState,
+            },
+          };
         });
       };
       const activateThreadEntryPoint = (threadId: ThreadId) => {
@@ -100,6 +123,7 @@ export function useHandleNewThread() {
       const resolveCreationState = (
         targetThreadId: ThreadId,
         draftThread: DraftThreadState | null,
+        creationOptions: NewThreadOptions | undefined,
       ) =>
         resolveTerminalThreadCreationState({
           activeDraftThread: activeDraftThreadSnapshot,
@@ -108,7 +132,7 @@ export function useHandleNewThread() {
           draftComposerState:
             useComposerDraftStore.getState().draftsByThreadId[targetThreadId] ?? null,
           draftThread,
-          options,
+          options: creationOptions,
           projectDefaultModelSelection,
           projectId,
         });
@@ -145,20 +169,32 @@ export function useHandleNewThread() {
           if (wantsTemporaryThread) {
             markTemporaryThread(bootstrapPlan.threadId);
           }
+          const preservedComposerDraft =
+            useComposerDraftStore.getState().draftsByThreadId[bootstrapPlan.threadId] ?? null;
           let resolvedStoredDraftThread: DraftThreadState | null = bootstrapPlan.draftThread;
-          const draftContextPatch = buildDraftThreadContextPatch(entryPoint, options);
+          const shouldPreserveStoredTerminalContext =
+            entryPoint === "terminal" && bootstrapPlan.draftThread.entryPoint === "terminal";
+          const draftContextPatch = shouldPreserveStoredTerminalContext
+            ? null
+            : buildDraftThreadContextPatch(entryPoint, options);
+          const creationOptions = shouldPreserveStoredTerminalContext ? undefined : options;
           if (draftContextPatch) {
             setDraftThreadContext(bootstrapPlan.threadId, draftContextPatch);
             resolvedStoredDraftThread = getDraftThread(bootstrapPlan.threadId);
           }
           applyProviderOverride(bootstrapPlan.threadId);
           setProjectDraftThreadId(projectId, bootstrapPlan.threadId, { entryPoint });
+          restoreComposerDraft(bootstrapPlan.threadId, preservedComposerDraft);
           activateThreadEntryPoint(bootstrapPlan.threadId);
           if (focusedThreadId === bootstrapPlan.threadId) {
             if (entryPoint === "terminal") {
               await createTerminalThread(
                 bootstrapPlan.threadId,
-                resolveCreationState(bootstrapPlan.threadId, resolvedStoredDraftThread),
+                resolveCreationState(
+                  bootstrapPlan.threadId,
+                  resolvedStoredDraftThread,
+                  creationOptions,
+                ),
               );
             }
             return;
@@ -167,10 +203,15 @@ export function useHandleNewThread() {
             to: "/$threadId",
             params: { threadId: bootstrapPlan.threadId },
           });
+          restoreComposerDraft(bootstrapPlan.threadId, preservedComposerDraft);
           if (entryPoint === "terminal") {
             await createTerminalThread(
               bootstrapPlan.threadId,
-              resolveCreationState(bootstrapPlan.threadId, resolvedStoredDraftThread),
+              resolveCreationState(
+                bootstrapPlan.threadId,
+                resolvedStoredDraftThread,
+                creationOptions,
+              ),
             );
           }
         })();
@@ -182,6 +223,8 @@ export function useHandleNewThread() {
         if (wantsTemporaryThread) {
           markTemporaryThread(bootstrapPlan.threadId);
         }
+        const preservedComposerDraft =
+          useComposerDraftStore.getState().draftsByThreadId[bootstrapPlan.threadId] ?? null;
         let resolvedActiveDraftThread: DraftThreadState | null = bootstrapPlan.draftThread;
         const draftContextPatch = buildDraftThreadContextPatch(entryPoint, options);
         if (draftContextPatch) {
@@ -190,11 +233,12 @@ export function useHandleNewThread() {
         }
         applyProviderOverride(bootstrapPlan.threadId);
         setProjectDraftThreadId(projectId, bootstrapPlan.threadId, { entryPoint });
+        restoreComposerDraft(bootstrapPlan.threadId, preservedComposerDraft);
         activateThreadEntryPoint(bootstrapPlan.threadId);
         if (entryPoint === "terminal") {
           return createTerminalThread(
             bootstrapPlan.threadId,
-            resolveCreationState(bootstrapPlan.threadId, resolvedActiveDraftThread),
+            resolveCreationState(bootstrapPlan.threadId, resolvedActiveDraftThread, options),
           );
         }
         return Promise.resolve();
@@ -224,7 +268,7 @@ export function useHandleNewThread() {
         if (entryPoint === "terminal") {
           await createTerminalThread(
             threadId,
-            resolveCreationState(threadId, getDraftThread(threadId)),
+            resolveCreationState(threadId, getDraftThread(threadId), options),
           );
         }
       })();

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -169,6 +169,11 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   {
+    shortcut: modShortcut("g", { altKey: true }),
+    command: "chat.newGemini",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
     shortcut: modShortcut("1"),
     command: "thread.jump.1",
     whenAst: whenAnd(
@@ -720,6 +725,13 @@ describe("chat/editor shortcuts", () => {
       "chat.newCodex",
     );
     assert.strictEqual(
+      resolveShortcutCommand(event({ key: "g", metaKey: true, altKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "chat.newGemini",
+    );
+    assert.strictEqual(
       resolveShortcutCommand(
         event({ code: "KeyC", key: "ç", metaKey: true, altKey: true }),
         DEFAULT_BINDINGS,
@@ -740,6 +752,17 @@ describe("chat/editor shortcuts", () => {
         },
       ),
       "chat.newCodex",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ code: "KeyG", key: "©", metaKey: true, altKey: true }),
+        DEFAULT_BINDINGS,
+        {
+          platform: "MacIntel",
+          context: { terminalFocus: false },
+        },
+      ),
+      "chat.newGemini",
     );
   });
 
@@ -940,7 +963,10 @@ describe("resolveShortcutCommand", () => {
 
   it("falls back to provider-specific new chat defaults when runtime config is missing them", () => {
     const legacyBindings = DEFAULT_BINDINGS.filter(
-      (binding) => binding.command !== "chat.newClaude" && binding.command !== "chat.newCodex",
+      (binding) =>
+        binding.command !== "chat.newClaude" &&
+        binding.command !== "chat.newCodex" &&
+        binding.command !== "chat.newGemini",
     );
 
     assert.strictEqual(
@@ -956,6 +982,13 @@ describe("resolveShortcutCommand", () => {
         context: { terminalFocus: false },
       }),
       "chat.newCodex",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "g", metaKey: true, altKey: true }), legacyBindings, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "chat.newGemini",
     );
     assert.strictEqual(
       resolveShortcutCommand(
@@ -978,6 +1011,17 @@ describe("resolveShortcutCommand", () => {
         },
       ),
       "chat.newCodex",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ code: "KeyG", key: "©", metaKey: true, altKey: true }),
+        legacyBindings,
+        {
+          platform: "MacIntel",
+          context: { terminalFocus: false },
+        },
+      ),
+      "chat.newGemini",
     );
   });
 });

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -94,6 +94,11 @@ export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
     whenAst: whenNotTerminalFocus,
   },
   {
+    command: "chat.newGemini",
+    shortcut: commandShortcut("g", { altKey: true }),
+    whenAst: whenNotTerminalFocus,
+  },
+  {
     command: "chat.split",
     shortcut: commandShortcut("\\"),
     whenAst: whenNotTerminalFocus,
@@ -608,6 +613,14 @@ export function isChatNewCodexShortcut(
   options?: ShortcutMatchOptions,
 ): boolean {
   return matchesCommandShortcut(event, keybindings, "chat.newCodex", options);
+}
+
+export function isChatNewGeminiShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "chat.newGemini", options);
 }
 
 export function isOpenFavoriteEditorShortcut(

--- a/apps/web/src/lib/openUsageRateLimits.test.ts
+++ b/apps/web/src/lib/openUsageRateLimits.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeOpenUsageSnapshot, normalizeOpenUsageUsageLines } from "./openUsageRateLimits";
+import {
+  normalizeOpenUsageSnapshot,
+  normalizeOpenUsageUsageLines,
+  openUsageProviderIdForProvider,
+} from "./openUsageRateLimits";
 import { mergeProviderRateLimits } from "./rateLimits";
 
 describe("openUsageRateLimits", () => {
@@ -138,5 +142,20 @@ describe("openUsageRateLimits", () => {
         subtitle: "via ccusage",
       },
     ]);
+  });
+
+  it("maps Gemini provider ids in both directions", () => {
+    expect(openUsageProviderIdForProvider("gemini")).toBe("gemini");
+    expect(
+      normalizeOpenUsageSnapshot({
+        providerId: "gemini",
+        fetchedAt: "2099-04-08T18:00:00.000Z",
+        lines: [{ type: "progress", label: "Daily", used: 5, limit: 10 }],
+      }),
+    ).toEqual({
+      provider: "gemini",
+      updatedAt: "2099-04-08T18:00:00.000Z",
+      limits: [{ window: "Daily", usedPercent: 50 }],
+    });
   });
 });

--- a/apps/web/src/lib/openUsageRateLimits.ts
+++ b/apps/web/src/lib/openUsageRateLimits.ts
@@ -62,6 +62,7 @@ function toUsedPercent(line: OpenUsageProgressLine): number | undefined {
 function toProviderKind(providerId: string | undefined): ProviderKind | null {
   if (providerId === "codex") return "codex";
   if (providerId === "claude") return "claudeAgent";
+  if (providerId === "gemini") return "gemini";
   return null;
 }
 
@@ -70,6 +71,7 @@ export function openUsageProviderIdForProvider(
 ): string | null {
   if (provider === "codex") return "codex";
   if (provider === "claudeAgent") return "claude";
+  if (provider === "gemini") return "gemini";
   return null;
 }
 

--- a/apps/web/src/lib/rateLimits.ts
+++ b/apps/web/src/lib/rateLimits.ts
@@ -384,6 +384,7 @@ export function deriveRateLimitLearnMoreHref(
   if (provider === "claudeAgent") {
     return "https://docs.anthropic.com/en/docs/about-claude/models#rate-limits";
   }
+  if (provider === "gemini") return "https://ai.google.dev/gemini-api/docs/quota";
   return null;
 }
 

--- a/apps/web/src/lib/threadHandoff.test.ts
+++ b/apps/web/src/lib/threadHandoff.test.ts
@@ -1,0 +1,54 @@
+import { type ModelSelection } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+import { resolveHandoffTargetProvider, resolveThreadHandoffModelSelection } from "./threadHandoff";
+
+describe("threadHandoff", () => {
+  it("cycles handoff targets across all supported providers", () => {
+    expect(resolveHandoffTargetProvider("codex")).toBe("claudeAgent");
+    expect(resolveHandoffTargetProvider("claudeAgent")).toBe("gemini");
+    expect(resolveHandoffTargetProvider("gemini")).toBe("codex");
+  });
+
+  it("prefers sticky model selection for the resolved handoff target", () => {
+    const stickySelection = {
+      provider: "gemini",
+      model: "gemini-2.5-pro",
+    } satisfies ModelSelection;
+
+    expect(
+      resolveThreadHandoffModelSelection({
+        sourceThread: {
+          modelSelection: {
+            provider: "claudeAgent",
+            model: "claude-sonnet-4-6",
+          },
+        },
+        projectDefaultModelSelection: {
+          provider: "gemini",
+          model: "gemini-3.1-pro-preview",
+        },
+        stickyModelSelectionByProvider: {
+          gemini: stickySelection,
+        },
+      }),
+    ).toEqual(stickySelection);
+  });
+
+  it("falls back to the resolved provider default model when no sticky or project default exists", () => {
+    expect(
+      resolveThreadHandoffModelSelection({
+        sourceThread: {
+          modelSelection: {
+            provider: "gemini",
+            model: "gemini-2.5-pro",
+          },
+        },
+        projectDefaultModelSelection: null,
+        stickyModelSelectionByProvider: {},
+      }),
+    ).toEqual({
+      provider: "codex",
+      model: "gpt-5.4",
+    });
+  });
+});

--- a/apps/web/src/lib/threadHandoff.ts
+++ b/apps/web/src/lib/threadHandoff.ts
@@ -9,6 +9,8 @@ import {
 import { type Thread } from "../types";
 import { randomUUID } from "./utils";
 
+const HANDOFF_PROVIDER_ORDER: ReadonlyArray<ProviderKind> = ["codex", "claudeAgent", "gemini"];
+
 function isImportableThreadMessage(
   message: Thread["messages"][number],
 ): message is Thread["messages"][number] & {
@@ -18,7 +20,11 @@ function isImportableThreadMessage(
 }
 
 export function resolveHandoffTargetProvider(sourceProvider: ProviderKind): ProviderKind {
-  return sourceProvider === "claudeAgent" ? "codex" : "claudeAgent";
+  const sourceIndex = HANDOFF_PROVIDER_ORDER.indexOf(sourceProvider);
+  if (sourceIndex === -1) {
+    return "codex";
+  }
+  return HANDOFF_PROVIDER_ORDER[(sourceIndex + 1) % HANDOFF_PROVIDER_ORDER.length]!;
 }
 
 export function resolveThreadHandoffBadgeLabel(thread: Pick<Thread, "handoff">): string | null {

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -1,11 +1,43 @@
 import type {
+  ClaudeModelSelection,
   ClaudeModelOptions,
+  CodexModelSelection,
   CodexModelOptions,
+  GeminiModelSelection,
+  GeminiModelOptions,
+  ModelSelection,
   ProviderKind,
   ProviderModelOptions,
 } from "@t3tools/contracts";
 
 export type ProviderOptions = ProviderModelOptions[ProviderKind];
+export interface ProviderModelOption {
+  slug: string;
+  name: string;
+}
+
+function modelOptionKey(option: Pick<ProviderModelOption, "slug">): string {
+  return option.slug.trim().toLowerCase();
+}
+
+export function mergeProviderModelOptions(
+  preferred: ReadonlyArray<ProviderModelOption>,
+  fallback: ReadonlyArray<ProviderModelOption>,
+): ProviderModelOption[] {
+  const merged = [...preferred];
+  const seen = new Set(preferred.map((option) => modelOptionKey(option)));
+
+  for (const option of fallback) {
+    const key = modelOptionKey(option);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    merged.push(option);
+  }
+
+  return merged;
+}
 
 export function buildNextProviderOptions(
   provider: ProviderKind,
@@ -15,5 +47,66 @@ export function buildNextProviderOptions(
   if (provider === "codex") {
     return { ...(modelOptions as CodexModelOptions | undefined), ...patch } as CodexModelOptions;
   }
-  return { ...(modelOptions as ClaudeModelOptions | undefined), ...patch } as ClaudeModelOptions;
+  if (provider === "claudeAgent") {
+    return { ...(modelOptions as ClaudeModelOptions | undefined), ...patch } as ClaudeModelOptions;
+  }
+  return {
+    ...(modelOptions as GeminiModelOptions | undefined),
+    thinkingLevel: undefined,
+    thinkingBudget: undefined,
+    ...patch,
+  } as GeminiModelOptions;
+}
+
+export function buildModelSelection(
+  provider: "codex",
+  model: string,
+  options?: CodexModelOptions | null | undefined,
+): CodexModelSelection;
+export function buildModelSelection(
+  provider: "claudeAgent",
+  model: string,
+  options?: ClaudeModelOptions | null | undefined,
+): ClaudeModelSelection;
+export function buildModelSelection(
+  provider: "gemini",
+  model: string,
+  options?: GeminiModelOptions | null | undefined,
+): GeminiModelSelection;
+export function buildModelSelection(
+  provider: ProviderKind,
+  model: string,
+  options?: ProviderOptions | null | undefined,
+): ModelSelection;
+export function buildModelSelection(
+  provider: ProviderKind,
+  model: string,
+  options?: ProviderOptions | null | undefined,
+): ModelSelection {
+  switch (provider) {
+    case "codex":
+      return options
+        ? {
+            provider,
+            model,
+            options: options as CodexModelOptions,
+          }
+        : { provider, model };
+    case "claudeAgent":
+      return options
+        ? {
+            provider,
+            model,
+            options: options as ClaudeModelOptions,
+          }
+        : { provider, model };
+    case "gemini":
+      return options
+        ? {
+            provider,
+            model,
+            options: options as GeminiModelOptions,
+          }
+        : { provider, model };
+  }
 }

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -4,6 +4,7 @@
 // Depends on: ChatView, splitViewStore, and pane-scoped browser/diff panels
 
 import {
+  type ProviderKind,
   type ProjectId,
   ThreadId,
   type ThreadId as ThreadIdType,
@@ -26,7 +27,7 @@ import { TbExchange } from "react-icons/tb";
 
 import ChatView from "../components/ChatView";
 import BrowserPanel from "../components/BrowserPanel";
-import { ClaudeAI, OpenAI } from "../components/Icons";
+import { ClaudeAI, Gemini, OpenAI } from "../components/Icons";
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
 import {
   DiffPanelHeaderSkeleton,
@@ -430,7 +431,7 @@ function SplitPaneEmptyState(props: {
     id: ThreadIdType;
     title: string | null;
     projectId: ProjectId;
-    modelSelection: { provider: "codex" | "claudeAgent" };
+    modelSelection: { provider: ProviderKind };
   }[];
   projects: readonly { id: ProjectId; name: string }[];
   otherPaneThreadId: ThreadIdType | null;
@@ -485,9 +486,12 @@ function SplitPaneEmptyState(props: {
   );
 }
 
-function PickerProviderGlyph(props: { provider: "codex" | "claudeAgent"; className?: string }) {
+function PickerProviderGlyph(props: { provider: ProviderKind; className?: string }) {
   if (props.provider === "claudeAgent") {
     return <ClaudeAI aria-hidden="true" className={cn("text-foreground", props.className)} />;
+  }
+  if (props.provider === "gemini") {
+    return <Gemini aria-hidden="true" className={cn("text-foreground", props.className)} />;
   }
 
   return <OpenAI aria-hidden="true" className={cn("text-muted-foreground/60", props.className)} />;
@@ -502,7 +506,7 @@ function SplitPaneSurface(props: {
     id: ThreadIdType;
     title: string | null;
     projectId: ProjectId;
-    modelSelection: { provider: "codex" | "claudeAgent" };
+    modelSelection: { provider: ProviderKind };
   }[];
   projects: readonly { id: ProjectId; name: string }[];
   onFocus: () => void;

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -24,7 +24,7 @@ import {
   useAppSettings,
 } from "../appSettings";
 import { APP_VERSION } from "../branding";
-import { ClaudeAI, OpenAI } from "../components/Icons";
+import { ClaudeAI, Gemini, OpenAI } from "../components/Icons";
 import { Button } from "../components/ui/button";
 import { Collapsible, CollapsibleContent } from "../components/ui/collapsible";
 import { Input } from "../components/ui/input";
@@ -112,7 +112,7 @@ const SIDEBAR_THREAD_SORT_ORDER_LABELS = {
   created_at: "Newest first",
 } as const;
 
-type InstallBinarySettingsKey = "claudeBinaryPath" | "codexBinaryPath";
+type InstallBinarySettingsKey = "claudeBinaryPath" | "codexBinaryPath" | "geminiBinaryPath";
 type InstallProviderSettings = {
   provider: ProviderKind;
   title: string;
@@ -147,6 +147,17 @@ const INSTALL_PROVIDER_SETTINGS: readonly InstallProviderSettings[] = [
     binaryDescription: (
       <>
         Leave blank to use <code>claude</code> from your PATH.
+      </>
+    ),
+  },
+  {
+    provider: "gemini",
+    title: "Gemini",
+    binaryPathKey: "geminiBinaryPath",
+    binaryPlaceholder: "Gemini binary path",
+    binaryDescription: (
+      <>
+        Leave blank to use <code>gemini</code> from your PATH.
       </>
     ),
   },
@@ -276,6 +287,7 @@ function SettingsRouteView() {
   const [openInstallProviders, setOpenInstallProviders] = useState<Record<ProviderKind, boolean>>({
     codex: Boolean(settings.codexBinaryPath || settings.codexHomePath),
     claudeAgent: Boolean(settings.claudeBinaryPath),
+    gemini: Boolean(settings.geminiBinaryPath),
   });
   const [selectedCustomModelProvider, setSelectedCustomModelProvider] =
     useState<ProviderKind>("codex");
@@ -284,6 +296,7 @@ function SettingsRouteView() {
   >({
     codex: "",
     claudeAgent: "",
+    gemini: "",
   });
   const [customModelErrorByProvider, setCustomModelErrorByProvider] = useState<
     Partial<Record<ProviderKind, string | null>>
@@ -296,6 +309,7 @@ function SettingsRouteView() {
   const codexBinaryPath = settings.codexBinaryPath;
   const codexHomePath = settings.codexHomePath;
   const claudeBinaryPath = settings.claudeBinaryPath;
+  const geminiBinaryPath = settings.geminiBinaryPath;
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
   const availableEditors = serverConfigQuery.data?.availableEditors;
   const managedWorktrees = serverWorktreesQuery.data?.worktrees ?? [];
@@ -350,7 +364,10 @@ function SettingsRouteView() {
   )!;
   const selectedCustomModelInput = customModelInputByProvider[selectedCustomModelProvider];
   const selectedCustomModelError = customModelErrorByProvider[selectedCustomModelProvider] ?? null;
-  const totalCustomModels = settings.customCodexModels.length + settings.customClaudeModels.length;
+  const totalCustomModels =
+    settings.customCodexModels.length +
+    settings.customClaudeModels.length +
+    settings.customGeminiModels.length;
   const savedCustomModelRows = MODEL_PROVIDER_SETTINGS.flatMap((providerSettings) =>
     getCustomModelsForProvider(settings, providerSettings.provider).map((slug) => ({
       key: `${providerSettings.provider}:${slug}`,
@@ -364,6 +381,7 @@ function SettingsRouteView() {
     : savedCustomModelRows.slice(0, 5);
   const isInstallSettingsDirty =
     settings.claudeBinaryPath !== defaults.claudeBinaryPath ||
+    settings.geminiBinaryPath !== defaults.geminiBinaryPath ||
     settings.codexBinaryPath !== defaults.codexBinaryPath ||
     settings.codexHomePath !== defaults.codexHomePath;
 
@@ -403,7 +421,9 @@ function SettingsRouteView() {
       ? ["Terminal close confirmation"]
       : []),
     ...(isGitTextGenerationModelDirty ? ["Git writing model"] : []),
-    ...(settings.customCodexModels.length > 0 || settings.customClaudeModels.length > 0
+    ...(settings.customCodexModels.length > 0 ||
+    settings.customClaudeModels.length > 0 ||
+    settings.customGeminiModels.length > 0
       ? ["Custom models"]
       : []),
     ...(isInstallSettingsDirty ? ["Provider installs"] : []),
@@ -516,11 +536,13 @@ function SettingsRouteView() {
     setOpenInstallProviders({
       codex: false,
       claudeAgent: false,
+      gemini: false,
     });
     setSelectedCustomModelProvider("codex");
     setCustomModelInputByProvider({
       codex: "",
       claudeAgent: "",
+      gemini: "",
     });
     setCustomModelErrorByProvider({});
     setShowAllCustomModels(false);
@@ -814,7 +836,7 @@ function SettingsRouteView() {
               <Select
                 value={settings.defaultProvider}
                 onValueChange={(value) => {
-                  if (value !== "codex" && value !== "claudeAgent") return;
+                  if (value !== "codex" && value !== "claudeAgent" && value !== "gemini") return;
                   updateSettings({ defaultProvider: value });
                 }}
               >
@@ -823,10 +845,16 @@ function SettingsRouteView() {
                     <span className="flex items-center gap-2">
                       {settings.defaultProvider === "claudeAgent" ? (
                         <ClaudeAI className="size-3.5 text-foreground" />
+                      ) : settings.defaultProvider === "gemini" ? (
+                        <Gemini className="size-3.5 text-foreground" />
                       ) : (
                         <OpenAI className="size-3.5" />
                       )}
-                      {settings.defaultProvider === "claudeAgent" ? "Claude" : "Codex"}
+                      {settings.defaultProvider === "claudeAgent"
+                        ? "Claude"
+                        : settings.defaultProvider === "gemini"
+                          ? "Gemini"
+                          : "Codex"}
                     </span>
                   </SelectValue>
                 </SelectTrigger>
@@ -841,6 +869,12 @@ function SettingsRouteView() {
                     <span className="flex items-center gap-2">
                       <ClaudeAI className="size-3.5 text-foreground" />
                       Claude
+                    </span>
+                  </SelectItem>
+                  <SelectItem hideIndicator value="gemini">
+                    <span className="flex items-center gap-2">
+                      <Gemini className="size-3.5 text-foreground" />
+                      Gemini
                     </span>
                   </SelectItem>
                 </SelectPopup>
@@ -1677,6 +1711,7 @@ function SettingsRouteView() {
                     updateSettings({
                       customCodexModels: defaults.customCodexModels,
                       customClaudeModels: defaults.customClaudeModels,
+                      customGeminiModels: defaults.customGeminiModels,
                     });
                     setCustomModelErrorByProvider({});
                     setShowAllCustomModels(false);
@@ -1690,7 +1725,7 @@ function SettingsRouteView() {
                 <Select
                   value={selectedCustomModelProvider}
                   onValueChange={(value) => {
-                    if (value !== "codex" && value !== "claudeAgent") {
+                    if (value !== "codex" && value !== "claudeAgent" && value !== "gemini") {
                       return;
                     }
                     setSelectedCustomModelProvider(value);
@@ -1814,10 +1849,12 @@ function SettingsRouteView() {
                       claudeBinaryPath: defaults.claudeBinaryPath,
                       codexBinaryPath: defaults.codexBinaryPath,
                       codexHomePath: defaults.codexHomePath,
+                      geminiBinaryPath: defaults.geminiBinaryPath,
                     });
                     setOpenInstallProviders({
                       codex: false,
                       claudeAgent: false,
+                      gemini: false,
                     });
                   }}
                 />
@@ -1832,11 +1869,15 @@ function SettingsRouteView() {
                     providerSettings.provider === "codex"
                       ? settings.codexBinaryPath !== defaults.codexBinaryPath ||
                         settings.codexHomePath !== defaults.codexHomePath
-                      : settings.claudeBinaryPath !== defaults.claudeBinaryPath;
+                      : providerSettings.provider === "claudeAgent"
+                        ? settings.claudeBinaryPath !== defaults.claudeBinaryPath
+                        : settings.geminiBinaryPath !== defaults.geminiBinaryPath;
                   const binaryPathValue =
                     providerSettings.binaryPathKey === "claudeBinaryPath"
                       ? claudeBinaryPath
-                      : codexBinaryPath;
+                      : providerSettings.binaryPathKey === "geminiBinaryPath"
+                        ? geminiBinaryPath
+                        : codexBinaryPath;
 
                   return (
                     <Collapsible
@@ -1892,7 +1933,9 @@ function SettingsRouteView() {
                                     updateSettings(
                                       providerSettings.binaryPathKey === "claudeBinaryPath"
                                         ? { claudeBinaryPath: event.target.value }
-                                        : { codexBinaryPath: event.target.value },
+                                        : providerSettings.binaryPathKey === "geminiBinaryPath"
+                                          ? { geminiBinaryPath: event.target.value }
+                                          : { codexBinaryPath: event.target.value },
                                     )
                                   }
                                   placeholder={providerSettings.binaryPlaceholder}

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -138,13 +138,22 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
-      if (command === "chat.newClaude" || command === "chat.newCodex") {
-        const projectId = activeProjectId ?? (allowProjectFallback ? projects[0]?.id : null);
+      if (
+        command === "chat.newClaude" ||
+        command === "chat.newCodex" ||
+        command === "chat.newGemini"
+      ) {
+        const projectId = activeProjectId ?? projects[0]?.id;
         if (!projectId) return;
         event.preventDefault();
         event.stopPropagation();
         void handleNewThread(projectId, {
-          provider: command === "chat.newClaude" ? "claudeAgent" : "codex",
+          provider:
+            command === "chat.newClaude"
+              ? "claudeAgent"
+              : command === "chat.newCodex"
+                ? "codex"
+                : "gemini",
           branch: activeThread?.branch ?? activeDraftThread?.branch ?? null,
           worktreePath: activeThread?.worktreePath ?? activeDraftThread?.worktreePath ?? null,
           envMode:

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1669,15 +1669,22 @@ describe("hasLiveTurnTailWork", () => {
 });
 
 describe("PROVIDER_OPTIONS", () => {
-  it("lists Codex and Claude as available providers", () => {
+  it("lists Codex, Claude, and Gemini as available providers", () => {
     const claude = PROVIDER_OPTIONS.find((option) => option.value === "claudeAgent");
+    const gemini = PROVIDER_OPTIONS.find((option) => option.value === "gemini");
     expect(PROVIDER_OPTIONS).toEqual([
       { value: "codex", label: "Codex", available: true },
       { value: "claudeAgent", label: "Claude", available: true },
+      { value: "gemini", label: "Gemini", available: true },
     ]);
     expect(claude).toEqual({
       value: "claudeAgent",
       label: "Claude",
+      available: true,
+    });
+    expect(gemini).toEqual({
+      value: "gemini",
+      label: "Gemini",
       available: true,
     });
   });

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -36,6 +36,7 @@ export const PROVIDER_OPTIONS: Array<{
 }> = [
   { value: "codex", label: "Codex", available: true },
   { value: "claudeAgent", label: "Claude", available: true },
+  { value: "gemini", label: "Gemini", available: true },
 ];
 
 export interface WorkLogEntry {

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -1522,7 +1522,7 @@ function toLegacySessionStatus(
 }
 
 function toLegacyProvider(providerName: string | null): ProviderKind {
-  if (providerName === "codex" || providerName === "claudeAgent") {
+  if (providerName === "codex" || providerName === "claudeAgent" || providerName === "gemini") {
     return providerName;
   }
   return "codex";

--- a/packages/contracts/src/agentMentions.ts
+++ b/packages/contracts/src/agentMentions.ts
@@ -198,10 +198,14 @@ const CLAUDE_AGENT_MENTION_ALIASES: Record<string, ClaudeSubagentAliasDefinition
   },
 };
 
-export const AGENT_MENTION_ALIASES_BY_PROVIDER = {
+export const AGENT_MENTION_ALIASES_BY_PROVIDER: Record<
+  ProviderKind,
+  Record<string, AgentAliasDefinition>
+> = {
   codex: CODEX_AGENT_MENTION_ALIASES,
   claudeAgent: CLAUDE_AGENT_MENTION_ALIASES,
-} as const satisfies Record<ProviderKind, Record<string, AgentAliasDefinition>>;
+  gemini: {},
+};
 
 // Backward compatibility for legacy call sites that still expect a flat alias table.
 export const AGENT_MENTION_ALIASES: Record<string, AgentAliasDefinition> = Object.assign(
@@ -212,6 +216,7 @@ export const AGENT_MENTION_ALIASES: Record<string, AgentAliasDefinition> = Objec
 const AGENT_MENTION_AUTOCOMPLETE_ALIASES_BY_PROVIDER: Record<ProviderKind, readonly string[]> = {
   codex: ["5.4", "mini", "5.3-codex", "spark", "5.2", "5.2-codex"],
   claudeAgent: ["explore", "review", "build", "plan"],
+  gemini: [],
 };
 
 function mapAgentEntries(input: Record<string, AgentAliasDefinition>): ResolvedAgentAlias[] {

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -32,6 +32,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "chat.newTerminal",
   "chat.newClaude",
   "chat.newCodex",
+  "chat.newGemini",
   "chat.split",
   "thread.jump.1",
   "thread.jump.2",

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -77,6 +77,7 @@ const GEMINI_2_5_CAPABILITIES: ModelCapabilities = {
   supportsFastMode: false,
   supportsThinkingToggle: false,
   promptInjectedEffortLevels: [],
+  contextWindowOptions: [],
 };
 
 type ModelDefinition = {
@@ -292,6 +293,7 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
         supportsFastMode: false,
         supportsThinkingToggle: false,
         promptInjectedEffortLevels: [],
+        contextWindowOptions: [],
       },
     },
     {
@@ -310,6 +312,7 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
         supportsFastMode: false,
         supportsThinkingToggle: false,
         promptInjectedEffortLevels: [],
+        contextWindowOptions: [],
       },
     },
     {
@@ -323,6 +326,7 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
         supportsFastMode: false,
         supportsThinkingToggle: false,
         promptInjectedEffortLevels: [],
+        contextWindowOptions: [],
       },
     },
     {
@@ -336,6 +340,7 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
         supportsFastMode: false,
         supportsThinkingToggle: false,
         promptInjectedEffortLevels: [],
+        contextWindowOptions: [],
       },
     },
     {

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -12,7 +12,15 @@ export const CLAUDE_CODE_EFFORT_OPTIONS = [
   "ultrathink",
 ] as const;
 export type ClaudeCodeEffort = (typeof CLAUDE_CODE_EFFORT_OPTIONS)[number];
-export type ProviderReasoningEffort = CodexReasoningEffort | ClaudeCodeEffort;
+export const GEMINI_THINKING_LEVEL_OPTIONS = ["LOW", "HIGH"] as const;
+export type GeminiThinkingLevel = (typeof GEMINI_THINKING_LEVEL_OPTIONS)[number];
+export const GEMINI_THINKING_BUDGET_OPTIONS = [-1, 512, 0] as const;
+export type GeminiThinkingBudget = (typeof GEMINI_THINKING_BUDGET_OPTIONS)[number];
+export type ProviderReasoningEffort =
+  | CodexReasoningEffort
+  | ClaudeCodeEffort
+  | GeminiThinkingLevel
+  | `${GeminiThinkingBudget}`;
 
 export const CodexModelOptions = Schema.Struct({
   reasoningEffort: Schema.optional(Schema.Literals(CODEX_REASONING_EFFORT_OPTIONS)),
@@ -28,9 +36,16 @@ export const ClaudeModelOptions = Schema.Struct({
 });
 export type ClaudeModelOptions = typeof ClaudeModelOptions.Type;
 
+export const GeminiModelOptions = Schema.Struct({
+  thinkingLevel: Schema.optional(Schema.Literals(GEMINI_THINKING_LEVEL_OPTIONS)),
+  thinkingBudget: Schema.optional(Schema.Literals(GEMINI_THINKING_BUDGET_OPTIONS)),
+});
+export type GeminiModelOptions = typeof GeminiModelOptions.Type;
+
 export const ProviderModelOptions = Schema.Struct({
   codex: Schema.optional(CodexModelOptions),
   claudeAgent: Schema.optional(ClaudeModelOptions),
+  gemini: Schema.optional(GeminiModelOptions),
 });
 export type ProviderModelOptions = typeof ProviderModelOptions.Type;
 
@@ -255,6 +270,116 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
       },
     },
   ],
+  gemini: [
+    {
+      slug: "auto-gemini-3",
+      name: "Auto Gemini 3",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "HIGH", label: "High", isDefault: true },
+          { value: "LOW", label: "Low" },
+        ],
+        supportsFastMode: false,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: [],
+      },
+    },
+    {
+      slug: "auto-gemini-2.5",
+      name: "Auto Gemini 2.5",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "-1", label: "Dynamic", isDefault: true },
+          { value: "512", label: "512 Tokens" },
+          { value: "0", label: "Off" },
+        ],
+        supportsFastMode: false,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: [],
+      },
+    },
+    {
+      slug: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "HIGH", label: "High", isDefault: true },
+          { value: "LOW", label: "Low" },
+        ],
+        supportsFastMode: false,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: [],
+      },
+    },
+    {
+      slug: "gemini-3-flash-preview",
+      name: "Gemini 3 Flash Preview",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "HIGH", label: "High", isDefault: true },
+          { value: "LOW", label: "Low" },
+        ],
+        supportsFastMode: false,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: [],
+      },
+    },
+    {
+      slug: "gemini-3.1-flash-lite-preview",
+      name: "Gemini 3.1 Flash Lite Preview",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "HIGH", label: "High", isDefault: true },
+          { value: "LOW", label: "Low" },
+        ],
+        supportsFastMode: false,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: [],
+      },
+    },
+    {
+      slug: "gemini-2.5-pro",
+      name: "Gemini 2.5 Pro",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "-1", label: "Dynamic", isDefault: true },
+          { value: "512", label: "512 Tokens" },
+          { value: "0", label: "Off" },
+        ],
+        supportsFastMode: false,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: [],
+      },
+    },
+    {
+      slug: "gemini-2.5-flash",
+      name: "Gemini 2.5 Flash",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "-1", label: "Dynamic", isDefault: true },
+          { value: "512", label: "512 Tokens" },
+          { value: "0", label: "Off" },
+        ],
+        supportsFastMode: false,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: [],
+      },
+    },
+    {
+      slug: "gemini-2.5-flash-lite",
+      name: "Gemini 2.5 Flash Lite",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "-1", label: "Dynamic", isDefault: true },
+          { value: "512", label: "512 Tokens" },
+          { value: "0", label: "Off" },
+        ],
+        supportsFastMode: false,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: [],
+      },
+    },
+  ],
 } as const satisfies Record<ProviderKind, readonly ModelDefinition[]>;
 export type ModelOptionsByProvider = typeof MODEL_OPTIONS_BY_PROVIDER;
 
@@ -264,6 +389,7 @@ export type ModelSlug = BuiltInModelSlug | (string & {});
 export const DEFAULT_MODEL_BY_PROVIDER: Record<ProviderKind, ModelSlug> = {
   codex: "gpt-5.4",
   claudeAgent: "claude-sonnet-4-6",
+  gemini: "auto-gemini-3",
 };
 
 // Backward compatibility for existing Codex-only call sites.
@@ -299,6 +425,18 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
     "claude-haiku-4.5": "claude-haiku-4-5",
     "claude-haiku-4-5-20251001": "claude-haiku-4-5",
   },
+  gemini: {
+    auto: "auto-gemini-3",
+    "auto-gemini-3": "auto-gemini-3",
+    "auto-gemini-2.5": "auto-gemini-2.5",
+    "gemini-3-pro-preview": "gemini-3.1-pro-preview",
+    "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
+    "gemini-3-flash-preview": "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite-preview",
+    "gemini-2.5-pro": "gemini-2.5-pro",
+    "gemini-2.5-flash": "gemini-2.5-flash",
+    "gemini-2.5-flash-lite": "gemini-2.5-flash-lite",
+  },
 };
 
 // ── Agent mention aliases ─────────────────────────────────────────────
@@ -328,4 +466,5 @@ export const MODEL_CAPABILITIES_INDEX = Object.fromEntries(
 export const PROVIDER_DISPLAY_NAMES: Record<ProviderKind, string> = {
   codex: "Codex",
   claudeAgent: "Claude",
+  gemini: "Gemini",
 };

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -69,6 +69,16 @@ export type ModelCapabilities = {
   readonly contextWindowOptions: readonly ContextWindowOption[];
 };
 
+const GEMINI_2_5_CAPABILITIES: ModelCapabilities = {
+  reasoningEffortLevels: [
+    { value: "-1", label: "Dynamic", isDefault: true },
+    { value: "512", label: "512 Tokens" },
+  ],
+  supportsFastMode: false,
+  supportsThinkingToggle: false,
+  promptInjectedEffortLevels: [],
+};
+
 type ModelDefinition = {
   readonly slug: string;
   readonly name: string;
@@ -287,16 +297,7 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     {
       slug: "auto-gemini-2.5",
       name: "Auto Gemini 2.5",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "-1", label: "Dynamic", isDefault: true },
-          { value: "512", label: "512 Tokens" },
-          { value: "0", label: "Off" },
-        ],
-        supportsFastMode: false,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-      },
+      capabilities: GEMINI_2_5_CAPABILITIES,
     },
     {
       slug: "gemini-3.1-pro-preview",
@@ -340,44 +341,17 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     {
       slug: "gemini-2.5-pro",
       name: "Gemini 2.5 Pro",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "-1", label: "Dynamic", isDefault: true },
-          { value: "512", label: "512 Tokens" },
-          { value: "0", label: "Off" },
-        ],
-        supportsFastMode: false,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-      },
+      capabilities: GEMINI_2_5_CAPABILITIES,
     },
     {
       slug: "gemini-2.5-flash",
       name: "Gemini 2.5 Flash",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "-1", label: "Dynamic", isDefault: true },
-          { value: "512", label: "512 Tokens" },
-          { value: "0", label: "Off" },
-        ],
-        supportsFastMode: false,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-      },
+      capabilities: GEMINI_2_5_CAPABILITIES,
     },
     {
       slug: "gemini-2.5-flash-lite",
       name: "Gemini 2.5 Flash Lite",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "-1", label: "Dynamic", isDefault: true },
-          { value: "512", label: "512 Tokens" },
-          { value: "0", label: "Off" },
-        ],
-        supportsFastMode: false,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-      },
+      capabilities: GEMINI_2_5_CAPABILITIES,
     },
   ],
 } as const satisfies Record<ProviderKind, readonly ModelDefinition[]>;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1,5 +1,5 @@
 import { Option, Schema, SchemaIssue, Struct } from "effect";
-import { ClaudeModelOptions, CodexModelOptions } from "./model";
+import { ClaudeModelOptions, CodexModelOptions, GeminiModelOptions } from "./model";
 import { ProviderMentionReference, ProviderSkillReference } from "./providerDiscovery";
 import { ProjectKind } from "./project";
 import {
@@ -37,7 +37,7 @@ export const ORCHESTRATION_WS_CHANNELS = {
   threadEvent: "orchestration.threadEvent",
 } as const;
 
-export const ProviderKind = Schema.Literals(["codex", "claudeAgent"]);
+export const ProviderKind = Schema.Literals(["codex", "claudeAgent", "gemini"]);
 export type ProviderKind = typeof ProviderKind.Type;
 export const ProviderApprovalPolicy = Schema.Literals([
   "untrusted",
@@ -68,7 +68,18 @@ export const ClaudeModelSelection = Schema.Struct({
 });
 export type ClaudeModelSelection = typeof ClaudeModelSelection.Type;
 
-export const ModelSelection = Schema.Union([CodexModelSelection, ClaudeModelSelection]);
+export const GeminiModelSelection = Schema.Struct({
+  provider: Schema.Literal("gemini"),
+  model: TrimmedNonEmptyString,
+  options: Schema.optional(GeminiModelOptions),
+});
+export type GeminiModelSelection = typeof GeminiModelSelection.Type;
+
+export const ModelSelection = Schema.Union([
+  CodexModelSelection,
+  ClaudeModelSelection,
+  GeminiModelSelection,
+]);
 export type ModelSelection = typeof ModelSelection.Type;
 
 export const CodexProviderStartOptions = Schema.Struct({
@@ -82,9 +93,14 @@ export const ClaudeProviderStartOptions = Schema.Struct({
   maxThinkingTokens: Schema.optional(NonNegativeInt),
 });
 
+export const GeminiProviderStartOptions = Schema.Struct({
+  binaryPath: Schema.optional(TrimmedNonEmptyString),
+});
+
 export const ProviderStartOptions = Schema.Struct({
   codex: Schema.optional(CodexProviderStartOptions),
   claudeAgent: Schema.optional(ClaudeProviderStartOptions),
+  gemini: Schema.optional(GeminiProviderStartOptions),
 });
 export type ProviderStartOptions = typeof ProviderStartOptions.Type;
 

--- a/packages/contracts/src/providerDiscovery.ts
+++ b/packages/contracts/src/providerDiscovery.ts
@@ -1,7 +1,7 @@
 import { Schema } from "effect";
 import { TrimmedNonEmptyString } from "./baseSchemas";
 
-const ProviderDiscoveryKind = Schema.Literals(["codex", "claudeAgent"]);
+const ProviderDiscoveryKind = Schema.Literals(["codex", "claudeAgent", "gemini"]);
 
 export const ProviderSkillInterface = Schema.Struct({
   displayName: Schema.optional(TrimmedNonEmptyString),

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -24,6 +24,9 @@ const RuntimeEventRawSource = Schema.Literals([
   "claude.sdk.message",
   "claude.sdk.permission",
   "codex.sdk.thread-event",
+  "gemini.acp.message",
+  "gemini.acp.stdout",
+  "gemini.acp.stderr",
 ]);
 export type RuntimeEventRawSource = typeof RuntimeEventRawSource.Type;
 

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -11,15 +11,18 @@ import {
   applyClaudePromptEffortPrefix,
   getDefaultContextWindow,
   getDefaultModel,
+  getGeminiThinkingModelAlias,
   getModelCapabilities,
   getModelOptions,
   hasContextWindowOption,
   isClaudeUltrathinkPrompt,
   normalizeClaudeModelOptions,
   normalizeCodexModelOptions,
+  normalizeGeminiModelOptions,
   normalizeModelSlug,
   resolveApiModelId,
   resolveSelectableModel,
+  resolveGeminiApiModelId,
   resolveModelSlug,
   resolveModelSlugForProvider,
   getDefaultEffort,
@@ -155,7 +158,7 @@ describe("resolveSelectableModel", () => {
 });
 
 describe("getModelCapabilities reasoningEffortLevels", () => {
-  const values = (provider: "codex" | "claudeAgent", model: string | null) =>
+  const values = (provider: "codex" | "claudeAgent" | "gemini", model: string | null) =>
     getModelCapabilities(provider, model).reasoningEffortLevels.map((l) => l.value);
 
   it("returns codex reasoning options for codex", () => {
@@ -197,6 +200,16 @@ describe("getModelCapabilities reasoningEffortLevels", () => {
     expect(values("claudeAgent", "claude-haiku-4-5")).toEqual([]);
   });
 
+  it("keeps Gemini 2.5 Pro and auto 2.5 on supported budgets only", () => {
+    expect(values("gemini", "gemini-2.5-pro")).toEqual(["-1", "512"]);
+    expect(values("gemini", "auto-gemini-2.5")).toEqual(["-1", "512"]);
+  });
+
+  it("keeps all Gemini 2.5 models on CLI-safe budgets only", () => {
+    expect(values("gemini", "gemini-2.5-flash")).toEqual(["-1", "512"]);
+    expect(values("gemini", "gemini-2.5-flash-lite")).toEqual(["-1", "512"]);
+  });
+
   it("co-locates labels with effort values", () => {
     const levels = getModelCapabilities("claudeAgent", "claude-opus-4-6").reasoningEffortLevels;
     const high = levels.find((l) => l.value === "high");
@@ -214,6 +227,7 @@ describe("getDefaultEffort", () => {
     expect(getDefaultEffort(getModelCapabilities("claudeAgent", "claude-opus-4-7"))).toBe("high");
     expect(getDefaultEffort(getModelCapabilities("claudeAgent", "claude-opus-4-6"))).toBe("high");
     expect(getDefaultEffort(getModelCapabilities("claudeAgent", "claude-haiku-4-5"))).toBeNull();
+    expect(getDefaultEffort(getModelCapabilities("gemini", "gemini-2.5-flash-lite"))).toBe("-1");
   });
 });
 
@@ -356,6 +370,32 @@ describe("normalizeClaudeModelOptions", () => {
     ).toEqual({
       thinking: false,
     });
+  });
+});
+
+describe("normalizeGeminiModelOptions", () => {
+  it("drops unsupported thinking-off overrides for the Gemini 2.5 family", () => {
+    expect(normalizeGeminiModelOptions("gemini-2.5-pro", { thinkingBudget: 0 })).toBeUndefined();
+    expect(normalizeGeminiModelOptions("auto-gemini-2.5", { thinkingBudget: 0 })).toBeUndefined();
+    expect(normalizeGeminiModelOptions("gemini-2.5-flash", { thinkingBudget: 0 })).toBeUndefined();
+    expect(
+      normalizeGeminiModelOptions("gemini-2.5-flash-lite", { thinkingBudget: 0 }),
+    ).toBeUndefined();
+  });
+});
+
+describe("getGeminiThinkingModelAlias", () => {
+  it("refuses unsupported Gemini 2.5 off aliases", () => {
+    expect(getGeminiThinkingModelAlias("gemini-2.5-pro", { thinkingBudget: 0 })).toBeNull();
+    expect(resolveGeminiApiModelId("gemini-2.5-pro", { thinkingBudget: 0 })).toBe("gemini-2.5-pro");
+    expect(getGeminiThinkingModelAlias("gemini-2.5-flash", { thinkingBudget: 0 })).toBeNull();
+    expect(resolveGeminiApiModelId("gemini-2.5-flash", { thinkingBudget: 0 })).toBe(
+      "gemini-2.5-flash",
+    );
+    expect(getGeminiThinkingModelAlias("gemini-2.5-flash-lite", { thinkingBudget: 0 })).toBeNull();
+    expect(resolveGeminiApiModelId("gemini-2.5-flash-lite", { thinkingBudget: 0 })).toBe(
+      "gemini-2.5-flash-lite",
+    );
   });
 });
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -6,6 +6,9 @@ import {
   type ClaudeModelOptions,
   type ClaudeCodeEffort,
   type CodexModelOptions,
+  type GeminiModelOptions,
+  type GeminiThinkingBudget,
+  type GeminiThinkingLevel,
   type ModelCapabilities,
   type ModelSelection,
   type ModelSlug,
@@ -16,11 +19,71 @@ import {
 const MODEL_SLUG_SET_BY_PROVIDER: Record<ProviderKind, ReadonlySet<ModelSlug>> = {
   claudeAgent: new Set(MODEL_OPTIONS_BY_PROVIDER.claudeAgent.map((option) => option.slug)),
   codex: new Set(MODEL_OPTIONS_BY_PROVIDER.codex.map((option) => option.slug)),
+  gemini: new Set(MODEL_OPTIONS_BY_PROVIDER.gemini.map((option) => option.slug)),
 };
 
 export interface SelectableModelOption {
   slug: string;
   name: string;
+}
+
+export type GeminiThinkingConfigKind = "budget" | "level";
+
+const GEMINI_3_MODEL_PATTERN = /^(?:auto-)?gemini-3(?:[.-]|$)/i;
+const GEMINI_2_5_MODEL_PATTERN = /^(?:auto-)?gemini-2\.5(?:[.-]|$)/i;
+const GEMINI_THINKING_LEVEL_SET = new Set<GeminiThinkingLevel>(["LOW", "HIGH"]);
+const GEMINI_THINKING_BUDGET_MAP = new Map<string, GeminiThinkingBudget>([
+  ["-1", -1],
+  ["0", 0],
+  ["512", 512],
+]);
+
+export const EMPTY_MODEL_CAPABILITIES: ModelCapabilities = {
+  reasoningEffortLevels: [],
+  supportsFastMode: false,
+  supportsThinkingToggle: false,
+  promptInjectedEffortLevels: [],
+  contextWindowOptions: [],
+};
+export const DEFAULT_GEMINI_MODEL_CAPABILITIES = EMPTY_MODEL_CAPABILITIES;
+
+export const GEMINI_3_MODEL_CAPABILITIES: ModelCapabilities = {
+  reasoningEffortLevels: [
+    { value: "HIGH", label: "High", isDefault: true },
+    { value: "LOW", label: "Low" },
+  ],
+  supportsFastMode: false,
+  supportsThinkingToggle: false,
+  promptInjectedEffortLevels: [],
+  contextWindowOptions: [],
+};
+
+export const GEMINI_2_5_MODEL_CAPABILITIES: ModelCapabilities = {
+  reasoningEffortLevels: [
+    { value: "-1", label: "Dynamic", isDefault: true },
+    { value: "512", label: "512 Tokens" },
+  ],
+  supportsFastMode: false,
+  supportsThinkingToggle: false,
+  promptInjectedEffortLevels: [],
+  contextWindowOptions: [],
+};
+
+function isGeminiThinkingLevel(value: string): value is GeminiThinkingLevel {
+  return GEMINI_THINKING_LEVEL_SET.has(value as GeminiThinkingLevel);
+}
+
+function isGeminiThinkingBudget(value: string): value is `${GeminiThinkingBudget}` {
+  return GEMINI_THINKING_BUDGET_MAP.has(value);
+}
+
+function sanitizeGeminiAliasSegment(value: string): string {
+  const sanitized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized || "model";
 }
 
 export function getModelOptions(provider: ProviderKind = "codex") {
@@ -29,6 +92,114 @@ export function getModelOptions(provider: ProviderKind = "codex") {
 
 export function getDefaultModel(provider: ProviderKind = "codex"): ModelSlug {
   return DEFAULT_MODEL_BY_PROVIDER[provider];
+}
+
+export function getGeminiThinkingConfigKind(
+  model: string | null | undefined,
+): GeminiThinkingConfigKind | null {
+  const trimmed = trimOrNull(model);
+  if (!trimmed) {
+    return null;
+  }
+  if (GEMINI_3_MODEL_PATTERN.test(trimmed)) {
+    return "level";
+  }
+  if (GEMINI_2_5_MODEL_PATTERN.test(trimmed)) {
+    return "budget";
+  }
+  return null;
+}
+
+export function geminiCapabilitiesForModel(
+  modelId: string | null | undefined,
+  fallbackCapabilities: ModelCapabilities = EMPTY_MODEL_CAPABILITIES,
+): ModelCapabilities {
+  const trimmed = trimOrNull(modelId)?.toLowerCase();
+  switch (getGeminiThinkingConfigKind(modelId)) {
+    case "level":
+      return GEMINI_3_MODEL_CAPABILITIES;
+    case "budget":
+      if (!trimmed) {
+        return fallbackCapabilities;
+      }
+      return GEMINI_2_5_MODEL_CAPABILITIES;
+    default:
+      return fallbackCapabilities;
+  }
+}
+
+export function getGeminiThinkingSelectionValue(
+  caps: ModelCapabilities,
+  modelOptions: GeminiModelOptions | null | undefined,
+): string | null {
+  const candidates = [
+    trimOrNull(modelOptions?.thinkingLevel),
+    modelOptions?.thinkingBudget !== undefined ? String(modelOptions.thinkingBudget) : null,
+  ];
+
+  return (
+    candidates.find(
+      (candidate): candidate is string => !!candidate && hasEffortLevel(caps, candidate),
+    ) ??
+    candidates.find((candidate): candidate is string => !!candidate) ??
+    null
+  );
+}
+
+export function geminiModelOptionsFromEffortValue(
+  value: string | null | undefined,
+): GeminiModelOptions | undefined {
+  const trimmed = trimOrNull(value);
+  if (!trimmed) {
+    return undefined;
+  }
+  if (isGeminiThinkingLevel(trimmed)) {
+    return { thinkingLevel: trimmed };
+  }
+  if (isGeminiThinkingBudget(trimmed)) {
+    return {
+      thinkingBudget: GEMINI_THINKING_BUDGET_MAP.get(trimmed) as GeminiThinkingBudget,
+    };
+  }
+  return undefined;
+}
+
+export function getGeminiThinkingModelAlias(
+  model: string,
+  modelOptions: GeminiModelOptions | null | undefined,
+): string | null {
+  const kind = getGeminiThinkingConfigKind(model);
+  if (!kind || !modelOptions) {
+    return null;
+  }
+
+  const caps = getModelCapabilities("gemini", model);
+  const effort = getGeminiThinkingSelectionValue(caps, modelOptions);
+  if (!effort || !hasEffortLevel(caps, effort)) {
+    return null;
+  }
+  const nextOptions = geminiModelOptionsFromEffortValue(effort);
+  if (!nextOptions) {
+    return null;
+  }
+
+  const base = sanitizeGeminiAliasSegment(model);
+  if (kind === "level" && nextOptions.thinkingLevel) {
+    return `dpcode-gemini-${base}-thinking-level-${nextOptions.thinkingLevel.toLowerCase()}`;
+  }
+  if (kind === "budget" && nextOptions.thinkingBudget !== undefined) {
+    const budget =
+      nextOptions.thinkingBudget === -1 ? "dynamic" : String(nextOptions.thinkingBudget);
+    return `dpcode-gemini-${base}-thinking-budget-${budget}`;
+  }
+  return null;
+}
+
+export function resolveGeminiApiModelId(
+  model: string,
+  modelOptions: GeminiModelOptions | null | undefined,
+): string {
+  return getGeminiThinkingModelAlias(model, modelOptions) ?? model;
 }
 
 // ── Effort helpers ────────────────────────────────────────────────────
@@ -63,13 +234,10 @@ export function getModelCapabilities(
   if (slug && MODEL_CAPABILITIES_INDEX[provider]?.[slug]) {
     return MODEL_CAPABILITIES_INDEX[provider][slug];
   }
-  return {
-    reasoningEffortLevels: [],
-    supportsFastMode: false,
-    supportsThinkingToggle: false,
-    promptInjectedEffortLevels: [],
-    contextWindowOptions: [],
-  };
+  if (provider === "gemini") {
+    return geminiCapabilitiesForModel(slug ?? model, EMPTY_MODEL_CAPABILITIES);
+  }
+  return EMPTY_MODEL_CAPABILITIES;
 }
 
 export function isClaudeUltrathinkPrompt(text: string | null | undefined): boolean {
@@ -207,6 +375,32 @@ export function normalizeClaudeModelOptions(
     ...(contextWindow ? { contextWindow } : {}),
   };
   return Object.keys(nextOptions).length > 0 ? nextOptions : undefined;
+}
+
+export function normalizeGeminiModelOptions(
+  model: string | null | undefined,
+  modelOptions: GeminiModelOptions | null | undefined,
+): GeminiModelOptions | undefined {
+  const caps = getModelCapabilities("gemini", model);
+  const effort = getGeminiThinkingSelectionValue(caps, modelOptions);
+  if (!effort || !hasEffortLevel(caps, effort)) {
+    return undefined;
+  }
+  const defaultEffort = getDefaultEffort(caps);
+  const nextOptions = geminiModelOptionsFromEffortValue(effort);
+  if (!nextOptions) {
+    return undefined;
+  }
+
+  const normalizedEffort =
+    nextOptions.thinkingLevel !== undefined
+      ? nextOptions.thinkingLevel
+      : String(nextOptions.thinkingBudget);
+  if (normalizedEffort === defaultEffort) {
+    return undefined;
+  }
+
+  return nextOptions;
 }
 
 export function resolveApiModelId(modelSelection: ModelSelection): string {


### PR DESCRIPTION
## What changed

- add Gemini provider support across contracts, shared model handling, server runtime, and web UI
- add Gemini model selection and thinking-option handling in the composer flow
- add Gemini install/settings support and Gemini-aware handoff/import surfaces
- merge the latest `main` into the Gemini branch and resolve the merge conflicts needed to target `main`
- align visible provider copy with the current `main` naming

## Why

This brings Gemini in as a first-class provider while keeping the branch compatible with the current `main` line. The merge conflict work was needed because the original PR landed on a staging branch, not `main`.

## Impact

- users can configure and run Gemini alongside the existing providers
- Gemini models and thinking settings flow through the UI and provider runtime correctly
- handoff and import flows can target Gemini without reintroducing older provider wording

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`