### PR TITLE
Default Codex to GPT-5.5

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -432,7 +432,7 @@ describe("resolveCodexModelForAccount", () => {
         planType: "plus",
         sparkEnabled: false,
       }),
-    ).toBe("gpt-5.3-codex");
+    ).toBe("gpt-5.5");
   });
 
   it("keeps spark for supported plans", () => {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -234,7 +234,7 @@ const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
   "unknown thread",
   "does not exist",
 ];
-const CODEX_DEFAULT_MODEL = "gpt-5.3-codex";
+const CODEX_DEFAULT_MODEL = "gpt-5.5";
 const CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
 const CODEX_SPARK_DISABLED_PLAN_TYPES = new Set<CodexPlanType>(["free", "go", "plus"]);
 const CODEX_PROCESS_SHELL_ENV_NAMES = ["PATH", "SSH_AUTH_SOCK"] as const;

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
@@ -157,7 +157,7 @@ function normalizeLegacyEventRow(row: PersistedEventRow): PersistedEventRow {
     const nextPayload = { ...row.payload };
     const legacyModel =
       readTrimmedString(row.payload, "model") ??
-      (row.type === "thread.created" ? "gpt-5.4" : undefined);
+      (row.type === "thread.created" ? "gpt-5.5" : undefined);
     if (legacyModel !== undefined) {
       nextPayload.modelSelection = legacyModelSelection({
         provider: row.payload.provider,

--- a/apps/server/src/persistence/Migrations/016_CanonicalizeModelSelections.test.ts
+++ b/apps/server/src/persistence/Migrations/016_CanonicalizeModelSelections.test.ts
@@ -342,7 +342,7 @@ layer("016_CanonicalizeModelSelections", (it) => {
             title: "Ancient Thread",
             modelSelection: {
               provider: "codex",
-              model: "gpt-5.4",
+              model: "gpt-5.5",
             },
             runtimeMode: "full-access",
             interactionMode: "default",

--- a/apps/server/src/persistence/Migrations/016_CanonicalizeModelSelections.ts
+++ b/apps/server/src/persistence/Migrations/016_CanonicalizeModelSelections.ts
@@ -226,7 +226,7 @@ export default Effect.gen(function* () {
     SET payload_json = json_set(
       payload_json,
       '$.modelSelection',
-      json(json_object('provider', 'codex', 'model', 'gpt-5.4'))
+      json(json_object('provider', 'codex', 'model', 'gpt-5.5'))
     )
     WHERE event_type = 'thread.created'
       AND json_type(payload_json, '$.modelSelection') IS NULL

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -47,6 +47,7 @@ describe("getAppModelOptions", () => {
     const options = getAppModelOptions("codex", ["custom/internal-model"]);
 
     expect(options.map((option) => option.slug)).toEqual([
+      "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",
       "gpt-5.3-codex",
@@ -99,7 +100,7 @@ describe("resolveAppModelSelection", () => {
 
   it("falls back to the provider default when no model is selected", () => {
     expect(resolveAppModelSelection("codex", { codex: [], claudeAgent: [], gemini: [] }, "")).toBe(
-      "gpt-5.4",
+      "gpt-5.5",
     );
   });
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -29,7 +29,6 @@ import {
 } from "@t3tools/contracts";
 import {
   applyClaudePromptEffortPrefix,
-  formatModelDisplayName,
   getModelCapabilities,
   normalizeModelSlug,
 } from "@t3tools/shared/model";
@@ -335,7 +334,11 @@ import {
   resolveDiffEnvironmentState,
   resolveThreadEnvironmentMode,
 } from "../lib/threadEnvironment";
-import { buildModelSelection, buildNextProviderOptions } from "../providerModelOptions";
+import {
+  buildModelSelection,
+  buildNextProviderOptions,
+  mergeDynamicModelOptions,
+} from "../providerModelOptions";
 import {
   isDuplicateProjectCreateError,
   waitForRecoverableProjectForDuplicateCreate,
@@ -437,85 +440,6 @@ function warnVoiceGuard(event: string, details?: Record<string, unknown>) {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/** Turn a raw model slug like "gpt-5.3-codex-spark" into "GPT-5.3 Codex Spark". */
-function formatModelSlug(slug: string): string {
-  return slug
-    .replace(/^gpt-/i, "GPT-")
-    .replace(/^claude-/i, "Claude ")
-    .replace(/-/g, " ")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-function normalizeDynamicModelSlug(provider: ProviderKind, slug: string): string {
-  if (provider === "claudeAgent") {
-    const withoutContextSuffix = slug.replace(/\[[^\]]+\]$/u, "");
-    return normalizeModelSlug(withoutContextSuffix, provider) ?? withoutContextSuffix;
-  }
-  return normalizeModelSlug(slug, provider) ?? slug;
-}
-
-function mergeDynamicModelOptions(input: {
-  provider: ProviderKind;
-  staticOptions: ReadonlyArray<{
-    slug: string;
-    name: string;
-    isCustom?: boolean;
-  }>;
-  dynamicModels: ReadonlyArray<{ slug: string; name?: string | null }>;
-}): ReadonlyArray<{ slug: string; name: string; isCustom?: boolean }> {
-  const staticNameBySlug = new Map(input.staticOptions.map((model) => [model.slug, model.name]));
-  const dynamicNormalizedSlugs = new Set<string>();
-  const normalizedDynamicOptions: Array<{ slug: string; name: string }> = [];
-
-  for (const dynamicModel of input.dynamicModels) {
-    const rawName = dynamicModel.name?.trim() ?? "";
-    const isClaudeDefaultAlias =
-      input.provider === "claudeAgent" &&
-      (rawName.toLowerCase() === "default (recommended)" ||
-        rawName.toLowerCase() === "default recommended" ||
-        dynamicModel.slug.trim().toLowerCase() === "default");
-    if (isClaudeDefaultAlias) {
-      continue;
-    }
-
-    const normalizedSlug = normalizeDynamicModelSlug(input.provider, dynamicModel.slug);
-    const rawSlug = dynamicModel.slug.trim().toLowerCase();
-    const displayNameFallback =
-      formatModelDisplayName(normalizedSlug) ?? formatModelSlug(normalizedSlug);
-    if (dynamicNormalizedSlugs.has(normalizedSlug)) {
-      continue;
-    }
-    dynamicNormalizedSlugs.add(normalizedSlug);
-    normalizedDynamicOptions.push({
-      slug: normalizedSlug,
-      name:
-        staticNameBySlug.get(normalizedSlug) ??
-        (rawName.length > 0 &&
-        rawName.toLowerCase() !== rawSlug &&
-        rawName.toLowerCase() !== normalizedSlug.toLowerCase()
-          ? rawName
-          : displayNameFallback),
-    });
-  }
-
-  const customOnlyModels = input.staticOptions.filter(
-    (model) => "isCustom" in model && model.isCustom && !dynamicNormalizedSlugs.has(model.slug),
-  );
-  const staticBuiltInModels = input.staticOptions.filter(
-    (model) => !("isCustom" in model) || model.isCustom !== true,
-  );
-  const missingStaticBuiltIns = staticBuiltInModels.filter(
-    (model) => !dynamicNormalizedSlugs.has(model.slug),
-  );
-
-  const orderedDynamicOptions =
-    input.provider === "claudeAgent"
-      ? normalizedDynamicOptions.toReversed()
-      : normalizedDynamicOptions;
-
-  return [...orderedDynamicOptions, ...missingStaticBuiltIns, ...customOnlyModels];
 }
 
 function skillMentionPrefix(provider: string): string {

--- a/apps/web/src/lib/threadHandoff.test.ts
+++ b/apps/web/src/lib/threadHandoff.test.ts
@@ -53,7 +53,7 @@ describe("threadHandoff", () => {
       }),
     ).toEqual({
       provider: "codex",
-      model: "gpt-5.4",
+      model: "gpt-5.5",
     });
   });
 });

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { mergeDynamicModelOptions } from "./providerModelOptions";
+
+describe("mergeDynamicModelOptions", () => {
+  it("keeps Codex built-in ordering ahead of runtime discovery ordering", () => {
+    const merged = mergeDynamicModelOptions({
+      provider: "codex",
+      staticOptions: [
+        { slug: "gpt-5.5", name: "GPT-5.5", isCustom: false },
+        { slug: "gpt-5.4", name: "GPT-5.4", isCustom: false },
+        { slug: "gpt-5.4-mini", name: "GPT-5.4 Mini", isCustom: false },
+      ],
+      dynamicModels: [
+        { slug: "gpt-5.4", name: "GPT-5.4" },
+        { slug: "gpt-5.5", name: "GPT-5.5" },
+        { slug: "gpt-5.4-mini", name: "GPT-5.4 Mini" },
+        { slug: "custom/runtime-codex", name: "Runtime Codex" },
+      ],
+    });
+
+    expect(merged.map((model) => model.slug)).toEqual([
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "custom/runtime-codex",
+    ]);
+  });
+
+  it("preserves Claude runtime ordering behavior", () => {
+    const merged = mergeDynamicModelOptions({
+      provider: "claudeAgent",
+      staticOptions: [{ slug: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", isCustom: false }],
+      dynamicModels: [
+        { slug: "default", name: "Default (recommended)" },
+        { slug: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
+        { slug: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+      ],
+    });
+
+    expect(merged.map((model) => model.slug)).toEqual([
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
+    ]);
+  });
+});

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -9,11 +9,13 @@ import type {
   ProviderKind,
   ProviderModelOptions,
 } from "@t3tools/contracts";
+import { formatModelDisplayName, normalizeModelSlug } from "@t3tools/shared/model";
 
 export type ProviderOptions = ProviderModelOptions[ProviderKind];
 export interface ProviderModelOption {
   slug: string;
   name: string;
+  isCustom?: boolean;
 }
 
 function modelOptionKey(option: Pick<ProviderModelOption, "slug">): string {
@@ -37,6 +39,91 @@ export function mergeProviderModelOptions(
   }
 
   return merged;
+}
+
+/** Turn a raw model slug like "gpt-5.3-codex-spark" into "GPT-5.3 Codex Spark". */
+function formatModelSlug(slug: string): string {
+  return slug
+    .replace(/^gpt-/i, "GPT-")
+    .replace(/^claude-/i, "Claude ")
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function normalizeDynamicModelSlug(provider: ProviderKind, slug: string): string {
+  if (provider === "claudeAgent") {
+    const withoutContextSuffix = slug.replace(/\[[^\]]+\]$/u, "");
+    return normalizeModelSlug(withoutContextSuffix, provider) ?? withoutContextSuffix;
+  }
+  return normalizeModelSlug(slug, provider) ?? slug;
+}
+
+export function mergeDynamicModelOptions(input: {
+  provider: ProviderKind;
+  staticOptions: ReadonlyArray<ProviderModelOption>;
+  dynamicModels: ReadonlyArray<{ slug: string; name?: string | null }>;
+}): ReadonlyArray<ProviderModelOption> {
+  const staticNameBySlug = new Map(input.staticOptions.map((model) => [model.slug, model.name]));
+  const dynamicNormalizedSlugs = new Set<string>();
+  const normalizedDynamicOptions: ProviderModelOption[] = [];
+
+  for (const dynamicModel of input.dynamicModels) {
+    const rawName = dynamicModel.name?.trim() ?? "";
+    const isClaudeDefaultAlias =
+      input.provider === "claudeAgent" &&
+      (rawName.toLowerCase() === "default (recommended)" ||
+        rawName.toLowerCase() === "default recommended" ||
+        dynamicModel.slug.trim().toLowerCase() === "default");
+    if (isClaudeDefaultAlias) {
+      continue;
+    }
+
+    const normalizedSlug = normalizeDynamicModelSlug(input.provider, dynamicModel.slug);
+    const rawSlug = dynamicModel.slug.trim().toLowerCase();
+    const displayNameFallback =
+      formatModelDisplayName(normalizedSlug) ?? formatModelSlug(normalizedSlug);
+    if (dynamicNormalizedSlugs.has(normalizedSlug)) {
+      continue;
+    }
+    dynamicNormalizedSlugs.add(normalizedSlug);
+    normalizedDynamicOptions.push({
+      slug: normalizedSlug,
+      name:
+        staticNameBySlug.get(normalizedSlug) ??
+        (rawName.length > 0 &&
+        rawName.toLowerCase() !== rawSlug &&
+        rawName.toLowerCase() !== normalizedSlug.toLowerCase()
+          ? rawName
+          : displayNameFallback),
+    });
+  }
+
+  const customOnlyModels = input.staticOptions.filter(
+    (model) => model.isCustom === true && !dynamicNormalizedSlugs.has(model.slug),
+  );
+  const staticBuiltInModels = input.staticOptions.filter((model) => model.isCustom !== true);
+  const missingStaticBuiltIns = staticBuiltInModels.filter(
+    (model) => !dynamicNormalizedSlugs.has(model.slug),
+  );
+
+  if (input.provider === "codex") {
+    const dynamicBySlug = new Map(normalizedDynamicOptions.map((model) => [model.slug, model]));
+    const staticBuiltInSlugs = new Set(staticBuiltInModels.map((model) => model.slug));
+    const orderedStaticBuiltIns = staticBuiltInModels.map(
+      (model) => dynamicBySlug.get(model.slug) ?? model,
+    );
+    const dynamicOnlyModels = normalizedDynamicOptions.filter(
+      (model) => !staticBuiltInSlugs.has(model.slug),
+    );
+    return [...orderedStaticBuiltIns, ...dynamicOnlyModels, ...customOnlyModels];
+  }
+
+  const orderedDynamicOptions =
+    input.provider === "claudeAgent"
+      ? normalizedDynamicOptions.toReversed()
+      : normalizedDynamicOptions;
+
+  return [...orderedDynamicOptions, ...missingStaticBuiltIns, ...customOnlyModels];
 }
 
 export function buildNextProviderOptions(

--- a/packages/contracts/src/agentMentions.test.ts
+++ b/packages/contracts/src/agentMentions.test.ts
@@ -10,6 +10,14 @@ describe("agentMentions", () => {
   it("shows one preferred alias per Codex model in autocomplete", () => {
     expect(getAgentMentionAutocompleteAliases("codex")).toEqual([
       {
+        alias: "5.5",
+        provider: "codex",
+        kind: "model",
+        model: "gpt-5.5",
+        displayName: "GPT-5.5",
+        color: "violet",
+      },
+      {
         alias: "5.4",
         provider: "codex",
         kind: "model",

--- a/packages/contracts/src/agentMentions.ts
+++ b/packages/contracts/src/agentMentions.ts
@@ -39,6 +39,13 @@ export type ResolvedAgentAlias = AgentAliasDefinition & {
 };
 
 const CODEX_AGENT_MENTION_ALIASES: Record<string, CodexAgentAliasDefinition> = {
+  "5.5": {
+    provider: "codex",
+    kind: "model",
+    model: "gpt-5.5",
+    displayName: "GPT-5.5",
+    color: "violet",
+  },
   "5.4": {
     provider: "codex",
     kind: "model",
@@ -214,7 +221,7 @@ export const AGENT_MENTION_ALIASES: Record<string, AgentAliasDefinition> = Objec
 );
 
 const AGENT_MENTION_AUTOCOMPLETE_ALIASES_BY_PROVIDER: Record<ProviderKind, readonly string[]> = {
-  codex: ["5.4", "mini", "5.3-codex", "spark", "5.2", "5.2-codex"],
+  codex: ["5.5", "5.4", "mini", "5.3-codex", "spark", "5.2", "5.2-codex"],
   claudeAgent: ["explore", "review", "build", "plan"],
   gemini: [],
 };

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -83,6 +83,19 @@ const GEMINI_2_5_CAPABILITIES: ModelCapabilities = {
   contextWindowOptions: [],
 };
 
+const CODEX_FAST_MODEL_CAPABILITIES: ModelCapabilities = {
+  reasoningEffortLevels: [
+    { value: "low", label: "Low" },
+    { value: "medium", label: "Medium" },
+    { value: "high", label: "High", isDefault: true },
+    { value: "xhigh", label: "Extra High" },
+  ],
+  supportsFastMode: true,
+  supportsThinkingToggle: false,
+  promptInjectedEffortLevels: [],
+  contextWindowOptions: [],
+};
+
 type ModelDefinition = {
   readonly slug: string;
   readonly name: string;
@@ -96,100 +109,39 @@ type ModelDefinition = {
 export const MODEL_OPTIONS_BY_PROVIDER = {
   codex: [
     {
+      slug: "gpt-5.5",
+      name: "GPT-5.5",
+      capabilities: CODEX_FAST_MODEL_CAPABILITIES,
+    },
+    {
       slug: "gpt-5.4",
       name: "GPT-5.4",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "low", label: "Low" },
-          { value: "medium", label: "Medium" },
-          { value: "high", label: "High", isDefault: true },
-          { value: "xhigh", label: "Extra High" },
-        ],
-        supportsFastMode: true,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-        contextWindowOptions: [],
-      },
+      capabilities: CODEX_FAST_MODEL_CAPABILITIES,
     },
     {
       slug: "gpt-5.4-mini",
       name: "GPT-5.4 Mini",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "low", label: "Low" },
-          { value: "medium", label: "Medium" },
-          { value: "high", label: "High", isDefault: true },
-          { value: "xhigh", label: "Extra High" },
-        ],
-        supportsFastMode: true,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-        contextWindowOptions: [],
-      },
+      capabilities: CODEX_FAST_MODEL_CAPABILITIES,
     },
     {
       slug: "gpt-5.3-codex",
       name: "GPT-5.3 Codex",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "low", label: "Low" },
-          { value: "medium", label: "Medium" },
-          { value: "high", label: "High", isDefault: true },
-          { value: "xhigh", label: "Extra High" },
-        ],
-        supportsFastMode: true,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-        contextWindowOptions: [],
-      },
+      capabilities: CODEX_FAST_MODEL_CAPABILITIES,
     },
     {
       slug: "gpt-5.3-codex-spark",
       name: "GPT-5.3 Codex Spark",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "low", label: "Low" },
-          { value: "medium", label: "Medium" },
-          { value: "high", label: "High", isDefault: true },
-          { value: "xhigh", label: "Extra High" },
-        ],
-        supportsFastMode: true,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-        contextWindowOptions: [],
-      },
+      capabilities: CODEX_FAST_MODEL_CAPABILITIES,
     },
     {
       slug: "gpt-5.2-codex",
       name: "GPT-5.2 Codex",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "low", label: "Low" },
-          { value: "medium", label: "Medium" },
-          { value: "high", label: "High", isDefault: true },
-          { value: "xhigh", label: "Extra High" },
-        ],
-        supportsFastMode: true,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-        contextWindowOptions: [],
-      },
+      capabilities: CODEX_FAST_MODEL_CAPABILITIES,
     },
     {
       slug: "gpt-5.2",
       name: "GPT-5.2",
-      capabilities: {
-        reasoningEffortLevels: [
-          { value: "low", label: "Low" },
-          { value: "medium", label: "Medium" },
-          { value: "high", label: "High", isDefault: true },
-          { value: "xhigh", label: "Extra High" },
-        ],
-        supportsFastMode: true,
-        supportsThinkingToggle: false,
-        promptInjectedEffortLevels: [],
-        contextWindowOptions: [],
-      },
+      capabilities: CODEX_FAST_MODEL_CAPABILITIES,
     },
   ],
   claudeAgent: [
@@ -369,7 +321,7 @@ type BuiltInModelSlug = (typeof MODEL_OPTIONS_BY_PROVIDER)[ProviderKind][number]
 export type ModelSlug = BuiltInModelSlug | (string & {});
 
 export const DEFAULT_MODEL_BY_PROVIDER: Record<ProviderKind, ModelSlug> = {
-  codex: "gpt-5.4",
+  codex: "gpt-5.5",
   claudeAgent: "claude-sonnet-4-6",
   gemini: "auto-gemini-3",
 };
@@ -381,6 +333,7 @@ export const DEFAULT_GIT_TEXT_GENERATION_MODEL = "gpt-5.4-mini" as const;
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string, ModelSlug>> = {
   codex: {
+    "5.5": "gpt-5.5",
     "5.4": "gpt-5.4",
     "5.3": "gpt-5.3-codex",
     "gpt-5.3": "gpt-5.3-codex",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -32,6 +32,7 @@ import {
 
 describe("normalizeModelSlug", () => {
   it("maps known aliases to canonical slugs", () => {
+    expect(normalizeModelSlug("5.5")).toBe("gpt-5.5");
     expect(normalizeModelSlug("5.3")).toBe("gpt-5.3-codex");
     expect(normalizeModelSlug("gpt-5.3")).toBe("gpt-5.3-codex");
   });
@@ -163,6 +164,7 @@ describe("getModelCapabilities reasoningEffortLevels", () => {
     getModelCapabilities(provider, model).reasoningEffortLevels.map((l) => l.value);
 
   it("returns codex reasoning options for codex", () => {
+    expect(values("codex", "gpt-5.5")).toEqual([...CODEX_REASONING_EFFORT_OPTIONS]);
     expect(values("codex", "gpt-5.4")).toEqual([...CODEX_REASONING_EFFORT_OPTIONS]);
   });
 
@@ -224,6 +226,7 @@ describe("getModelCapabilities reasoningEffortLevels", () => {
 
 describe("getDefaultEffort", () => {
   it("returns the default effort from capabilities", () => {
+    expect(getDefaultEffort(getModelCapabilities("codex", "gpt-5.5"))).toBe("high");
     expect(getDefaultEffort(getModelCapabilities("codex", "gpt-5.4"))).toBe("high");
     expect(getDefaultEffort(getModelCapabilities("claudeAgent", "claude-opus-4-7"))).toBe("high");
     expect(getDefaultEffort(getModelCapabilities("claudeAgent", "claude-opus-4-6"))).toBe("high");
@@ -241,7 +244,7 @@ describe("hasEffortLevel", () => {
     const opus47Caps = getModelCapabilities("claudeAgent", "claude-opus-4-7");
     expect(hasEffortLevel(opus47Caps, "xhigh")).toBe(true);
 
-    const codexCaps = getModelCapabilities("codex", "gpt-5.4");
+    const codexCaps = getModelCapabilities("codex", "gpt-5.5");
     expect(hasEffortLevel(codexCaps, "xhigh")).toBe(true);
     expect(hasEffortLevel(codexCaps, "max")).toBe(false);
   });


### PR DESCRIPTION
## Change description
- Adds GPT-5.5 as the first built-in Codex model, default Codex model, and 5.5 mention/model alias.
- Shares Codex Fast mode capabilities across GPT-5.x Codex models so GPT-5.5 supports Fast mode.
- Keeps Codex built-in selector ordering ahead of runtime discovery ordering, so GPT-5.5 stays first even when model/list returns another order.

## Test results
- `bun run test` from the repo root passed.
- `bun fmt`, `bun lint`, and `bun typecheck` were not run because the repo instructions say not to run them unless explicitly requested.

## Deployment impact
- No deployment or migration steps expected. Existing legacy fallback normalization now uses GPT-5.5 for ancient Codex thread-created events without model data.

## Review focus
- Codex default-model fallback paths in server/web persistence.
- Dynamic model-list merge behavior in `apps/web/src/providerModelOptions.ts`.
- Whether the selector ordering should remain static-first for all future Codex runtime models.