### PR TITLE
Add toast close button and feature flags

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeftIcon,
   ChevronDownIcon,
   ChevronRightIcon,
+  FlagIcon,
   FolderIcon,
   GitPullRequestIcon,
   type LucideIcon,
@@ -72,6 +73,12 @@ import {
 import { isElectron } from "../env";
 import { APP_VERSION } from "../branding";
 import { showConfirmDialogFallback } from "../confirmDialogFallback";
+import {
+  FEATURE_FLAGS,
+  setFeatureFlagEnabled,
+  useFeatureFlags,
+  type ToggleFeatureFlagId,
+} from "../featureFlags";
 import { isMacPlatform, newCommandId, newProjectId, newThreadId, randomUUID } from "../lib/utils";
 import { persistAppStateNow, useStore } from "../store";
 import { getThreadFromState, getThreadsFromState } from "../threadDerivation";
@@ -146,7 +153,18 @@ import {
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import { Kbd, KbdGroup } from "./ui/kbd";
-import { Menu, MenuGroup, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
+import {
+  Menu,
+  MenuCheckboxItem,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSeparator,
+  MenuTrigger,
+} from "./ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import {
   SidebarContent,
@@ -1070,6 +1088,7 @@ export default function Sidebar() {
   const isOnSettings = useLocation({ select: (loc) => loc.pathname === "/settings" });
   const isOnWorkspace = pathname.startsWith("/workspace");
   const { settings: appSettings, updateSettings } = useAppSettings();
+  const featureFlags = useFeatureFlags();
   const { handleNewThread } = useHandleNewThread();
   const { handleNewChat } = useHandleNewChat();
   const { createThreadHandoff } = useThreadHandoff();
@@ -5166,6 +5185,32 @@ export default function Sidebar() {
     setAllProjectsExpanded(true);
   }, [allProjectsExpanded, collapseProjectsExcept, focusedProjectId, setAllProjectsExpanded]);
 
+  const triggerActionFailedToasts = useCallback(() => {
+    const copyText =
+      "Error: Git command failed in /Users/ibrahime/Documents/Projects/dpcode\n\n" +
+      "Command: git push upstream main\n" +
+      "fatal: unable to access upstream remote for local debug toast preview";
+    const toastData = {
+      copyText,
+      ...(featureFlags["persist-action-failed-debug-toasts"]
+        ? {}
+        : { dismissAfterVisibleMs: 30_000 }),
+    };
+
+    toastManager.add({
+      type: "error",
+      title: "Action failed",
+      description: "Error: Git command failed in /Users/ibrahime/Documents/Projects/dpcode",
+      data: toastData,
+    });
+    toastManager.add({
+      type: "error",
+      title: "Action failed",
+      description: "Error: Git command failed in /Users/ibrahime/Documents/Projects/dpcode",
+      data: toastData,
+    });
+  }, [featureFlags]);
+
   const brandWordmark = (
     <Tooltip>
       <TooltipTrigger
@@ -5214,9 +5259,7 @@ export default function Sidebar() {
     </div>
   );
 
-  const sidebarBrand = (
-    <div className="flex min-w-0 px-4 pt-3 pb-2">{brandWordmark}</div>
-  );
+  const sidebarBrand = <div className="flex min-w-0 px-4 pt-3 pb-2">{brandWordmark}</div>;
 
   return (
     <>
@@ -5802,50 +5845,58 @@ export default function Sidebar() {
         ) : null}
         <SidebarMenu>
           <SidebarMenuItem>
-            <div className="flex items-center gap-2">
-              {!isOnSettings && (
-                <SidebarMenuButton
-                  size="default"
-                  className="h-8 flex-1 gap-2.5 rounded-lg px-2 text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/72 hover:bg-[var(--sidebar-accent)]"
-                  onClick={() => void navigate({ to: "/settings" })}
-                >
-                  <SettingsIcon className="size-[15px]" />
-                  <span>Settings</span>
-                </SidebarMenuButton>
-              )}
-              {showDesktopUpdateButton ? (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <button
-                        type="button"
-                        aria-label={desktopUpdateTooltip}
-                        aria-disabled={desktopUpdateButtonDisabled || undefined}
-                        disabled={desktopUpdateButtonDisabled}
-                        className={desktopUpdateRowButtonClasses}
-                        onClick={handleDesktopUpdateButtonClick}
-                      >
-                        <span className="flex min-w-0 flex-1 flex-col leading-tight">
-                          <span className="truncate text-[10px] font-semibold">
-                            {desktopUpdateButtonPresentation.label}
+            <div className="flex flex-col gap-1">
+              {!isOnSettings ? (
+                <FeatureFlagsMenu
+                  values={featureFlags}
+                  onTriggerActionFailedToasts={triggerActionFailedToasts}
+                />
+              ) : null}
+              <div className="flex items-center gap-2">
+                {!isOnSettings && (
+                  <SidebarMenuButton
+                    size="default"
+                    className="h-8 flex-1 gap-2.5 rounded-lg px-2 text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/72 hover:bg-[var(--sidebar-accent)]"
+                    onClick={() => void navigate({ to: "/settings" })}
+                  >
+                    <SettingsIcon className="size-[15px]" />
+                    <span>Settings</span>
+                  </SidebarMenuButton>
+                )}
+                {showDesktopUpdateButton ? (
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <button
+                          type="button"
+                          aria-label={desktopUpdateTooltip}
+                          aria-disabled={desktopUpdateButtonDisabled || undefined}
+                          disabled={desktopUpdateButtonDisabled}
+                          className={desktopUpdateRowButtonClasses}
+                          onClick={handleDesktopUpdateButtonClick}
+                        >
+                          <span className="flex min-w-0 flex-1 flex-col leading-tight">
+                            <span className="truncate text-[10px] font-semibold">
+                              {desktopUpdateButtonPresentation.label}
+                            </span>
+                            {desktopUpdateButtonPresentation.secondaryLabel ? (
+                              <span className="truncate text-[9px] text-white/80">
+                                {desktopUpdateButtonPresentation.secondaryLabel}
+                              </span>
+                            ) : null}
                           </span>
-                          {desktopUpdateButtonPresentation.secondaryLabel ? (
-                            <span className="truncate text-[9px] text-white/80">
-                              {desktopUpdateButtonPresentation.secondaryLabel}
+                          {desktopUpdateButtonPresentation.progressPercent !== null ? (
+                            <span className="rounded-full bg-white/20 px-1.5 py-0.5 text-[9px] font-semibold tabular-nums text-white/95">
+                              {desktopUpdateButtonPresentation.progressPercent}%
                             </span>
                           ) : null}
-                        </span>
-                        {desktopUpdateButtonPresentation.progressPercent !== null ? (
-                          <span className="rounded-full bg-white/20 px-1.5 py-0.5 text-[9px] font-semibold tabular-nums text-white/95">
-                            {desktopUpdateButtonPresentation.progressPercent}%
-                          </span>
-                        ) : null}
-                      </button>
-                    }
-                  />
-                  <TooltipPopup side="top">{desktopUpdateTooltip}</TooltipPopup>
-                </Tooltip>
-              ) : null}
+                        </button>
+                      }
+                    />
+                    <TooltipPopup side="top">{desktopUpdateTooltip}</TooltipPopup>
+                  </Tooltip>
+                ) : null}
+              </div>
             </div>
           </SidebarMenuItem>
         </SidebarMenu>
@@ -5898,6 +5949,76 @@ export default function Sidebar() {
         />
       ) : null}
     </>
+  );
+}
+
+function FeatureFlagsMenu({
+  values,
+  onTriggerActionFailedToasts,
+}: {
+  values: Record<ToggleFeatureFlagId, boolean>;
+  onTriggerActionFailedToasts: () => void;
+}) {
+  return (
+    <Menu>
+      <MenuTrigger
+        render={
+          <SidebarMenuButton
+            size="default"
+            className="h-8 flex-1 gap-2.5 rounded-lg px-2 text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/72 hover:bg-[var(--sidebar-accent)]"
+          />
+        }
+      >
+        <FlagIcon className="size-[15px]" />
+        <span>Feature flags</span>
+      </MenuTrigger>
+      <MenuPopup
+        align="start"
+        side="top"
+        className="min-w-72 rounded-lg border-[color:var(--color-border)] bg-[var(--color-background-elevated-primary-opaque)] shadow-lg"
+      >
+        <MenuGroup>
+          <MenuGroupLabel>Local feature flags</MenuGroupLabel>
+          {FEATURE_FLAGS.map((flag) => {
+            if (flag.kind === "action") {
+              return (
+                <MenuItem key={flag.id} onClick={onTriggerActionFailedToasts} className="py-2">
+                  <div className="flex min-w-0 flex-col gap-0.5">
+                    <span>{flag.label}</span>
+                    <span className="text-[length:var(--app-font-size-ui-xs,10px)] leading-4 text-muted-foreground/70">
+                      {flag.description}
+                    </span>
+                  </div>
+                </MenuItem>
+              );
+            }
+
+            return (
+              <MenuCheckboxItem
+                key={flag.id}
+                checked={values[flag.id]}
+                onCheckedChange={(checked) => {
+                  setFeatureFlagEnabled(flag.id, Boolean(checked));
+                }}
+                variant="switch"
+                className="py-2"
+              >
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  <span>{flag.label}</span>
+                  <span className="text-[length:var(--app-font-size-ui-xs,10px)] leading-4 text-muted-foreground/70">
+                    {flag.description}
+                  </span>
+                </div>
+              </MenuCheckboxItem>
+            );
+          })}
+        </MenuGroup>
+        <MenuSeparator />
+        <div className="px-2 py-1.5 text-[length:var(--app-font-size-ui-xs,10px)] leading-4 text-muted-foreground/58">
+          Stored only in this browser profile.
+        </div>
+      </MenuPopup>
+    </Menu>
   );
 }
 

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -12,6 +12,7 @@ import {
   InfoIcon,
   LoaderCircleIcon,
   TriangleAlertIcon,
+  XIcon,
 } from "~/lib/icons";
 
 import { cn } from "~/lib/utils";
@@ -205,6 +206,19 @@ function ToastActions({
   );
 }
 
+function ToastCloseButton() {
+  return (
+    <Toast.Close
+      aria-label="Dismiss toast"
+      className="absolute top-2 right-2 inline-flex size-6 items-center justify-center rounded-md text-muted-foreground opacity-70 transition-colors hover:bg-muted hover:text-foreground hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      data-slot="toast-close"
+      title="Dismiss toast"
+    >
+      <XIcon className="size-3.5" />
+    </Toast.Close>
+  );
+}
+
 function ToastProvider({ children, position = "top-right", ...props }: ToastProviderProps) {
   return (
     <Toast.Provider toastManager={toastManager} {...props}>
@@ -331,7 +345,7 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
               />
               <Toast.Content
                 className={cn(
-                  "pointer-events-auto flex items-start gap-2 overflow-hidden px-3.5 py-3 text-sm transition-opacity duration-250 data-expanded:opacity-100",
+                  "pointer-events-auto relative flex items-start gap-2 overflow-hidden px-3.5 py-3 pr-10 text-sm transition-opacity duration-250 data-expanded:opacity-100",
                   hideCollapsedContent &&
                     "not-data-expanded:pointer-events-none not-data-expanded:opacity-0",
                 )}
@@ -356,6 +370,7 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
                   />
                   <ToastActions actionProps={toast.actionProps} copyText={toast.data?.copyText} />
                 </div>
+                <ToastCloseButton />
               </Toast.Content>
             </Toast.Root>
           );
@@ -415,7 +430,7 @@ function AnchoredToasts() {
                       <Toast.Title data-slot="toast-title" />
                     </Toast.Content>
                   ) : (
-                    <Toast.Content className="pointer-events-auto flex items-start gap-2 overflow-hidden px-3.5 py-3 text-sm">
+                    <Toast.Content className="pointer-events-auto relative flex items-start gap-2 overflow-hidden px-3.5 py-3 pr-10 text-sm">
                       {Icon && (
                         <div
                           className="[&>svg]:h-lh [&>svg]:w-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
@@ -439,6 +454,7 @@ function AnchoredToasts() {
                           copyText={toast.data?.copyText}
                         />
                       </div>
+                      <ToastCloseButton />
                     </Toast.Content>
                   )}
                 </Toast.Root>

--- a/apps/web/src/featureFlags.ts
+++ b/apps/web/src/featureFlags.ts
@@ -1,0 +1,140 @@
+import { useSyncExternalStore } from "react";
+
+export type FeatureFlag =
+  | {
+      id: "trigger-action-failed-toasts";
+      kind: "action";
+      label: string;
+      description: string;
+    }
+  | {
+      id: ToggleFeatureFlagId;
+      kind: "toggle";
+      label: string;
+      description: string;
+      defaultEnabled: boolean;
+    };
+
+export type ToggleFeatureFlagId = "persist-action-failed-debug-toasts";
+
+type FeatureFlagState = Record<ToggleFeatureFlagId, boolean>;
+
+const FEATURE_FLAG_STORAGE_KEY = "dpcode:feature-flags";
+
+const DEFAULT_FEATURE_FLAG_STATE: FeatureFlagState = {
+  "persist-action-failed-debug-toasts": false,
+};
+
+export const FEATURE_FLAGS: readonly FeatureFlag[] = [
+  {
+    id: "trigger-action-failed-toasts",
+    kind: "action",
+    label: "Trigger action failed toasts",
+    description: "Show stacked Git action failure toasts for local UI testing.",
+  },
+  {
+    id: "persist-action-failed-debug-toasts",
+    kind: "toggle",
+    label: "Keep debug error toasts open",
+    description: "Disable auto-dismiss for locally triggered error toasts.",
+    defaultEnabled: DEFAULT_FEATURE_FLAG_STATE["persist-action-failed-debug-toasts"],
+  },
+];
+
+const listeners = new Set<() => void>();
+let memoryState = DEFAULT_FEATURE_FLAG_STATE;
+let cachedRawFeatureFlagState: string | null | undefined;
+let cachedFeatureFlagState = DEFAULT_FEATURE_FLAG_STATE;
+
+function canUseLocalStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function normalizeFeatureFlagState(value: unknown): FeatureFlagState {
+  if (!value || typeof value !== "object") {
+    return DEFAULT_FEATURE_FLAG_STATE;
+  }
+
+  const record = value as Partial<Record<ToggleFeatureFlagId, unknown>>;
+  return {
+    "persist-action-failed-debug-toasts":
+      typeof record["persist-action-failed-debug-toasts"] === "boolean"
+        ? record["persist-action-failed-debug-toasts"]
+        : DEFAULT_FEATURE_FLAG_STATE["persist-action-failed-debug-toasts"],
+  };
+}
+
+function readFeatureFlagState(): FeatureFlagState {
+  if (!canUseLocalStorage()) {
+    return memoryState;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(FEATURE_FLAG_STORAGE_KEY);
+    if (raw === cachedRawFeatureFlagState) {
+      return cachedFeatureFlagState;
+    }
+
+    cachedRawFeatureFlagState = raw;
+    cachedFeatureFlagState = normalizeFeatureFlagState(raw ? JSON.parse(raw) : null);
+    return cachedFeatureFlagState;
+  } catch {
+    return DEFAULT_FEATURE_FLAG_STATE;
+  }
+}
+
+function writeFeatureFlagState(state: FeatureFlagState): void {
+  memoryState = state;
+
+  if (canUseLocalStorage()) {
+    try {
+      const raw = JSON.stringify(state);
+      window.localStorage.setItem(FEATURE_FLAG_STORAGE_KEY, raw);
+      cachedRawFeatureFlagState = raw;
+      cachedFeatureFlagState = state;
+    } catch {
+      // Local feature flags are best-effort developer tools.
+    }
+  }
+
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribeFeatureFlags(listener: () => void): () => void {
+  listeners.add(listener);
+
+  if (typeof window === "undefined") {
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === FEATURE_FLAG_STORAGE_KEY) {
+      listener();
+    }
+  };
+
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+export function setFeatureFlagEnabled(id: ToggleFeatureFlagId, enabled: boolean): void {
+  writeFeatureFlagState({
+    ...readFeatureFlagState(),
+    [id]: enabled,
+  });
+}
+
+export function useFeatureFlags(): FeatureFlagState {
+  return useSyncExternalStore(
+    subscribeFeatureFlags,
+    readFeatureFlagState,
+    () => DEFAULT_FEATURE_FLAG_STATE,
+  );
+}

--- a/apps/web/src/lib/icons.tsx
+++ b/apps/web/src/lib/icons.tsx
@@ -34,6 +34,7 @@ import {
   IconExternalLink,
   IconEye,
   IconFile,
+  IconFlag,
   IconFlask2,
   IconFolder,
   IconFolderOpen,
@@ -141,6 +142,7 @@ export const AdjustmentsIcon = adaptIcon(IconAdjustments);
 export const ArchiveIcon = adaptIcon(IconArchive);
 export const BrainIcon = adaptIcon(IconBrain);
 export const FileIcon = adaptIcon(IconFile);
+export const FlagIcon = adaptIcon(IconFlag);
 export const FlaskConicalIcon = adaptIcon(IconFlask2);
 export const FolderClosedIcon = adaptIcon(IconFolder);
 export const FolderIcon = adaptIcon(IconFolder);


### PR DESCRIPTION
## Summary

- Add a shared local feature flag registry persisted in browser localStorage.
- Add a Feature flags dropdown above Settings in the sidebar footer.
- Add a one-shot flag to trigger stacked Action failed toasts for validating toast behavior.
- Add top-right dismiss buttons to standard and anchored non-tooltip toasts.

## Root cause

Action failure toasts could remain stacked without an explicit close affordance, making it hard to dismiss long-lived failures. The new local debug action makes the exact stacked state reproducible while validating the dismiss UI.

## Validation

- bun --filter @t3tools/web typecheck
- bun fmt && bun lint && bun typecheck

Note: bun lint exits successfully with existing warnings unrelated to this change.