### PR TITLE
Add OpenCode model picker search

### DIFF
--- a/apps/web/src/components/chat/PickerPanelShell.tsx
+++ b/apps/web/src/components/chat/PickerPanelShell.tsx
@@ -10,6 +10,7 @@ export function PickerPanelShell(props: {
   searchPlaceholder?: string;
   query?: string;
   onQueryChange?: (query: string) => void;
+  stopSearchKeyPropagation?: boolean;
   children: ReactNode;
   footer?: ReactNode;
   widthClassName?: string;
@@ -18,6 +19,7 @@ export function PickerPanelShell(props: {
     searchPlaceholder = "Search",
     query = "",
     onQueryChange,
+    stopSearchKeyPropagation = false,
     children,
     footer,
     widthClassName = "w-72",
@@ -35,6 +37,9 @@ export function PickerPanelShell(props: {
             placeholder={searchPlaceholder}
             value={query}
             onChange={(event) => onQueryChange(event.target.value)}
+            onKeyDownCapture={
+              stopSearchKeyPropagation ? (event) => event.stopPropagation() : undefined
+            }
           />
         </div>
       ) : null}

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -36,11 +36,22 @@ const MODEL_OPTIONS_BY_PROVIDER = {
   ],
 } as const satisfies Record<ProviderKind, ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>>;
 
+const MANY_OPENCODE_MODELS = Array.from({ length: 16 }, (_, index) => ({
+  slug: `${index % 2 === 0 ? "openai" : "anthropic"}/model-${index + 1}` as ModelSlug,
+  name: `${index % 2 === 0 ? "GPT" : "Claude"} ${index + 1}`,
+  upstreamProviderId: index % 2 === 0 ? "openai" : "anthropic",
+  upstreamProviderName: index % 2 === 0 ? "OpenAI" : "Anthropic",
+})) satisfies ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>;
+
 async function mountPicker(props: {
   provider: ProviderKind;
   model: ModelSlug;
   lockedProvider: ProviderKind | null;
   providers?: ReadonlyArray<ServerProviderStatus>;
+  modelOptionsByProvider?: Record<
+    ProviderKind,
+    ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>
+  >;
 }) {
   const host = document.createElement("div");
   document.body.append(host);
@@ -50,7 +61,7 @@ async function mountPicker(props: {
       provider={props.provider}
       model={props.model}
       lockedProvider={props.lockedProvider}
-      modelOptionsByProvider={MODEL_OPTIONS_BY_PROVIDER}
+      modelOptionsByProvider={props.modelOptionsByProvider ?? MODEL_OPTIONS_BY_PROVIDER}
       {...(props.providers ? { providers: props.providers } : {})}
       onProviderModelChange={onProviderModelChange}
     />,
@@ -150,6 +161,54 @@ describe("ProviderModelPicker", () => {
         expect(text).toContain("OpenAI");
         expect(text).toContain("GPT-5");
       });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows OpenCode search when the provider has at least fifteen models", async () => {
+    const mounted = await mountPicker({
+      provider: "opencode",
+      model: MANY_OPENCODE_MODELS[0]!.slug,
+      lockedProvider: "opencode",
+      modelOptionsByProvider: {
+        ...MODEL_OPTIONS_BY_PROVIDER,
+        opencode: MANY_OPENCODE_MODELS,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await expect
+        .element(page.getByPlaceholder("Search models or providers"))
+        .toBeInTheDocument();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("filters OpenCode models by upstream provider name", async () => {
+    const mounted = await mountPicker({
+      provider: "opencode",
+      model: MANY_OPENCODE_MODELS[0]!.slug,
+      lockedProvider: "opencode",
+      modelOptionsByProvider: {
+        ...MODEL_OPTIONS_BY_PROVIDER,
+        opencode: MANY_OPENCODE_MODELS,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+      await page.getByPlaceholder("Search models or providers").fill("Anthropic");
+
+      await vi.waitFor(() => {
+        expect(document.body.textContent ?? "").toContain("Claude 2");
+      });
+
+      await expect.element(page.getByRole("menuitemradio", { name: "Claude 2" })).toBeInTheDocument();
+      await expect.element(page.getByRole("menuitemradio", { name: "GPT 1" })).not.toBeInTheDocument();
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -5,7 +5,7 @@
 
 import { type ModelSlug, type ProviderKind, type ServerProviderStatus } from "@t3tools/contracts";
 import { resolveSelectableModel } from "@t3tools/shared/model";
-import { Fragment, memo, useCallback, useState } from "react";
+import { Fragment, memo, useCallback, useDeferredValue, useMemo, useState } from "react";
 import { type ProviderPickerKind, PROVIDER_OPTIONS } from "../../session-logic";
 import {
   Menu,
@@ -23,6 +23,7 @@ import {
 } from "../ui/menu";
 import { ClaudeAI, Gemini, Icon, OpenAI, OpenCodeIcon } from "../Icons";
 import { cn } from "~/lib/utils";
+import { PickerPanelShell } from "./PickerPanelShell";
 import { PickerTriggerButton } from "./PickerTriggerButton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ShortcutKbd } from "../ui/shortcut-kbd";
@@ -86,6 +87,20 @@ function providerIconClassName(
     : fallbackClassName;
 }
 
+const OPENCODE_MODEL_SEARCH_THRESHOLD = 15;
+
+function buildOpenCodeModelSearchText(option: ProviderModelOption): string {
+  return [
+    option.name,
+    option.slug,
+    option.upstreamProviderName,
+    option.upstreamProviderId,
+  ]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join(" ")
+    .toLowerCase();
+}
+
 export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   provider: ProviderKind;
   model: ModelSlug;
@@ -102,6 +117,8 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
 }) {
   const { onOpenChange, open } = props;
   const [uncontrolledMenuOpen, setUncontrolledMenuOpen] = useState(false);
+  const [openCodeSearchQuery, setOpenCodeSearchQuery] = useState("");
+  const deferredOpenCodeSearchQuery = useDeferredValue(openCodeSearchQuery);
   const activeProvider = props.lockedProvider ?? props.provider;
   const isMenuOpen = open ?? uncontrolledMenuOpen;
   const selectedProviderOptions = props.modelOptionsByProvider[activeProvider];
@@ -112,6 +129,9 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
     (nextOpen: boolean) => {
       if (open === undefined) {
         setUncontrolledMenuOpen(nextOpen);
+      }
+      if (!nextOpen) {
+        setOpenCodeSearchQuery("");
       }
       onOpenChange?.(nextOpen);
     },
@@ -131,31 +151,60 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   };
 
   const renderModelRadioGroup = (provider: ProviderKind) => {
-    const groupedOptions = groupProviderModelOptions(props.modelOptionsByProvider[provider]);
+    const providerOptions = props.modelOptionsByProvider[provider];
+    const shouldShowOpenCodeSearch =
+      provider === "opencode" && providerOptions.length >= OPENCODE_MODEL_SEARCH_THRESHOLD;
+    const normalizedOpenCodeSearchQuery = deferredOpenCodeSearchQuery.trim().toLowerCase();
+    const filteredOptions =
+      shouldShowOpenCodeSearch && normalizedOpenCodeSearchQuery.length > 0
+        ? providerOptions.filter((option) =>
+            buildOpenCodeModelSearchText(option).includes(normalizedOpenCodeSearchQuery),
+          )
+        : providerOptions;
+    const groupedOptions = groupProviderModelOptions(filteredOptions);
+
+    const content =
+      groupedOptions.length > 0 ? (
+        <MenuRadioGroup
+          value={activeProvider === provider ? props.model : ""}
+          onValueChange={(value) => handleModelChange(provider, value)}
+        >
+          {groupedOptions.map((group, index) => (
+            <Fragment key={`${provider}:${group.key}`}>
+              <MenuGroup>
+                {group.label ? <MenuGroupLabel>{group.label}</MenuGroupLabel> : null}
+                {group.options.map((modelOption) => (
+                  <MenuRadioItem
+                    key={`${provider}:${modelOption.slug}`}
+                    value={modelOption.slug}
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    {modelOption.name}
+                  </MenuRadioItem>
+                ))}
+              </MenuGroup>
+              {index < groupedOptions.length - 1 ? <MenuSeparator /> : null}
+            </Fragment>
+          ))}
+        </MenuRadioGroup>
+      ) : (
+        <div className="px-2 py-2 text-muted-foreground text-sm">No matches</div>
+      );
+
+    if (!shouldShowOpenCodeSearch) {
+      return content;
+    }
 
     return (
-      <MenuRadioGroup
-        value={activeProvider === provider ? props.model : ""}
-        onValueChange={(value) => handleModelChange(provider, value)}
+      <PickerPanelShell
+        searchPlaceholder="Search models or providers"
+        query={openCodeSearchQuery}
+        onQueryChange={setOpenCodeSearchQuery}
+        stopSearchKeyPropagation
+        widthClassName="w-80"
       >
-        {groupedOptions.map((group, index) => (
-          <Fragment key={`${provider}:${group.key}`}>
-            <MenuGroup>
-              {group.label ? <MenuGroupLabel>{group.label}</MenuGroupLabel> : null}
-              {group.options.map((modelOption) => (
-                <MenuRadioItem
-                  key={`${provider}:${modelOption.slug}`}
-                  value={modelOption.slug}
-                  onClick={() => setMenuOpen(false)}
-                >
-                  {modelOption.name}
-                </MenuRadioItem>
-              ))}
-            </MenuGroup>
-            {index < groupedOptions.length - 1 ? <MenuSeparator /> : null}
-          </Fragment>
-        ))}
-      </MenuRadioGroup>
+        {content}
+      </PickerPanelShell>
     );
   };
 


### PR DESCRIPTION
## Summary
- add thresholded search to the OpenCode model picker when the list reaches 15 models
- match OpenCode search against model names, slugs, and upstream provider labels
- add browser coverage for thresholded search visibility and provider-name filtering

## Testing
- bun run --cwd apps/web test:browser -- src/components/chat/ProviderModelPicker.browser.tsx