### PR TITLE
Fix Windows desktop chrome and project recovery

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -18,12 +18,13 @@ import {
   shell,
   systemPreferences,
 } from "electron";
-import type { MenuItemConstructorOptions } from "electron";
+import type { IpcMainInvokeEvent, MenuItemConstructorOptions } from "electron";
 import * as Effect from "effect/Effect";
 import type {
   DesktopTheme,
   DesktopUpdateActionResult,
   DesktopUpdateState,
+  DesktopWindowState,
 } from "@t3tools/contracts";
 import { autoUpdater } from "electron-updater";
 
@@ -61,6 +62,7 @@ import { isArm64HostRunningIntelBuild, resolveDesktopRuntimeInfo } from "./runti
 import { DesktopBrowserManager } from "./browserManager";
 import { registerBrowserIpcHandlers, sendBrowserState } from "./browserIpc";
 import { BrowserUsePipeServer } from "./browserUsePipeServer";
+import { resolveDesktopWindowChrome, resolveDesktopWindowState } from "./windowChrome";
 
 syncShellEnvironment();
 
@@ -76,6 +78,11 @@ const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_CHECK_CHANNEL = "desktop:update-check";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
+const WINDOW_STATE_CHANNEL = "desktop:window-state";
+const WINDOW_GET_STATE_CHANNEL = "desktop:window-get-state";
+const WINDOW_MINIMIZE_CHANNEL = "desktop:window-minimize";
+const WINDOW_TOGGLE_MAXIMIZE_CHANNEL = "desktop:window-toggle-maximize";
+const WINDOW_CLOSE_CHANNEL = "desktop:window-close";
 const NOTIFICATIONS_IS_SUPPORTED_CHANNEL = "desktop:notifications-is-supported";
 const NOTIFICATIONS_SHOW_CHANNEL = "desktop:notifications-show";
 const BASE_DIR = process.env.T3CODE_HOME?.trim() || Path.join(OS.homedir(), ".dpcode");
@@ -978,6 +985,23 @@ function emitUpdateState(): void {
   }
 }
 
+function resolveIpcOwnerWindow(event: IpcMainInvokeEvent | undefined): BrowserWindow | null {
+  return (
+    (event ? BrowserWindow.fromWebContents(event.sender) : null) ??
+    BrowserWindow.getFocusedWindow() ??
+    mainWindow
+  );
+}
+
+function emitWindowState(window: BrowserWindow | null): void {
+  if (!window || window.isDestroyed()) {
+    return;
+  }
+
+  const state: DesktopWindowState = resolveDesktopWindowState(window);
+  window.webContents.send(WINDOW_STATE_CHANNEL, state);
+}
+
 function setUpdateState(patch: Partial<DesktopUpdateState>): void {
   updateState = { ...updateState, ...patch };
   emitUpdateState();
@@ -1604,6 +1628,40 @@ function registerIpcHandlers(): void {
     } satisfies DesktopUpdateActionResult;
   });
 
+  ipcMain.removeHandler(WINDOW_GET_STATE_CHANNEL);
+  ipcMain.handle(WINDOW_GET_STATE_CHANNEL, async (event) => {
+    const window = resolveIpcOwnerWindow(event);
+    return window ? resolveDesktopWindowState(window) : { isMaximized: false };
+  });
+
+  ipcMain.removeHandler(WINDOW_MINIMIZE_CHANNEL);
+  ipcMain.handle(WINDOW_MINIMIZE_CHANNEL, async (event) => {
+    resolveIpcOwnerWindow(event)?.minimize();
+  });
+
+  ipcMain.removeHandler(WINDOW_TOGGLE_MAXIMIZE_CHANNEL);
+  ipcMain.handle(WINDOW_TOGGLE_MAXIMIZE_CHANNEL, async (event) => {
+    const window = resolveIpcOwnerWindow(event);
+    if (!window) {
+      return { isMaximized: false };
+    }
+
+    if (window.isFullScreen()) {
+      window.setFullScreen(false);
+    } else if (window.isMaximized()) {
+      window.unmaximize();
+    } else {
+      window.maximize();
+    }
+
+    return resolveDesktopWindowState(window);
+  });
+
+  ipcMain.removeHandler(WINDOW_CLOSE_CHANNEL);
+  ipcMain.handle(WINDOW_CLOSE_CHANNEL, async (event) => {
+    resolveIpcOwnerWindow(event)?.close();
+  });
+
   ipcMain.removeHandler(NOTIFICATIONS_IS_SUPPORTED_CHANNEL);
   ipcMain.handle(NOTIFICATIONS_IS_SUPPORTED_CHANNEL, async () => Notification.isSupported());
 
@@ -1655,10 +1713,7 @@ function createWindow(): BrowserWindow {
     autoHideMenuBar: true,
     ...getIconOption(),
     title: APP_DISPLAY_NAME,
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 16, y: 18 },
-    vibrancy: "under-window",
-    visualEffectState: "active",
+    ...resolveDesktopWindowChrome(process.platform),
     backgroundColor: "#00000000",
     webPreferences: {
       preload: Path.join(__dirname, "preload.js"),
@@ -1720,10 +1775,16 @@ function createWindow(): BrowserWindow {
   window.webContents.on("did-finish-load", () => {
     window.setTitle(APP_DISPLAY_NAME);
     emitUpdateState();
+    emitWindowState(window);
   });
   window.once("ready-to-show", () => {
     window.show();
   });
+  const emitCurrentWindowState = () => emitWindowState(window);
+  window.on("maximize", emitCurrentWindowState);
+  window.on("unmaximize", emitCurrentWindowState);
+  window.on("enter-full-screen", emitCurrentWindowState);
+  window.on("leave-full-screen", emitCurrentWindowState);
 
   if (isDevelopment) {
     void window.loadURL(process.env.VITE_DEV_SERVER_URL as string);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -15,6 +15,11 @@ const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_CHECK_CHANNEL = "desktop:update-check";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
+const WINDOW_STATE_CHANNEL = "desktop:window-state";
+const WINDOW_GET_STATE_CHANNEL = "desktop:window-get-state";
+const WINDOW_MINIMIZE_CHANNEL = "desktop:window-minimize";
+const WINDOW_TOGGLE_MAXIMIZE_CHANNEL = "desktop:window-toggle-maximize";
+const WINDOW_CLOSE_CHANNEL = "desktop:window-close";
 const NOTIFICATIONS_IS_SUPPORTED_CHANNEL = "desktop:notifications-is-supported";
 const NOTIFICATIONS_SHOW_CHANNEL = "desktop:notifications-show";
 const wsUrl = process.env.T3CODE_DESKTOP_WS_URL ?? null;
@@ -55,6 +60,23 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     return () => {
       ipcRenderer.removeListener(UPDATE_STATE_CHANNEL, wrappedListener);
     };
+  },
+  window: {
+    minimize: () => ipcRenderer.invoke(WINDOW_MINIMIZE_CHANNEL),
+    toggleMaximize: () => ipcRenderer.invoke(WINDOW_TOGGLE_MAXIMIZE_CHANNEL),
+    close: () => ipcRenderer.invoke(WINDOW_CLOSE_CHANNEL),
+    getState: () => ipcRenderer.invoke(WINDOW_GET_STATE_CHANNEL),
+    onState: (listener) => {
+      const wrappedListener = (_event: Electron.IpcRendererEvent, state: unknown) => {
+        if (typeof state !== "object" || state === null) return;
+        listener(state as Parameters<typeof listener>[0]);
+      };
+
+      ipcRenderer.on(WINDOW_STATE_CHANNEL, wrappedListener);
+      return () => {
+        ipcRenderer.removeListener(WINDOW_STATE_CHANNEL, wrappedListener);
+      };
+    },
   },
   notifications: {
     isSupported: () => ipcRenderer.invoke(NOTIFICATIONS_IS_SUPPORTED_CHANNEL),

--- a/apps/desktop/src/windowChrome.test.ts
+++ b/apps/desktop/src/windowChrome.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDesktopWindowChrome, resolveDesktopWindowState } from "./windowChrome";
+
+describe("resolveDesktopWindowChrome", () => {
+  it("keeps native inset traffic lights on macOS", () => {
+    expect(resolveDesktopWindowChrome("darwin")).toEqual({
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 16, y: 18 },
+      vibrancy: "under-window",
+      visualEffectState: "active",
+    });
+  });
+
+  it("switches Windows and Linux to a hidden custom title bar", () => {
+    expect(resolveDesktopWindowChrome("win32")).toEqual({
+      titleBarStyle: "hidden",
+    });
+    expect(resolveDesktopWindowChrome("linux")).toEqual({
+      titleBarStyle: "hidden",
+    });
+  });
+});
+
+describe("resolveDesktopWindowState", () => {
+  it("treats maximized windows as maximized", () => {
+    expect(
+      resolveDesktopWindowState({
+        isMaximized: () => true,
+        isFullScreen: () => false,
+      }),
+    ).toEqual({
+      isMaximized: true,
+    });
+  });
+
+  it("treats fullscreen windows as maximized for renderer chrome", () => {
+    expect(
+      resolveDesktopWindowState({
+        isMaximized: () => false,
+        isFullScreen: () => true,
+      }),
+    ).toEqual({
+      isMaximized: true,
+    });
+  });
+});

--- a/apps/desktop/src/windowChrome.ts
+++ b/apps/desktop/src/windowChrome.ts
@@ -1,0 +1,30 @@
+import type { BrowserWindow, BrowserWindowConstructorOptions } from "electron";
+import type { DesktopWindowState } from "@t3tools/contracts";
+
+export function resolveDesktopWindowChrome(
+  platform: NodeJS.Platform,
+): Pick<
+  BrowserWindowConstructorOptions,
+  "titleBarStyle" | "trafficLightPosition" | "vibrancy" | "visualEffectState"
+> {
+  if (platform === "darwin") {
+    return {
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 16, y: 18 },
+      vibrancy: "under-window",
+      visualEffectState: "active",
+    };
+  }
+
+  return {
+    titleBarStyle: "hidden",
+  };
+}
+
+export function resolveDesktopWindowState(
+  window: Pick<BrowserWindow, "isMaximized" | "isFullScreen">,
+): DesktopWindowState {
+  return {
+    isMaximized: window.isMaximized() || window.isFullScreen(),
+  };
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -261,6 +261,7 @@ import {
 import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "./ComposerPromptEditor";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { ChatHeader } from "./chat/ChatHeader";
+import { DesktopWindowControls } from "./chat/DesktopWindowControls";
 import { ChatTranscriptPane } from "./chat/ChatTranscriptPane";
 import { ComposerSlashStatusDialog } from "./chat/ComposerSlashStatusDialog";
 import { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
@@ -327,6 +328,7 @@ import {
   resolveDiffEnvironmentState,
   resolveThreadEnvironmentMode,
 } from "../lib/threadEnvironment";
+import { supportsCustomDesktopTitleBar } from "../lib/desktopWindow";
 import { buildModelSelection, buildNextProviderOptions } from "../providerModelOptions";
 import { waitForRecoverableProjectForDuplicateCreate } from "../lib/projectCreateRecovery";
 
@@ -1006,6 +1008,7 @@ export default function ChatView({
     ? activeProject?.folderName
     : activeProject?.name;
   const isChatProject = isHomeChatContainer;
+  const usesCustomDesktopTitleBar = supportsCustomDesktopTitleBar();
   const activeProjectScripts =
     activeProject?.kind === "project" ? activeProject.scripts : undefined;
   const threadLineageThreads = useStore(
@@ -4590,6 +4593,7 @@ export default function ChatView({
               message: description,
               workspaceRoot: firstSendTarget.creation.workspaceRoot,
               loadSnapshot: () => api.orchestration.getSnapshot().catch(() => null),
+              repairSnapshot: () => api.orchestration.repairState().catch(() => null),
             });
           if (!snapshot || !recoveredProject) {
             throw error;
@@ -6230,12 +6234,16 @@ export default function ChatView({
         {isElectron && (
           <div
             className={cn(
-              "drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5",
-              settings.sidebarSide === "right" && "pl-[90px]",
+              "drag-region flex h-[52px] shrink-0 items-center border-b border-border",
+              usesCustomDesktopTitleBar ? "pl-5 pr-0" : "px-5",
+              !usesCustomDesktopTitleBar && settings.sidebarSide === "right" && "pl-[90px]",
             )}
           >
-            <SidebarHeaderTrigger className="size-7 shrink-0" />
-            <span className="text-xs text-muted-foreground/50">No active thread</span>
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <SidebarHeaderTrigger className="size-7 shrink-0" />
+              <span className="text-xs text-muted-foreground/50">No active thread</span>
+            </div>
+            <DesktopWindowControls />
           </div>
         )}
         <div className="flex flex-1 items-center justify-center">
@@ -6891,9 +6899,17 @@ export default function ChatView({
       {/* Top bar */}
       <header
         className={cn(
-          "border-b border-border px-3 sm:px-5",
-          isElectron ? "drag-region flex h-[52px] items-center" : "py-2 sm:py-3",
-          isElectron && settings.sidebarSide === "right" && "pl-[90px] sm:pl-[90px]",
+          "border-b border-border",
+          isElectron
+            ? cn(
+                "drag-region flex h-[52px] items-center",
+                usesCustomDesktopTitleBar ? "pl-5 pr-0" : "px-5",
+              )
+            : "px-3 py-2 sm:px-5 sm:py-3",
+          isElectron &&
+            !usesCustomDesktopTitleBar &&
+            settings.sidebarSide === "right" &&
+            "pl-[90px]",
         )}
       >
         <ChatHeader
@@ -6955,6 +6971,7 @@ export default function ChatView({
           onNavigateToThread={onNavigateToThread}
           onRenameThread={() => setRenameDialogOpen(true)}
         />
+        <DesktopWindowControls />
       </header>
 
       <RenameThreadDialog

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -330,7 +330,10 @@ import {
 } from "../lib/threadEnvironment";
 import { supportsCustomDesktopTitleBar } from "../lib/desktopWindow";
 import { buildModelSelection, buildNextProviderOptions } from "../providerModelOptions";
-import { waitForRecoverableProjectForDuplicateCreate } from "../lib/projectCreateRecovery";
+import {
+  isDuplicateProjectCreateError,
+  waitForRecoverableProjectForDuplicateCreate,
+} from "../lib/projectCreateRecovery";
 
 const ATTACHMENT_PREVIEW_HANDOFF_TTL_MS = 5000;
 const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
@@ -4587,6 +4590,10 @@ export default function ChatView({
         } catch (error) {
           const description =
             error instanceof Error ? error.message : "Failed to create the selected project.";
+          if (!isDuplicateProjectCreateError(description)) {
+            throw error;
+          }
+
           // If the server already knows this workspace root, reuse that project and continue.
           const { snapshot, project: recoveredProject } =
             await waitForRecoverableProjectForDuplicateCreate({

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -72,6 +72,7 @@ import {
 import { isElectron } from "../env";
 import { APP_VERSION } from "../branding";
 import { showConfirmDialogFallback } from "../confirmDialogFallback";
+import { supportsCustomDesktopTitleBar } from "../lib/desktopWindow";
 import { isMacPlatform, newCommandId, newProjectId, newThreadId, randomUUID } from "../lib/utils";
 import { persistAppStateNow, useStore } from "../store";
 import { getThreadFromState, getThreadsFromState } from "../threadDerivation";
@@ -217,6 +218,10 @@ import type {
 } from "./SidebarSearchPalette.logic";
 import { useFocusedChatContext } from "../focusedChatContext";
 import { showContextMenuFallback } from "../contextMenuFallback";
+import {
+  waitForRecoverableProjectForDuplicateCreate,
+  waitForRecoverableProjectInReadModel,
+} from "../lib/projectCreateRecovery";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const THREAD_PREVIEW_LIMIT = 5;
@@ -249,12 +254,6 @@ const PROJECT_CONTEXT_MENU_COPY_PATH_ICON =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>';
 const PROJECT_CONTEXT_MENU_ARCHIVE_ICON = renderToStaticMarkup(<HiOutlineArchiveBox />);
 const PROJECT_CONTEXT_MENU_DELETE_THREADS_ICON = renderToStaticMarkup(<Trash2 />);
-
-function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 function threadJumpLabelMapsEqual(
   left: ReadonlyMap<ThreadId, string>,
@@ -1135,6 +1134,7 @@ export default function Sidebar() {
   const [renamingWorkspaceId, setRenamingWorkspaceId] = useState<string | null>(null);
   const [renamingWorkspaceTitle, setRenamingWorkspaceTitle] = useState("");
   const [installingDesktopUpdate, setInstallingDesktopUpdate] = useState(false);
+  const usesCustomDesktopTitleBar = supportsCustomDesktopTitleBar();
   const selectedThreadIds = useThreadSelectionStore((s) => s.selectedThreadIds);
   const toggleThreadSelection = useThreadSelectionStore((s) => s.toggleThread);
   const rangeSelectTo = useThreadSelectionStore((s) => s.rangeSelectTo);
@@ -1432,32 +1432,14 @@ export default function Sidebar() {
     ): Promise<{
       project: OrchestrationReadModel["projects"][number] | null;
       snapshot: OrchestrationReadModel | null;
-    }> => {
-      let latestSnapshot: OrchestrationReadModel | null = null;
-
-      for (let attempt = 1; attempt <= ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS; attempt += 1) {
-        const snapshot = await api.orchestration.getSnapshot().catch(() => null);
-        if (snapshot) {
-          latestSnapshot = snapshot;
-          const project =
-            snapshot.projects.find(
-              (candidate) => candidate.id === projectId && candidate.deletedAt === null,
-            ) ?? null;
-          if (project) {
-            return { project, snapshot };
-          }
-        }
-
-        if (attempt < ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS) {
-          await wait(ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS * attempt);
-        }
-      }
-
-      return {
-        project: null,
-        snapshot: latestSnapshot,
-      };
-    },
+    }> =>
+      waitForRecoverableProjectInReadModel({
+        projectId,
+        loadSnapshot: () => api.orchestration.getSnapshot().catch(() => null),
+        repairSnapshot: () => api.orchestration.repairState().catch(() => null),
+        maxAttempts: ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS,
+        delayMs: ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS,
+      }),
     [],
   );
 
@@ -1468,35 +1450,14 @@ export default function Sidebar() {
     ): Promise<{
       project: OrchestrationReadModel["projects"][number] | null;
       snapshot: OrchestrationReadModel | null;
-    }> => {
-      let latestSnapshot: OrchestrationReadModel | null = null;
-
-      for (let attempt = 1; attempt <= ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS; attempt += 1) {
-        const snapshot = await api.orchestration.getSnapshot().catch(() => null);
-        if (snapshot) {
-          latestSnapshot = snapshot;
-          const project =
-            snapshot.projects.find(
-              (candidate) =>
-                candidate.deletedAt === null &&
-                findWorkspaceRootMatch([candidate], workspaceRoot, (item) => item.workspaceRoot) !==
-                  undefined,
-            ) ?? null;
-          if (project) {
-            return { project, snapshot };
-          }
-        }
-
-        if (attempt < ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS) {
-          await wait(ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS * attempt);
-        }
-      }
-
-      return {
-        project: null,
-        snapshot: latestSnapshot,
-      };
-    },
+    }> =>
+      waitForRecoverableProjectInReadModel({
+        workspaceRoot,
+        loadSnapshot: () => api.orchestration.getSnapshot().catch(() => null),
+        repairSnapshot: () => api.orchestration.repairState().catch(() => null),
+        maxAttempts: ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS,
+        delayMs: ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS,
+      }),
     [],
   );
 
@@ -1766,6 +1727,24 @@ export default function Sidebar() {
         const description =
           error instanceof Error ? error.message : "An error occurred while adding the project.";
         if (isDuplicateProjectCreateError(description)) {
+          const { project, snapshot } = await waitForRecoverableProjectForDuplicateCreate({
+            message: description,
+            workspaceRoot: cwd,
+            loadSnapshot: () => api.orchestration.getSnapshot().catch(() => null),
+            repairSnapshot: () => api.orchestration.repairState().catch(() => null),
+            maxAttempts: ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS,
+            delayMs: ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS,
+          });
+          if (snapshot) {
+            syncServerReadModel(snapshot);
+          }
+          if (project && snapshot) {
+            const recovered = await openExistingProjectFromSnapshot(project.id, snapshot);
+            if (recovered) {
+              finishAddingProject();
+              return;
+            }
+          }
           const duplicateProjectId = extractDuplicateProjectCreateProjectId(description);
           const recovered = duplicateProjectId
             ? await recoverExistingProjectFromServer(api, ProjectId.makeUnsafe(duplicateProjectId))
@@ -1793,6 +1772,8 @@ export default function Sidebar() {
       recoverExistingProjectFromServer,
       recoverExistingProjectByWorkspaceRootFromServer,
       recoverProjectThreadFromServer,
+      syncServerReadModel,
+      openExistingProjectFromSnapshot,
       setProjectExpanded,
     ],
   );
@@ -5018,7 +4999,7 @@ export default function Sidebar() {
           <SidebarHeader
             className={cn(
               "drag-region h-[48px] flex-row items-center gap-2 px-4 py-0 font-system-ui",
-              appSettings.sidebarSide === "left" && "pl-[90px]",
+              !usesCustomDesktopTitleBar && appSettings.sidebarSide === "left" && "pl-[90px]",
             )}
           >
             {wordmark}

--- a/apps/web/src/components/WorkspaceView.tsx
+++ b/apps/web/src/components/WorkspaceView.tsx
@@ -398,6 +398,9 @@ export default function WorkspaceView({ workspaceId }: { workspaceId: string }) 
               ? cn(
                   "drag-region flex h-[52px] items-center",
                   usesCustomDesktopTitleBar ? "pl-5 pr-0" : "px-5",
+                  !usesCustomDesktopTitleBar &&
+                    settings.sidebarSide === "right" &&
+                    "pl-[90px]",
                 )
               : "px-3 sm:px-5",
           )}

--- a/apps/web/src/components/WorkspaceView.tsx
+++ b/apps/web/src/components/WorkspaceView.tsx
@@ -1,22 +1,22 @@
-// FILE: WorkspaceView.tsx
-// Purpose: Render a dedicated terminal-only workspace page backed by a synthetic terminal scope.
-// Layer: Workspace route surface
-
-import { Plus, SettingsIcon } from "~/lib/icons";
 import { type TerminalCliKind } from "@t3tools/shared/terminalThreads";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
-import { readNativeApi } from "~/nativeApi";
 import { useAppSettings } from "~/appSettings";
+import { DesktopWindowControls } from "~/components/chat/DesktopWindowControls";
+import { readNativeApi } from "~/nativeApi";
 import { Button } from "~/components/ui/button";
 import { SidebarHeaderTrigger, SidebarInset } from "~/components/ui/sidebar";
+import { isElectron } from "~/env";
+import { Plus, SettingsIcon } from "~/lib/icons";
+import { supportsCustomDesktopTitleBar } from "~/lib/desktopWindow";
 import {
   confirmTerminalTabClose,
   resolveTerminalCloseTitle,
 } from "~/lib/terminalCloseConfirmation";
 import { resolveTerminalNewAction } from "~/lib/terminalNewAction";
 import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
+import { cn } from "~/lib/utils";
 import { selectThreadTerminalState, useTerminalStateStore } from "~/terminalStateStore";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
 import WorkspaceSettingsSheet from "./WorkspaceSettingsSheet";
@@ -38,6 +38,7 @@ function randomTerminalId(): string {
 
 export default function WorkspaceView({ workspaceId }: { workspaceId: string }) {
   const { settings } = useAppSettings();
+  const usesCustomDesktopTitleBar = supportsCustomDesktopTitleBar();
   const workspace = useWorkspaceStore((state) =>
     state.workspacePages.find((entry) => entry.id === workspaceId),
   );
@@ -390,8 +391,18 @@ export default function WorkspaceView({ workspaceId }: { workspaceId: string }) 
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
-        <header className="border-b border-border px-3 sm:px-5">
-          <div className="flex h-[52px] items-center gap-2 sm:gap-3">
+        <header
+          className={cn(
+            "border-b border-border",
+            isElectron
+              ? cn(
+                  "drag-region flex h-[52px] items-center",
+                  usesCustomDesktopTitleBar ? "pl-5 pr-0" : "px-5",
+                )
+              : "px-3 sm:px-5",
+          )}
+        >
+          <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
             <SidebarHeaderTrigger className="size-7 shrink-0" />
             <div className="flex min-w-0 flex-1 items-center gap-2">
               {renaming ? (
@@ -443,6 +454,7 @@ export default function WorkspaceView({ workspaceId }: { workspaceId: string }) 
               </Button>
             </div>
           </div>
+          <DesktopWindowControls />
         </header>
 
         <div className="min-h-0 min-w-0 flex-1">

--- a/apps/web/src/components/WorkspaceView.tsx
+++ b/apps/web/src/components/WorkspaceView.tsx
@@ -426,7 +426,7 @@ export default function WorkspaceView({ workspaceId }: { workspaceId: string }) 
                 />
               ) : (
                 <h2
-                  className="max-w-[clamp(16rem,50vw,40rem)] cursor-default truncate text-sm font-medium text-foreground"
+                  className="max-w-[clamp(16rem,50vw,40rem)] cursor-default truncate text-sm font-medium text-foreground [-webkit-app-region:no-drag]"
                   title="Double-click to rename"
                   onDoubleClick={() => setRenaming(true)}
                 >

--- a/apps/web/src/components/chat/DesktopWindowControls.tsx
+++ b/apps/web/src/components/chat/DesktopWindowControls.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+import { LuCopy, LuMinus, LuSquare, LuX } from "react-icons/lu";
+
+import { cn } from "~/lib/utils";
+import {
+  DEFAULT_DESKTOP_WINDOW_STATE,
+  readDesktopBridge,
+  supportsCustomDesktopTitleBar,
+} from "~/lib/desktopWindow";
+
+export function DesktopWindowControls({ className }: { className?: string }) {
+  const [windowState, setWindowState] = useState(DEFAULT_DESKTOP_WINDOW_STATE);
+  const usesCustomDesktopTitleBar = supportsCustomDesktopTitleBar();
+
+  useEffect(() => {
+    if (!usesCustomDesktopTitleBar) {
+      return;
+    }
+
+    const bridge = readDesktopBridge();
+    if (!bridge) {
+      return;
+    }
+
+    let active = true;
+    void bridge.window
+      .getState()
+      .then((state) => {
+        if (active) {
+          setWindowState(state);
+        }
+      })
+      .catch(() => {});
+
+    const unsubscribe = bridge.window.onState((state) => {
+      if (active) {
+        setWindowState(state);
+      }
+    });
+
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, [usesCustomDesktopTitleBar]);
+
+  const bridge = readDesktopBridge();
+  if (!usesCustomDesktopTitleBar || !bridge) {
+    return null;
+  }
+
+  const controlButtonClassName =
+    "inline-flex h-full w-[46px] items-center justify-center text-muted-foreground/72 transition-colors hover:bg-accent/75 hover:text-foreground";
+
+  return (
+    <div
+      className={cn(
+        "flex h-full shrink-0 self-stretch items-stretch border-l border-border/70 [-webkit-app-region:no-drag]",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        className={controlButtonClassName}
+        aria-label="Minimize window"
+        onClick={() => {
+          void bridge.window.minimize();
+        }}
+      >
+        <LuMinus className="size-3.5 stroke-[1.85]" />
+      </button>
+      <button
+        type="button"
+        className={controlButtonClassName}
+        aria-label={windowState.isMaximized ? "Restore window" : "Maximize window"}
+        onClick={() => {
+          void bridge.window
+            .toggleMaximize()
+            .then((state) => {
+              setWindowState(state);
+            })
+            .catch(() => {});
+        }}
+      >
+        {windowState.isMaximized ? (
+          <LuCopy className="size-3.5 stroke-[1.85]" />
+        ) : (
+          <LuSquare className="size-[13px] stroke-[1.85]" />
+        )}
+      </button>
+      <button
+        type="button"
+        className={cn(
+          controlButtonClassName,
+          "hover:bg-red-500 hover:text-white dark:hover:bg-red-600",
+        )}
+        aria-label="Close window"
+        onClick={() => {
+          void bridge.window.close();
+        }}
+      >
+        <LuX className="size-3.5 stroke-[1.85]" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/lib/desktopProjectRecovery.test.ts
+++ b/apps/web/src/lib/desktopProjectRecovery.test.ts
@@ -1,0 +1,113 @@
+import { ProjectId, ThreadId, type OrchestrationReadModel } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import { hasLiveThreadsWithMissingProjects } from "./desktopProjectRecovery";
+
+function makeProject(
+  overrides: Partial<OrchestrationReadModel["projects"][number]> = {},
+): OrchestrationReadModel["projects"][number] {
+  return {
+    id: ProjectId.makeUnsafe("project-1"),
+    kind: "project",
+    title: "Project",
+    workspaceRoot: "/tmp/project",
+    defaultModelSelection: {
+      provider: "codex",
+      model: "gpt-5.3-codex",
+    },
+    scripts: [],
+    createdAt: "2026-04-20T08:00:00.000Z",
+    updatedAt: "2026-04-20T08:00:00.000Z",
+    deletedAt: null,
+    ...overrides,
+  };
+}
+
+function makeThread(
+  overrides: Partial<OrchestrationReadModel["threads"][number]> = {},
+): OrchestrationReadModel["threads"][number] {
+  return {
+    id: ThreadId.makeUnsafe("thread-1"),
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: "Thread",
+    modelSelection: {
+      provider: "codex",
+      model: "gpt-5.3-codex",
+    },
+    runtimeMode: "approval-required",
+    interactionMode: "chat",
+    envMode: "local",
+    branch: null,
+    worktreePath: null,
+    associatedWorktreePath: null,
+    associatedWorktreeBranch: null,
+    associatedWorktreeRef: null,
+    parentThreadId: null,
+    subagentAgentId: null,
+    subagentNickname: null,
+    subagentRole: null,
+    forkSourceThreadId: null,
+    lastKnownPr: null,
+    latestTurn: null,
+    handoff: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    createdAt: "2026-04-20T08:00:00.000Z",
+    updatedAt: "2026-04-20T08:00:00.000Z",
+    archivedAt: null,
+    deletedAt: null,
+    messages: [],
+    activities: [],
+    proposedPlans: [],
+    checkpoints: [],
+    session: null,
+    ...overrides,
+  };
+}
+
+function makeSnapshot(
+  overrides: Partial<OrchestrationReadModel> = {},
+): OrchestrationReadModel {
+  return {
+    snapshotSequence: 1,
+    updatedAt: "2026-04-20T08:00:00.000Z",
+    projects: [makeProject()],
+    threads: [makeThread()],
+    ...overrides,
+  };
+}
+
+describe("desktopProjectRecovery", () => {
+  it("returns false when live threads still have live project rows", () => {
+    const snapshot = makeSnapshot();
+
+    expect(hasLiveThreadsWithMissingProjects(snapshot)).toBe(false);
+  });
+
+  it("returns true when a live thread references a missing project row", () => {
+    const snapshot = makeSnapshot({
+      projects: [],
+    });
+
+    expect(hasLiveThreadsWithMissingProjects(snapshot)).toBe(true);
+  });
+
+  it("returns true when a live thread references a deleted project row", () => {
+    const snapshot = makeSnapshot({
+      projects: [makeProject({ deletedAt: "2026-04-20T09:00:00.000Z" })],
+    });
+
+    expect(hasLiveThreadsWithMissingProjects(snapshot)).toBe(true);
+  });
+
+  it("ignores deleted threads when deciding whether repair is needed", () => {
+    const snapshot = makeSnapshot({
+      projects: [],
+      threads: [makeThread({ deletedAt: "2026-04-20T09:00:00.000Z" })],
+    });
+
+    expect(hasLiveThreadsWithMissingProjects(snapshot)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/desktopProjectRecovery.ts
+++ b/apps/web/src/lib/desktopProjectRecovery.ts
@@ -1,0 +1,13 @@
+import type { OrchestrationReadModel } from "@t3tools/contracts";
+
+export function hasLiveThreadsWithMissingProjects(snapshot: OrchestrationReadModel): boolean {
+  const liveProjectIds = new Set(
+    snapshot.projects
+      .filter((project) => project.deletedAt === null)
+      .map((project) => project.id),
+  );
+
+  return snapshot.threads.some(
+    (thread) => thread.deletedAt === null && !liveProjectIds.has(thread.projectId),
+  );
+}

--- a/apps/web/src/lib/desktopWindow.test.ts
+++ b/apps/web/src/lib/desktopWindow.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldUseCustomDesktopTitleBar } from "./desktopWindow";
+
+describe("shouldUseCustomDesktopTitleBar", () => {
+  it("stays on native chrome outside Electron", () => {
+    expect(
+      shouldUseCustomDesktopTitleBar({
+        isElectron: false,
+        platform: "Win32",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps macOS on the native traffic-light title bar", () => {
+    expect(
+      shouldUseCustomDesktopTitleBar({
+        isElectron: true,
+        platform: "MacIntel",
+      }),
+    ).toBe(false);
+  });
+
+  it("enables custom renderer chrome on Windows and Linux", () => {
+    expect(
+      shouldUseCustomDesktopTitleBar({
+        isElectron: true,
+        platform: "Win32",
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseCustomDesktopTitleBar({
+        isElectron: true,
+        platform: "Linux x86_64",
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/desktopWindow.ts
+++ b/apps/web/src/lib/desktopWindow.ts
@@ -1,0 +1,30 @@
+import type { DesktopBridge, DesktopWindowState } from "@t3tools/contracts";
+
+import { isElectron } from "../env";
+import { isMacPlatform } from "./utils";
+
+export const DEFAULT_DESKTOP_WINDOW_STATE: DesktopWindowState = {
+  isMaximized: false,
+};
+
+export function shouldUseCustomDesktopTitleBar(input: {
+  isElectron: boolean;
+  platform: string;
+}): boolean {
+  return input.isElectron && !isMacPlatform(input.platform);
+}
+
+export function supportsCustomDesktopTitleBar(): boolean {
+  return shouldUseCustomDesktopTitleBar({
+    isElectron,
+    platform: typeof navigator === "undefined" ? "" : navigator.platform ?? "",
+  });
+}
+
+export function readDesktopBridge(): DesktopBridge | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window.desktopBridge ?? null;
+}

--- a/apps/web/src/lib/projectCreateRecovery.test.ts
+++ b/apps/web/src/lib/projectCreateRecovery.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   extractDuplicateProjectCreateProjectId,
+  findRecoverableProject,
   findRecoverableProjectForDuplicateCreate,
   isDuplicateProjectCreateError,
+  waitForRecoverableProjectInReadModel,
   waitForRecoverableProjectForDuplicateCreate,
 } from "./projectCreateRecovery";
 
@@ -86,6 +88,29 @@ describe("projectCreateRecovery", () => {
     expect(recovered?.id).toBe("project-123");
   });
 
+  it("finds a recoverable project by exact id before falling back to workspace root", () => {
+    const recovered = findRecoverableProject({
+      projectId: "project-123",
+      workspaceRoot: "/Users/tester/Code/one",
+      projects: [
+        {
+          id: "project-123",
+          kind: "project",
+          workspaceRoot: "/Users/tester/Code/two",
+          deletedAt: null,
+        },
+        {
+          id: "project-456",
+          kind: "project",
+          workspaceRoot: "/Users/tester/Code/one",
+          deletedAt: null,
+        },
+      ],
+    });
+
+    expect(recovered?.id).toBe("project-123");
+  });
+
   it("ignores deleted and non-project rows during recovery", () => {
     const recovered = findRecoverableProjectForDuplicateCreate({
       message:
@@ -140,6 +165,79 @@ describe("projectCreateRecovery", () => {
     });
 
     expect(attempts).toBe(3);
+    expect(result.project?.id).toBe("project-123");
+    expect(result.snapshot?.projects).toHaveLength(1);
+  });
+
+  it("repairs the snapshot after polling when a directly created project is still missing", async () => {
+    let repairCalls = 0;
+
+    const result = await waitForRecoverableProjectInReadModel({
+      projectId: "project-123",
+      workspaceRoot: "/Users/tester/Code/one",
+      loadSnapshot: async () => ({
+        snapshotSequence: 1,
+        updatedAt: "2026-04-21T00:00:00.000Z",
+        projects: [],
+        threads: [],
+      }),
+      repairSnapshot: async () => {
+        repairCalls += 1;
+        return {
+          snapshotSequence: 2,
+          updatedAt: "2026-04-21T00:00:01.000Z",
+          projects: [
+            {
+              id: "project-123",
+              kind: "project",
+              title: "One",
+              workspaceRoot: "/Users/tester/Code/one",
+              defaultModelSelection: null,
+              scripts: [],
+              createdAt: "2026-04-21T00:00:00.000Z",
+              updatedAt: "2026-04-21T00:00:01.000Z",
+              deletedAt: null,
+            },
+          ],
+          threads: [],
+        };
+      },
+      maxAttempts: 2,
+      delayMs: 0,
+    });
+
+    expect(repairCalls).toBe(1);
+    expect(result.project?.id).toBe("project-123");
+    expect(result.snapshot?.projects).toHaveLength(1);
+  });
+
+  it("repairs duplicate-create recovery when the fresh snapshot still has no project rows", async () => {
+    let repairCalls = 0;
+
+    const result = await waitForRecoverableProjectForDuplicateCreate({
+      message:
+        "Orchestration command invariant failed (project.create): Project 'project-123' already uses workspace root '/Users/tester/Code/one'.",
+      workspaceRoot: "/Users/tester/Code/one",
+      loadSnapshot: async () => ({
+        projects: [],
+      }),
+      repairSnapshot: async () => {
+        repairCalls += 1;
+        return {
+          projects: [
+            {
+              id: "project-123",
+              workspaceRoot: "/Users/tester/Code/one",
+              deletedAt: null,
+            },
+          ],
+        };
+      },
+      maxAttempts: 2,
+      delayMs: 0,
+    });
+
+    expect(repairCalls).toBe(1);
     expect(result.project?.id).toBe("project-123");
     expect(result.snapshot?.projects).toHaveLength(1);
   });

--- a/apps/web/src/lib/projectCreateRecovery.ts
+++ b/apps/web/src/lib/projectCreateRecovery.ts
@@ -2,6 +2,7 @@
 // Purpose: Centralizes duplicate `project.create` error parsing and recovery helpers.
 // Exports: duplicate-create error guards plus snapshot matching for import recovery.
 
+import type { OrchestrationReadModel } from "@t3tools/contracts";
 import { workspaceRootsEqual } from "@t3tools/shared/threadWorkspace";
 
 const DUPLICATE_PROJECT_CREATE_ERROR_PREFIX =
@@ -18,6 +19,11 @@ export interface DuplicateProjectCreateRecoveryCandidate {
 
 interface SnapshotWithProjects<T extends DuplicateProjectCreateRecoveryCandidate> {
   readonly projects: readonly T[];
+}
+
+interface ProjectLookupInput {
+  readonly projectId?: string | null | undefined;
+  readonly workspaceRoot?: string | null | undefined;
 }
 
 function isRecoverableProjectKind(kind: string | undefined): boolean {
@@ -49,29 +55,25 @@ export function extractDuplicateProjectCreateProjectId(message: string): string 
   return message.slice(DUPLICATE_PROJECT_CREATE_ERROR_PREFIX.length, duplicateMarkerIndex) || null;
 }
 
-// Prefers the explicit duplicate id, then falls back to workspace-root matching for older clients.
-export function findRecoverableProjectForDuplicateCreate<
-  T extends DuplicateProjectCreateRecoveryCandidate,
->(input: {
-  readonly message: string;
-  readonly projects: readonly T[];
-  readonly workspaceRoot: string;
-}): T | null {
-  if (!isDuplicateProjectCreateError(input.message)) {
-    return null;
-  }
-
-  const duplicateProjectId = extractDuplicateProjectCreateProjectId(input.message);
-  if (duplicateProjectId) {
+export function findRecoverableProject<T extends DuplicateProjectCreateRecoveryCandidate>(
+  input: ProjectLookupInput & {
+    readonly projects: readonly T[];
+  },
+): T | null {
+  if (input.projectId) {
     const projectById = input.projects.find(
       (project) =>
         project.deletedAt === null &&
         isRecoverableProjectKind(project.kind) &&
-        project.id === duplicateProjectId,
+        project.id === input.projectId,
     );
     if (projectById) {
       return projectById;
     }
+  }
+
+  if (!input.workspaceRoot) {
+    return null;
   }
 
   return (
@@ -84,6 +86,81 @@ export function findRecoverableProjectForDuplicateCreate<
   );
 }
 
+// Prefers the explicit duplicate id, then falls back to workspace-root matching for older clients.
+export function findRecoverableProjectForDuplicateCreate<
+  T extends DuplicateProjectCreateRecoveryCandidate,
+>(input: {
+  readonly message: string;
+  readonly projects: readonly T[];
+  readonly workspaceRoot: string;
+}): T | null {
+  if (!isDuplicateProjectCreateError(input.message)) {
+    return null;
+  }
+
+  return findRecoverableProject({
+    projects: input.projects,
+    projectId: extractDuplicateProjectCreateProjectId(input.message),
+    workspaceRoot: input.workspaceRoot,
+  });
+}
+
+export async function waitForRecoverableProjectInReadModel(input: ProjectLookupInput & {
+  readonly loadSnapshot: () => Promise<OrchestrationReadModel | null>;
+  readonly repairSnapshot?: (() => Promise<OrchestrationReadModel | null>) | undefined;
+  readonly maxAttempts?: number;
+  readonly delayMs?: number;
+}): Promise<{
+  project: OrchestrationReadModel["projects"][number] | null;
+  snapshot: OrchestrationReadModel | null;
+}> {
+  let latestSnapshot: OrchestrationReadModel | null = null;
+  const maxAttempts = input.maxAttempts ?? DEFAULT_RECOVERY_MAX_ATTEMPTS;
+  const delayMs = input.delayMs ?? DEFAULT_RECOVERY_DELAY_MS;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const snapshot = await input.loadSnapshot();
+    if (snapshot) {
+      latestSnapshot = snapshot;
+      const project = findRecoverableProject({
+        projects: snapshot.projects,
+        projectId: input.projectId,
+        workspaceRoot: input.workspaceRoot,
+      });
+      if (project) {
+        return { project, snapshot };
+      }
+    }
+
+    if (attempt < maxAttempts) {
+      await wait(delayMs * attempt);
+    }
+  }
+
+  if (input.repairSnapshot) {
+    const repairedSnapshot = await input.repairSnapshot();
+    if (repairedSnapshot) {
+      latestSnapshot = repairedSnapshot;
+      const repairedProject = findRecoverableProject({
+        projects: repairedSnapshot.projects,
+        projectId: input.projectId,
+        workspaceRoot: input.workspaceRoot,
+      });
+      if (repairedProject) {
+        return {
+          project: repairedProject,
+          snapshot: repairedSnapshot,
+        };
+      }
+    }
+  }
+
+  return {
+    project: null,
+    snapshot: latestSnapshot,
+  };
+}
+
 // Retries snapshot reads briefly so freshly restored projects can be reused by the first-send flow.
 export async function waitForRecoverableProjectForDuplicateCreate<
   TSnapshot extends SnapshotWithProjects<DuplicateProjectCreateRecoveryCandidate>,
@@ -91,6 +168,7 @@ export async function waitForRecoverableProjectForDuplicateCreate<
   readonly message: string;
   readonly workspaceRoot: string;
   readonly loadSnapshot: () => Promise<TSnapshot | null>;
+  readonly repairSnapshot?: (() => Promise<TSnapshot | null>) | undefined;
   readonly maxAttempts?: number;
   readonly delayMs?: number;
 }): Promise<{
@@ -117,6 +195,24 @@ export async function waitForRecoverableProjectForDuplicateCreate<
 
     if (attempt < maxAttempts) {
       await wait(delayMs * attempt);
+    }
+  }
+
+  if (input.repairSnapshot) {
+    const repairedSnapshot = await input.repairSnapshot();
+    if (repairedSnapshot) {
+      latestSnapshot = repairedSnapshot;
+      const repairedProject = findRecoverableProjectForDuplicateCreate({
+        message: input.message,
+        projects: repairedSnapshot.projects,
+        workspaceRoot: input.workspaceRoot,
+      }) as TSnapshot["projects"][number] | null;
+      if (repairedProject) {
+        return {
+          project: repairedProject,
+          snapshot: repairedSnapshot,
+        };
+      }
     }
   }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -49,6 +49,7 @@ import { useWorkspaceStore, workspaceThreadId } from "../workspaceStore";
 import { useRetainedThreadDetailIds } from "../threadDetailSubscriptionRetention";
 import { useAppTypography } from "../hooks/useAppTypography";
 import { invalidateGitQueries } from "../lib/gitReactQuery";
+import { hasLiveThreadsWithMissingProjects } from "../lib/desktopProjectRecovery";
 import { parseDiffRouteSearch } from "../diffRouteSearch";
 import { resolveSplitViewThreadIds, selectSplitView, useSplitViewStore } from "../splitViewStore";
 
@@ -769,12 +770,15 @@ function DesktopProjectBootstrap() {
     attemptedRecoveryRef.current = true;
 
     // Shell subscriptions should normally hydrate the sidebar. If the desktop
-    // UI comes up empty against a non-empty local database, force one read-model
-    // refresh and fall back to repair only when the snapshot is still empty.
+    // UI comes up empty, or threads resolve before their project rows do, force
+    // one read-model refresh and fall back to repair before accepting the state.
     void api.orchestration
       .getSnapshot()
       .then((snapshot) => {
-        if (snapshot.projects.length > 0 || snapshot.threads.length > 0) {
+        const needsRepair =
+          (snapshot.projects.length === 0 && snapshot.threads.length === 0) ||
+          hasLiveThreadsWithMissingProjects(snapshot);
+        if (!needsRepair) {
           syncServerReadModel(snapshot);
           return snapshot;
         }

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -25,6 +25,7 @@ import {
   useAppSettings,
 } from "../appSettings";
 import { APP_VERSION } from "../branding";
+import { DesktopWindowControls } from "../components/chat/DesktopWindowControls";
 import { ClaudeAI, Gemini, OpenAI } from "../components/Icons";
 import { Button } from "../components/ui/button";
 import { Collapsible, CollapsibleContent } from "../components/ui/collapsible";
@@ -43,6 +44,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../components/ui/tooltip"
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { isElectron } from "../env";
 import { useTheme } from "../hooks/useTheme";
+import { supportsCustomDesktopTitleBar } from "../lib/desktopWindow";
 import { gitRemoveWorktreeMutationOptions } from "../lib/gitReactQuery";
 import {
   ArchiveIcon,
@@ -2117,8 +2119,11 @@ function SettingsRouteView() {
         {isElectron ? (
           <div
             className={cn(
-              "drag-region flex h-[52px] shrink-0 items-center border-b border-border/70 px-5",
-              settings.sidebarSide === "right" && "pl-[90px]",
+              "drag-region flex h-[52px] shrink-0 items-center border-b border-border/70",
+              supportsCustomDesktopTitleBar() ? "pl-5 pr-0" : "px-5",
+              !supportsCustomDesktopTitleBar() &&
+                settings.sidebarSide === "right" &&
+                "pl-[90px]",
             )}
           >
             <SidebarHeaderTrigger className="size-7 shrink-0" />
@@ -2136,6 +2141,7 @@ function SettingsRouteView() {
                 Restore defaults
               </Button>
             </div>
+            <DesktopWindowControls />
           </div>
         ) : (
           <header className="border-b border-border/70 px-3 py-2 sm:px-5">

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -216,6 +216,10 @@ export interface DesktopNotificationInput {
   threadId?: ThreadId;
 }
 
+export interface DesktopWindowState {
+  isMaximized: boolean;
+}
+
 export interface DesktopBridge {
   getWsUrl: () => string | null;
   pickFolder: () => Promise<string | null>;
@@ -236,6 +240,13 @@ export interface DesktopBridge {
   downloadUpdate: () => Promise<DesktopUpdateActionResult>;
   installUpdate: () => Promise<DesktopUpdateActionResult>;
   onUpdateState: (listener: (state: DesktopUpdateState) => void) => () => void;
+  window: {
+    minimize: () => Promise<void>;
+    toggleMaximize: () => Promise<DesktopWindowState>;
+    close: () => Promise<void>;
+    getState: () => Promise<DesktopWindowState>;
+    onState: (listener: (state: DesktopWindowState) => void) => () => void;
+  };
   notifications: {
     isSupported: () => Promise<boolean>;
     show: (input: DesktopNotificationInput) => Promise<boolean>;


### PR DESCRIPTION
## Summary

This PR fixes three desktop issues:

1. [#35](https://github.com/Emanuele-web04/dpcode/issues/35): existing threads could disappear because desktop startup accepted a broken snapshot where live threads existed without matching live project rows.
2. [#43](https://github.com/Emanuele-web04/dpcode/issues/43): `project.create` could succeed without surfacing the created project, and retrying the same folder then failed with the duplicate workspace-root invariant.
3. Windows desktop chrome: the app was always taking the macOS title-bar path, which left the DP header offset incorrectly on Windows and Linux.

## What changed

### Issue #35: thread/sidebar recovery on desktop startup

- Detect broken desktop snapshots where live threads exist without matching live project rows.
- Repair that snapshot shape during desktop bootstrap instead of only repairing fully empty snapshots.
- Prevent the sidebar from accepting that broken state and coming up empty even though thread data still exists.

### Issue #43: project-add recovery after silent success

- Centralize project recovery helpers so add-project and duplicate-create flows share the same read-model lookup behavior.
- Retry the read model briefly after project creation.
- Fall back to `repairState()` when polling still cannot surface the created project.
- Recover duplicate-create flows by reopening the existing project instead of leaving the UI empty and surfacing the duplicate workspace-root error on retry.

### Windows desktop chrome

- Split desktop window chrome by platform instead of always using the macOS inset title bar.
- Keep the native macOS traffic-light/title-bar behavior on macOS.
- Use a hidden title bar on Windows and Linux and expose renderer-driven window controls through the desktop bridge.
- Sync maximize/fullscreen state back to the renderer so maximize/restore icons stay in the correct state.
- Remove the extra right-edge gap in the custom desktop header so the control strip sits flush against the window edge.
- Render the same Windows controls across:
  - active chat header
  - empty-thread header
  - settings header
  - dedicated workspace header
- Update the custom control icons to the intended Windows-style minimize / maximize / restore / close states.

## Why

There were two separate recovery failures in the desktop app:

- In [#35](https://github.com/Emanuele-web04/dpcode/issues/35), desktop startup could accept a broken local/read-model snapshot and show an empty sidebar even though live threads still existed.
- In [#43](https://github.com/Emanuele-web04/dpcode/issues/43), the first add-project attempt could succeed internally but fail to appear in the UI, and retrying the same folder then produced:

`Orchestration command invariant failed (project.create): Project '<id>' already uses workspace root '<path>'`

Separately, the Windows title bar/header was still following the macOS chrome path, which left the branding and window controls misaligned on Windows/Linux.

## Validation

Ran targeted tests:

- `bun run test src/windowChrome.test.ts` in `apps/desktop`
- `bun run test src/lib/desktopWindow.test.ts src/lib/projectCreateRecovery.test.ts src/lib/desktopProjectRecovery.test.ts` in `apps/web`

Results:

- desktop: 1 file, 4 tests passed
- web: 3 files, 17 tests passed

## Notes

- I intentionally left unrelated/generated changes out of this PR, including `bun.lock`, `apps/web/src/routeTree.gen.ts`, and `apps/web/public/mockServiceWorker.js`.
- Before/after screenshots for the Windows chrome surfaces still need to be attached because part of this PR is a UI fix.
