### PR TITLE
Add Gemini CLI support across runtime and setup flows

### DIFF
--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-DP Code runs as a **Node.js WebSocket server** that wraps `codex app-server` (JSON-RPC over stdio) and serves a React web app.
+DP Code runs as a **Node.js WebSocket server** that wraps provider runtimes such as `codex app-server`, Claude Code, and Gemini CLI ACP, then serves a React web app.
 
 ```
 ┌─────────────────────────────────┐
@@ -21,7 +21,8 @@ DP Code runs as a **Node.js WebSocket server** that wraps `codex app-server` (JS
 └──────────┬──────────────────────┘
            │ JSON-RPC over stdio
 ┌──────────▼──────────────────────┐
-│  codex app-server               │
+│  Provider runtime               │
+│  Codex / Claude / Gemini        │
 └─────────────────────────────────┘
 ```
 
@@ -31,7 +32,7 @@ DP Code runs as a **Node.js WebSocket server** that wraps `codex app-server` (JS
 
 - **Server**: `apps/server` is the main coordinator. It serves the web app, accepts WebSocket requests, waits for startup readiness before welcoming clients, and sends all outbound pushes through a single ordered push path.
 
-- **Provider runtime**: `codex app-server` does the actual provider/session work. The server talks to it over JSON-RPC on stdio and translates those runtime events into the app's orchestration model.
+- **Provider runtime**: provider-specific adapters handle the actual provider/session work. Codex uses `codex app-server`, Claude uses the Claude runtime integration, and Gemini uses Gemini CLI ACP. The server talks to those runtimes over their provider-native transports and translates their runtime events into the app's orchestration model.
 
 - **Background workers**: Long-running async flows such as runtime ingestion, command reaction, and checkpoint processing run as queue-backed workers. This keeps work ordered, reduces timing races, and gives tests a deterministic way to wait for the system to go idle.
 
@@ -74,7 +75,7 @@ sequenceDiagram
     participant Transport as WsTransport
     participant Server as wsServer
     participant Provider as ProviderService
-    participant Codex as codex app-server
+    participant Runtime as provider runtime
     participant Ingest as ProviderRuntimeIngestion
     participant Engine as OrchestrationEngine
     participant Push as ServerPushBus
@@ -82,8 +83,8 @@ sequenceDiagram
     Browser->>Transport: Send user action
     Transport->>Server: Typed WebSocket request
     Server->>Provider: Route request
-    Provider->>Codex: JSON-RPC over stdio
-    Codex-->>Ingest: Provider runtime events
+    Provider->>Runtime: Provider-native request
+    Runtime-->>Ingest: Provider runtime events
     Ingest->>Engine: Normalize into orchestration events
     Engine-->>Server: Domain events
     Server->>Push: Publish orchestration.domainEvent
@@ -92,7 +93,7 @@ sequenceDiagram
 
 1. A user action in the browser becomes a typed request through [`WsTransport`][1] and the browser API layer in [`nativeApi`][12].
 2. [`wsServer`][3] decodes that request using the shared WebSocket contracts in [`ws.ts`][6] and routes it to the right service.
-3. [`ProviderService`][8] starts or resumes a session and talks to `codex app-server` over JSON-RPC on stdio.
+3. [`ProviderService`][8] starts or resumes a session and talks to the selected provider runtime through the matching adapter.
 4. Provider-native events are pulled back into the server by [`ProviderRuntimeIngestion`][9], which converts them into orchestration events.
 5. [`OrchestrationEngine`][10] persists those events, updates the read model, and exposes them as domain events.
 6. [`wsServer`][3] pushes those updates to the browser through [`ServerPushBus`][5] on channels defined in [`orchestration.ts`][11].

--- a/.docs/gemini-prerequisites.md
+++ b/.docs/gemini-prerequisites.md
@@ -1,0 +1,13 @@
+# Gemini prerequisites
+
+- Install Gemini CLI so `gemini` is on your PATH, or set a custom Gemini binary path in DP Code Settings.
+- Authenticate Gemini CLI before running DP Code:
+  - Open `gemini` and choose Sign in with Google, or
+  - configure `GEMINI_API_KEY`, or
+  - configure Vertex AI credentials as documented by Gemini CLI.
+- DP Code starts Gemini in ACP mode via `gemini --acp` for each Gemini-backed session.
+- DP Code may inject a temporary `GEMINI_CLI_SYSTEM_SETTINGS_PATH` file so DP Code's Gemini thinking controls resolve to documented Gemini model aliases and budgets.
+- Official docs:
+  - Authentication: https://www.geminicli.com/docs/get-started/authentication/
+  - ACP mode: https://www.geminicli.com/docs/cli/acp-mode/
+  - Configuration: https://www.geminicli.com/docs/reference/configuration/

--- a/.docs/provider-architecture.md
+++ b/.docs/provider-architecture.md
@@ -13,7 +13,7 @@ Methods mirror the `NativeApi` interface defined in `@t3tools/contracts`:
 - `providers.respondToRequest`, `providers.stopSession`
 - `shell.openInEditor`, `server.getConfig`
 
-Codex is the only implemented provider. `claudeCode` is reserved in contracts/UI.
+Codex, Claude, and Gemini are implemented provider adapters. Codex uses `codex app-server`, Claude uses the Claude Code runtime integration, and Gemini uses Gemini CLI ACP (`gemini --acp`).
 
 ## Client transport
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## Project Snapshot
 
-DP Code is a minimal web GUI for using coding agents like Codex and Claude.
+DP Code is a minimal web GUI for using coding agents like Codex, Claude, and Gemini.
 
 This repository is a VERY EARLY WIP. Proposing sweeping changes that improve long-term maintainability is encouraged.
 
@@ -27,25 +27,30 @@ Long term maintainability is a core priority. If you add new functionality, firs
 
 ## Package Roles
 
-- `apps/server`: Node.js WebSocket server. Wraps Codex app-server (JSON-RPC over stdio), serves the React web app, and manages provider sessions.
+- `apps/server`: Node.js WebSocket server. Wraps provider runtimes (Codex app-server, Claude Code, and Gemini CLI ACP), serves the React web app, and manages provider sessions.
 - `apps/web`: React/Vite UI. Owns session UX, conversation/event rendering, and client-side state. Connects to the server via WebSocket.
 - `packages/contracts`: Shared effect/Schema schemas and TypeScript contracts for provider events, WebSocket protocol, and model/session types. Keep this package schema-only — no runtime logic.
 - `packages/shared`: Shared runtime utilities consumed by both server and web. Uses explicit subpath exports (e.g. `@t3tools/shared/git`) — no barrel index.
 
-## Codex App Server (Important)
+## Provider Runtimes (Important)
 
-DP Code is currently Codex-first. The server starts `codex app-server` (JSON-RPC over stdio) per provider session, then streams structured events to the browser through WebSocket push messages.
+DP Code is still Codex-first, but the app now supports three provider backends through the same orchestration boundary:
 
-How we use it in this codebase:
+- Codex via `codex app-server` (JSON-RPC over stdio)
+- Claude via the Claude Code / Agent SDK integration
+- Gemini via Gemini CLI ACP (`gemini --acp`)
 
-- Session startup/resume and turn lifecycle are brokered in `apps/server/src/codexAppServerManager.ts`.
-- Provider dispatch and thread event logging are coordinated in `apps/server/src/providerManager.ts`.
+How we use them in this codebase:
+
+- Provider session startup/resume, turn lifecycle, and runtime event mapping live in `apps/server/src/provider/Layers/CodexAdapter.ts`, `apps/server/src/provider/Layers/ClaudeAdapter.ts`, and `apps/server/src/provider/Layers/GeminiAdapter.ts`.
+- Provider health and runtime model discovery live under `apps/server/src/provider/Layers/ProviderHealth.ts` and `apps/server/src/provider/Layers/ProviderDiscoveryService.ts`.
 - WebSocket server routes NativeApi methods in `apps/server/src/wsServer.ts`.
 - Web app consumes orchestration domain events via WebSocket push on channel `orchestration.domainEvent` (provider runtime activity is projected into orchestration events server-side).
 
 Docs:
 
 - Codex App Server docs: https://developers.openai.com/codex/sdk/#app-server
+- Gemini CLI ACP docs: https://www.geminicli.com/docs/cli/acp-mode/
 
 ## Reference Repos
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 
 ## Project Snapshot
 
-DP Code is a minimal web GUI for using coding agents like Codex and Claude.
+DP Code is a minimal web GUI for using coding agents like Codex, Claude, and Gemini.
 
 This repository is a VERY EARLY WIP. Proposing sweeping changes that improve long-term maintainability is encouraged.
 
@@ -27,25 +27,30 @@ Long term maintainability is a core priority. If you add new functionality, firs
 
 ## Package Roles
 
-- `apps/server`: Node.js WebSocket server. Wraps Codex app-server (JSON-RPC over stdio), serves the React web app, and manages provider sessions.
+- `apps/server`: Node.js WebSocket server. Wraps provider runtimes (Codex app-server, Claude Code, and Gemini CLI ACP), serves the React web app, and manages provider sessions.
 - `apps/web`: React/Vite UI. Owns session UX, conversation/event rendering, and client-side state. Connects to the server via WebSocket.
 - `packages/contracts`: Shared effect/Schema schemas and TypeScript contracts for provider events, WebSocket protocol, and model/session types. Keep this package schema-only — no runtime logic.
 - `packages/shared`: Shared runtime utilities consumed by both server and web. Uses explicit subpath exports (e.g. `@t3tools/shared/git`) — no barrel index.
 
-## Codex App Server (Important)
+## Provider Runtimes (Important)
 
-DP Code is currently Codex-first. The server starts `codex app-server` (JSON-RPC over stdio) per provider session, then streams structured events to the browser through WebSocket push messages.
+DP Code is still Codex-first, but the app now supports three provider backends through the same orchestration boundary:
 
-How we use it in this codebase:
+- Codex via `codex app-server` (JSON-RPC over stdio)
+- Claude via the Claude Code / Agent SDK integration
+- Gemini via Gemini CLI ACP (`gemini --acp`)
 
-- Session startup/resume and turn lifecycle are brokered in `apps/server/src/codexAppServerManager.ts`.
-- Provider dispatch and thread event logging are coordinated in `apps/server/src/providerManager.ts`.
+How we use them in this codebase:
+
+- Provider session startup/resume, turn lifecycle, and runtime event mapping live in `apps/server/src/provider/Layers/CodexAdapter.ts`, `apps/server/src/provider/Layers/ClaudeAdapter.ts`, and `apps/server/src/provider/Layers/GeminiAdapter.ts`.
+- Provider health and runtime model discovery live under `apps/server/src/provider/Layers/ProviderHealth.ts` and `apps/server/src/provider/Layers/ProviderDiscoveryService.ts`.
 - WebSocket server routes NativeApi methods in `apps/server/src/wsServer.ts`.
 - Web app consumes orchestration domain events via WebSocket push on channel `orchestration.domainEvent` (provider runtime activity is projected into orchestration events server-side).
 
 Docs:
 
 - Codex App Server docs: https://developers.openai.com/codex/sdk/#app-server
+- Gemini CLI ACP docs: https://www.geminicli.com/docs/cli/acp-mode/
 
 ## Reference Repos
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,25 @@
 # DP Code
 
-DP Code is a minimal web GUI for coding agents (currently Codex and Claude, more coming soon).
+DP Code is a minimal web GUI for coding agents like Codex, Claude Code, and Gemini CLI.
 
 This project started as a clone of [T3Code](https://github.com/pingdotgg/t3code), and has since been customized into its own product with different branding, packaging, release wiring, and product-level behavior.
 
 ## How to use
 
 > [!WARNING]
-> You need to have [Codex CLI](https://github.com/openai/codex) installed and authorized for DP Code to work.
+> You need to have the provider CLI you want to use installed and authenticated before DP Code can start a session.
+
+- [Codex CLI](https://github.com/openai/codex) is required for Codex sessions.
+- Claude Code is required for Claude sessions.
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli) is required for Gemini sessions.
+
+Gemini setup notes:
+
+- Install `gemini` so it is on your PATH, or set a custom Gemini binary path in Settings.
+- Authenticate by opening `gemini` and choosing Sign in with Google, or configure `GEMINI_API_KEY` / Vertex AI as documented in the [official Gemini CLI authentication guide](https://www.geminicli.com/docs/get-started/authentication/).
+- DP Code starts Gemini through ACP mode (`gemini --acp`) and may inject a temporary `GEMINI_CLI_SYSTEM_SETTINGS_PATH` file to map DP Code's Gemini thinking controls onto documented Gemini model aliases.
+
+See [`.docs/gemini-prerequisites.md`](./.docs/gemini-prerequisites.md) and [`.docs/codex-prerequisites.md`](./.docs/codex-prerequisites.md) for provider-specific setup notes.
 
 You can also just install the desktop app. It's cooler.
 

--- a/apps/server/src/homeMigration.test.ts
+++ b/apps/server/src/homeMigration.test.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { DatabaseSync } from "node:sqlite";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -53,6 +54,50 @@ const readMarker = (markerPath: string) =>
   };
 
 it.layer(NodeServices.layer)("homeMigration", (it) => {
+  it("can be imported by Bun without eagerly requiring node:sqlite", () => {
+    const result = spawnSync(
+      "bun",
+      [
+        "--eval",
+        "import('./homeMigration.ts').then(() => process.exit(0)).catch((error) => { console.error(error); process.exit(1); });",
+      ],
+      {
+        cwd: import.meta.dirname,
+        encoding: "utf8",
+      },
+    );
+
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout || "Bun import failed.");
+  });
+
+  it.effect("skips non-default homes without loading sqlite bindings", () =>
+    Effect.gen(function* () {
+      const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "dpcode-home-migration-"));
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => fs.rmSync(tempHome, { recursive: true, force: true })),
+      );
+
+      const result = yield* migrateLegacyHomeIfNeeded(
+        {
+          baseDir: path.join(tempHome, "custom-home"),
+          homeDir: tempHome,
+          devUrl: undefined,
+        },
+        {
+          loadDatabaseSync: async () => {
+            throw new Error("should not load sqlite bindings when migration is skipped");
+          },
+        },
+      );
+
+      assert.deepStrictEqual(result, {
+        status: "skipped",
+        reason: "non-default-home",
+        importedArtifacts: [],
+      });
+    }),
+  );
+
   it.effect("imports legacy userdata into the new default home", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/homeMigration.ts
+++ b/apps/server/src/homeMigration.ts
@@ -2,10 +2,8 @@
  * FILE: homeMigration.ts
  * Purpose: Imports legacy ~/.t3 state into the new ~/.dpcode home on first startup.
  * Layer: Startup utility
- * Depends on: config path derivation, Effect filesystem/path services, and node:sqlite snapshots
+ * Depends on: config path derivation, Effect filesystem/path services, and lazy node:sqlite snapshots
  */
-import { DatabaseSync } from "node:sqlite";
-
 import { Data, Effect, FileSystem, Path } from "effect";
 
 import { deriveServerPaths } from "./config";
@@ -42,6 +40,10 @@ interface LegacyHomeMigrationInput {
   readonly devUrl: URL | undefined;
 }
 
+interface LegacyHomeMigrationDependencies {
+  readonly loadDatabaseSync?: () => Promise<DatabaseSyncConstructor>;
+}
+
 interface MigrationMarker {
   readonly status: MigrationMarkerStatus;
   readonly sourceBaseDir: string;
@@ -55,6 +57,25 @@ interface MigrationMarker {
 }
 
 const IMPORTABLE_ARTIFACTS = ["database", "keybindings", "attachments", "anonymousId"] as const;
+
+type DatabaseSyncInstance = {
+  readonly exec: (sql: string) => void;
+  readonly close: () => void;
+};
+
+type DatabaseSyncConstructor = new (
+  path: string,
+  options?: { readonly readOnly?: boolean },
+) => DatabaseSyncInstance;
+
+let cachedDatabaseSyncConstructor: Promise<DatabaseSyncConstructor> | undefined;
+
+const loadDatabaseSync = () => {
+  cachedDatabaseSyncConstructor ??= import("node:sqlite").then(
+    (module) => module.DatabaseSync as unknown as DatabaseSyncConstructor,
+  );
+  return cachedDatabaseSyncConstructor;
+};
 
 const writeMigrationMarker = (markerPath: string, marker: MigrationMarker) =>
   Effect.gen(function* () {
@@ -118,9 +139,14 @@ const readMigrationMarker = (markerPath: string) =>
     } satisfies MigrationMarker;
   });
 
-const snapshotSqliteDatabase = (sourcePath: string, targetPath: string) =>
-  Effect.try({
-    try: () => {
+const snapshotSqliteDatabase = (
+  sourcePath: string,
+  targetPath: string,
+  loadDatabaseSyncFn: () => Promise<DatabaseSyncConstructor> = loadDatabaseSync,
+) =>
+  Effect.tryPromise({
+    try: async () => {
+      const DatabaseSync = await loadDatabaseSyncFn();
       const escapedTargetPath = targetPath.replaceAll("'", "''");
       const sourceDb = new DatabaseSync(sourcePath, { readOnly: true });
       try {
@@ -177,7 +203,10 @@ const cleanUpStagingDir = (stagingBaseDir: string) =>
     yield* fs.remove(stagingBaseDir, { recursive: true }).pipe(Effect.catch(() => Effect.void));
   });
 
-export const migrateLegacyHomeIfNeeded = Effect.fn(function* (input: LegacyHomeMigrationInput) {
+export const migrateLegacyHomeIfNeeded = Effect.fn(function* (
+  input: LegacyHomeMigrationInput,
+  dependencies?: LegacyHomeMigrationDependencies,
+) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const canonicalTargetBaseDir = path.resolve(path.join(input.homeDir, DPCODE_HOME_DIRNAME));
@@ -282,7 +311,11 @@ export const migrateLegacyHomeIfNeeded = Effect.fn(function* (input: LegacyHomeM
     );
 
     if (pendingArtifacts.has("database")) {
-      yield* snapshotSqliteDatabase(sourcePaths.dbPath, stagingPaths.dbPath);
+      yield* snapshotSqliteDatabase(
+        sourcePaths.dbPath,
+        stagingPaths.dbPath,
+        dependencies?.loadDatabaseSync,
+      );
     }
     if (pendingArtifacts.has("keybindings")) {
       yield* stageFileCopy(sourcePaths.keybindingsConfigPath, stagingPaths.keybindingsConfigPath);

--- a/apps/server/src/provider/Layers/GeminiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GeminiAdapter.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGeminiThinkingModelConfigAliases } from "./GeminiAdapter";
+
+describe("buildGeminiThinkingModelConfigAliases", () => {
+  it("creates the official Gemini 3 thinking levels and Gemini 2.5 budget presets", () => {
+    const aliases = buildGeminiThinkingModelConfigAliases([
+      "gemini-3-pro-preview",
+      "gemini-2.5-pro",
+    ]);
+
+    expect(aliases["dpcode-gemini-gemini-3-pro-preview-thinking-level-high"]).toEqual({
+      extends: "chat-base-3",
+      modelConfig: {
+        model: "gemini-3-pro-preview",
+        generateContentConfig: {
+          thinkingConfig: {
+            thinkingLevel: "HIGH",
+          },
+        },
+      },
+    });
+
+    expect(aliases["dpcode-gemini-gemini-3-pro-preview-thinking-level-medium"]).toEqual({
+      extends: "chat-base-3",
+      modelConfig: {
+        model: "gemini-3-pro-preview",
+        generateContentConfig: {
+          thinkingConfig: {
+            thinkingLevel: "MEDIUM",
+          },
+        },
+      },
+    });
+
+    expect(aliases["dpcode-gemini-gemini-3-pro-preview-thinking-level-low"]).toEqual({
+      extends: "chat-base-3",
+      modelConfig: {
+        model: "gemini-3-pro-preview",
+        generateContentConfig: {
+          thinkingConfig: {
+            thinkingLevel: "LOW",
+          },
+        },
+      },
+    });
+
+    expect(aliases["dpcode-gemini-gemini-3-pro-preview-thinking-level-minimal"]).toEqual({
+      extends: "chat-base-3",
+      modelConfig: {
+        model: "gemini-3-pro-preview",
+        generateContentConfig: {
+          thinkingConfig: {
+            thinkingLevel: "MINIMAL",
+          },
+        },
+      },
+    });
+
+    expect(aliases["dpcode-gemini-gemini-2-5-pro-thinking-budget-8192"]).toEqual({
+      extends: "chat-base-2.5",
+      modelConfig: {
+        model: "gemini-2.5-pro",
+        generateContentConfig: {
+          thinkingConfig: {
+            thinkingBudget: 8192,
+          },
+        },
+      },
+    });
+
+    expect(aliases["dpcode-gemini-gemini-2-5-pro-thinking-budget-512"]).toEqual({
+      extends: "chat-base-2.5",
+      modelConfig: {
+        model: "gemini-2.5-pro",
+        generateContentConfig: {
+          thinkingConfig: {
+            thinkingBudget: 512,
+          },
+        },
+      },
+    });
+
+    expect(aliases["dpcode-gemini-gemini-2-5-pro-thinking-budget-0"]).toEqual({
+      extends: "chat-base-2.5",
+      modelConfig: {
+        model: "gemini-2.5-pro",
+        generateContentConfig: {
+          thinkingConfig: {
+            thinkingBudget: 0,
+          },
+        },
+      },
+    });
+  });
+});

--- a/apps/server/src/provider/Layers/GeminiAdapter.ts
+++ b/apps/server/src/provider/Layers/GeminiAdapter.ts
@@ -63,8 +63,13 @@ const GEMINI_TMP_DIR = path.join(os.homedir(), ".gemini", "tmp");
 const GEMINI_CHAT_DIR_NAME = "chats";
 const GEMINI_SESSION_FILE_PREFIX = "session-";
 const DPCODE_GEMINI_SETTINGS_DIR = path.join(os.tmpdir(), "dpcode", "gemini");
-const GEMINI_3_THINKING_LEVELS: ReadonlyArray<GeminiThinkingLevel> = ["HIGH", "LOW"];
-const GEMINI_2_5_THINKING_BUDGETS: ReadonlyArray<GeminiThinkingBudget> = [-1, 512, 0];
+const GEMINI_3_THINKING_LEVELS: ReadonlyArray<GeminiThinkingLevel> = [
+  "HIGH",
+  "MEDIUM",
+  "LOW",
+  "MINIMAL",
+];
+const GEMINI_2_5_THINKING_BUDGETS: ReadonlyArray<GeminiThinkingBudget> = [8192, 512, 0];
 
 type JsonRpcId = number | string;
 type GeminiToolKind =

--- a/apps/server/src/provider/geminiAcpProbe.test.ts
+++ b/apps/server/src/provider/geminiAcpProbe.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { normalizeGeminiCapabilityProbeResult } from "./geminiAcpProbe";
+import { normalizeGeminiCapabilityProbeResult, parseGeminiAcpProbeError } from "./geminiAcpProbe";
 
 describe("normalizeGeminiCapabilityProbeResult", () => {
   it("treats authenticated ACP sessions without model discovery as ready", () => {
@@ -42,5 +42,21 @@ describe("normalizeGeminiCapabilityProbeResult", () => {
     };
 
     expect(normalizeGeminiCapabilityProbeResult(result)).toEqual(result);
+  });
+});
+
+describe("parseGeminiAcpProbeError", () => {
+  it("returns actionable guidance for authentication errors", () => {
+    expect(
+      parseGeminiAcpProbeError({
+        code: -32_000,
+        message: "Authentication required: auth method not configured.",
+      }),
+    ).toEqual({
+      status: "error",
+      auth: { status: "unauthenticated" },
+      message:
+        "Gemini is not authenticated. Open `gemini` and choose Sign in with Google, or configure `GEMINI_API_KEY` / Vertex AI credentials. Authentication required: auth method not configured.",
+    });
   });
 });

--- a/apps/server/src/provider/geminiAcpProbe.ts
+++ b/apps/server/src/provider/geminiAcpProbe.ts
@@ -61,7 +61,7 @@ function formatGeminiDiscoveryWarning(detail: string): string {
 }
 
 function formatGeminiAuthMessage(detail: string): string {
-  return `Gemini is not authenticated. ${detail}`;
+  return `Gemini is not authenticated. Open \`gemini\` and choose Sign in with Google, or configure \`GEMINI_API_KEY\` / Vertex AI credentials. ${detail}`;
 }
 
 function formatGeminiModelDiscoveryFallbackMessage(): string {

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -124,7 +124,7 @@ function resetComposerDraftStore() {
 }
 
 function modelSelection(
-  provider: "codex" | "claudeAgent",
+  provider: "codex" | "claudeAgent" | "gemini",
   model: string,
   options?: ModelSelection["options"],
 ): ModelSelection {
@@ -617,6 +617,7 @@ describe("composerDraftStore project draft thread mapping", () => {
       envMode: "worktree",
       runtimeMode: "full-access",
       interactionMode: "default",
+      lastKnownPr: null,
       createdAt: "2026-01-01T00:00:00.000Z",
     });
     expect(useComposerDraftStore.getState().getDraftThread(threadId)).toEqual({
@@ -627,6 +628,7 @@ describe("composerDraftStore project draft thread mapping", () => {
       envMode: "worktree",
       runtimeMode: "full-access",
       interactionMode: "default",
+      lastKnownPr: null,
       createdAt: "2026-01-01T00:00:00.000Z",
     });
   });
@@ -888,6 +890,46 @@ describe("composerDraftStore modelSelection", () => {
       modelSelection("codex", "gpt-5.3-codex", {
         reasoningEffort: "xhigh",
         fastMode: true,
+      }),
+    );
+  });
+
+  it("round-trips expanded Gemini reasoning options through persisted draft state", () => {
+    const store = useComposerDraftStore.getState();
+    store.setModelSelection(
+      threadId,
+      modelSelection("gemini", "gemini-3-pro-preview", {
+        thinkingLevel: "MEDIUM",
+      }),
+    );
+    store.setStickyModelSelection(
+      modelSelection("gemini", "gemini-2.5-pro", {
+        thinkingBudget: 8192,
+      }),
+    );
+
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const persistedState = persistApi.getOptions().partialize(useComposerDraftStore.getState());
+    const mergedState = persistApi
+      .getOptions()
+      .merge(persistedState, useComposerDraftStore.getInitialState());
+
+    expect(mergedState.draftsByThreadId[threadId]?.modelSelectionByProvider.gemini).toEqual(
+      modelSelection("gemini", "gemini-3-pro-preview", {
+        thinkingLevel: "MEDIUM",
+      }),
+    );
+    expect(mergedState.stickyModelSelectionByProvider.gemini).toEqual(
+      modelSelection("gemini", "gemini-2.5-pro", {
+        thinkingBudget: 8192,
       }),
     );
   });

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -752,7 +752,10 @@ function normalizeProviderModelOptions(
       : undefined;
 
   const geminiThinkingLevel: GeminiThinkingLevel | undefined =
-    geminiCandidate?.thinkingLevel === "LOW" || geminiCandidate?.thinkingLevel === "HIGH"
+    geminiCandidate?.thinkingLevel === "MINIMAL" ||
+    geminiCandidate?.thinkingLevel === "LOW" ||
+    geminiCandidate?.thinkingLevel === "MEDIUM" ||
+    geminiCandidate?.thinkingLevel === "HIGH"
       ? geminiCandidate.thinkingLevel
       : undefined;
   const rawGeminiThinkingBudget =
@@ -762,7 +765,7 @@ function normalizeProviderModelOptions(
         ? Number(geminiCandidate.thinkingBudget)
         : undefined;
   const geminiThinkingBudget: GeminiThinkingBudget | undefined =
-    rawGeminiThinkingBudget === -1 ||
+    rawGeminiThinkingBudget === 8192 ||
     rawGeminiThinkingBudget === 0 ||
     rawGeminiThinkingBudget === 512
       ? rawGeminiThinkingBudget

--- a/apps/web/src/lib/providerAvailability.test.ts
+++ b/apps/web/src/lib/providerAvailability.test.ts
@@ -29,7 +29,7 @@ describe("normalizeProviderStatusForLocalConfig", () => {
       available: true,
       status: "warning",
       message:
-        "Gemini uses a custom local binary path in this app. Availability will be confirmed when you start a Gemini session.",
+        "Gemini uses a custom local binary path in this app. Availability will be confirmed when you start a session.",
     });
   });
 
@@ -87,9 +87,27 @@ describe("isProviderUsable", () => {
 
 describe("providerUnavailableReason", () => {
   it("returns provider-specific guidance", () => {
-    expect(providerUnavailableReason({ ...BASE_STATUS, authStatus: "unauthenticated" })).toBe(
-      "Gemini is not authenticated yet.",
-    );
+    expect(
+      providerUnavailableReason({
+        ...BASE_STATUS,
+        authStatus: "unauthenticated",
+        message: undefined,
+      }),
+    ).toBe("Gemini is not authenticated yet.");
     expect(providerUnavailableReason(BASE_STATUS)).toBe(BASE_STATUS.message);
+  });
+
+  it("prefers detailed authentication guidance when the provider exposes one", () => {
+    expect(
+      providerUnavailableReason({
+        ...BASE_STATUS,
+        available: true,
+        authStatus: "unauthenticated",
+        message:
+          "Gemini is not authenticated. Open `gemini` and choose Sign in with Google, or configure `GEMINI_API_KEY` / Vertex AI credentials.",
+      }),
+    ).toBe(
+      "Gemini is not authenticated. Open `gemini` and choose Sign in with Google, or configure `GEMINI_API_KEY` / Vertex AI credentials.",
+    );
   });
 });

--- a/apps/web/src/lib/providerAvailability.ts
+++ b/apps/web/src/lib/providerAvailability.ts
@@ -52,7 +52,7 @@ export function providerUnavailableReason(status: ServerProviderStatus | null | 
   }
   const providerLabel = PROVIDER_DISPLAY_NAMES[status.provider] ?? status.provider;
   if (status.authStatus === "unauthenticated") {
-    return `${providerLabel} is not authenticated yet.`;
+    return status.message ?? `${providerLabel} is not authenticated yet.`;
   }
   if (!status.available) {
     return status.message ?? `${providerLabel} is unavailable right now.`;

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -159,7 +159,18 @@ const INSTALL_PROVIDER_SETTINGS: readonly InstallProviderSettings[] = [
     binaryPlaceholder: "Gemini binary path",
     binaryDescription: (
       <>
-        Leave blank to use <code>gemini</code> from your PATH.
+        Leave blank to use <code>gemini</code> from your PATH. After install, open{" "}
+        <code>gemini</code> and choose Sign in with Google, or configure <code>GEMINI_API_KEY</code>{" "}
+        / Vertex AI per the{" "}
+        <a
+          href="https://www.geminicli.com/docs/get-started/authentication/"
+          target="_blank"
+          rel="noreferrer"
+          className="underline underline-offset-4"
+        >
+          official Gemini CLI auth docs
+        </a>
+        .
       </>
     ),
   },

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -12,9 +12,9 @@ export const CLAUDE_CODE_EFFORT_OPTIONS = [
   "ultrathink",
 ] as const;
 export type ClaudeCodeEffort = (typeof CLAUDE_CODE_EFFORT_OPTIONS)[number];
-export const GEMINI_THINKING_LEVEL_OPTIONS = ["LOW", "HIGH"] as const;
+export const GEMINI_THINKING_LEVEL_OPTIONS = ["MINIMAL", "LOW", "MEDIUM", "HIGH"] as const;
 export type GeminiThinkingLevel = (typeof GEMINI_THINKING_LEVEL_OPTIONS)[number];
-export const GEMINI_THINKING_BUDGET_OPTIONS = [-1, 512, 0] as const;
+export const GEMINI_THINKING_BUDGET_OPTIONS = [8192, 512, 0] as const;
 export type GeminiThinkingBudget = (typeof GEMINI_THINKING_BUDGET_OPTIONS)[number];
 export type ProviderReasoningEffort =
   | CodexReasoningEffort
@@ -71,8 +71,22 @@ export type ModelCapabilities = {
 
 const GEMINI_2_5_CAPABILITIES: ModelCapabilities = {
   reasoningEffortLevels: [
-    { value: "-1", label: "Dynamic", isDefault: true },
+    { value: "8192", label: "Default (8192 Tokens)", isDefault: true },
     { value: "512", label: "512 Tokens" },
+    { value: "0", label: "0 Tokens" },
+  ],
+  supportsFastMode: false,
+  supportsThinkingToggle: false,
+  promptInjectedEffortLevels: [],
+  contextWindowOptions: [],
+};
+
+const GEMINI_3_CAPABILITIES: ModelCapabilities = {
+  reasoningEffortLevels: [
+    { value: "HIGH", label: "High", isDefault: true },
+    { value: "MEDIUM", label: "Medium" },
+    { value: "LOW", label: "Low" },
+    { value: "MINIMAL", label: "Minimal" },
   ],
   supportsFastMode: false,
   supportsThinkingToggle: false,
@@ -284,64 +298,33 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
   gemini: [
     {
       slug: "auto-gemini-3",
-      name: "Auto Gemini 3",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "HIGH", label: "High", isDefault: true },
-          { value: "LOW", label: "Low" },
-        ],
-        supportsFastMode: false,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-        contextWindowOptions: [],
-      },
+      name: "Auto (Gemini 3)",
+      capabilities: GEMINI_3_CAPABILITIES,
     },
     {
       slug: "auto-gemini-2.5",
-      name: "Auto Gemini 2.5",
+      name: "Auto (Gemini 2.5)",
       capabilities: GEMINI_2_5_CAPABILITIES,
+    },
+    {
+      slug: "gemini-3-pro-preview",
+      name: "Gemini 3 Pro Preview",
+      capabilities: GEMINI_3_CAPABILITIES,
     },
     {
       slug: "gemini-3.1-pro-preview",
       name: "Gemini 3.1 Pro Preview",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "HIGH", label: "High", isDefault: true },
-          { value: "LOW", label: "Low" },
-        ],
-        supportsFastMode: false,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-        contextWindowOptions: [],
-      },
+      capabilities: GEMINI_3_CAPABILITIES,
     },
     {
       slug: "gemini-3-flash-preview",
       name: "Gemini 3 Flash Preview",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "HIGH", label: "High", isDefault: true },
-          { value: "LOW", label: "Low" },
-        ],
-        supportsFastMode: false,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-        contextWindowOptions: [],
-      },
+      capabilities: GEMINI_3_CAPABILITIES,
     },
     {
       slug: "gemini-3.1-flash-lite-preview",
       name: "Gemini 3.1 Flash Lite Preview",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "HIGH", label: "High", isDefault: true },
-          { value: "LOW", label: "Low" },
-        ],
-        supportsFastMode: false,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-        contextWindowOptions: [],
-      },
+      capabilities: GEMINI_3_CAPABILITIES,
     },
     {
       slug: "gemini-2.5-pro",
@@ -406,9 +389,12 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
   },
   gemini: {
     auto: "auto-gemini-3",
+    pro: "gemini-3-pro-preview",
+    flash: "gemini-3-flash-preview",
+    "flash-lite": "gemini-2.5-flash-lite",
     "auto-gemini-3": "auto-gemini-3",
     "auto-gemini-2.5": "auto-gemini-2.5",
-    "gemini-3-pro-preview": "gemini-3.1-pro-preview",
+    "gemini-3-pro-preview": "gemini-3-pro-preview",
     "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
     "gemini-3-flash-preview": "gemini-3-flash-preview",
     "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite-preview",

--- a/packages/contracts/src/provider.test.ts
+++ b/packages/contracts/src/provider.test.ts
@@ -86,6 +86,36 @@ describe("ProviderSessionStartInput", () => {
     expect(parsed.providerOptions?.claudeAgent?.maxThinkingTokens).toBe(12_000);
     expect(parsed.runtimeMode).toBe("full-access");
   });
+
+  it("accepts Gemini runtime knobs and official preview models", () => {
+    const parsed = decodeProviderSessionStartInput({
+      threadId: "thread-1",
+      provider: "gemini",
+      cwd: "/tmp/workspace",
+      modelSelection: {
+        provider: "gemini",
+        model: "gemini-3-pro-preview",
+        options: {
+          thinkingLevel: "MEDIUM",
+        },
+      },
+      providerOptions: {
+        gemini: {
+          binaryPath: "/usr/local/bin/gemini",
+        },
+      },
+      runtimeMode: "approval-required",
+    });
+    expect(parsed.provider).toBe("gemini");
+    expect(parsed.modelSelection?.provider).toBe("gemini");
+    expect(parsed.modelSelection?.model).toBe("gemini-3-pro-preview");
+    if (parsed.modelSelection?.provider !== "gemini") {
+      throw new Error("Expected gemini modelSelection");
+    }
+    expect(parsed.modelSelection.options?.thinkingLevel).toBe("MEDIUM");
+    expect(parsed.providerOptions?.gemini?.binaryPath).toBe("/usr/local/bin/gemini");
+    expect(parsed.runtimeMode).toBe("approval-required");
+  });
 });
 
 describe("ProviderSendTurnInput", () => {
@@ -149,5 +179,24 @@ describe("ProviderSendTurnInput", () => {
       throw new Error("Expected claude modelSelection");
     }
     expect(parsed.modelSelection.options?.effort).toBe("xhigh");
+  });
+
+  it("accepts Gemini modelSelection with expanded thinking controls", () => {
+    const parsed = decodeProviderSendTurnInput({
+      threadId: "thread-1",
+      modelSelection: {
+        provider: "gemini",
+        model: "gemini-2.5-pro",
+        options: {
+          thinkingBudget: 8192,
+        },
+      },
+    });
+
+    expect(parsed.modelSelection?.provider).toBe("gemini");
+    if (parsed.modelSelection?.provider !== "gemini") {
+      throw new Error("Expected gemini modelSelection");
+    }
+    expect(parsed.modelSelection.options?.thinkingBudget).toBe(8192);
   });
 });

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -57,6 +57,14 @@ describe("normalizeModelSlug", () => {
     expect(normalizeModelSlug("opus-4.6", "claudeAgent")).toBe("claude-opus-4-6");
     expect(normalizeModelSlug("claude-haiku-4-5-20251001", "claudeAgent")).toBe("claude-haiku-4-5");
   });
+
+  it("uses official Gemini aliases and preserves preview model ids", () => {
+    expect(normalizeModelSlug("auto", "gemini")).toBe("auto-gemini-3");
+    expect(normalizeModelSlug("pro", "gemini")).toBe("gemini-3-pro-preview");
+    expect(normalizeModelSlug("flash", "gemini")).toBe("gemini-3-flash-preview");
+    expect(normalizeModelSlug("flash-lite", "gemini")).toBe("gemini-2.5-flash-lite");
+    expect(normalizeModelSlug("gemini-3-pro-preview", "gemini")).toBe("gemini-3-pro-preview");
+  });
 });
 
 describe("resolveModelSlug", () => {
@@ -155,6 +163,22 @@ describe("resolveSelectableModel", () => {
       ]),
     ).toBeNull();
   });
+
+  it("resolves Gemini convenience aliases against the official picker surface", () => {
+    expect(
+      resolveSelectableModel("gemini", "pro", [
+        { slug: "auto-gemini-3", name: "Auto (Gemini 3)" },
+        { slug: "gemini-3-pro-preview", name: "Gemini 3 Pro Preview" },
+        { slug: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
+      ]),
+    ).toBe("gemini-3-pro-preview");
+    expect(
+      resolveSelectableModel("gemini", "flash", [
+        { slug: "auto-gemini-3", name: "Auto (Gemini 3)" },
+        { slug: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
+      ]),
+    ).toBe("gemini-3-flash-preview");
+  });
 });
 
 describe("getModelCapabilities reasoningEffortLevels", () => {
@@ -201,13 +225,24 @@ describe("getModelCapabilities reasoningEffortLevels", () => {
   });
 
   it("keeps Gemini 2.5 Pro and auto 2.5 on supported budgets only", () => {
-    expect(values("gemini", "gemini-2.5-pro")).toEqual(["-1", "512"]);
-    expect(values("gemini", "auto-gemini-2.5")).toEqual(["-1", "512"]);
+    expect(values("gemini", "gemini-2.5-pro")).toEqual(["8192", "512", "0"]);
+    expect(values("gemini", "auto-gemini-2.5")).toEqual(["8192", "512", "0"]);
   });
 
   it("keeps all Gemini 2.5 models on CLI-safe budgets only", () => {
-    expect(values("gemini", "gemini-2.5-flash")).toEqual(["-1", "512"]);
-    expect(values("gemini", "gemini-2.5-flash-lite")).toEqual(["-1", "512"]);
+    expect(values("gemini", "gemini-2.5-flash")).toEqual(["8192", "512", "0"]);
+    expect(values("gemini", "gemini-2.5-flash-lite")).toEqual(["8192", "512", "0"]);
+  });
+
+  it("exposes the full Gemini 3 thinking-level range", () => {
+    expect(values("gemini", "auto-gemini-3")).toEqual(["HIGH", "MEDIUM", "LOW", "MINIMAL"]);
+    expect(values("gemini", "gemini-3-pro-preview")).toEqual(["HIGH", "MEDIUM", "LOW", "MINIMAL"]);
+    expect(values("gemini", "gemini-3-flash-preview")).toEqual([
+      "HIGH",
+      "MEDIUM",
+      "LOW",
+      "MINIMAL",
+    ]);
   });
 
   it("co-locates labels with effort values", () => {
@@ -227,7 +262,8 @@ describe("getDefaultEffort", () => {
     expect(getDefaultEffort(getModelCapabilities("claudeAgent", "claude-opus-4-7"))).toBe("high");
     expect(getDefaultEffort(getModelCapabilities("claudeAgent", "claude-opus-4-6"))).toBe("high");
     expect(getDefaultEffort(getModelCapabilities("claudeAgent", "claude-haiku-4-5"))).toBeNull();
-    expect(getDefaultEffort(getModelCapabilities("gemini", "gemini-2.5-flash-lite"))).toBe("-1");
+    expect(getDefaultEffort(getModelCapabilities("gemini", "gemini-2.5-flash-lite"))).toBe("8192");
+    expect(getDefaultEffort(getModelCapabilities("gemini", "gemini-3-pro-preview"))).toBe("HIGH");
   });
 });
 
@@ -374,28 +410,53 @@ describe("normalizeClaudeModelOptions", () => {
 });
 
 describe("normalizeGeminiModelOptions", () => {
-  it("drops unsupported thinking-off overrides for the Gemini 2.5 family", () => {
-    expect(normalizeGeminiModelOptions("gemini-2.5-pro", { thinkingBudget: 0 })).toBeUndefined();
-    expect(normalizeGeminiModelOptions("auto-gemini-2.5", { thinkingBudget: 0 })).toBeUndefined();
-    expect(normalizeGeminiModelOptions("gemini-2.5-flash", { thinkingBudget: 0 })).toBeUndefined();
+  it("drops the default Gemini 2.5 budget while preserving documented lower budgets", () => {
+    expect(normalizeGeminiModelOptions("gemini-2.5-pro", { thinkingBudget: 8192 })).toBeUndefined();
     expect(
-      normalizeGeminiModelOptions("gemini-2.5-flash-lite", { thinkingBudget: 0 }),
+      normalizeGeminiModelOptions("auto-gemini-2.5", { thinkingBudget: 8192 }),
     ).toBeUndefined();
+    expect(normalizeGeminiModelOptions("gemini-2.5-flash", { thinkingBudget: 512 })).toEqual({
+      thinkingBudget: 512,
+    });
+    expect(normalizeGeminiModelOptions("gemini-2.5-flash-lite", { thinkingBudget: 0 })).toEqual({
+      thinkingBudget: 0,
+    });
+  });
+
+  it("preserves the expanded Gemini 3 thinking levels when they differ from the default", () => {
+    expect(
+      normalizeGeminiModelOptions("gemini-3-pro-preview", { thinkingLevel: "HIGH" }),
+    ).toBeUndefined();
+    expect(
+      normalizeGeminiModelOptions("gemini-3-pro-preview", { thinkingLevel: "MEDIUM" }),
+    ).toEqual({
+      thinkingLevel: "MEDIUM",
+    });
+    expect(
+      normalizeGeminiModelOptions("gemini-3-pro-preview", { thinkingLevel: "MINIMAL" }),
+    ).toEqual({
+      thinkingLevel: "MINIMAL",
+    });
   });
 });
 
 describe("getGeminiThinkingModelAlias", () => {
-  it("refuses unsupported Gemini 2.5 off aliases", () => {
-    expect(getGeminiThinkingModelAlias("gemini-2.5-pro", { thinkingBudget: 0 })).toBeNull();
-    expect(resolveGeminiApiModelId("gemini-2.5-pro", { thinkingBudget: 0 })).toBe("gemini-2.5-pro");
-    expect(getGeminiThinkingModelAlias("gemini-2.5-flash", { thinkingBudget: 0 })).toBeNull();
+  it("creates aliases for documented Gemini 2.5 budget overrides", () => {
+    expect(getGeminiThinkingModelAlias("gemini-2.5-pro", { thinkingBudget: 512 })).toBe(
+      "dpcode-gemini-gemini-2-5-pro-thinking-budget-512",
+    );
     expect(resolveGeminiApiModelId("gemini-2.5-flash", { thinkingBudget: 0 })).toBe(
-      "gemini-2.5-flash",
+      "dpcode-gemini-gemini-2-5-flash-thinking-budget-0",
     );
-    expect(getGeminiThinkingModelAlias("gemini-2.5-flash-lite", { thinkingBudget: 0 })).toBeNull();
-    expect(resolveGeminiApiModelId("gemini-2.5-flash-lite", { thinkingBudget: 0 })).toBe(
-      "gemini-2.5-flash-lite",
+  });
+
+  it("creates aliases for the expanded Gemini 3 thinking levels", () => {
+    expect(getGeminiThinkingModelAlias("gemini-3-pro-preview", { thinkingLevel: "MEDIUM" })).toBe(
+      "dpcode-gemini-gemini-3-pro-preview-thinking-level-medium",
     );
+    expect(
+      getGeminiThinkingModelAlias("gemini-3-flash-preview", { thinkingLevel: "MINIMAL" }),
+    ).toBe("dpcode-gemini-gemini-3-flash-preview-thinking-level-minimal");
   });
 });
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -31,9 +31,14 @@ export type GeminiThinkingConfigKind = "budget" | "level";
 
 const GEMINI_3_MODEL_PATTERN = /^(?:auto-)?gemini-3(?:[.-]|$)/i;
 const GEMINI_2_5_MODEL_PATTERN = /^(?:auto-)?gemini-2\.5(?:[.-]|$)/i;
-const GEMINI_THINKING_LEVEL_SET = new Set<GeminiThinkingLevel>(["LOW", "HIGH"]);
+const GEMINI_THINKING_LEVEL_SET = new Set<GeminiThinkingLevel>([
+  "MINIMAL",
+  "LOW",
+  "MEDIUM",
+  "HIGH",
+]);
 const GEMINI_THINKING_BUDGET_MAP = new Map<string, GeminiThinkingBudget>([
-  ["-1", -1],
+  ["8192", 8192],
   ["0", 0],
   ["512", 512],
 ]);
@@ -50,7 +55,9 @@ export const DEFAULT_GEMINI_MODEL_CAPABILITIES = EMPTY_MODEL_CAPABILITIES;
 export const GEMINI_3_MODEL_CAPABILITIES: ModelCapabilities = {
   reasoningEffortLevels: [
     { value: "HIGH", label: "High", isDefault: true },
+    { value: "MEDIUM", label: "Medium" },
     { value: "LOW", label: "Low" },
+    { value: "MINIMAL", label: "Minimal" },
   ],
   supportsFastMode: false,
   supportsThinkingToggle: false,
@@ -60,8 +67,9 @@ export const GEMINI_3_MODEL_CAPABILITIES: ModelCapabilities = {
 
 export const GEMINI_2_5_MODEL_CAPABILITIES: ModelCapabilities = {
   reasoningEffortLevels: [
-    { value: "-1", label: "Dynamic", isDefault: true },
+    { value: "8192", label: "Default (8192 Tokens)", isDefault: true },
     { value: "512", label: "512 Tokens" },
+    { value: "0", label: "0 Tokens" },
   ],
   supportsFastMode: false,
   supportsThinkingToggle: false,
@@ -188,9 +196,7 @@ export function getGeminiThinkingModelAlias(
     return `dpcode-gemini-${base}-thinking-level-${nextOptions.thinkingLevel.toLowerCase()}`;
   }
   if (kind === "budget" && nextOptions.thinkingBudget !== undefined) {
-    const budget =
-      nextOptions.thinkingBudget === -1 ? "dynamic" : String(nextOptions.thinkingBudget);
-    return `dpcode-gemini-${base}-thinking-budget-${budget}`;
+    return `dpcode-gemini-${base}-thinking-budget-${String(nextOptions.thinkingBudget)}`;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- align DP Code's Gemini provider behavior with the current Gemini CLI documentation by updating Gemini model aliases, Gemini 3 reasoning levels, Gemini 2.5 budgets, and Gemini-specific runtime normalization/tests
- add first-class Gemini setup guidance in the app and repo docs, including PATH/binary override messaging plus Sign in with Google, `GEMINI_API_KEY`, Vertex AI, and the official Gemini auth docs link
- fix legacy home migration startup so Windows/Bun verification no longer crashes before startup decisions run by deferring `node:sqlite` loading until a legacy database snapshot is actually needed

## Why
- make Gemini a real supported provider instead of a partial integration with stale model semantics and incomplete setup guidance
- keep the implementation aligned with documented Gemini CLI behavior so the UX and provider wiring match the official surface area
- keep the PR focused to the committed Gemini branch diff only; unrelated local working tree changes were left out of the PR

## Test plan
- [x] `bun x vitest run packages/shared/src/model.test.ts packages/contracts/src/provider.test.ts apps/server/src/provider/Layers/GeminiAdapter.test.ts apps/server/src/provider/geminiAcpProbe.test.ts apps/server/src/homeMigration.test.ts apps/web/src/lib/providerAvailability.test.ts apps/web/src/composerDraftStore.test.ts`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] manually verified the Gemini settings and picker flow in the running app, including provider selection, install/auth copy, Gemini 3 reasoning levels, and Gemini 2.5 budget options