### PR TITLE
Fix sidebar project sort reset

### DIFF
--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 import { Option, Schema } from "effect";
 import { TrimmedNonEmptyString, ProviderKind, type ProviderStartOptions } from "@t3tools/contracts";
 import {
@@ -35,7 +35,6 @@ type CustomModelSettingsKey =
   | "customClaudeModels"
   | "customGeminiModels"
   | "customOpenCodeModels";
-const LEGACY_DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "updated_at";
 export type ProviderCustomModelConfig = {
   provider: ProviderKind;
   settingsKey: CustomModelSettingsKey;
@@ -406,27 +405,6 @@ export function useAppSettings() {
     DEFAULT_APP_SETTINGS,
     AppSettingsSchema,
   );
-  const migratedLegacyProjectSortRef = useRef(false);
-
-  useEffect(() => {
-    if (migratedLegacyProjectSortRef.current) {
-      return;
-    }
-    migratedLegacyProjectSortRef.current = true;
-
-    setSettings((previous) => {
-      const normalized = normalizeAppSettings(previous);
-      if (normalized.sidebarProjectSortOrder !== LEGACY_DEFAULT_SIDEBAR_PROJECT_SORT_ORDER) {
-        return normalized;
-      }
-
-      // Preserve folder muscle memory for older installs that inherited the recency-based default.
-      return {
-        ...normalized,
-        sidebarProjectSortOrder: DEFAULT_SIDEBAR_PROJECT_SORT_ORDER,
-      };
-    });
-  }, [setSettings]);
 
   const updateSettings = useCallback(
     (patch: Partial<AppSettings>) => {


### PR DESCRIPTION
## Summary
- remove the runtime legacy migration that rewrote project sort order from updated_at to manual on hook mount
- preserve explicit sidebar project sort choices when creating a new thread

## Testing
- Not run: focused test command failed locally because turbo is not installed/on PATH in this workspace.