### PR TITLE
Clean threads notifcations

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -285,8 +285,10 @@ describe("resolveThreadStatusPill", () => {
     interactionMode: "plan" as const,
     latestTurn: null,
     lastVisitedAt: undefined,
+    dismissedStatusKey: undefined,
     proposedPlans: [],
     hasLiveTailWork: false,
+    updatedAt: "2026-03-09T10:05:00.000Z",
     session: {
       provider: "codex" as const,
       status: "running" as const,
@@ -420,6 +422,27 @@ describe("resolveThreadStatusPill", () => {
         hasPendingUserInput: false,
       }),
     ).toMatchObject({ label: "Completed", pulse: false });
+  });
+
+  it("hides a dismissible status when its dismissal key matches", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          hasActionableProposedPlan: true,
+          latestTurn: makeLatestTurn(),
+          dismissedStatusKey:
+            "Plan Ready:2026-03-09T10:05:00.000Z:turn-1:2026-03-09T10:05:00.000Z:2026-03-09T10:00:00.000Z",
+          session: {
+            ...baseThread.session,
+            status: "ready",
+            orchestrationStatus: "ready",
+          },
+        },
+        hasPendingApprovals: false,
+        hasPendingUserInput: false,
+      }),
+    ).toBeNull();
   });
 });
 
@@ -1047,6 +1070,32 @@ describe("deriveSidebarProjectData", () => {
         }),
       ],
     });
+  });
+
+  it("uses the provided thread-status resolver for project status", () => {
+    const project = makeProject();
+    const threadOne = makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe("thread-1"),
+      title: "One",
+      hasPendingApprovals: true,
+    });
+
+    const data = deriveSidebarProjectData({
+      projects: [project],
+      sortedSidebarThreadsByProjectId: groupSidebarThreadsByProjectId([threadOne]),
+      splitViewsByProjectId: groupSplitViewsByProjectId([]),
+      splitViewBySourceThreadId: new Map(),
+      pinnedThreadIds: [],
+      pinnedThreadIdSet: new Set(),
+      expandedParentThreadIds: new Set(),
+      expandedThreadListProjectCwds: new Set(),
+      normalizeProjectCwd: (cwd) => cwd,
+      activeSidebarThreadId: undefined,
+      previewLimit: 5,
+      resolveThreadStatus: () => null,
+    });
+
+    expect(data.get(project.id)?.projectStatus).toBeNull();
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -91,6 +91,8 @@ export interface ThreadStatusPill {
   colorClass: string;
   dotClass: string;
   pulse: boolean;
+  dismissible?: boolean;
+  dismissalKey?: string;
 }
 
 const THREAD_STATUS_PRIORITY: Record<ThreadStatusPill["label"], number> = {
@@ -104,12 +106,34 @@ const THREAD_STATUS_PRIORITY: Record<ThreadStatusPill["label"], number> = {
 
 type ThreadStatusInput = Pick<
   Thread,
-  "interactionMode" | "latestTurn" | "lastVisitedAt" | "session"
+  "interactionMode" | "latestTurn" | "lastVisitedAt" | "session" | "updatedAt"
 > & {
   proposedPlans?: Thread["proposedPlans"] | undefined;
   hasActionableProposedPlan?: boolean | undefined;
   hasLiveTailWork?: boolean | undefined;
+  dismissedStatusKey?: string | undefined;
 };
+
+function createThreadStatusDismissalKey(
+  label: Extract<ThreadStatusPill["label"], "Pending Approval" | "Awaiting Input" | "Plan Ready">,
+  thread: ThreadStatusInput,
+): string {
+  return [
+    label,
+    thread.updatedAt ?? "",
+    thread.latestTurn?.turnId ?? "",
+    thread.latestTurn?.completedAt ?? "",
+    thread.session?.updatedAt ?? "",
+  ].join(":");
+}
+
+function createCompletedDismissalKey(thread: ThreadStatusInput): string | null {
+  if (!thread.latestTurn?.completedAt) {
+    return null;
+  }
+
+  return ["Completed", thread.latestTurn.turnId, thread.latestTurn.completedAt].join(":");
+}
 
 export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
   if (!thread.latestTurn?.completedAt) return false;
@@ -219,20 +243,32 @@ export function resolveThreadStatusPill(input: {
   const { hasPendingApprovals, hasPendingUserInput, thread } = input;
 
   if (hasPendingApprovals) {
+    const dismissalKey = createThreadStatusDismissalKey("Pending Approval", thread);
+    if (thread.dismissedStatusKey === dismissalKey) {
+      return null;
+    }
     return {
       label: "Pending Approval",
       colorClass: "text-amber-600 dark:text-amber-300/90",
       dotClass: "bg-amber-500 dark:bg-amber-300/90",
       pulse: false,
+      dismissible: true,
+      dismissalKey,
     };
   }
 
   if (hasPendingUserInput) {
+    const dismissalKey = createThreadStatusDismissalKey("Awaiting Input", thread);
+    if (thread.dismissedStatusKey === dismissalKey) {
+      return null;
+    }
     return {
       label: "Awaiting Input",
       colorClass: "text-indigo-600 dark:text-indigo-300/90",
       dotClass: "bg-indigo-500 dark:bg-indigo-300/90",
       pulse: false,
+      dismissible: true,
+      dismissalKey,
     };
   }
 
@@ -242,6 +278,7 @@ export function resolveThreadStatusPill(input: {
       colorClass: "text-sky-600 dark:text-sky-300/80",
       dotClass: "bg-sky-500 dark:bg-sky-300/80",
       pulse: true,
+      dismissible: false,
     };
   }
 
@@ -254,6 +291,7 @@ export function resolveThreadStatusPill(input: {
       colorClass: "text-sky-600 dark:text-sky-300/80",
       dotClass: "bg-sky-500 dark:bg-sky-300/80",
       pulse: true,
+      dismissible: false,
     };
   }
 
@@ -263,6 +301,7 @@ export function resolveThreadStatusPill(input: {
       colorClass: "text-sky-600 dark:text-sky-300/80",
       dotClass: "bg-sky-500 dark:bg-sky-300/80",
       pulse: true,
+      dismissible: false,
     };
   }
 
@@ -276,20 +315,32 @@ export function resolveThreadStatusPill(input: {
         findLatestProposedPlan(thread.proposedPlans ?? [], thread.latestTurn?.turnId ?? null),
       ));
   if (hasPlanReadyPrompt) {
+    const dismissalKey = createThreadStatusDismissalKey("Plan Ready", thread);
+    if (thread.dismissedStatusKey === dismissalKey) {
+      return null;
+    }
     return {
       label: "Plan Ready",
       colorClass: "text-violet-600 dark:text-violet-300/90",
       dotClass: "bg-violet-500 dark:bg-violet-300/90",
       pulse: false,
+      dismissible: true,
+      dismissalKey,
     };
   }
 
   if (!thread.hasLiveTailWork && hasUnseenCompletion(thread)) {
+    const dismissalKey = createCompletedDismissalKey(thread);
+    if (dismissalKey && thread.dismissedStatusKey === dismissalKey) {
+      return null;
+    }
     return {
       label: "Completed",
       colorClass: "text-emerald-600 dark:text-emerald-300/90",
       dotClass: "bg-emerald-500 dark:bg-emerald-300/90",
       pulse: false,
+      dismissible: true,
+      ...(dismissalKey ? { dismissalKey } : {}),
     };
   }
 
@@ -879,6 +930,9 @@ export function deriveSidebarProjectData(input: {
   normalizeProjectCwd: (cwd: string) => string;
   activeSidebarThreadId: ThreadId | undefined;
   previewLimit: number;
+  resolveThreadStatus?: (
+    thread: SidebarThreadSummary,
+  ) => ReturnType<typeof resolveThreadStatusPill>;
 }): ReadonlyMap<ProjectId, SidebarDerivedProjectData> {
   const byProjectId = new Map<ProjectId, SidebarDerivedProjectData>();
 
@@ -894,11 +948,13 @@ export function deriveSidebarProjectData(input: {
     );
     const projectStatus = resolveProjectStatusIndicator(
       allProjectThreads.map((thread) =>
-        resolveThreadStatusPill({
-          thread,
-          hasPendingApprovals: thread.hasPendingApprovals,
-          hasPendingUserInput: thread.hasPendingUserInput,
-        }),
+        input.resolveThreadStatus
+          ? input.resolveThreadStatus(thread)
+          : resolveThreadStatusPill({
+              thread,
+              hasPendingApprovals: thread.hasPendingApprovals,
+              hasPendingUserInput: thread.hasPendingUserInput,
+            }),
       ),
     );
     const isThreadListExpanded = input.expandedThreadListProjectCwds.has(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1024,6 +1024,7 @@ export default function Sidebar() {
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const sidebarThreadSummaryById = useStore((store) => store.sidebarThreadSummaryById);
   const syncServerReadModel = useStore((store) => store.syncServerReadModel);
+  const markThreadVisited = useStore((store) => store.markThreadVisited);
   const markThreadUnread = useStore((store) => store.markThreadUnread);
   const toggleProject = useStore((store) => store.toggleProject);
   const setProjectExpanded = useStore((store) => store.setProjectExpanded);
@@ -1117,6 +1118,9 @@ export default function Sidebar() {
   const [chatThreadListExpanded, setChatThreadListExpanded] = useState(
     () => readSidebarUiState().chatThreadListExpanded,
   );
+  const [dismissedThreadStatusKeyByThreadId, setDismissedThreadStatusKeyByThreadId] = useState<
+    Record<string, string>
+  >(() => readSidebarUiState().dismissedThreadStatusKeyByThreadId);
   const [lastThreadRoute, setLastThreadRoute] = useState(
     () => readSidebarUiState().lastThreadRoute,
   );
@@ -1149,6 +1153,68 @@ export default function Sidebar() {
   const selectSidebarDisplayThreads = useMemo(() => createSidebarDisplayThreadsSelector(), []);
   const sidebarThreads = useStore(selectSidebarThreads);
   const sidebarDisplayThreads = useStore(selectSidebarDisplayThreads);
+  const dismissThreadStatus = useCallback(
+    (threadId: ThreadId, statusKey: string | null | undefined) => {
+      if (!statusKey) {
+        return;
+      }
+      setDismissedThreadStatusKeyByThreadId((current) => {
+        if (current[threadId] === statusKey) {
+          return current;
+        }
+        return {
+          ...current,
+          [threadId]: statusKey,
+        };
+      });
+    },
+    [],
+  );
+  const clearDismissedThreadStatus = useCallback((threadId: ThreadId) => {
+    setDismissedThreadStatusKeyByThreadId((current) => {
+      if (!(threadId in current)) {
+        return current;
+      }
+      const next = { ...current };
+      delete next[threadId];
+      return next;
+    });
+  }, []);
+  const resolveThreadStatusForSidebar = useCallback(
+    (thread: SidebarThreadSummary) =>
+      resolveThreadStatusPill({
+        thread: {
+          ...thread,
+          dismissedStatusKey: dismissedThreadStatusKeyByThreadId[thread.id],
+        },
+        hasPendingApprovals: thread.hasPendingApprovals,
+        hasPendingUserInput: thread.hasPendingUserInput,
+      }),
+    [dismissedThreadStatusKeyByThreadId],
+  );
+  const clearThreadNotification = useCallback(
+    (threadId: ThreadId) => {
+      const thread = sidebarThreadSummaryById[threadId];
+      if (!thread) {
+        return;
+      }
+      const threadStatus = resolveThreadStatusForSidebar(thread);
+      if (!threadStatus?.dismissible) {
+        return;
+      }
+      if (threadStatus.label === "Completed") {
+        markThreadVisited(threadId, thread.latestTurn?.completedAt ?? undefined);
+        return;
+      }
+      dismissThreadStatus(threadId, threadStatus.dismissalKey);
+    },
+    [
+      dismissThreadStatus,
+      markThreadVisited,
+      resolveThreadStatusForSidebar,
+      sidebarThreadSummaryById,
+    ],
+  );
   const routeThreadSummary = routeThreadId
     ? (sidebarThreadSummaryById[routeThreadId] ?? null)
     : null;
@@ -2586,6 +2652,7 @@ export default function Sidebar() {
         hasPendingApprovals,
         hasPendingUserInput,
       });
+      const threadStatus = threadSummary ? resolveThreadStatusForSidebar(threadSummary) : null;
       const handoffTargets = canHandoff
         ? resolveAvailableHandoffTargetProviders(thread.modelSelection.provider)
         : [];
@@ -2602,6 +2669,9 @@ export default function Sidebar() {
         [
           { id: "rename", label: "Rename thread" },
           { id: "toggle-pin", label: isPinned ? "Unpin thread" : "Pin thread" },
+          ...(threadStatus?.dismissible
+            ? [{ id: "clear-notification", label: "Clear notification" }]
+            : []),
           { id: "mark-unread", label: "Mark unread" },
           ...handoffItems,
           { id: "copy-path", label: "Copy Path" },
@@ -2628,7 +2698,12 @@ export default function Sidebar() {
       }
 
       if (clicked === "mark-unread") {
+        clearDismissedThreadStatus(threadId);
         markThreadUnread(threadId);
+        return;
+      }
+      if (clicked === "clear-notification") {
+        clearThreadNotification(threadId);
         return;
       }
       if (typeof clicked === "string" && clicked.startsWith("handoff:")) {
@@ -2759,11 +2834,14 @@ export default function Sidebar() {
       confirmAndDeleteThread,
       copyPathToClipboard,
       copyThreadIdToClipboard,
+      clearDismissedThreadStatus,
+      clearThreadNotification,
       handoffThread,
       markThreadUnread,
       navigate,
       pinnedThreadIdSet,
       projectCwdById,
+      resolveThreadStatusForSidebar,
       sidebarThreadSummaryById,
       togglePinnedThread,
     ],
@@ -2837,6 +2915,7 @@ export default function Sidebar() {
 
       if (clicked === "mark-unread") {
         for (const id of ids) {
+          clearDismissedThreadStatus(id);
           markThreadUnread(id);
         }
         clearSelection();
@@ -2884,6 +2963,7 @@ export default function Sidebar() {
       appSettings.confirmThreadDelete,
       archiveThread,
       clearSelection,
+      clearDismissedThreadStatus,
       deleteThread,
       markThreadUnread,
       removeFromSelection,
@@ -3338,6 +3418,7 @@ export default function Sidebar() {
         normalizeProjectCwd: normalizeSidebarProjectThreadListCwd,
         activeSidebarThreadId: activeSidebarThreadId ?? undefined,
         previewLimit: THREAD_PREVIEW_LIMIT,
+        resolveThreadStatus: resolveThreadStatusForSidebar,
       }),
     [
       activeSidebarThreadId,
@@ -3349,6 +3430,7 @@ export default function Sidebar() {
       splitViewBySourceThreadId,
       splitViewsByProjectId,
       standardProjects,
+      resolveThreadStatusForSidebar,
     ],
   );
   const allProjectsExpanded = useMemo(
@@ -3375,13 +3457,33 @@ export default function Sidebar() {
   }, [prunePinnedThreads, sidebarThreads, threadsHydrated]);
 
   useEffect(() => {
+    const retainedThreadIds = new Set(sidebarThreads.map((thread) => thread.id));
+    setDismissedThreadStatusKeyByThreadId((current) => {
+      const nextEntries = Object.entries(current).filter(([threadId]) =>
+        retainedThreadIds.has(ThreadId.makeUnsafe(threadId)),
+      );
+      if (nextEntries.length === Object.keys(current).length) {
+        return current;
+      }
+      return Object.fromEntries(nextEntries);
+    });
+  }, [sidebarThreads]);
+
+  useEffect(() => {
     persistSidebarUiState({
       chatSectionExpanded,
       chatThreadListExpanded,
       expandedProjectThreadListCwds: [...expandedThreadListsByProject],
+      dismissedThreadStatusKeyByThreadId,
       lastThreadRoute,
     });
-  }, [chatSectionExpanded, chatThreadListExpanded, expandedThreadListsByProject, lastThreadRoute]);
+  }, [
+    chatSectionExpanded,
+    chatThreadListExpanded,
+    dismissedThreadStatusKeyByThreadId,
+    expandedThreadListsByProject,
+    lastThreadRoute,
+  ]);
 
   useEffect(() => {
     if (isOnWorkspace || isOnSettings || routeThreadId === null) {
@@ -3614,12 +3716,12 @@ export default function Sidebar() {
     return (
       <button
         type="button"
+        data-testid={`thread-archive-${threadId}`}
         aria-label="Archive thread"
         title="Archive thread"
         className={cn(
-          "sidebar-icon-button pointer-events-none absolute inset-y-0 right-0 my-auto inline-flex justify-center opacity-0 transition-[opacity,color] hover:text-foreground/82",
+          "sidebar-icon-button inline-flex justify-center hover:text-foreground/82",
           compact ? "size-[18px]" : "size-5",
-          "group-hover/thread-row:pointer-events-auto group-hover/thread-row:opacity-100 group-focus-within/thread-row:pointer-events-auto group-focus-within/thread-row:opacity-100",
           toneClassName,
         )}
         onMouseDown={(event) => {
@@ -3634,6 +3736,56 @@ export default function Sidebar() {
       >
         <HiOutlineArchiveBox className={cn("shrink-0", compact ? "size-[11px]" : "size-3")} />
       </button>
+    );
+  }
+
+  function renderThreadHoverActions(input: {
+    threadId: ThreadId;
+    toneClassName: string;
+    compact?: boolean;
+  }) {
+    const compact = input.compact === true;
+    const isPendingConfirmation = pendingArchiveConfirmationThreadId === input.threadId;
+
+    if (isPendingConfirmation) {
+      return (
+        <div
+          data-testid={`thread-hover-actions-${input.threadId}`}
+          className="pointer-events-none absolute inset-y-0 right-0 my-auto inline-flex items-center opacity-100"
+        >
+          <button
+            type="button"
+            aria-label="Confirm archive"
+            title="Confirm archive"
+            className={cn(
+              "pointer-events-auto inline-flex h-5 items-center rounded-full px-2.5 text-[10px] font-normal leading-none tracking-[-0.01em] opacity-100 transition-colors",
+              "bg-red-400/12 text-red-400 hover:bg-red-400/16 hover:text-red-300",
+              "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-red-400/45",
+              compact ? "h-4.5 px-1.5 text-[10px]" : undefined,
+            )}
+            onMouseDown={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              void inlineConfirmArchiveThread(input.threadId);
+            }}
+          >
+            <span>Confirm</span>
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div
+        data-testid={`thread-hover-actions-${input.threadId}`}
+        className="pointer-events-none absolute inset-y-0 right-0 my-auto inline-flex items-center opacity-0 transition-opacity group-hover/thread-row:pointer-events-auto group-hover/thread-row:opacity-100 group-focus-within/thread-row:pointer-events-auto group-focus-within/thread-row:opacity-100"
+      >
+        {renderThreadArchiveAction(input.threadId, input.toneClassName, { compact })}
+      </div>
     );
   }
 
@@ -3652,11 +3804,7 @@ export default function Sidebar() {
       thread,
       includeHandoffBadge: true,
     });
-    const threadStatus = resolveThreadStatusPill({
-      thread,
-      hasPendingApprovals: thread.hasPendingApprovals,
-      hasPendingUserInput: thread.hasPendingUserInput,
-    });
+    const threadStatus = resolveThreadStatusForSidebar(thread);
     const isSubagentThread = Boolean(thread.parentThreadId);
     const prStatus = prStatusIndicator(prByThreadId.get(thread.id) ?? null);
     const leadingPrStatus = isSubagentThread || thread.forkSourceThreadId ? null : prStatus;
@@ -3799,7 +3947,9 @@ export default function Sidebar() {
                   {formatRelativeTime(thread.updatedAt ?? thread.createdAt)}
                 </span>
               ) : null}
-              {renderThreadArchiveAction(thread.id, "text-muted-foreground/42", {
+              {renderThreadHoverActions({
+                threadId: thread.id,
+                toneClassName: "text-muted-foreground/42",
                 compact: isSubagentThread,
               })}
             </div>
@@ -3823,11 +3973,7 @@ export default function Sidebar() {
     const isPinned = pinnedThreadIdSet.has(thread.id);
     const isSelected = selectedThreadIds.has(thread.id);
     const isHighlighted = isActive || isSelected;
-    const threadStatus = resolveThreadStatusPill({
-      thread,
-      hasPendingApprovals: thread.hasPendingApprovals,
-      hasPendingUserInput: thread.hasPendingUserInput,
-    });
+    const threadStatus = resolveThreadStatusForSidebar(thread);
     const prStatus = prStatusIndicator(prByThreadId.get(thread.id) ?? null);
     const terminalStatus = terminalStatusFromThreadState({
       runningTerminalIds: threadTerminalState.runningTerminalIds,
@@ -4120,7 +4266,9 @@ export default function Sidebar() {
                   {formatRelativeTime(thread.updatedAt ?? thread.createdAt)}
                 </span>
               ) : null}
-              {renderThreadArchiveAction(thread.id, secondaryMetaClass, {
+              {renderThreadHoverActions({
+                threadId: thread.id,
+                toneClassName: secondaryMetaClass,
                 compact: isSubagentThread,
               })}
             </div>

--- a/apps/web/src/components/Sidebar.uiState.test.ts
+++ b/apps/web/src/components/Sidebar.uiState.test.ts
@@ -39,6 +39,7 @@ describe("Sidebar.uiState", () => {
       chatSectionExpanded: false,
       chatThreadListExpanded: false,
       expandedProjectThreadListCwds: [],
+      dismissedThreadStatusKeyByThreadId: {},
       lastThreadRoute: null,
     });
   });
@@ -52,6 +53,9 @@ describe("Sidebar.uiState", () => {
         "/Users/tester/Code/demo/",
         "/Users/tester/Code/other",
       ],
+      dismissedThreadStatusKeyByThreadId: {
+        "thread-123": "Plan Ready:turn-1",
+      },
       lastThreadRoute: {
         threadId: "thread-123",
         splitViewId: "split-456",
@@ -65,6 +69,9 @@ describe("Sidebar.uiState", () => {
         normalizeSidebarProjectThreadListCwd("/Users/tester/Code/demo"),
         normalizeSidebarProjectThreadListCwd("/Users/tester/Code/other"),
       ],
+      dismissedThreadStatusKeyByThreadId: {
+        "thread-123": "Plan Ready:turn-1",
+      },
       lastThreadRoute: {
         threadId: "thread-123",
         splitViewId: "split-456",
@@ -79,6 +86,11 @@ describe("Sidebar.uiState", () => {
         chatSectionExpanded: true,
         chatThreadListExpanded: false,
         expandedProjectThreadListCwds: ["/Users/tester/Code/demo", 42, null, ""],
+        dismissedThreadStatusKeyByThreadId: {
+          "thread-123": "Awaiting Input:turn-2",
+          "": "bad",
+          "thread-456": 42,
+        },
         lastThreadRoute: {
           threadId: "thread-123",
           splitViewId: 42,
@@ -92,6 +104,9 @@ describe("Sidebar.uiState", () => {
       expandedProjectThreadListCwds: [
         normalizeSidebarProjectThreadListCwd("/Users/tester/Code/demo"),
       ],
+      dismissedThreadStatusKeyByThreadId: {
+        "thread-123": "Awaiting Input:turn-2",
+      },
       lastThreadRoute: {
         threadId: "thread-123",
       },
@@ -113,6 +128,7 @@ describe("Sidebar.uiState", () => {
       chatSectionExpanded: false,
       chatThreadListExpanded: false,
       expandedProjectThreadListCwds: [],
+      dismissedThreadStatusKeyByThreadId: {},
       lastThreadRoute: null,
     });
   });

--- a/apps/web/src/components/Sidebar.uiState.ts
+++ b/apps/web/src/components/Sidebar.uiState.ts
@@ -6,6 +6,7 @@ export type SidebarUiState = {
   chatSectionExpanded: boolean;
   chatThreadListExpanded: boolean;
   expandedProjectThreadListCwds: string[];
+  dismissedThreadStatusKeyByThreadId: Record<string, string>;
   lastThreadRoute: {
     threadId: string;
     splitViewId?: string | undefined;
@@ -16,6 +17,7 @@ const DEFAULT_SIDEBAR_UI_STATE: SidebarUiState = {
   chatSectionExpanded: false,
   chatThreadListExpanded: false,
   expandedProjectThreadListCwds: [],
+  dismissedThreadStatusKeyByThreadId: {},
   lastThreadRoute: null,
 };
 
@@ -38,6 +40,7 @@ export function readSidebarUiState(): SidebarUiState {
       chatSectionExpanded?: boolean;
       chatThreadListExpanded?: boolean;
       expandedProjectThreadListCwds?: string[];
+      dismissedThreadStatusKeyByThreadId?: Record<string, string>;
       lastThreadRoute?: {
         threadId?: unknown;
         splitViewId?: unknown;
@@ -68,6 +71,15 @@ export function readSidebarUiState(): SidebarUiState {
             .filter((cwd) => cwd.length > 0),
         ),
       ],
+      dismissedThreadStatusKeyByThreadId: Object.fromEntries(
+        Object.entries(parsed.dismissedThreadStatusKeyByThreadId ?? {}).filter(
+          ([threadId, statusKey]) =>
+            typeof threadId === "string" &&
+            threadId.length > 0 &&
+            typeof statusKey === "string" &&
+            statusKey.length > 0,
+        ),
+      ),
       lastThreadRoute,
     };
   } catch {
@@ -93,6 +105,11 @@ export function persistSidebarUiState(input: SidebarUiState): void {
               .filter((cwd) => cwd.length > 0),
           ),
         ],
+        dismissedThreadStatusKeyByThreadId: Object.fromEntries(
+          Object.entries(input.dismissedThreadStatusKeyByThreadId).filter(
+            ([threadId, statusKey]) => threadId.length > 0 && statusKey.length > 0,
+          ),
+        ),
         lastThreadRoute: input.lastThreadRoute
           ? {
               threadId: input.lastThreadRoute.threadId,


### PR DESCRIPTION
## Summary
- allow switching away from the prompt-prefixed Ultrathink effort mode while still warning when the prompt body contains `ultrathink`
- add dismissible sidebar thread notification pills and persist dismissed notification keys locally
- make legacy home database snapshot import work under Bun by using the Bun sqlite adapter at runtime

## Why
These changes bring over the merged behavior we wanted for composer effort switching and sidebar notifications, and they remove the Bun startup blocker in legacy home migration.

## Validation
- `bunx vitest run src/components/Sidebar.logic.test.ts src/components/Sidebar.uiState.test.ts`
- `bun fmt`
- `bun lint`
- `bun typecheck`
