### PR TITLE
Improve GPT model display names

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -66,6 +66,17 @@ describe("getAppModelOptions", () => {
       isCustom: true,
     });
   });
+
+  it("formats unknown GPT custom models with a readable label", () => {
+    const options = getAppModelOptions("codex", ["gpt-5.1-codex-max"]);
+
+    expect(options.at(-1)).toEqual({
+      slug: "gpt-5.1-codex-max",
+      name: "GPT-5.1 Codex Max",
+      isCustom: true,
+    });
+  });
+
   it("keeps a saved custom provider model available as an exact slug option", () => {
     const options = getAppModelOptions("claudeAgent", ["claude/custom-opus"], "claude/custom-opus");
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { Option, Schema } from "effect";
 import { TrimmedNonEmptyString, ProviderKind, type ProviderStartOptions } from "@t3tools/contracts";
 import {
+  formatModelDisplayName,
   getDefaultModel,
   getModelOptions,
   normalizeModelSlug,
@@ -229,7 +230,7 @@ export function getAppModelOptions(
     seen.add(slug);
     options.push({
       slug,
-      name: slug,
+      name: formatModelDisplayName(slug) ?? slug,
       isCustom: true,
     });
   }
@@ -245,7 +246,7 @@ export function getAppModelOptions(
   ) {
     options.push({
       slug: normalizedSelectedModel,
-      name: normalizedSelectedModel,
+      name: formatModelDisplayName(normalizedSelectedModel) ?? normalizedSelectedModel,
       isCustom: true,
     });
   }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -29,6 +29,7 @@ import {
 } from "@t3tools/contracts";
 import {
   applyClaudePromptEffortPrefix,
+  formatModelDisplayName,
   getModelCapabilities,
   normalizeModelSlug,
 } from "@t3tools/shared/model";
@@ -446,6 +447,9 @@ function mergeDynamicModelOptions(input: {
     }
 
     const normalizedSlug = normalizeDynamicModelSlug(input.provider, dynamicModel.slug);
+    const rawSlug = dynamicModel.slug.trim().toLowerCase();
+    const displayNameFallback =
+      formatModelDisplayName(normalizedSlug) ?? formatModelSlug(normalizedSlug);
     if (dynamicNormalizedSlugs.has(normalizedSlug)) {
       continue;
     }
@@ -454,8 +458,11 @@ function mergeDynamicModelOptions(input: {
       slug: normalizedSlug,
       name:
         staticNameBySlug.get(normalizedSlug) ??
-        dynamicModel.name ??
-        formatModelSlug(normalizedSlug),
+        (rawName.length > 0 &&
+        rawName.toLowerCase() !== rawSlug &&
+        rawName.toLowerCase() !== normalizedSlug.toLowerCase()
+          ? rawName
+          : displayNameFallback),
     });
   }
 

--- a/apps/web/src/lib/subagentPresentation.test.ts
+++ b/apps/web/src/lib/subagentPresentation.test.ts
@@ -215,4 +215,8 @@ describe("formatSubagentModelLabel", () => {
     expect(formatSubagentModelLabel("gpt-5.4-mini")).toBe("GPT-5.4 Mini");
     expect(formatSubagentModelLabel("gpt-5.3-codex-spark")).toBe("GPT-5.3 Codex Spark");
   });
+
+  it("humanizes unknown GPT subagent models", () => {
+    expect(formatSubagentModelLabel("gpt-5.1-codex-max")).toBe("GPT-5.1 Codex Max");
+  });
 });

--- a/apps/web/src/lib/subagentPresentation.ts
+++ b/apps/web/src/lib/subagentPresentation.ts
@@ -2,12 +2,12 @@
 // Purpose: Normalizes subagent identity, nickname colors, and status labels for sidebar/chat UI.
 // Exports: Shared presentation helpers consumed by sidebar rows, chat cards, and thread hydration.
 
-import { MODEL_OPTIONS } from "@t3tools/contracts";
 import {
   buildSubagentIdentityDirectory,
   extractSubagentIdentityHints as extractParsedSubagentIdentityHints,
   resolveSubagentIdentityFromDirectory,
 } from "@t3tools/shared/subagents";
+import { formatModelDisplayName } from "@t3tools/shared/model";
 
 const SUBAGENT_ACCENT_PALETTE = [
   "#b84e44",
@@ -62,10 +62,6 @@ const subagentIdentityDirectoryByActivities = new WeakMap<
   ReadonlyArray<SubagentThreadActivityLike>,
   ReturnType<typeof buildSubagentIdentityDirectory>
 >();
-
-const MODEL_LABEL_BY_SLUG = new Map(
-  MODEL_OPTIONS.map((model) => [model.slug.toLowerCase(), model.name]),
-);
 
 function basename(value: string): string {
   const slashIndex = Math.max(value.lastIndexOf("/"), value.lastIndexOf("\\"));
@@ -357,9 +353,5 @@ export function humanizeSubagentStatus(
 }
 
 export function formatSubagentModelLabel(model: string | null | undefined): string | undefined {
-  const normalized = normalizeWhitespace(model);
-  if (!normalized) {
-    return undefined;
-  }
-  return MODEL_LABEL_BY_SLUG.get(normalized.toLowerCase()) ?? normalized;
+  return formatModelDisplayName(normalizeWhitespace(model));
 }

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -9,6 +9,7 @@ import {
 
 import {
   applyClaudePromptEffortPrefix,
+  formatModelDisplayName,
   getDefaultContextWindow,
   getDefaultModel,
   getGeminiThinkingModelAlias,
@@ -274,6 +275,21 @@ describe("applyClaudePromptEffortPrefix", () => {
 
   it("leaves non-ultrathink prompts unchanged", () => {
     expect(applyClaudePromptEffortPrefix("Investigate this", "high")).toBe("Investigate this");
+  });
+});
+
+describe("formatModelDisplayName", () => {
+  it("returns built-in display names for known models", () => {
+    expect(formatModelDisplayName("gpt-5.3-codex")).toBe("GPT-5.3 Codex");
+  });
+
+  it("humanizes unknown GPT model slugs", () => {
+    expect(formatModelDisplayName("gpt-5.1-codex-max")).toBe("GPT-5.1 Codex Max");
+    expect(formatModelDisplayName("gpt-5.1-codex-mini")).toBe("GPT-5.1 Codex Mini");
+  });
+
+  it("leaves non-GPT custom slugs unchanged", () => {
+    expect(formatModelDisplayName("custom/internal-model")).toBe("custom/internal-model");
   });
 });
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -128,6 +128,28 @@ export function geminiCapabilitiesForModel(
   }
 }
 
+const MODEL_NAME_BY_SLUG = new Map(
+  Object.values(MODEL_OPTIONS_BY_PROVIDER)
+    .flat()
+    .map((option) => [option.slug.toLowerCase(), option.name] as const),
+);
+
+function humanizeUnknownModelSlug(slug: string): string {
+  if (!slug.toLowerCase().startsWith("gpt-")) return slug;
+  const [, version, ...rest] = slug.split("-");
+  if (rest.length === 0) return `GPT-${version}`;
+  return `GPT-${version} ${rest.map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join(" ")}`;
+}
+
+export function formatModelDisplayName(model: string | null | undefined): string | undefined {
+  const normalized = trimOrNull(model);
+  if (!normalized) {
+    return undefined;
+  }
+
+  return MODEL_NAME_BY_SLUG.get(normalized.toLowerCase()) ?? humanizeUnknownModelSlug(normalized);
+}
+
 export function getGeminiThinkingSelectionValue(
   caps: ModelCapabilities,
   modelOptions: GeminiModelOptions | null | undefined,


### PR DESCRIPTION
## Summary
- reuse shared GPT display-name formatting for custom and dynamic model options
- keep the model picker, app settings, and subagent presentation consistent
- preserve the provider settings shape needed by the current web UI while applying the naming updates

## Verification
- bun fmt
- bun lint
- bun typecheck