### PR TITLE
Add favourites for OpenCode models

### DIFF
--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -43,6 +43,21 @@ const MANY_OPENCODE_MODELS = Array.from({ length: 16 }, (_, index) => ({
   upstreamProviderName: index % 2 === 0 ? "OpenAI" : "Anthropic",
 })) satisfies ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>;
 
+const OPENCODE_FAVORITE_SORT_MODELS = [
+  {
+    slug: "anthropic/claude-favorite-sort" as ModelSlug,
+    name: "Claude Favorite Sort",
+    upstreamProviderId: "anthropic",
+    upstreamProviderName: "Anthropic",
+  },
+  {
+    slug: "openai/gpt-favorite-sort" as ModelSlug,
+    name: "GPT Favorite Sort",
+    upstreamProviderId: "openai",
+    upstreamProviderName: "OpenAI",
+  },
+] satisfies ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>;
+
 async function mountPicker(props: {
   provider: ProviderKind;
   model: ModelSlug;
@@ -80,6 +95,7 @@ async function mountPicker(props: {
 describe("ProviderModelPicker", () => {
   afterEach(() => {
     document.body.innerHTML = "";
+    localStorage.clear();
   });
 
   it("shows provider submenus when provider switching is allowed", async () => {
@@ -211,6 +227,46 @@ describe("ProviderModelPicker", () => {
       await expect
         .element(page.getByRole("menuitemradio", { name: "GPT 1" }))
         .not.toBeInTheDocument();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows favourited OpenCode models in their own top category", async () => {
+    const mounted = await mountPicker({
+      provider: "opencode",
+      model: "anthropic/claude-favorite-sort",
+      lockedProvider: "opencode",
+      modelOptionsByProvider: {
+        ...MODEL_OPTIONS_BY_PROVIDER,
+        opencode: OPENCODE_FAVORITE_SORT_MODELS,
+      },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text.indexOf("Anthropic")).toBeLessThan(text.indexOf("OpenAI"));
+      });
+
+      await page.getByRole("button", { name: "Add GPT Favorite Sort to favourites" }).click();
+
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text.indexOf("Favourites")).toBeLessThan(text.indexOf("Anthropic"));
+        expect(text.indexOf("GPT Favorite Sort")).toBeGreaterThan(text.indexOf("Favourites"));
+        expect(text.indexOf("GPT Favorite Sort")).toBeLessThan(text.indexOf("Anthropic"));
+      });
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "GPT Favorite Sort" }))
+        .toBeInTheDocument();
+      expect(
+        Array.from(document.querySelectorAll('[role="menuitemradio"]')).filter((element) =>
+          element.textContent?.includes("GPT Favorite Sort"),
+        ),
+      ).toHaveLength(1);
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -5,7 +5,8 @@
 
 import { type ModelSlug, type ProviderKind, type ServerProviderStatus } from "@t3tools/contracts";
 import { resolveSelectableModel } from "@t3tools/shared/model";
-import { Fragment, memo, useCallback, useDeferredValue, useState } from "react";
+import * as Schema from "effect/Schema";
+import { Fragment, memo, useCallback, useDeferredValue, useMemo, useState } from "react";
 import { type ProviderPickerKind, PROVIDER_OPTIONS } from "../../session-logic";
 import { formatProviderModelOptionName } from "../../providerModelOptions";
 import {
@@ -28,7 +29,13 @@ import { PickerPanelShell } from "./PickerPanelShell";
 import { PickerTriggerButton } from "./PickerTriggerButton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ShortcutKbd } from "../ui/shortcut-kbd";
-import { groupProviderModelOptions, type ProviderModelOption } from "../../providerModelOptions";
+import {
+  groupProviderModelOptions,
+  groupProviderModelOptionsWithFavorites,
+  type ProviderModelOption,
+} from "../../providerModelOptions";
+import { useLocalStorage } from "../../hooks/useLocalStorage";
+import { StarFilledIcon, StarIcon } from "../../lib/icons";
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {
   value: ProviderKind;
@@ -89,6 +96,8 @@ function providerIconClassName(
 }
 
 const OPENCODE_MODEL_SEARCH_THRESHOLD = 15;
+const OPENCODE_FAVORITE_MODEL_STORAGE_KEY = "dpcode:opencode-favourite-models:v1";
+const OpenCodeFavoriteModelSlugs = Schema.Array(Schema.String);
 
 function buildOpenCodeModelSearchText(option: ProviderModelOption): string {
   return [option.name, option.slug, option.upstreamProviderName, option.upstreamProviderId]
@@ -114,9 +123,18 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   const { onOpenChange, open } = props;
   const [uncontrolledMenuOpen, setUncontrolledMenuOpen] = useState(false);
   const [openCodeSearchQuery, setOpenCodeSearchQuery] = useState("");
+  const [openCodeFavoriteModelSlugs, setOpenCodeFavoriteModelSlugs] = useLocalStorage(
+    OPENCODE_FAVORITE_MODEL_STORAGE_KEY,
+    [],
+    OpenCodeFavoriteModelSlugs,
+  );
   const deferredOpenCodeSearchQuery = useDeferredValue(openCodeSearchQuery);
   const activeProvider = props.lockedProvider ?? props.provider;
   const isMenuOpen = open ?? uncontrolledMenuOpen;
+  const openCodeFavoriteModelSlugSet = useMemo(
+    () => new Set(openCodeFavoriteModelSlugs),
+    [openCodeFavoriteModelSlugs],
+  );
   const selectedProviderOptions = props.modelOptionsByProvider[activeProvider];
   const selectedModelLabel =
     selectedProviderOptions.find((option) => option.slug === props.model)?.name ??
@@ -149,6 +167,19 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
     props.onProviderModelChange(provider, resolvedModel);
     setMenuOpen(false);
   };
+  const toggleOpenCodeFavorite = useCallback(
+    (slug: string) => {
+      setOpenCodeFavoriteModelSlugs((current) => {
+        const normalizedCurrent = Array.from(
+          new Set(current.filter((entry) => entry.trim().length > 0)),
+        );
+        return normalizedCurrent.includes(slug)
+          ? normalizedCurrent.filter((entry) => entry !== slug)
+          : [...normalizedCurrent, slug];
+      });
+    },
+    [setOpenCodeFavoriteModelSlugs],
+  );
 
   const renderModelRadioGroup = (provider: ProviderKind) => {
     const providerOptions = props.modelOptionsByProvider[provider];
@@ -161,7 +192,13 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
             buildOpenCodeModelSearchText(option).includes(normalizedOpenCodeSearchQuery),
           )
         : providerOptions;
-    const groupedOptions = groupProviderModelOptions(filteredOptions);
+    const groupedOptions =
+      provider === "opencode"
+        ? groupProviderModelOptionsWithFavorites({
+            options: filteredOptions,
+            favoriteSlugs: openCodeFavoriteModelSlugSet,
+          })
+        : groupProviderModelOptions(filteredOptions);
 
     const content =
       groupedOptions.length > 0 ? (
@@ -173,15 +210,51 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
             <Fragment key={`${provider}:${group.key}`}>
               <MenuGroup>
                 {group.label ? <MenuGroupLabel>{group.label}</MenuGroupLabel> : null}
-                {group.options.map((modelOption) => (
-                  <MenuRadioItem
-                    key={`${provider}:${modelOption.slug}`}
-                    value={modelOption.slug}
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    {modelOption.name}
-                  </MenuRadioItem>
-                ))}
+                {group.options.map((modelOption) => {
+                  const isOpenCodeFavorite =
+                    provider === "opencode" && openCodeFavoriteModelSlugSet.has(modelOption.slug);
+                  return (
+                    <MenuRadioItem
+                      key={`${provider}:${modelOption.slug}`}
+                      value={modelOption.slug}
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      {provider === "opencode" ? (
+                        <span className="flex min-w-0 items-center gap-2">
+                          <span className="min-w-0 flex-1 truncate">{modelOption.name}</span>
+                          <button
+                            type="button"
+                            aria-label={
+                              isOpenCodeFavorite
+                                ? `Remove ${modelOption.name} from favourites`
+                                : `Add ${modelOption.name} to favourites`
+                            }
+                            className={cn(
+                              "-me-2 inline-flex size-6 shrink-0 items-center justify-center rounded-sm text-muted-foreground/55 transition-colors hover:bg-[var(--color-background-elevated-tertiary)] hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/60",
+                              isOpenCodeFavorite && "text-amber-300 hover:text-amber-200",
+                            )}
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              toggleOpenCodeFavorite(modelOption.slug);
+                            }}
+                            onPointerDown={(event) => {
+                              event.stopPropagation();
+                            }}
+                          >
+                            {isOpenCodeFavorite ? (
+                              <StarFilledIcon aria-hidden="true" className="size-3.5" />
+                            ) : (
+                              <StarIcon aria-hidden="true" className="size-3.5" />
+                            )}
+                          </button>
+                        </span>
+                      ) : (
+                        modelOption.name
+                      )}
+                    </MenuRadioItem>
+                  );
+                })}
               </MenuGroup>
               {index < groupedOptions.length - 1 ? <MenuSeparator /> : null}
             </Fragment>

--- a/apps/web/src/lib/icons.tsx
+++ b/apps/web/src/lib/icons.tsx
@@ -71,6 +71,8 @@ import {
   IconSearch,
   IconSelector,
   IconSettings,
+  IconStar,
+  IconStarFilled,
   IconSun,
   IconTerminal,
   IconTerminal2,
@@ -224,6 +226,8 @@ export const RotateCcwIcon = adaptIcon(IconRotate2);
 export const Rows3Icon = adaptIcon(IconLayoutDistributeHorizontal);
 export const SearchIcon = adaptIcon(IconSearch);
 export const SettingsIcon = adaptIcon(IconSettings);
+export const StarIcon = adaptIcon(IconStar);
+export const StarFilledIcon = adaptIcon(IconStarFilled);
 export const SunIcon = adaptIcon(IconSun);
 export const MoonIcon = adaptIcon(IconMoon);
 export const DeviceLaptopIcon = adaptIcon(IconDeviceLaptop);

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -5,7 +5,12 @@
 
 import { describe, expect, it } from "vitest";
 
-import { formatProviderModelOptionName } from "./providerModelOptions";
+import {
+  formatProviderModelOptionName,
+  groupProviderModelOptions,
+  groupProviderModelOptionsWithFavorites,
+  type ProviderModelOption,
+} from "./providerModelOptions";
 
 describe("formatProviderModelOptionName", () => {
   it("humanizes unknown OpenCode runtime model slugs using the model identifier", () => {
@@ -33,5 +38,58 @@ describe("formatProviderModelOptionName", () => {
         slug: "custom/internal-model",
       }),
     ).toBe("custom/internal-model");
+  });
+});
+
+describe("groupProviderModelOptions", () => {
+  it("groups provider models by upstream provider", () => {
+    const options = [
+      {
+        slug: "anthropic/claude-sonnet",
+        name: "Claude Sonnet",
+        upstreamProviderId: "anthropic",
+        upstreamProviderName: "Anthropic",
+      },
+      {
+        slug: "openai/gpt-5",
+        name: "GPT-5",
+        upstreamProviderId: "openai",
+        upstreamProviderName: "OpenAI",
+      },
+    ] satisfies ProviderModelOption[];
+
+    const groupedOptions = groupProviderModelOptions(options);
+
+    expect(groupedOptions.map((group) => group.label)).toEqual(["Anthropic", "OpenAI"]);
+  });
+});
+
+describe("groupProviderModelOptionsWithFavorites", () => {
+  it("adds a favourites group ahead of the normal provider groups", () => {
+    const options = [
+      {
+        slug: "anthropic/claude-sonnet",
+        name: "Claude Sonnet",
+        upstreamProviderId: "anthropic",
+        upstreamProviderName: "Anthropic",
+      },
+      {
+        slug: "openai/gpt-5",
+        name: "GPT-5",
+        upstreamProviderId: "openai",
+        upstreamProviderName: "OpenAI",
+      },
+    ] satisfies ProviderModelOption[];
+
+    const groupedOptions = groupProviderModelOptionsWithFavorites({
+      options,
+      favoriteSlugs: new Set(["openai/gpt-5"]),
+    });
+
+    expect(groupedOptions.map((group) => group.label)).toEqual(["Favourites", "Anthropic"]);
+    expect(groupedOptions[0]?.options.map((option) => option.slug)).toEqual(["openai/gpt-5"]);
+    expect(
+      groupedOptions.flatMap((group) => group.options.map((option) => option.slug)),
+    ).toEqual(["openai/gpt-5", "anthropic/claude-sonnet"]);
   });
 });

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -113,6 +113,33 @@ export function groupProviderModelOptions(
   return groupedOptions;
 }
 
+export function groupProviderModelOptionsWithFavorites(input: {
+  options: ReadonlyArray<ProviderModelOption>;
+  favoriteSlugs: ReadonlySet<string>;
+  favoriteLabel?: string;
+}): ProviderModelOptionGroup[] {
+  if (input.favoriteSlugs.size === 0) {
+    return groupProviderModelOptions(input.options);
+  }
+
+  const favoriteOptions = input.options.filter((option) => input.favoriteSlugs.has(option.slug));
+  if (favoriteOptions.length === 0) {
+    return groupProviderModelOptions(input.options);
+  }
+  const groupedOptions = groupProviderModelOptions(
+    input.options.filter((option) => !input.favoriteSlugs.has(option.slug)),
+  );
+
+  return [
+    {
+      key: "__favorites__",
+      label: input.favoriteLabel ?? "Favourites",
+      options: favoriteOptions,
+    },
+    ...groupedOptions,
+  ];
+}
+
 export function buildNextProviderOptions(
   provider: ProviderKind,
   modelOptions: ProviderOptions | null | undefined,


### PR DESCRIPTION
## Summary
- Add a star toggle for OpenCode models in the provider/model picker.
- Persist favourite OpenCode models locally and show them in a dedicated `Favourites` category at the top of the OpenCode menu.
- Keep favourited models out of their original provider category to avoid duplicate radio items.

## Tests
- `bun run --cwd apps/web test providerModelOptions.test.ts`
- `bun run --cwd apps/web test:browser ProviderModelPicker.browser.tsx`
- `git diff --check`

## Review Focus
- OpenCode picker grouping and duplicate-prevention behavior.
- Star toggle interaction inside the model menu.
- Local favourite persistence schema and storage key.