### PR TITLE
fix: add macOS microphone entitlements to desktop packaging

### DIFF
--- a/apps/desktop/resources/entitlements.mac.inherit.plist
+++ b/apps/desktop/resources/entitlements.mac.inherit.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/desktop/resources/entitlements.mac.plist
+++ b/apps/desktop/resources/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+  </dict>
+</plist>

--- a/scripts/build-desktop-artifact-mac-config.test.ts
+++ b/scripts/build-desktop-artifact-mac-config.test.ts
@@ -1,0 +1,78 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import {
+  createDesktopPlatformBuildConfig,
+  MAC_ENTITLEMENTS_PATH,
+  MAC_INHERITED_ENTITLEMENTS_PATH,
+  MICROPHONE_USAGE_DESCRIPTION,
+} from "./lib/desktop-platform-build-config.ts";
+
+describe("createDesktopPlatformBuildConfig", () => {
+  it("adds explicit microphone entitlements to macOS builds", () => {
+    const config = createDesktopPlatformBuildConfig({
+      platform: "mac",
+      target: "dmg",
+      hasMacIconComposer: false,
+    });
+    const mac = config.mac as Record<string, unknown>;
+    const extendInfo = mac.extendInfo as Record<string, unknown>;
+
+    assert.deepStrictEqual(mac.target, ["dmg", "zip"]);
+    assert.equal(mac.hardenedRuntime, true);
+    assert.equal(mac.entitlements, MAC_ENTITLEMENTS_PATH);
+    assert.equal(mac.entitlementsInherit, MAC_INHERITED_ENTITLEMENTS_PATH);
+    assert.equal(extendInfo.NSMicrophoneUsageDescription, MICROPHONE_USAGE_DESCRIPTION);
+    assert.equal(config.afterPack, undefined);
+    assert.equal(config.dmg, undefined);
+  });
+
+  it("preserves the icon composer packaging path for macOS builds", () => {
+    const config = createDesktopPlatformBuildConfig({
+      platform: "mac",
+      target: "dmg",
+      hasMacIconComposer: true,
+    });
+    const mac = config.mac as Record<string, unknown>;
+    const extendInfo = mac.extendInfo as Record<string, unknown>;
+
+    assert.equal(mac.icon, "icon.icon");
+    assert.equal(extendInfo.CFBundleIconFile, "icon.icns");
+    assert.equal(config.afterPack, "./electron-builder-after-pack.cjs");
+    assert.deepStrictEqual(config.dmg, { icon: "icon.icns" });
+  });
+
+  it("leaves non-macOS platform configs unchanged", () => {
+    const linux = createDesktopPlatformBuildConfig({
+      platform: "linux",
+      target: "AppImage",
+      hasMacIconComposer: false,
+    });
+    const win = createDesktopPlatformBuildConfig({
+      platform: "win",
+      target: "nsis",
+      hasMacIconComposer: false,
+      windowsAzureSignOptions: { publisherName: "T3 Tools" },
+    });
+
+    assert.equal(linux.mac, undefined);
+    assert.equal(linux.afterPack, undefined);
+    assert.deepStrictEqual(linux.linux, {
+      target: ["AppImage"],
+      executableName: "dpcode",
+      icon: "icon.png",
+      category: "Development",
+      desktop: {
+        entry: {
+          StartupWMClass: "dpcode",
+        },
+      },
+    });
+
+    assert.equal(win.mac, undefined);
+    assert.deepStrictEqual(win.win, {
+      target: ["nsis"],
+      icon: "icon.ico",
+      azureSignOptions: { publisherName: "T3 Tools" },
+    });
+  });
+});

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -13,6 +13,7 @@ import desktopPackageJson from "../apps/desktop/package.json" with { type: "json
 import serverPackageJson from "../apps/server/package.json" with { type: "json" };
 
 import { BRAND_ASSET_PATHS } from "./lib/brand-assets.ts";
+import { createDesktopPlatformBuildConfig } from "./lib/desktop-platform-build-config.ts";
 import { resolveCatalogDependencies } from "./lib/resolve-catalog.ts";
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
@@ -23,8 +24,6 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 const BuildPlatform = Schema.Literals(["mac", "linux", "win"]);
 const BuildArch = Schema.Literals(["arm64", "x64", "universal"]);
-const MICROPHONE_USAGE_DESCRIPTION =
-  "DP Code needs microphone access so you can record voice notes and transcribe them into the chat composer.";
 
 const RepoRoot = Effect.service(Path.Path).pipe(
   Effect.flatMap((path) => path.fromFileUrl(new URL("..", import.meta.url))),
@@ -534,49 +533,18 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     ];
   }
 
-  if (platform === "mac") {
-    buildConfig.mac = {
-      target: target === "dmg" ? [target, "zip"] : [target],
-      icon: hasMacIconComposer ? "icon.icon" : "icon.icns",
-      category: "public.app-category.developer-tools",
-      extendInfo: {
-        NSMicrophoneUsageDescription: MICROPHONE_USAGE_DESCRIPTION,
-        ...(hasMacIconComposer ? { CFBundleIconFile: "icon.icns" } : {}),
-      },
-    };
-    if (hasMacIconComposer) {
-      // Keep the DMG volume icon and pre-Tahoe bundle metadata on the legacy path while Tahoe uses Assets.car.
-      buildConfig.afterPack = "./electron-builder-after-pack.cjs";
-      buildConfig.dmg = {
-        icon: "icon.icns",
-      };
-    }
-  }
+  const windowsAzureSignOptions =
+    platform === "win" && signed ? yield* AzureTrustedSigningOptionsConfig : undefined;
 
-  if (platform === "linux") {
-    buildConfig.linux = {
-      target: [target],
-      executableName: "dpcode",
-      icon: "icon.png",
-      category: "Development",
-      desktop: {
-        entry: {
-          StartupWMClass: "dpcode",
-        },
-      },
-    };
-  }
-
-  if (platform === "win") {
-    const winConfig: Record<string, unknown> = {
-      target: [target],
-      icon: "icon.ico",
-    };
-    if (signed) {
-      winConfig.azureSignOptions = yield* AzureTrustedSigningOptionsConfig;
-    }
-    buildConfig.win = winConfig;
-  }
+  Object.assign(
+    buildConfig,
+    createDesktopPlatformBuildConfig({
+      platform,
+      target,
+      hasMacIconComposer,
+      windowsAzureSignOptions,
+    }),
+  );
 
   return buildConfig;
 });

--- a/scripts/lib/desktop-platform-build-config.ts
+++ b/scripts/lib/desktop-platform-build-config.ts
@@ -1,0 +1,86 @@
+// FILE: desktop-platform-build-config.ts
+// Purpose: Builds platform-specific electron-builder config fragments for desktop artifacts.
+// Layer: Release/build helper
+// Depends on: Desktop packaging policy and electron-builder config shape.
+
+export const MICROPHONE_USAGE_DESCRIPTION =
+  "DP Code needs microphone access so you can record voice notes and transcribe them into the chat composer.";
+export const MAC_ENTITLEMENTS_PATH = "apps/desktop/resources/entitlements.mac.plist";
+export const MAC_INHERITED_ENTITLEMENTS_PATH =
+  "apps/desktop/resources/entitlements.mac.inherit.plist";
+const MAC_AFTER_PACK_HOOK_PATH = "./electron-builder-after-pack.cjs";
+const MAC_DMG_ICON_PATH = "icon.icns";
+
+export interface DesktopPlatformBuildConfig {
+  readonly afterPack?: string;
+  readonly dmg?: {
+    readonly icon: string;
+  };
+  readonly linux?: Record<string, unknown>;
+  readonly mac?: Record<string, unknown>;
+  readonly win?: Record<string, unknown>;
+}
+
+export interface CreateDesktopPlatformBuildConfigInput {
+  readonly hasMacIconComposer: boolean;
+  readonly platform: "linux" | "mac" | "win";
+  readonly target: string;
+  readonly windowsAzureSignOptions?: Record<string, string>;
+}
+
+export function createDesktopPlatformBuildConfig(
+  input: CreateDesktopPlatformBuildConfigInput,
+): DesktopPlatformBuildConfig {
+  if (input.platform === "mac") {
+    const mac = {
+      target: input.target === "dmg" ? [input.target, "zip"] : [input.target],
+      icon: input.hasMacIconComposer ? "icon.icon" : MAC_DMG_ICON_PATH,
+      category: "public.app-category.developer-tools",
+      hardenedRuntime: true,
+      entitlements: MAC_ENTITLEMENTS_PATH,
+      entitlementsInherit: MAC_INHERITED_ENTITLEMENTS_PATH,
+      extendInfo: {
+        NSMicrophoneUsageDescription: MICROPHONE_USAGE_DESCRIPTION,
+        ...(input.hasMacIconComposer ? { CFBundleIconFile: MAC_DMG_ICON_PATH } : {}),
+      },
+    } satisfies Record<string, unknown>;
+
+    if (!input.hasMacIconComposer) {
+      return { mac };
+    }
+
+    return {
+      mac,
+      afterPack: MAC_AFTER_PACK_HOOK_PATH,
+      dmg: {
+        icon: MAC_DMG_ICON_PATH,
+      },
+    };
+  }
+
+  if (input.platform === "linux") {
+    return {
+      linux: {
+        target: [input.target],
+        executableName: "dpcode",
+        icon: "icon.png",
+        category: "Development",
+        desktop: {
+          entry: {
+            StartupWMClass: "dpcode",
+          },
+        },
+      },
+    };
+  }
+
+  return {
+    win: {
+      target: [input.target],
+      icon: "icon.ico",
+      ...(input.windowsAzureSignOptions
+        ? { azureSignOptions: input.windowsAzureSignOptions }
+        : {}),
+    },
+  };
+}


### PR DESCRIPTION
# Summary
- Add explicit macOS entitlements files for signed desktop builds so the app and Electron helpers request microphone access under hardened runtime.
- Make the desktop artifact builder set `mac.hardenedRuntime`, `mac.entitlements`, and `mac.entitlementsInherit` explicitly instead of relying on `app-builder-lib` defaults.
- Cover the macOS packaging config with a focused unit test in the `scripts` workspace.

# Changes
- Added `apps/desktop/resources/entitlements.mac.plist` and `apps/desktop/resources/entitlements.mac.inherit.plist` with the existing hardened-runtime keys plus `com.apple.security.device.audio-input`.
- Extracted platform-specific desktop packaging config into `scripts/lib/desktop-platform-build-config.ts` and updated `scripts/build-desktop-artifact.ts` to use it.
- Added `scripts/build-desktop-artifact-mac-config.test.ts` to verify macOS entitlements, hardened runtime, and icon-composer packaging behavior.

# Testing
- `cd /Users/paulbouzian/dev/oss/dpcode/scripts && bun run test` - Pass (`3` test files, `22` tests passed).
- `cd /Users/paulbouzian/dev/oss/dpcode && bun run dist:desktop:dmg -- --keep-stage` - Fail before desktop packaging because `@t3tools/web` currently cannot resolve `@legendapp/list/react` from `apps/web/src/components/chat/MessagesTimeline.tsx`.
- `cd /Users/paulbouzian/dev/oss/dpcode && node scripts/build-desktop-artifact.ts --platform mac --target dmg --skip-build --keep-stage` - Fail because the bundled server client output is missing; this is downstream from the existing web build failure above.
- Not run: Signed artifact verification and end-to-end microphone prompt validation require a release-quality macOS signed/notarized build.

# Risks and Rollback
- Risk: Low - the change is scoped to macOS desktop packaging/signing configuration and does not alter runtime media-permission logic.
- Rollback: Revert commit `5b8c4473ed87a8c31dc46099354301ff3fd6534f` to restore the previous packaging config and remove the explicit entitlement files.

# Notes
- This addresses the packaged macOS issue where TCC denies microphone access because the signed app bundle is missing `com.apple.security.device.audio-input`.

# Review Setup
- App deploy: Required - reviewers need a new signed macOS desktop artifact or release build from this branch; a normal web deploy is not sufficient.
- Supabase Edge Functions: None.
- SQL migrations: None.
- Reviewer steps: Build or wait for a signed/notarized macOS desktop release from this branch, install the app, click the voice recording button, confirm the macOS microphone permission prompt appears, grant access, and verify the app shows up in `Privacy & Security > Microphone` and recording starts successfully.
