### PR TITLE
Support OpenCode todo list events

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -1909,9 +1909,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       throw new Error("No ChatGPT session token is available. Sign in to ChatGPT in Codex.");
     }
     if (authMethod !== "chatgpt" && authMethod !== "chatgptAuthTokens") {
-      throw new Error(
-        "Voice transcription requires a ChatGPT-authenticated Codex session.",
-      );
+      throw new Error("Voice transcription requires a ChatGPT-authenticated Codex session.");
     }
 
     return {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2277,17 +2277,17 @@ describe("ProviderRuntimeIngestion", () => {
     });
 
     harness.emit({
-      type: "turn.plan.updated",
-      eventId: asEventId("evt-turn-plan-updated"),
+      type: "turn.tasks.updated",
+      eventId: asEventId("evt-turn-tasks-updated"),
       provider: "codex",
       createdAt: now,
       threadId: asThreadId("thread-1"),
       turnId: asTurnId("turn-p1"),
       payload: {
-        explanation: "Working through the plan",
-        plan: [
-          { step: "Inspect files", status: "completed" },
-          { step: "Apply patch", status: "in_progress" },
+        explanation: "Working through the tasks",
+        tasks: [
+          { task: "Inspect files", status: "completed" },
+          { task: "Apply patch", status: "inProgress" },
         ],
       },
     });
@@ -2340,7 +2340,7 @@ describe("ProviderRuntimeIngestion", () => {
       (entry) =>
         entry.title === "Renamed by provider" &&
         entry.activities.some(
-          (activity: ProviderRuntimeTestActivity) => activity.kind === "turn.plan.updated",
+          (activity: ProviderRuntimeTestActivity) => activity.kind === "turn.tasks.updated",
         ) &&
         entry.activities.some(
           (activity: ProviderRuntimeTestActivity) => activity.kind === "tool.updated",
@@ -2355,15 +2355,15 @@ describe("ProviderRuntimeIngestion", () => {
 
     expect(thread.title).toBe("Renamed by provider");
 
-    const planActivity = thread.activities.find(
-      (activity: ProviderRuntimeTestActivity) => activity.id === "evt-turn-plan-updated",
+    const taskActivity = thread.activities.find(
+      (activity: ProviderRuntimeTestActivity) => activity.id === "evt-turn-tasks-updated",
     );
-    const planPayload =
-      planActivity?.payload && typeof planActivity.payload === "object"
-        ? (planActivity.payload as Record<string, unknown>)
+    const taskPayload =
+      taskActivity?.payload && typeof taskActivity.payload === "object"
+        ? (taskActivity.payload as Record<string, unknown>)
         : undefined;
-    expect(planActivity?.kind).toBe("turn.plan.updated");
-    expect(Array.isArray(planPayload?.plan)).toBe(true);
+    expect(taskActivity?.kind).toBe("turn.tasks.updated");
+    expect(Array.isArray(taskPayload?.tasks)).toBe(true);
 
     const toolUpdate = thread.activities.find(
       (activity: ProviderRuntimeTestActivity) => activity.id === "evt-item-updated",

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -484,16 +484,16 @@ function runtimeEventToActivities(
       ];
     }
 
-    case "turn.plan.updated": {
+    case "turn.tasks.updated": {
       return [
         {
           id: event.eventId,
           createdAt: event.createdAt,
           tone: "info",
-          kind: "turn.plan.updated",
-          summary: "Plan updated",
+          kind: "turn.tasks.updated",
+          summary: "Tasks updated",
           payload: {
-            plan: event.payload.plan,
+            tasks: event.payload.tasks,
             ...(event.payload.explanation !== undefined
               ? { explanation: event.payload.explanation }
               : {}),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1628,13 +1628,13 @@ describe("ClaudeAdapterLive", () => {
       } as unknown as SDKMessage);
 
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
-      const planEvent = runtimeEvents.find((event) => event.type === "turn.plan.updated");
-      assert.equal(planEvent?.type, "turn.plan.updated");
-      if (planEvent?.type === "turn.plan.updated") {
-        assert.deepEqual(planEvent.payload.plan, [
-          { step: "Inspecting files", status: "inProgress" },
-          { step: "Patch UI", status: "pending" },
-          { step: "Run checks", status: "completed" },
+      const taskEvent = runtimeEvents.find((event) => event.type === "turn.tasks.updated");
+      assert.equal(taskEvent?.type, "turn.tasks.updated");
+      if (taskEvent?.type === "turn.tasks.updated") {
+        assert.deepEqual(taskEvent.payload.tasks, [
+          { task: "Inspecting files", status: "inProgress" },
+          { task: "Patch UI", status: "pending" },
+          { task: "Run checks", status: "completed" },
         ]);
       }
     }).pipe(
@@ -1643,7 +1643,7 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("updates shared turn plans from Claude TodoWrite json deltas", () => {
+  it.effect("updates shared turn task lists from Claude TodoWrite json deltas", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
@@ -1699,12 +1699,12 @@ describe("ClaudeAdapterLive", () => {
       } as unknown as SDKMessage);
 
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
-      const planEvent = runtimeEvents.findLast((event) => event.type === "turn.plan.updated");
-      assert.equal(planEvent?.type, "turn.plan.updated");
-      if (planEvent?.type === "turn.plan.updated") {
-        assert.deepEqual(planEvent.payload.plan, [
-          { step: "Inspect files", status: "pending" },
-          { step: "Patching UI", status: "inProgress" },
+      const taskEvent = runtimeEvents.findLast((event) => event.type === "turn.tasks.updated");
+      assert.equal(taskEvent?.type, "turn.tasks.updated");
+      if (taskEvent?.type === "turn.tasks.updated") {
+        assert.deepEqual(taskEvent.payload.tasks, [
+          { task: "Inspect files", status: "pending" },
+          { task: "Patching UI", status: "inProgress" },
         ]);
       }
     }).pipe(

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -615,7 +615,6 @@ function summarizeToolRequest(toolName: string, input: Record<string, unknown>):
   return `${toolName}: ${serialized.slice(0, 397)}...`;
 }
 
-// Claude TodoWrite becomes the shared plan checklist that both providers feed into the same UI.
 function normalizeClaudeTodoStatus(value: unknown): "pending" | "inProgress" | "completed" {
   if (value === "completed") {
     return "completed";
@@ -626,9 +625,9 @@ function normalizeClaudeTodoStatus(value: unknown): "pending" | "inProgress" | "
   return "pending";
 }
 
-function normalizeClaudeTodoPlan(input: Record<string, unknown>): {
-  readonly plan: ReadonlyArray<{
-    readonly step: string;
+function normalizeClaudeTodoTasks(input: Record<string, unknown>): {
+  readonly tasks: ReadonlyArray<{
+    readonly task: string;
     readonly status: "pending" | "inProgress" | "completed";
   }>;
 } | null {
@@ -637,7 +636,7 @@ function normalizeClaudeTodoPlan(input: Record<string, unknown>): {
     return null;
   }
 
-  const plan = todos
+  const tasks = todos
     .map((entry) => {
       if (!entry || typeof entry !== "object") {
         return null;
@@ -646,25 +645,25 @@ function normalizeClaudeTodoPlan(input: Record<string, unknown>): {
       const status = normalizeClaudeTodoStatus(todo.status);
       const content = trimOrNull(typeof todo.content === "string" ? todo.content : null);
       const activeForm = trimOrNull(typeof todo.activeForm === "string" ? todo.activeForm : null);
-      const step = status === "inProgress" ? (activeForm ?? content) : (content ?? activeForm);
-      if (!step) {
+      const task = status === "inProgress" ? (activeForm ?? content) : (content ?? activeForm);
+      if (!task) {
         return null;
       }
       return {
-        step,
+        task,
         status,
       };
     })
     .filter(
       (
-        step,
-      ): step is {
-        readonly step: string;
+        task,
+      ): task is {
+        readonly task: string;
         readonly status: "pending" | "inProgress" | "completed";
-      } => step !== null,
+      } => task !== null,
     );
 
-  return plan.length > 0 ? { plan } : null;
+  return tasks.length > 0 ? { tasks } : null;
 }
 
 function titleForTool(itemType: CanonicalItemType): string {
@@ -1633,8 +1632,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         });
       });
 
-    // Normalizes Claude TodoWrite tool calls into the same runtime plan event Codex already emits.
-    const emitTodoPlanUpdated = (
+    // Normalizes Claude TodoWrite tool calls into the shared runtime task-list event.
+    const emitTodoTasksUpdated = (
       context: ClaudeSessionContext,
       input: {
         readonly toolInput: Record<string, unknown>;
@@ -1649,20 +1648,20 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           return;
         }
 
-        const planPayload = normalizeClaudeTodoPlan(input.toolInput);
-        if (!planPayload) {
+        const tasksPayload = normalizeClaudeTodoTasks(input.toolInput);
+        if (!tasksPayload) {
           return;
         }
 
         const stamp = yield* makeEventStamp();
         yield* offerRuntimeEvent({
-          type: "turn.plan.updated",
+          type: "turn.tasks.updated",
           eventId: stamp.eventId,
           provider: PROVIDER,
           createdAt: stamp.createdAt,
           threadId: context.session.threadId,
           turnId: turnState.turnId,
-          payload: planPayload,
+          payload: tasksPayload,
           providerRefs: nativeProviderRefs(context, {
             providerItemId: input.toolUseId,
           }),
@@ -2000,7 +1999,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               },
             });
             if (nextTool.toolName === "TodoWrite") {
-              yield* emitTodoPlanUpdated(context, {
+              yield* emitTodoTasksUpdated(context, {
                 toolInput: nextTool.input,
                 toolUseId: nextTool.itemId,
                 rawMethod: "claude/stream_event/content_block_delta/input_json_delta",
@@ -2076,7 +2075,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             },
           });
           if (toolName === "TodoWrite") {
-            yield* emitTodoPlanUpdated(context, {
+            yield* emitTodoTasksUpdated(context, {
               toolInput,
               toolUseId: tool.itemId,
               rawMethod: "claude/stream_event/content_block_start",

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -869,16 +869,16 @@ function mapToRuntimeEvents(
     return [
       {
         ...runtimeEventBase(event, canonicalThreadId),
-        type: "turn.plan.updated",
+        type: "turn.tasks.updated",
         payload: {
           ...(asString(payload?.explanation)
             ? { explanation: asString(payload?.explanation) }
             : {}),
-          plan: steps
+          tasks: steps
             .map((entry) => asObject(entry))
             .filter((entry): entry is Record<string, unknown> => entry !== undefined)
             .map((entry) => ({
-              step: asString(entry.step) ?? "step",
+              task: asString(entry.step) ?? "task",
               status:
                 entry.status === "completed" || entry.status === "inProgress"
                   ? entry.status

--- a/apps/server/src/provider/Layers/GeminiAdapter.ts
+++ b/apps/server/src/provider/Layers/GeminiAdapter.ts
@@ -1588,18 +1588,18 @@ const makeGeminiAdapter = Effect.fn("makeGeminiAdapter")(function* (
         yield* offerRuntimeEvent({
           ...makeEventBase(context),
           turnId: context.turnState.turnId,
-          type: "turn.plan.updated",
+          type: "turn.tasks.updated",
           payload: {
-            plan: entries
+            tasks: entries
               .map((entry) => {
-                const planEntry = asRecord(entry);
-                const step = trimToUndefined(planEntry?.content);
-                const status = trimToUndefined(planEntry?.status);
-                if (!step || !status) {
+                const taskEntry = asRecord(entry);
+                const task = trimToUndefined(taskEntry?.content);
+                const status = trimToUndefined(taskEntry?.status);
+                if (!task || !status) {
                   return null;
                 }
                 return {
-                  step,
+                  task,
                   status:
                     status === "in_progress"
                       ? "inProgress"
@@ -1611,7 +1611,7 @@ const makeGeminiAdapter = Effect.fn("makeGeminiAdapter")(function* (
               .filter(
                 (
                   entry,
-                ): entry is { step: string; status: "pending" | "inProgress" | "completed" } =>
+                ): entry is { task: string; status: "pending" | "inProgress" | "completed" } =>
                   entry !== null,
               ),
           },

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1437,4 +1437,78 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
       "turn.completed",
     ]);
   });
+
+  it("maps OpenCode todo updates into shared turn tasks", async () => {
+    const eventQueue = createSubscribedEventQueue();
+    const runtime = createMockOpenCodeRuntime();
+    const client = runtime.runtime.createOpenCodeSdkClient({
+      baseUrl: "http://127.0.0.1:4099",
+      directory: process.cwd(),
+    }) as unknown as {
+      event: {
+        subscribe: () => Promise<{ stream: AsyncIterable<unknown> }>;
+      };
+    };
+    client.event.subscribe = async () => ({ stream: eventQueue.stream });
+
+    const events = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
+          Effect.forkChild,
+        );
+
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId: asThreadId("thread-todo-updated"),
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: asThreadId("thread-todo-updated"),
+          input: "work through todos",
+          attachments: [],
+          modelSelection: {
+            provider: "opencode",
+            model: "openai/gpt-5.4",
+          },
+        });
+
+        eventQueue.push({
+          type: "todo.updated",
+          properties: {
+            sessionID: "opencode-session-1",
+            todos: [
+              { content: "Inspect OpenCode events", status: "completed", priority: "high" },
+              { content: "Wire todo updates", status: "in_progress", priority: "medium" },
+              { content: "Report back", status: "pending", priority: "low" },
+            ],
+          },
+        });
+
+        const runtimeEvents = Array.from(yield* Fiber.join(eventsFiber));
+        eventQueue.close();
+        return runtimeEvents;
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({ runtime: runtime.runtime }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    const taskEvent = events.find((event) => event.type === "turn.tasks.updated");
+    expect(taskEvent?.type).toBe("turn.tasks.updated");
+    if (taskEvent?.type === "turn.tasks.updated") {
+      expect(taskEvent.payload.tasks).toEqual([
+        { task: "Inspect OpenCode events", status: "completed" },
+        { task: "Wire todo updates", status: "inProgress" },
+        { task: "Report back", status: "pending" },
+      ]);
+    }
+  });
 });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -24,6 +24,7 @@ import type {
   Part,
   PermissionRequest,
   QuestionRequest,
+  Todo,
 } from "@opencode-ai/sdk/v2";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
@@ -248,10 +249,16 @@ function ensureSessionContext(
 ): OpenCodeSessionContext {
   const session = sessions.get(threadId);
   if (!session) {
-    throw new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId });
+    throw new ProviderAdapterSessionNotFoundError({
+      provider: PROVIDER,
+      threadId,
+    });
   }
   if (Ref.getUnsafe(session.stopped)) {
-    throw new ProviderAdapterSessionClosedError({ provider: PROVIDER, threadId });
+    throw new ProviderAdapterSessionClosedError({
+      provider: PROVIDER,
+      threadId,
+    });
   }
   return session;
 }
@@ -267,6 +274,45 @@ function normalizeQuestionRequest(request: QuestionRequest): ReadonlyArray<UserI
     })),
     ...(question.multiple ? { multiSelect: true } : {}),
   }));
+}
+
+function normalizeOpenCodeTodoStatus(value: unknown): "pending" | "inProgress" | "completed" {
+  if (value === "completed") {
+    return "completed";
+  }
+  if (value === "in_progress") {
+    return "inProgress";
+  }
+  return "pending";
+}
+
+function normalizeOpenCodeTodoTasks(todos: ReadonlyArray<Todo>): {
+  readonly tasks: ReadonlyArray<{
+    readonly task: string;
+    readonly status: "pending" | "inProgress" | "completed";
+  }>;
+} | null {
+  const tasks = todos
+    .map((todo) => {
+      const task = todo.content.trim();
+      if (task.length === 0) {
+        return null;
+      }
+      return {
+        task,
+        status: normalizeOpenCodeTodoStatus(todo.status),
+      };
+    })
+    .filter(
+      (
+        task,
+      ): task is {
+        readonly task: string;
+        readonly status: "pending" | "inProgress" | "completed";
+      } => task !== null,
+    );
+
+  return tasks.length > 0 ? { tasks } : null;
 }
 
 function resolveTextStreamKind(part: Part | undefined): "assistant_text" | "reasoning_text" {
@@ -1013,11 +1059,17 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         Queue.offer(runtimeEvents, event).pipe(Effect.asVoid);
       const writeNativeEvent = (
         threadId: ThreadId,
-        event: { readonly observedAt: string; readonly event: Record<string, unknown> },
+        event: {
+          readonly observedAt: string;
+          readonly event: Record<string, unknown>;
+        },
       ) => (nativeEventLogger ? nativeEventLogger.write(event, threadId) : Effect.void);
       const writeNativeEventBestEffort = (
         threadId: ThreadId,
-        event: { readonly observedAt: string; readonly event: Record<string, unknown> },
+        event: {
+          readonly observedAt: string;
+          readonly event: Record<string, unknown>;
+        },
       ) => writeNativeEvent(threadId, event).pipe(Effect.catchCause(() => Effect.void));
 
       const emitContextCompactionProgress = Effect.fn("emitContextCompactionProgress")(function* (
@@ -1100,7 +1152,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           },
         }).pipe(Effect.ignore);
         yield* runOpenCodeSdk("session.abort", () =>
-          context.client.session.abort({ sessionID: context.openCodeSessionId }),
+          context.client.session.abort({
+            sessionID: context.openCodeSessionId,
+          }),
         ).pipe(Effect.ignore({ log: true }));
         yield* Scope.close(context.sessionScope, Exit.void);
       });
@@ -1490,14 +1544,38 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             break;
           }
 
+          case "todo.updated": {
+            const tasksPayload = normalizeOpenCodeTodoTasks(event.properties.todos);
+            if (!tasksPayload) {
+              break;
+            }
+            yield* emit({
+              ...buildEventBase({
+                threadId: context.session.threadId,
+                turnId,
+                raw: event,
+              }),
+              type: "turn.tasks.updated",
+              payload: tasksPayload,
+            });
+            break;
+          }
+
           case "session.status": {
             if (event.properties.status.type === "busy") {
-              updateProviderSession(context, { status: "running", activeTurnId: turnId });
+              updateProviderSession(context, {
+                status: "running",
+                activeTurnId: turnId,
+              });
             }
 
             if (event.properties.status.type === "retry") {
               yield* emit({
-                ...buildEventBase({ threadId: context.session.threadId, turnId, raw: event }),
+                ...buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId,
+                  raw: event,
+                }),
                 type: "runtime.warning",
                 payload: {
                   message: event.properties.status.message,
@@ -1512,7 +1590,11 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
               clearActiveTurnState(context);
               updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
               yield* emit({
-                ...buildEventBase({ threadId: context.session.threadId, turnId, raw: event }),
+                ...buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId,
+                  raw: event,
+                }),
                 type: "turn.completed",
                 payload: {
                   state: "completed",
@@ -1573,7 +1655,10 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
               });
             }
             yield* emit({
-              ...buildEventBase({ threadId: context.session.threadId, raw: event }),
+              ...buildEventBase({
+                threadId: context.session.threadId,
+                raw: event,
+              }),
               type: "runtime.error",
               payload: {
                 message,
@@ -1710,7 +1795,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           const raceWinner = sessions.get(input.threadId);
           if (raceWinner) {
             yield* runOpenCodeSdk("session.abort", () =>
-              started.client.session.abort({ sessionID: started.openCodeSessionId }),
+              started.client.session.abort({
+                sessionID: started.openCodeSessionId,
+              }),
             ).pipe(Effect.ignore);
             yield* Scope.close(started.sessionScope, Exit.void).pipe(Effect.ignore);
             return raceWinner.session;
@@ -1807,7 +1894,10 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         const fileParts = toOpenCodeFileParts({
           attachments: input.attachments,
           resolveAttachmentPath: (attachment) =>
-            resolveAttachmentPath({ attachmentsDir: serverConfig.attachmentsDir, attachment }),
+            resolveAttachmentPath({
+              attachmentsDir: serverConfig.attachmentsDir,
+              attachment,
+            }),
         });
         if ((!text || text.length === 0) && fileParts.length === 0) {
           return yield* new ProviderAdapterValidationError({
@@ -1894,7 +1984,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           const context = ensureSessionContext(sessions, threadId);
           const activeTurnId = turnId ?? context.activeTurnId;
           yield* runOpenCodeSdk("session.abort", () =>
-            context.client.session.abort({ sessionID: context.openCodeSessionId }),
+            context.client.session.abort({
+              sessionID: context.openCodeSessionId,
+            }),
           ).pipe(Effect.mapError(toRequestError));
           clearActiveTurnState(context);
           updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
@@ -1978,7 +2070,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         function* (threadId) {
           const context = ensureSessionContext(sessions, threadId);
           const messages = yield* runOpenCodeSdk("session.messages", () =>
-            context.client.session.messages({ sessionID: context.openCodeSessionId }),
+            context.client.session.messages({
+              sessionID: context.openCodeSessionId,
+            }),
           ).pipe(Effect.mapError(toRequestError));
 
           return buildOpenCodeThreadSnapshot({
@@ -2049,7 +2143,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         function* (threadId, numTurns) {
           const context = ensureSessionContext(sessions, threadId);
           const messages = yield* runOpenCodeSdk("session.messages", () =>
-            context.client.session.messages({ sessionID: context.openCodeSessionId }),
+            context.client.session.messages({
+              sessionID: context.openCodeSessionId,
+            }),
           ).pipe(Effect.mapError(toRequestError));
 
           const assistantMessages = (messages.data ?? []).filter(
@@ -2179,7 +2275,11 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             const credentialProviderIDs = yield* openCodeRuntime.loadOpenCodeCredentialProviderIDs(
               activeContext.client,
             );
-            return yield* fn({ client: activeContext.client, inventory, credentialProviderIDs });
+            return yield* fn({
+              client: activeContext.client,
+              inventory,
+              credentialProviderIDs,
+            });
           }
 
           return yield* Effect.scoped(

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -573,22 +573,22 @@ function createSnapshotWithActiveInlinePlan(): OrchestrationReadModel {
               {
                 id: EventId.makeUnsafe("activity-inline-plan"),
                 createdAt: isoAt(1_002),
-                kind: "turn.plan.updated",
-                summary: "Plan updated",
+                kind: "turn.tasks.updated",
+                summary: "Tasks updated",
                 tone: "info",
                 turnId: activeTurnId,
                 payload: {
-                  plan: [
+                  tasks: [
                     {
-                      step: "Inspecting ChatView boundaries",
+                      task: "Inspecting ChatView boundaries",
                       status: "inProgress",
                     },
                     {
-                      step: "Patch the shared checklist receiver",
+                      task: "Patch the shared checklist receiver",
                       status: "pending",
                     },
                     {
-                      step: "Run final validation",
+                      task: "Run final validation",
                       status: "completed",
                     },
                   ],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -133,7 +133,7 @@ import {
   derivePhase,
   deriveTimelineEntries,
   deriveActiveWorkStartedAt,
-  deriveActivePlanState,
+  deriveActiveTaskListState,
   deriveActiveBackgroundTasksState,
   findSidebarProposedPlan,
   findLatestProposedPlan,
@@ -293,7 +293,7 @@ import { ComposerVoiceButton } from "./chat/ComposerVoiceButton";
 import { ComposerVoiceRecorderBar } from "./chat/ComposerVoiceRecorderBar";
 import { ComposerReferenceAttachments } from "./chat/ComposerReferenceAttachments";
 import { TranscriptSelectionActionLayer } from "./chat/TranscriptSelectionActionLayer";
-import { ActivePlanCard } from "./chat/ActivePlanCard";
+import { ActiveTaskListCard } from "./chat/ActiveTaskListCard";
 import { useTranscriptAssistantSelectionAction } from "./chat/useTranscriptAssistantSelectionAction";
 import {
   getComposerProviderState,
@@ -1582,11 +1582,11 @@ export default function ChatView({
     ],
   );
   const planSidebarLabel = sidebarProposedPlan || interactionMode === "plan" ? "Plan" : "Tasks";
-  const activePlan = useMemo(
+  const activeTaskList = useMemo(
     () =>
       latestTurnSettled
         ? null
-        : deriveActivePlanState(threadActivities, activeLatestTurn?.turnId ?? undefined),
+        : deriveActiveTaskListState(threadActivities, activeLatestTurn?.turnId ?? undefined),
     [activeLatestTurn?.turnId, latestTurnSettled, threadActivities],
   );
   const activeBackgroundTasks = useMemo(
@@ -3251,13 +3251,13 @@ export default function ChatView({
     setPlanSidebarOpen((open) => {
       if (open) {
         planSidebarDismissedForTurnRef.current =
-          activePlan?.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
+          activeTaskList?.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
       } else {
         planSidebarDismissedForTurnRef.current = null;
       }
       return !open;
     });
-  }, [activePlan?.turnId, sidebarProposedPlan?.turnId]);
+  }, [activeTaskList?.turnId, sidebarProposedPlan?.turnId]);
   const setPlanMode = useCallback(
     (enabled: boolean) => {
       handleInteractionModeChange(enabled ? "plan" : "default");
@@ -6678,17 +6678,17 @@ export default function ChatView({
       : {}),
   };
 
-  // Composer layout keeps the plan card and footer actions in one render path so
+  // Composer layout keeps the task list and footer actions in one render path so
   // follow-up prompts and normal chat mode stay visually in sync.
-  const planCardAboveComposer = Boolean(activePlan && !planSidebarOpen);
+  const taskListAboveComposer = Boolean(activeTaskList && !planSidebarOpen);
 
   const composerSection = (
     <>
-      {activePlan && !planSidebarOpen ? (
+      {activeTaskList && !planSidebarOpen ? (
         <div className="mx-auto w-full max-w-3xl">
           <div className="mx-auto w-11/12">
-            <ActivePlanCard
-              activePlan={activePlan}
+            <ActiveTaskListCard
+              activeTaskList={activeTaskList}
               backgroundTaskCount={activeBackgroundTasks?.activeCount ?? 0}
               onOpenSidebar={() => setPlanSidebarOpen(true)}
             />
@@ -6710,7 +6710,7 @@ export default function ChatView({
                 data-testid="queued-follow-up-row"
                 className={cn(
                   "chat-composer-surface flex items-center gap-2 border border-b-0 border-[color:var(--color-border)] px-2.5 py-2 text-[12px] shadow-[0_1px_0_rgba(255,255,255,0.03)_inset]",
-                  queuedTurnIndex === 0 && !planCardAboveComposer
+                  queuedTurnIndex === 0 && !taskListAboveComposer
                     ? "rounded-t-2xl"
                     : "rounded-none",
                 )}
@@ -6958,7 +6958,7 @@ export default function ChatView({
                         </>
                       ) : null}
 
-                      {activePlan || sidebarProposedPlan || planSidebarOpen ? (
+                      {activeTaskList || sidebarProposedPlan || planSidebarOpen ? (
                         <>
                           <Separator
                             orientation="vertical"
@@ -7393,11 +7393,11 @@ export default function ChatView({
                     isGitRepo ? "pb-1" : "pb-2.5 sm:pb-3",
                   )}
                 >
-                  {activePlan && !planSidebarOpen ? (
+                  {activeTaskList && !planSidebarOpen ? (
                     <div className="mx-auto w-full max-w-3xl">
                       <div className="mx-auto w-11/12">
-                        <ActivePlanCard
-                          activePlan={activePlan}
+                        <ActiveTaskListCard
+                          activeTaskList={activeTaskList}
                           backgroundTaskCount={activeBackgroundTasks?.activeCount ?? 0}
                           onOpenSidebar={() => setPlanSidebarOpen(true)}
                         />
@@ -7419,7 +7419,7 @@ export default function ChatView({
                             data-testid="queued-follow-up-row"
                             className={cn(
                               "chat-composer-surface flex items-center gap-2 border border-b-0 border-[color:var(--color-border)] px-2.5 py-2 text-[12px] shadow-[0_1px_0_rgba(255,255,255,0.03)_inset]",
-                              queuedTurnIndex === 0 && !planCardAboveComposer
+                              queuedTurnIndex === 0 && !taskListAboveComposer
                                 ? "rounded-t-2xl"
                                 : "rounded-none",
                             )}
@@ -7677,7 +7677,7 @@ export default function ChatView({
                                     </>
                                   ) : null}
 
-                                  {activePlan || sidebarProposedPlan || planSidebarOpen ? (
+                                  {activeTaskList || sidebarProposedPlan || planSidebarOpen ? (
                                     <>
                                       <Separator
                                         orientation="vertical"
@@ -7972,7 +7972,7 @@ export default function ChatView({
         {/* Plan sidebar */}
         {planSidebarOpen ? (
           <PlanSidebar
-            activePlan={activePlan}
+            activeTaskList={activeTaskList}
             activeProposedPlan={sidebarProposedPlan}
             markdownCwd={threadWorkspaceCwd ?? undefined}
             workspaceRoot={activeProject?.cwd ?? undefined}
@@ -7980,7 +7980,7 @@ export default function ChatView({
             onClose={() => {
               setPlanSidebarOpen(false);
               // Track that the user explicitly dismissed for this turn so auto-open won't fight them.
-              const turnKey = activePlan?.turnId ?? sidebarProposedPlan?.turnId ?? null;
+              const turnKey = activeTaskList?.turnId ?? sidebarProposedPlan?.turnId ?? null;
               if (turnKey) {
                 planSidebarDismissedForTurnRef.current = turnKey;
               }

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -13,7 +13,7 @@ import {
   PanelRightCloseIcon,
 } from "~/lib/icons";
 import { cn } from "~/lib/utils";
-import type { ActivePlanState } from "../session-logic";
+import type { ActiveTaskListState } from "../session-logic";
 import type { LatestProposedPlanState } from "../session-logic";
 import { formatTimestamp } from "../timestampFormat";
 import {
@@ -51,7 +51,7 @@ function stepStatusIcon(status: string): React.ReactNode {
 }
 
 interface PlanSidebarProps {
-  activePlan: ActivePlanState | null;
+  activeTaskList: ActiveTaskListState | null;
   activeProposedPlan: LatestProposedPlanState | null;
   markdownCwd: string | undefined;
   workspaceRoot: string | undefined;
@@ -60,7 +60,7 @@ interface PlanSidebarProps {
 }
 
 const PlanSidebar = memo(function PlanSidebar({
-  activePlan,
+  activeTaskList,
   activeProposedPlan,
   markdownCwd,
   workspaceRoot,
@@ -128,9 +128,9 @@ const PlanSidebar = memo(function PlanSidebar({
           >
             Plan
           </Badge>
-          {activePlan ? (
+          {activeTaskList ? (
             <span className="text-[11px] text-muted-foreground/60">
-              {formatTimestamp(activePlan.createdAt, timestampFormat)}
+              {formatTimestamp(activeTaskList.createdAt, timestampFormat)}
             </span>
           ) : null}
         </div>
@@ -179,41 +179,41 @@ const PlanSidebar = memo(function PlanSidebar({
       <ScrollArea className="min-h-0 flex-1">
         <div className="p-3 space-y-4">
           {/* Explanation */}
-          {activePlan?.explanation ? (
+          {activeTaskList?.explanation ? (
             <p className="text-[13px] leading-relaxed text-muted-foreground/80">
-              {activePlan.explanation}
+              {activeTaskList.explanation}
             </p>
           ) : null}
 
-          {/* Plan Steps */}
-          {activePlan && activePlan.steps.length > 0 ? (
+          {/* Tasks */}
+          {activeTaskList && activeTaskList.tasks.length > 0 ? (
             <div className="space-y-1">
               <p className="mb-2 text-[10px] font-semibold tracking-widest text-muted-foreground/40 uppercase">
                 Steps
               </p>
-              {activePlan.steps.map((step) => (
+              {activeTaskList.tasks.map((task) => (
                 <div
-                  key={`${step.status}:${step.step}`}
+                  key={`${task.status}:${task.task}`}
                   className={cn(
                     "flex items-start gap-2.5 rounded-lg px-2.5 py-2 transition-colors duration-200",
-                    step.status === "inProgress" &&
+                    task.status === "inProgress" &&
                       "bg-[color-mix(in_srgb,var(--color-accent-blue)_5%,transparent)]",
-                    step.status === "completed" &&
+                    task.status === "completed" &&
                       "bg-[color-mix(in_srgb,var(--success)_5%,transparent)]",
                   )}
                 >
-                  <div className="mt-0.5">{stepStatusIcon(step.status)}</div>
+                  <div className="mt-0.5">{stepStatusIcon(task.status)}</div>
                   <p
                     className={cn(
                       "text-[13px] leading-snug",
-                      step.status === "completed"
+                      task.status === "completed"
                         ? "text-muted-foreground/50 line-through decoration-muted-foreground/20"
-                        : step.status === "inProgress"
+                        : task.status === "inProgress"
                           ? "text-foreground/90"
                           : "text-muted-foreground/70",
                     )}
                   >
-                    {step.step}
+                    {task.task}
                   </p>
                 </div>
               ))}
@@ -250,7 +250,7 @@ const PlanSidebar = memo(function PlanSidebar({
           ) : null}
 
           {/* Empty state */}
-          {!activePlan && !planMarkdown ? (
+          {!activeTaskList && !planMarkdown ? (
             <div className="flex flex-col items-center justify-center py-12 text-center">
               <p className="text-[13px] text-muted-foreground/40">No active plan yet.</p>
               <p className="mt-1 text-[11px] text-muted-foreground/30">

--- a/apps/web/src/components/chat/ActiveTaskListCard.tsx
+++ b/apps/web/src/components/chat/ActiveTaskListCard.tsx
@@ -1,23 +1,18 @@
-// FILE: ActivePlanCard.tsx
-// Purpose: Renders the skinny inline checklist for active turn plans above the composer.
-// Layer: Chat UI component
-// Depends on: session-logic active plan state and shared button/icon primitives
-
 import { memo } from "react";
 import { PiArrowsInSimple, PiSlidersHorizontal } from "react-icons/pi";
 
-import type { ActivePlanState } from "../../session-logic";
+import type { ActiveTaskListState } from "../../session-logic";
 import { BotIcon, CheckIcon, LoaderIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { Button } from "../ui/button";
 
-interface ActivePlanCardProps {
-  activePlan: ActivePlanState;
+interface ActiveTaskListCardProps {
+  activeTaskList: ActiveTaskListState;
   backgroundTaskCount?: number;
   onOpenSidebar: () => void;
 }
 
-function stepStatusIcon(status: ActivePlanState["steps"][number]["status"]) {
+function taskStatusIcon(status: ActiveTaskListState["tasks"][number]["status"]) {
   if (status === "completed") {
     return <CheckIcon className="size-3" />;
   }
@@ -27,18 +22,17 @@ function stepStatusIcon(status: ActivePlanState["steps"][number]["status"]) {
   return <span className="block size-[7px] rounded-full border border-current" />;
 }
 
-export const ActivePlanCard = memo(function ActivePlanCard({
-  activePlan,
+export const ActiveTaskListCard = memo(function ActiveTaskListCard({
+  activeTaskList,
   backgroundTaskCount = 0,
   onOpenSidebar,
-}: ActivePlanCardProps) {
-  const totalCount = activePlan.steps.length;
-  const completedCount = activePlan.steps.filter((step) => step.status === "completed").length;
-  const stepOccurrenceCount = new Map<string, number>();
+}: ActiveTaskListCardProps) {
+  const totalCount = activeTaskList.tasks.length;
+  const completedCount = activeTaskList.tasks.filter((task) => task.status === "completed").length;
+  const taskOccurrenceCount = new Map<string, number>();
 
   return (
     <div className="overflow-hidden rounded-t-2xl border border-b-0 border-[color:var(--color-border)] bg-[var(--color-background-surface-under)]">
-      {/* Header */}
       <div className="flex items-center justify-between gap-2 px-2.5 py-2">
         <div className="flex min-w-0 items-center gap-1.5 text-[12px] text-muted-foreground/80">
           <PiSlidersHorizontal className="size-3.5 shrink-0" />
@@ -52,50 +46,48 @@ export const ActivePlanCard = memo(function ActivePlanCard({
           size="icon-xs"
           className="size-5 shrink-0 rounded-md text-[var(--color-text-foreground-tertiary)] hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]"
           onClick={onOpenSidebar}
-          aria-label="Collapse plan"
-          title="Collapse plan"
+          aria-label="Collapse tasks"
+          title="Collapse tasks"
         >
           <PiArrowsInSimple className="size-3" />
         </Button>
       </div>
 
-      {/* Steps list */}
       <ol className="space-y-0 px-2.5 pb-2">
-        {activePlan.steps.map((step, index) => {
-          const occurrence = (stepOccurrenceCount.get(step.step) ?? 0) + 1;
-          stepOccurrenceCount.set(step.step, occurrence);
+        {activeTaskList.tasks.map((task, index) => {
+          const occurrence = (taskOccurrenceCount.get(task.task) ?? 0) + 1;
+          taskOccurrenceCount.set(task.task, occurrence);
 
           return (
-            <li key={`${step.step}:${occurrence}`} className="flex items-start gap-2 py-1">
+            <li key={`${task.task}:${occurrence}`} className="flex items-start gap-2 py-1">
               <div
                 className={cn(
                   "mt-[3px] flex min-w-0 shrink-0 items-center gap-1.5 text-[12px]",
-                  step.status === "completed"
+                  task.status === "completed"
                     ? "text-muted-foreground/45"
-                    : step.status === "inProgress"
+                    : task.status === "inProgress"
                       ? "text-foreground/80"
                       : "text-muted-foreground/60",
                 )}
               >
                 <span className="flex size-3.5 items-center justify-center">
-                  {stepStatusIcon(step.status)}
+                  {taskStatusIcon(task.status)}
                 </span>
                 <span className="tabular-nums">{index + 1}.</span>
               </div>
               <p
                 className={cn(
                   "min-w-0 flex-1 text-[13px] leading-5 text-foreground/85",
-                  step.status === "completed" && "text-muted-foreground/50 line-through",
+                  task.status === "completed" && "text-muted-foreground/50 line-through",
                 )}
               >
-                {step.step}
+                {task.task}
               </p>
             </li>
           );
         })}
       </ol>
 
-      {/* Background tasks section */}
       {backgroundTaskCount > 0 ? (
         <div className="flex items-center justify-between gap-2 border-t border-border/50 px-2.5 py-1.5 text-[11px] text-muted-foreground/70">
           <div className="flex min-w-0 items-center gap-1.5">
@@ -110,4 +102,4 @@ export const ActivePlanCard = memo(function ActivePlanCard({
   );
 });
 
-export type { ActivePlanCardProps };
+export type { ActiveTaskListCardProps };

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -10,7 +10,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveActiveBackgroundTasksState,
   deriveActiveWorkStartedAt,
-  deriveActivePlanState,
+  deriveActiveTaskListState,
   hasLiveLatestTurn,
   hasLiveTurnTailWork,
   PROVIDER_OPTIONS,
@@ -305,40 +305,40 @@ describe("derivePendingUserInputs", () => {
   });
 });
 
-describe("deriveActivePlanState", () => {
+describe("deriveActiveTaskListState", () => {
   it("returns the latest plan update for the active turn", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "plan-old",
         createdAt: "2026-02-23T00:00:01.000Z",
-        kind: "turn.plan.updated",
-        summary: "Plan updated",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
         tone: "info",
         turnId: "turn-1",
         payload: {
           explanation: "Initial plan",
-          plan: [{ step: "Inspect code", status: "pending" }],
+          tasks: [{ task: "Inspect code", status: "pending" }],
         },
       }),
       makeActivity({
         id: "plan-latest",
         createdAt: "2026-02-23T00:00:02.000Z",
-        kind: "turn.plan.updated",
-        summary: "Plan updated",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
         tone: "info",
         turnId: "turn-1",
         payload: {
           explanation: "Refined plan",
-          plan: [{ step: "Implement Codex user input", status: "inProgress" }],
+          tasks: [{ task: "Implement Codex user input", status: "inProgress" }],
         },
       }),
     ];
 
-    expect(deriveActivePlanState(activities, TurnId.makeUnsafe("turn-1"))).toEqual({
+    expect(deriveActiveTaskListState(activities, TurnId.makeUnsafe("turn-1"))).toEqual({
       createdAt: "2026-02-23T00:00:02.000Z",
       turnId: "turn-1",
       explanation: "Refined plan",
-      steps: [{ step: "Implement Codex user input", status: "inProgress" }],
+      tasks: [{ task: "Implement Codex user input", status: "inProgress" }],
     });
   });
 
@@ -347,20 +347,20 @@ describe("deriveActivePlanState", () => {
       makeActivity({
         id: "plan-from-turn-1",
         createdAt: "2026-02-23T00:00:01.000Z",
-        kind: "turn.plan.updated",
-        summary: "Plan updated",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
         tone: "info",
         turnId: "turn-1",
         payload: {
-          plan: [{ step: "Write tests", status: "inProgress" }],
+          tasks: [{ task: "Write tests", status: "inProgress" }],
         },
       }),
     ];
 
-    expect(deriveActivePlanState(activities, TurnId.makeUnsafe("turn-2"))).toEqual({
+    expect(deriveActiveTaskListState(activities, TurnId.makeUnsafe("turn-2"))).toEqual({
       createdAt: "2026-02-23T00:00:01.000Z",
       turnId: "turn-1",
-      steps: [{ step: "Write tests", status: "inProgress" }],
+      tasks: [{ task: "Write tests", status: "inProgress" }],
     });
   });
 
@@ -369,17 +369,17 @@ describe("deriveActivePlanState", () => {
       makeActivity({
         id: "completed-plan-from-turn-1",
         createdAt: "2026-02-23T00:00:01.000Z",
-        kind: "turn.plan.updated",
-        summary: "Plan updated",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
         tone: "info",
         turnId: "turn-1",
         payload: {
-          plan: [{ step: "Write tests", status: "completed" }],
+          tasks: [{ task: "Write tests", status: "completed" }],
         },
       }),
     ];
 
-    expect(deriveActivePlanState(activities, TurnId.makeUnsafe("turn-2"))).toBeNull();
+    expect(deriveActiveTaskListState(activities, TurnId.makeUnsafe("turn-2"))).toBeNull();
   });
 
   it("does not revive an unfinished prior-turn plan once that turn has completed", () => {
@@ -387,14 +387,14 @@ describe("deriveActivePlanState", () => {
       makeActivity({
         id: "unfinished-plan-from-turn-1",
         createdAt: "2026-02-23T00:00:01.000Z",
-        kind: "turn.plan.updated",
-        summary: "Plan updated",
+        kind: "turn.tasks.updated",
+        summary: "Tasks updated",
         tone: "info",
         turnId: "turn-1",
         payload: {
-          plan: [
-            { step: "Inspect theme implementation", status: "pending" },
-            { step: "Patch token plumbing", status: "pending" },
+          tasks: [
+            { task: "Inspect theme implementation", status: "pending" },
+            { task: "Patch token plumbing", status: "pending" },
           ],
         },
       }),
@@ -411,7 +411,7 @@ describe("deriveActivePlanState", () => {
       }),
     ];
 
-    expect(deriveActivePlanState(activities, TurnId.makeUnsafe("turn-2"))).toBeNull();
+    expect(deriveActiveTaskListState(activities, TurnId.makeUnsafe("turn-2"))).toBeNull();
   });
 });
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -101,12 +101,12 @@ export interface PendingUserInput {
   questions: ReadonlyArray<UserInputQuestion>;
 }
 
-export interface ActivePlanState {
+export interface ActiveTaskListState {
   createdAt: string;
   turnId: TurnId | null;
   explanation?: string | null;
-  steps: Array<{
-    step: string;
+  tasks: Array<{
+    task: string;
     status: "pending" | "inProgress" | "completed";
   }>;
 }
@@ -399,15 +399,61 @@ export function derivePendingUserInputs(
   );
 }
 
-export function deriveActivePlanState(
+function toActiveTaskListState(activity: OrchestrationThreadActivity): ActiveTaskListState | null {
+  const payload =
+    activity.payload && typeof activity.payload === "object"
+      ? (activity.payload as Record<string, unknown>)
+      : null;
+  const rawTasks = payload?.tasks;
+  if (!Array.isArray(rawTasks)) {
+    return null;
+  }
+  const tasks = rawTasks
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return null;
+      const record = entry as Record<string, unknown>;
+      if (typeof record.task !== "string") {
+        return null;
+      }
+      const status =
+        record.status === "completed" || record.status === "inProgress" ? record.status : "pending";
+      return {
+        task: record.task,
+        status,
+      };
+    })
+    .filter(
+      (
+        task,
+      ): task is {
+        task: string;
+        status: "pending" | "inProgress" | "completed";
+      } => task !== null,
+    );
+  if (tasks.length === 0) {
+    return null;
+  }
+  return {
+    createdAt: activity.createdAt,
+    turnId: activity.turnId,
+    ...(payload && "explanation" in payload
+      ? { explanation: payload.explanation as string | null }
+      : {}),
+    tasks,
+  };
+}
+
+export function deriveActiveTaskListState(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
   latestTurnId: TurnId | undefined,
-): ActivePlanState | null {
+): ActiveTaskListState | null {
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
-  const allPlanActivities = ordered.filter((activity) => activity.kind === "turn.plan.updated");
+  const allTaskListActivities = ordered.filter(
+    (activity) => activity.kind === "turn.tasks.updated",
+  );
   const settledTurnIds = new Set<TurnId>();
 
-  // A prior-turn plan only stays visible while that originating turn is still unresolved.
+  // A prior-turn task list only stays visible while that originating turn is still unresolved.
   for (const activity of ordered) {
     if (!activity.turnId) {
       continue;
@@ -417,75 +463,32 @@ export function deriveActivePlanState(
     }
   }
 
-  const toActivePlanState = (activity: OrchestrationThreadActivity): ActivePlanState | null => {
-    const payload =
-      activity.payload && typeof activity.payload === "object"
-        ? (activity.payload as Record<string, unknown>)
-        : null;
-    const rawPlan = payload?.plan;
-    if (!Array.isArray(rawPlan)) {
-      return null;
-    }
-    const steps = rawPlan
-      .map((entry) => {
-        if (!entry || typeof entry !== "object") return null;
-        const record = entry as Record<string, unknown>;
-        if (typeof record.step !== "string") {
-          return null;
-        }
-        const status =
-          record.status === "completed" || record.status === "inProgress"
-            ? record.status
-            : "pending";
-        return {
-          step: record.step,
-          status,
-        };
-      })
-      .filter(
-        (
-          step,
-        ): step is {
-          step: string;
-          status: "pending" | "inProgress" | "completed";
-        } => step !== null,
-      );
-    if (steps.length === 0) {
-      return null;
-    }
-    return {
-      createdAt: activity.createdAt,
-      turnId: activity.turnId,
-      ...(payload && "explanation" in payload
-        ? { explanation: payload.explanation as string | null }
-        : {}),
-      steps,
-    };
-  };
-
-  const currentTurnPlan = latestTurnId
-    ? (allPlanActivities
+  const currentTurnTaskList = latestTurnId
+    ? (allTaskListActivities
         .filter((activity) => activity.turnId === latestTurnId)
-        .map(toActivePlanState)
-        .findLast((plan) => plan !== null) ?? null)
+        .map(toActiveTaskListState)
+        .findLast((taskList) => taskList !== null) ?? null)
     : null;
-  if (currentTurnPlan) {
-    return currentTurnPlan;
+  if (currentTurnTaskList) {
+    return currentTurnTaskList;
   }
 
-  // Keep the most recent unfinished prior plan visible so implementation turns
-  // that have started but not emitted their own plan update can still show progress.
-  const latestPriorPlan =
-    allPlanActivities.map(toActivePlanState).findLast((plan) => plan !== null) ?? null;
-  if (!latestPriorPlan) {
+  // Keep the most recent unfinished prior task list visible so implementation turns
+  // that have started but not emitted their own task update can still show progress.
+  const latestPriorTaskList =
+    allTaskListActivities.map(toActiveTaskListState).findLast((taskList) => taskList !== null) ??
+    null;
+  if (!latestPriorTaskList) {
     return null;
   }
 
-  if (latestPriorPlan.turnId && settledTurnIds.has(latestPriorPlan.turnId)) {
+  if (latestPriorTaskList.turnId && settledTurnIds.has(latestPriorTaskList.turnId)) {
     return null;
   }
 
-  return latestPriorPlan.steps.some((step) => step.status !== "completed") ? latestPriorPlan : null;
+  return latestPriorTaskList.tasks.some((task) => task.status !== "completed")
+    ? latestPriorTaskList
+    : null;
 }
 
 // Counts still-running background work for the active turn so compact UI can surface agent activity.

--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -6,9 +6,9 @@ import { ProviderRuntimeEvent } from "./providerRuntime";
 const decodeRuntimeEvent = Schema.decodeUnknownSync(ProviderRuntimeEvent);
 
 describe("ProviderRuntimeEvent", () => {
-  it("decodes turn.plan.updated for plan rendering", () => {
+  it("decodes turn.tasks.updated for task-list rendering", () => {
     const parsed = decodeRuntimeEvent({
-      type: "turn.plan.updated",
+      type: "turn.tasks.updated",
       eventId: "event-1",
       provider: "claudeAgent",
       sessionId: "runtime-session-1",
@@ -17,19 +17,19 @@ describe("ProviderRuntimeEvent", () => {
       turnId: "turn-1",
       payload: {
         explanation: "Implement schema updates",
-        plan: [
-          { step: "Define event union", status: "completed" },
-          { step: "Wire adapter mapping", status: "inProgress" },
+        tasks: [
+          { task: "Define event union", status: "completed" },
+          { task: "Wire adapter mapping", status: "inProgress" },
         ],
       },
     });
 
-    expect(parsed.type).toBe("turn.plan.updated");
-    if (parsed.type !== "turn.plan.updated") {
-      throw new Error("expected turn.plan.updated");
+    expect(parsed.type).toBe("turn.tasks.updated");
+    if (parsed.type !== "turn.tasks.updated") {
+      throw new Error("expected turn.tasks.updated");
     }
-    expect(parsed.payload.plan).toHaveLength(2);
-    expect(parsed.payload.plan[1]?.status).toBe("inProgress");
+    expect(parsed.payload.tasks).toHaveLength(2);
+    expect(parsed.payload.tasks[1]?.status).toBe("inProgress");
   });
 
   it("decodes proposed-plan completion events", () => {

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -75,8 +75,8 @@ export type RuntimeThreadState = typeof RuntimeThreadState.Type;
 const RuntimeTurnState = Schema.Literals(["completed", "failed", "interrupted", "cancelled"]);
 export type RuntimeTurnState = typeof RuntimeTurnState.Type;
 
-const RuntimePlanStepStatus = Schema.Literals(["pending", "inProgress", "completed"]);
-export type RuntimePlanStepStatus = typeof RuntimePlanStepStatus.Type;
+const RuntimeTaskStatus = Schema.Literals(["pending", "inProgress", "completed"]);
+export type RuntimeTaskStatus = typeof RuntimeTaskStatus.Type;
 
 const RuntimeItemStatus = Schema.Literals(["inProgress", "completed", "failed", "declined"]);
 export type RuntimeItemStatus = typeof RuntimeItemStatus.Type;
@@ -165,7 +165,7 @@ const ProviderRuntimeEventType = Schema.Literals([
   "turn.started",
   "turn.completed",
   "turn.aborted",
-  "turn.plan.updated",
+  "turn.tasks.updated",
   "turn.proposed.delta",
   "turn.proposed.completed",
   "turn.diff.updated",
@@ -215,7 +215,7 @@ const ThreadRealtimeClosedType = Schema.Literal("thread.realtime.closed");
 const TurnStartedType = Schema.Literal("turn.started");
 const TurnCompletedType = Schema.Literal("turn.completed");
 const TurnAbortedType = Schema.Literal("turn.aborted");
-const TurnPlanUpdatedType = Schema.Literal("turn.plan.updated");
+const TurnTasksUpdatedType = Schema.Literal("turn.tasks.updated");
 const TurnProposedDeltaType = Schema.Literal("turn.proposed.delta");
 const TurnProposedCompletedType = Schema.Literal("turn.proposed.completed");
 const TurnDiffUpdatedType = Schema.Literal("turn.diff.updated");
@@ -373,17 +373,17 @@ const TurnAbortedPayload = Schema.Struct({
 });
 export type TurnAbortedPayload = typeof TurnAbortedPayload.Type;
 
-const RuntimePlanStep = Schema.Struct({
-  step: TrimmedNonEmptyStringSchema,
-  status: RuntimePlanStepStatus,
+const RuntimeTaskListItem = Schema.Struct({
+  task: TrimmedNonEmptyStringSchema,
+  status: RuntimeTaskStatus,
 });
-export type RuntimePlanStep = typeof RuntimePlanStep.Type;
+export type RuntimeTaskListItem = typeof RuntimeTaskListItem.Type;
 
-const TurnPlanUpdatedPayload = Schema.Struct({
+const TurnTasksUpdatedPayload = Schema.Struct({
   explanation: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
-  plan: Schema.Array(RuntimePlanStep),
+  tasks: Schema.Array(RuntimeTaskListItem),
 });
-export type TurnPlanUpdatedPayload = typeof TurnPlanUpdatedPayload.Type;
+export type TurnTasksUpdatedPayload = typeof TurnTasksUpdatedPayload.Type;
 
 const TurnProposedDeltaPayload = Schema.Struct({
   delta: Schema.String,
@@ -724,12 +724,12 @@ const ProviderRuntimeTurnAbortedEvent = Schema.Struct({
 });
 export type ProviderRuntimeTurnAbortedEvent = typeof ProviderRuntimeTurnAbortedEvent.Type;
 
-const ProviderRuntimeTurnPlanUpdatedEvent = Schema.Struct({
+const ProviderRuntimeTurnTasksUpdatedEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
-  type: TurnPlanUpdatedType,
-  payload: TurnPlanUpdatedPayload,
+  type: TurnTasksUpdatedType,
+  payload: TurnTasksUpdatedPayload,
 });
-export type ProviderRuntimeTurnPlanUpdatedEvent = typeof ProviderRuntimeTurnPlanUpdatedEvent.Type;
+export type ProviderRuntimeTurnTasksUpdatedEvent = typeof ProviderRuntimeTurnTasksUpdatedEvent.Type;
 
 const ProviderRuntimeTurnProposedDeltaEvent = Schema.Struct({
   ...ProviderRuntimeEventBase.fields,
@@ -965,7 +965,7 @@ export const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeTurnStartedEvent,
   ProviderRuntimeTurnCompletedEvent,
   ProviderRuntimeTurnAbortedEvent,
-  ProviderRuntimeTurnPlanUpdatedEvent,
+  ProviderRuntimeTurnTasksUpdatedEvent,
   ProviderRuntimeTurnProposedDeltaEvent,
   ProviderRuntimeTurnProposedCompletedEvent,
   ProviderRuntimeTurnDiffUpdatedEvent,


### PR DESCRIPTION
## Summary

This PR adds first-class handling for OpenCode SDK todo list updates.

- Maps OpenCode `todo.updated` events into DP Code's shared active task-list event so OpenCode todos can populate the existing above-composer task UI.
- Renames the shared runtime event from `turn.plan.updated` to `turn.tasks.updated` for clarity, including the payload shape from `plan/step` to `tasks/task`.
- Updates Codex, Claude, Gemini, provider ingestion, contracts, session derivation, and focused tests to use the clearer task-list terminology.
- Renames the active task-list state/card internals (`deriveActiveTaskListState`, `ActiveTaskListCard`) without changing the UI surface.

## Testing

- `bun fmt`
- `bun lint` — passes with existing warnings, 0 errors
- `bun typecheck`
- Focused Vitest coverage for provider runtime contracts, session logic, ChatView browser fixture, OpenCode adapter todo mapping, Claude TodoWrite mapping, and provider runtime ingestion
- Built the Linux AppImage and sanity-checked the active task-list lifecycle in a sandboxed app run

## Deployment Impact

No database migration or deployment coordination is required. This changes the canonical runtime event name used for active turn task-list updates; historical task activity is not migrated because this UI state is active-turn scoped.

## Review Focus

- OpenCode `todo.updated` normalization in `apps/server/src/provider/Layers/OpenCodeAdapter.ts`
- The `turn.tasks.updated` contract/payload rename across providers and ingestion
- Web task-list derivation/rendering rename to confirm there are no unintended UI changes
