### PR TITLE
Fix task banner controls

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -826,6 +826,7 @@ export default function ChatView({
   const [pendingUserInputQuestionIndexByRequestId, setPendingUserInputQuestionIndexByRequestId] =
     useState<Record<string, number>>({});
   const [planSidebarOpen, setPlanSidebarOpen] = useState(false);
+  const [activeTaskListCompact, setActiveTaskListCompact] = useState(false);
   const [isComposerFooterCompact, setIsComposerFooterCompact] = useState(false);
   const [composerCommandPicker, setComposerCommandPicker] = useState<
     null | "fork-target" | "review-target"
@@ -6685,11 +6686,13 @@ export default function ChatView({
   const composerSection = (
     <>
       {activeTaskList && !planSidebarOpen ? (
-        <div className="mx-auto w-full max-w-3xl">
-          <div className="mx-auto w-11/12">
+        <div className="pointer-events-none mx-auto w-full max-w-3xl">
+          <div className="pointer-events-auto mx-auto w-11/12">
             <ActiveTaskListCard
               activeTaskList={activeTaskList}
               backgroundTaskCount={activeBackgroundTasks?.activeCount ?? 0}
+              compact={activeTaskListCompact}
+              onCompactChange={setActiveTaskListCompact}
               onOpenSidebar={() => setPlanSidebarOpen(true)}
             />
           </div>
@@ -7393,17 +7396,6 @@ export default function ChatView({
                     isGitRepo ? "pb-1" : "pb-2.5 sm:pb-3",
                   )}
                 >
-                  {activeTaskList && !planSidebarOpen ? (
-                    <div className="mx-auto w-full max-w-3xl">
-                      <div className="mx-auto w-11/12">
-                        <ActiveTaskListCard
-                          activeTaskList={activeTaskList}
-                          backgroundTaskCount={activeBackgroundTasks?.activeCount ?? 0}
-                          onOpenSidebar={() => setPlanSidebarOpen(true)}
-                        />
-                      </div>
-                    </div>
-                  ) : null}
                   <form
                     ref={composerFormRef}
                     onSubmit={onSend}
@@ -7411,6 +7403,19 @@ export default function ChatView({
                     data-chat-composer-form="true"
                     data-chat-pane-scope={paneScopeId}
                   >
+                    {activeTaskList && !planSidebarOpen ? (
+                      <div className="pointer-events-none absolute inset-x-0 bottom-full z-20">
+                        <div className="pointer-events-auto mx-auto w-11/12">
+                          <ActiveTaskListCard
+                            activeTaskList={activeTaskList}
+                            backgroundTaskCount={activeBackgroundTasks?.activeCount ?? 0}
+                            compact={activeTaskListCompact}
+                            onCompactChange={setActiveTaskListCompact}
+                            onOpenSidebar={() => setPlanSidebarOpen(true)}
+                          />
+                        </div>
+                      </div>
+                    ) : null}
                     {queuedComposerTurns.length > 0 ? (
                       <div className="mx-auto flex w-11/12 flex-col">
                         {queuedComposerTurns.map((queuedTurn, queuedTurnIndex) => (

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -266,7 +266,9 @@ const ADD_PROJECT_EXISTING_SYNC_ERROR =
   "This folder is already linked, but the existing project has not synced into the sidebar yet. Try again in a moment.";
 const DebugFeatureFlagsMenu = import.meta.env.DEV
   ? lazy(() =>
-      import("./DebugFeatureFlagsMenu").then((module) => ({ default: module.DebugFeatureFlagsMenu })),
+      import("./DebugFeatureFlagsMenu").then((module) => ({
+        default: module.DebugFeatureFlagsMenu,
+      })),
     )
   : null;
 
@@ -4087,10 +4089,7 @@ export default function Sidebar() {
           onDragStart={(event) => {
             const dragImage = event.currentTarget as HTMLElement | null;
             event.dataTransfer.effectAllowed = "move";
-            event.dataTransfer.setData(
-              THREAD_DRAG_MIME,
-              JSON.stringify({ threadId: thread.id }),
-            );
+            event.dataTransfer.setData(THREAD_DRAG_MIME, JSON.stringify({ threadId: thread.id }));
             if (dragImage) {
               const rect = dragImage.getBoundingClientRect();
               event.dataTransfer.setDragImage(

--- a/apps/web/src/components/chat-drop-overlay/ChatPaneDropOverlay.tsx
+++ b/apps/web/src/components/chat-drop-overlay/ChatPaneDropOverlay.tsx
@@ -152,14 +152,7 @@ export function isThreadDragPayloadAllowed(
 }
 
 export function ChatPaneDropOverlay(props: ChatPaneDropOverlayProps) {
-  const {
-    onDrop,
-    canDropInDirection,
-    excludedThreadIds,
-    paneScopeId,
-    className,
-    children,
-  } = props;
+  const { onDrop, canDropInDirection, excludedThreadIds, paneScopeId, className, children } = props;
   const wrapperRef = useRef<HTMLDivElement>(null);
   const previewRef = useRef<HTMLDivElement>(null);
   const rectRef = useRef<DOMRect | null>(null);

--- a/apps/web/src/components/chat/ActiveTaskListCard.tsx
+++ b/apps/web/src/components/chat/ActiveTaskListCard.tsx
@@ -1,5 +1,10 @@
 import { memo } from "react";
-import { PiArrowsInSimple, PiSlidersHorizontal } from "react-icons/pi";
+import {
+  PiArrowsInSimple,
+  PiArrowsOutSimple,
+  PiSidebarSimple,
+  PiSlidersHorizontal,
+} from "react-icons/pi";
 
 import type { ActiveTaskListState } from "../../session-logic";
 import { BotIcon, CheckIcon, LoaderIcon } from "~/lib/icons";
@@ -9,6 +14,8 @@ import { Button } from "../ui/button";
 interface ActiveTaskListCardProps {
   activeTaskList: ActiveTaskListState;
   backgroundTaskCount?: number;
+  compact?: boolean;
+  onCompactChange: (compact: boolean) => void;
   onOpenSidebar: () => void;
 }
 
@@ -25,79 +32,107 @@ function taskStatusIcon(status: ActiveTaskListState["tasks"][number]["status"]) 
 export const ActiveTaskListCard = memo(function ActiveTaskListCard({
   activeTaskList,
   backgroundTaskCount = 0,
+  compact = false,
+  onCompactChange,
   onOpenSidebar,
 }: ActiveTaskListCardProps) {
   const totalCount = activeTaskList.tasks.length;
   const completedCount = activeTaskList.tasks.filter((task) => task.status === "completed").length;
+  const hasInProgressTask = activeTaskList.tasks.some((task) => task.status === "inProgress");
   const taskOccurrenceCount = new Map<string, number>();
 
   return (
     <div className="overflow-hidden rounded-t-2xl border border-b-0 border-[color:var(--color-border)] bg-[var(--color-background-surface-under)]">
       <div className="flex items-center justify-between gap-2 px-2.5 py-2">
         <div className="flex min-w-0 items-center gap-1.5 text-[12px] text-muted-foreground/80">
-          <PiSlidersHorizontal className="size-3.5 shrink-0" />
+          {compact && hasInProgressTask ? (
+            <LoaderIcon className="size-3.5 shrink-0 animate-spin" />
+          ) : (
+            <PiSlidersHorizontal className="size-3.5 shrink-0" />
+          )}
           <span className="truncate">
             {completedCount} out of {totalCount} tasks completed
           </span>
         </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          className="size-5 shrink-0 rounded-md text-[var(--color-text-foreground-tertiary)] hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]"
-          onClick={onOpenSidebar}
-          aria-label="Collapse tasks"
-          title="Collapse tasks"
-        >
-          <PiArrowsInSimple className="size-3" />
-        </Button>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="size-5 rounded-md text-[var(--color-text-foreground-tertiary)] hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]"
+            onClick={onOpenSidebar}
+            aria-label="Open tasks sidebar"
+            title="Open tasks sidebar"
+          >
+            <PiSidebarSimple className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="size-5 rounded-md text-[var(--color-text-foreground-tertiary)] hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]"
+            onClick={() => onCompactChange(!compact)}
+            aria-label={compact ? "Expand task banner" : "Collapse task banner"}
+            title={compact ? "Expand task banner" : "Collapse task banner"}
+          >
+            {compact ? (
+              <PiArrowsOutSimple className="size-3" />
+            ) : (
+              <PiArrowsInSimple className="size-3" />
+            )}
+          </Button>
+        </div>
       </div>
 
-      <ol className="space-y-0 px-2.5 pb-2">
-        {activeTaskList.tasks.map((task, index) => {
-          const occurrence = (taskOccurrenceCount.get(task.task) ?? 0) + 1;
-          taskOccurrenceCount.set(task.task, occurrence);
+      {compact ? null : (
+        <>
+          <ol className="space-y-0 px-2.5 pb-2">
+            {activeTaskList.tasks.map((task, index) => {
+              const occurrence = (taskOccurrenceCount.get(task.task) ?? 0) + 1;
+              taskOccurrenceCount.set(task.task, occurrence);
 
-          return (
-            <li key={`${task.task}:${occurrence}`} className="flex items-start gap-2 py-1">
-              <div
-                className={cn(
-                  "mt-[3px] flex min-w-0 shrink-0 items-center gap-1.5 text-[12px]",
-                  task.status === "completed"
-                    ? "text-muted-foreground/45"
-                    : task.status === "inProgress"
-                      ? "text-foreground/80"
-                      : "text-muted-foreground/60",
-                )}
-              >
-                <span className="flex size-3.5 items-center justify-center">
-                  {taskStatusIcon(task.status)}
+              return (
+                <li key={`${task.task}:${occurrence}`} className="flex items-start gap-2 py-1">
+                  <div
+                    className={cn(
+                      "mt-[3px] flex min-w-0 shrink-0 items-center gap-1.5 text-[12px]",
+                      task.status === "completed"
+                        ? "text-muted-foreground/45"
+                        : task.status === "inProgress"
+                          ? "text-foreground/80"
+                          : "text-muted-foreground/60",
+                    )}
+                  >
+                    <span className="flex size-3.5 items-center justify-center">
+                      {taskStatusIcon(task.status)}
+                    </span>
+                    <span className="tabular-nums">{index + 1}.</span>
+                  </div>
+                  <p
+                    className={cn(
+                      "min-w-0 flex-1 text-[13px] leading-5 text-foreground/85",
+                      task.status === "completed" && "text-muted-foreground/50 line-through",
+                    )}
+                  >
+                    {task.task}
+                  </p>
+                </li>
+              );
+            })}
+          </ol>
+
+          {backgroundTaskCount > 0 ? (
+            <div className="flex items-center justify-between gap-2 border-t border-border/50 px-2.5 py-1.5 text-[11px] text-muted-foreground/70">
+              <div className="flex min-w-0 items-center gap-1.5">
+                <BotIcon className="size-3 shrink-0" />
+                <span className="truncate">
+                  {backgroundTaskCount} background agent{backgroundTaskCount === 1 ? "" : "s"}
                 </span>
-                <span className="tabular-nums">{index + 1}.</span>
               </div>
-              <p
-                className={cn(
-                  "min-w-0 flex-1 text-[13px] leading-5 text-foreground/85",
-                  task.status === "completed" && "text-muted-foreground/50 line-through",
-                )}
-              >
-                {task.task}
-              </p>
-            </li>
-          );
-        })}
-      </ol>
-
-      {backgroundTaskCount > 0 ? (
-        <div className="flex items-center justify-between gap-2 border-t border-border/50 px-2.5 py-1.5 text-[11px] text-muted-foreground/70">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <BotIcon className="size-3 shrink-0" />
-            <span className="truncate">
-              {backgroundTaskCount} background agent{backgroundTaskCount === 1 ? "" : "s"}
-            </span>
-          </div>
-        </div>
-      ) : null}
+            </div>
+          ) : null}
+        </>
+      )}
     </div>
   );
 });

--- a/apps/web/src/hooks/useThreadActivationController.test.ts
+++ b/apps/web/src/hooks/useThreadActivationController.test.ts
@@ -229,12 +229,10 @@ describe("activateThreadFromSidebarIntent", () => {
       "split-second-pane-first",
     );
     expect(input.openChatThreadPage).not.toHaveBeenCalled();
-    expect(getFirstNavigateArgs(input).search({ keep: true, splitViewId: "split-first" })).toEqual(
-      {
-        keep: true,
-        splitViewId: "split-second",
-      },
-    );
+    expect(getFirstNavigateArgs(input).search({ keep: true, splitViewId: "split-first" })).toEqual({
+      keep: true,
+      splitViewId: "split-second",
+    });
   });
 
   it("does nothing when the current route already targets the same split pane", () => {

--- a/apps/web/src/hooks/useThreadActivationController.ts
+++ b/apps/web/src/hooks/useThreadActivationController.ts
@@ -6,11 +6,7 @@ import { useCallback } from "react";
 import type { useNavigate } from "@tanstack/react-router";
 import type { ThreadId } from "@t3tools/contracts";
 import type { LastThreadRoute } from "../chatRouteRestore";
-import {
-  type PaneId,
-  type SplitView,
-  type SplitViewId,
-} from "../splitViewStore";
+import { type PaneId, type SplitView, type SplitViewId } from "../splitViewStore";
 import { selectThreadTerminalState } from "../terminalStateStore";
 import {
   resolvePreferredSplitForCommand,

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -88,8 +88,9 @@ describe("groupProviderModelOptionsWithFavorites", () => {
 
     expect(groupedOptions.map((group) => group.label)).toEqual(["Favourites", "Anthropic"]);
     expect(groupedOptions[0]?.options.map((option) => option.slug)).toEqual(["openai/gpt-5"]);
-    expect(
-      groupedOptions.flatMap((group) => group.options.map((option) => option.slug)),
-    ).toEqual(["openai/gpt-5", "anthropic/claude-sonnet"]);
+    expect(groupedOptions.flatMap((group) => group.options.map((option) => option.slug))).toEqual([
+      "openai/gpt-5",
+      "anthropic/claude-sonnet",
+    ]);
   });
 });

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -950,10 +950,7 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
   const removePaneFromSplitView = useSplitViewStore((store) => store.removePaneFromSplitView);
   const removeSplitView = useSplitViewStore((store) => store.removeSplitView);
   const [threadPickerPaneId, setThreadPickerPaneId] = useState<PaneId | null>(null);
-  const {
-    splitView: activeSplitView,
-    routePaneId,
-  } = resolveActiveSplitView({
+  const { splitView: activeSplitView, routePaneId } = resolveActiveSplitView({
     splitView,
     routeThreadId: props.routeThreadId,
   });

--- a/apps/web/src/splitViewStore.ts
+++ b/apps/web/src/splitViewStore.ts
@@ -586,7 +586,9 @@ export const useSplitViewStore = create<SplitViewStore>()(
             };
           }
 
-          const hasAnyThread = collectLeaves(result.nextRoot).some((leaf) => leaf.threadId !== null);
+          const hasAnyThread = collectLeaves(result.nextRoot).some(
+            (leaf) => leaf.threadId !== null,
+          );
           if (!hasAnyThread) {
             delete nextSplitViewsById[splitViewId];
             delete nextSplitViewIdBySourceThreadId[current.sourceThreadId];

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -814,9 +814,9 @@ function normalizeChatMessages(
   previous: ChatMessage[] | undefined,
 ): ChatMessage[] {
   const previousById = new Map(previous?.map((message) => [message.id, message] as const));
-  const nextMessages = incoming.slice(-MAX_THREAD_MESSAGES).map((message) =>
-    normalizeChatMessage(message, previousById.get(message.id)),
-  );
+  const nextMessages = incoming
+    .slice(-MAX_THREAD_MESSAGES)
+    .map((message) => normalizeChatMessage(message, previousById.get(message.id)));
   return arraysShallowEqual(previous, nextMessages) ? previous : nextMessages;
 }
 

--- a/apps/web/src/threadActivation.logic.ts
+++ b/apps/web/src/threadActivation.logic.ts
@@ -73,9 +73,7 @@ export function resolvePreferredSplitForCommand(input: {
       splitView,
       paneId: resolveSplitViewPaneIdForThread(splitView, input.threadId),
     }))
-    .filter(
-      (match): match is { splitView: SplitView; paneId: PaneId } => match.paneId !== null,
-    );
+    .filter((match): match is { splitView: SplitView; paneId: PaneId } => match.paneId !== null);
 
   const sourceMatch = matchingSplits.find(
     ({ splitView }) => splitView.sourceThreadId === input.threadId,


### PR DESCRIPTION
## Summary
- Separate the task banner sidebar action from compact/expanded banner controls.
- Render the active task banner above the composer without reserving a full-width transcript row.
- Add compact banner mode that keeps progress visible in one line.

## Testing
- Not run; not requested.