### PR TITLE
Stabilize split chat routing

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -1909,9 +1909,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       throw new Error("No ChatGPT session token is available. Sign in to ChatGPT in Codex.");
     }
     if (authMethod !== "chatgpt" && authMethod !== "chatgptAuthTokens") {
-      throw new Error(
-        "Voice transcription requires a ChatGPT-authenticated Codex session.",
-      );
+      throw new Error("Voice transcription requires a ChatGPT-authenticated Codex session.");
     }
 
     return {

--- a/apps/server/src/terminal/Layers/NodePTY.test.ts
+++ b/apps/server/src/terminal/Layers/NodePTY.test.ts
@@ -1,7 +1,8 @@
 import { FileSystem, Path, Effect } from "effect";
 import { assert, it } from "@effect/vitest";
 
-import { ensureNodePtySpawnHelperExecutable } from "./NodePTY";
+import { PtyAdapter } from "../Services/PTY";
+import { ensureNodePtySpawnHelperExecutable, makeNodePtyLayer } from "./NodePTY";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 
 it.layer(NodeServices.layer)("ensureNodePtySpawnHelperExecutable", (it) => {
@@ -42,4 +43,35 @@ it.layer(NodeServices.layer)("ensureNodePtySpawnHelperExecutable", (it) => {
       assert.equal(mode & 0o111, 0o111);
     }),
   );
+
+  it.effect("defers node-pty native loading until a terminal is spawned", () => {
+    let loadCalls = 0;
+
+    return Effect.gen(function* () {
+      const adapter = yield* PtyAdapter;
+      assert.equal(loadCalls, 0);
+
+      const error = yield* adapter
+        .spawn({
+          shell: "/bin/sh",
+          args: ["-lc", "exit 0"],
+          cwd: process.cwd(),
+          cols: 80,
+          rows: 24,
+          env: {},
+        })
+        .pipe(Effect.flip);
+
+      assert.equal(loadCalls, 1);
+      assert.equal(error._tag, "PtySpawnError");
+      assert.equal(error.message, "Failed to load node-pty native module");
+    }).pipe(
+      Effect.provide(
+        makeNodePtyLayer(async () => {
+          loadCalls += 1;
+          throw new Error("native binding missing");
+        }),
+      ),
+    );
+  });
 });

--- a/apps/server/src/terminal/Layers/NodePTY.ts
+++ b/apps/server/src/terminal/Layers/NodePTY.ts
@@ -1,7 +1,22 @@
+// FILE: NodePTY.ts
+// Purpose: Provides the Node.js-backed PTY adapter used by terminal sessions.
+// Layer: Terminal infrastructure
+// Depends on: node-pty native bindings, Effect layers, PTY service contract
+
 import { createRequire } from "node:module";
 
 import { Effect, FileSystem, Layer, Path } from "effect";
-import { PtyAdapter, PtyAdapterShape, PtyExitEvent, PtyProcess } from "../Services/PTY";
+import {
+  PtyAdapter,
+  PtyAdapterShape,
+  PtyExitEvent,
+  PtyProcess,
+  PtySpawnInput,
+  PtySpawnError,
+} from "../Services/PTY";
+
+type NodePtyModule = typeof import("node-pty");
+type NodePtyLoader = () => Promise<NodePtyModule>;
 
 let didEnsureSpawnHelperExecutable = false;
 
@@ -92,34 +107,58 @@ class NodePtyProcess implements PtyProcess {
   }
 }
 
-export const layer = Layer.effect(
-  PtyAdapter,
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
+// Creates the adapter layer with an injectable loader so startup/lazy-load behavior is testable.
+export const makeNodePtyLayer = (loadNodePtyModule: NodePtyLoader = () => import("node-pty")) =>
+  Layer.effect(
+    PtyAdapter,
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
 
-    const nodePty = yield* Effect.promise(() => import("node-pty"));
+      // Load node-pty lazily so a bad packaged native binding cannot crash server startup.
+      const loadNodePty = yield* Effect.cached(
+        Effect.tryPromise({
+          try: loadNodePtyModule,
+          catch: (cause) =>
+            new PtySpawnError({
+              adapter: "node-pty",
+              message: "Failed to load node-pty native module",
+              cause,
+            }),
+        }),
+      );
+      const ensureNodePtySpawnHelperExecutableCached = yield* Effect.cached(
+        ensureNodePtySpawnHelperExecutable().pipe(
+          Effect.provideService(FileSystem.FileSystem, fs),
+          Effect.provideService(Path.Path, path),
+          Effect.orElseSucceed(() => undefined),
+        ),
+      );
 
-    const ensureNodePtySpawnHelperExecutableCached = yield* Effect.cached(
-      ensureNodePtySpawnHelperExecutable().pipe(
-        Effect.provideService(FileSystem.FileSystem, fs),
-        Effect.provideService(Path.Path, path),
-        Effect.orElseSucceed(() => undefined),
-      ),
-    );
+      return {
+        spawn: Effect.fn(function* (input: PtySpawnInput) {
+          const nodePty = yield* loadNodePty;
+          yield* ensureNodePtySpawnHelperExecutableCached;
+          const ptyProcess = yield* Effect.try({
+            try: () =>
+              nodePty.spawn(input.shell, input.args ?? [], {
+                cwd: input.cwd,
+                cols: input.cols,
+                rows: input.rows,
+                env: input.env,
+                name: globalThis.process.platform === "win32" ? "xterm-color" : "xterm-256color",
+              }),
+            catch: (cause) =>
+              new PtySpawnError({
+                adapter: "node-pty",
+                message: "Failed to spawn PTY process",
+                cause,
+              }),
+          });
+          return new NodePtyProcess(ptyProcess);
+        }),
+      } satisfies PtyAdapterShape;
+    }),
+  );
 
-    return {
-      spawn: Effect.fn(function* (input) {
-        yield* ensureNodePtySpawnHelperExecutableCached;
-        const ptyProcess = nodePty.spawn(input.shell, input.args ?? [], {
-          cwd: input.cwd,
-          cols: input.cols,
-          rows: input.rows,
-          env: input.env,
-          name: globalThis.process.platform === "win32" ? "xterm-color" : "xterm-256color",
-        });
-        return new NodePtyProcess(ptyProcess);
-      }),
-    } satisfies PtyAdapterShape;
-  }),
-);
+export const layer = makeNodePtyLayer();

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -11,7 +11,7 @@ import { useLocalStorage } from "./hooks/useLocalStorage";
 import { EnvMode } from "./components/BranchToolbar.logic";
 import { formatProviderModelOptionName, type ProviderModelOption } from "./providerModelOptions";
 
-const APP_SETTINGS_STORAGE_KEY = "t3code:app-settings:v1";
+const APP_SETTINGS_STORAGE_KEY = "dpcode:app-settings:v1";
 const MAX_CUSTOM_MODEL_COUNT = 32;
 export const MAX_CUSTOM_MODEL_LENGTH = 256;
 export const MIN_CHAT_FONT_SIZE_PX = 11;

--- a/apps/web/src/browserStateStore.ts
+++ b/apps/web/src/browserStateStore.ts
@@ -9,7 +9,7 @@ import type { ThreadBrowserState, ThreadId } from "@t3tools/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
-const BROWSER_STATE_STORAGE_KEY = "t3code:browser-state:v1";
+const BROWSER_STATE_STORAGE_KEY = "dpcode:browser-state:v1";
 const BROWSER_HISTORY_LIMIT = 12;
 const EMPTY_BROWSER_HISTORY: BrowserHistoryEntry[] = [];
 

--- a/apps/web/src/chatRouteRestore.test.ts
+++ b/apps/web/src/chatRouteRestore.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveRestorableThreadRoute } from "./chatRouteRestore";
+
+describe("resolveRestorableThreadRoute", () => {
+  it("returns the last thread route when the thread still exists", () => {
+    expect(
+      resolveRestorableThreadRoute({
+        lastThreadRoute: {
+          threadId: "thread-123",
+          splitViewId: "split-456",
+        },
+        availableThreadIds: new Set(["thread-123", "thread-789"]),
+      }),
+    ).toEqual({
+      threadId: "thread-123",
+      splitViewId: "split-456",
+    });
+  });
+
+  it("returns null when the remembered thread no longer exists", () => {
+    expect(
+      resolveRestorableThreadRoute({
+        lastThreadRoute: {
+          threadId: "thread-123",
+        },
+        availableThreadIds: new Set(["thread-789"]),
+      }),
+    ).toBeNull();
+  });
+
+  it("drops a stale split id while preserving the remembered thread", () => {
+    expect(
+      resolveRestorableThreadRoute({
+        lastThreadRoute: {
+          threadId: "thread-123",
+          splitViewId: "split-missing",
+        },
+        availableThreadIds: new Set(["thread-123"]),
+        availableSplitViewIds: new Set(["split-live"]),
+      }),
+    ).toEqual({
+      threadId: "thread-123",
+    });
+  });
+});

--- a/apps/web/src/chatRouteRestore.ts
+++ b/apps/web/src/chatRouteRestore.ts
@@ -1,0 +1,34 @@
+// FILE: chatRouteRestore.ts
+// Purpose: Validates saved chat routes before restoring them from startup or sidebar navigation.
+// Layer: Route helper
+// Exports: last-thread route type plus restore resolver shared by Sidebar and chat index.
+
+export type LastThreadRoute = {
+  threadId: string;
+  splitViewId?: string | undefined;
+};
+
+export function resolveRestorableThreadRoute(input: {
+  lastThreadRoute: LastThreadRoute | null;
+  availableThreadIds: ReadonlySet<string>;
+  availableSplitViewIds?: ReadonlySet<string>;
+}): LastThreadRoute | null {
+  const { lastThreadRoute, availableThreadIds, availableSplitViewIds } = input;
+  if (!lastThreadRoute) {
+    return null;
+  }
+
+  if (!availableThreadIds.has(lastThreadRoute.threadId)) {
+    return null;
+  }
+
+  if (
+    lastThreadRoute.splitViewId &&
+    availableSplitViewIds &&
+    !availableSplitViewIds.has(lastThreadRoute.splitViewId)
+  ) {
+    return { threadId: lastThreadRoute.threadId };
+  }
+
+  return lastThreadRoute;
+}

--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -62,6 +62,19 @@ describe("ChatMarkdown", () => {
     expect(markup.match(/class="katex"/g) ?? []).toHaveLength(1);
   });
 
+  it("keeps dollar signs in markdown file links from becoming math", async () => {
+    const source =
+      "Files touched:\n\n- [_chat.$threadId.tsx](/Users/julius/project/apps/web/src/routes/_chat.$threadId.tsx:1192)";
+    const markup = await renderMarkdown(source, "/Users/julius/project");
+
+    expect(markup).toContain(
+      'href="/Users/julius/project/apps/web/src/routes/_chat.$threadId.tsx:1192"',
+    );
+    expect(markup).toContain("_chat.$threadId.tsx");
+    expect(markup).not.toContain('class="katex"');
+    expect(markup).not.toContain("CHATMARKDOWNLITERALDOLLARPLACEHOLDER");
+  });
+
   it("does not turn ordinary dollar text or escaped dollars into math", async () => {
     const markup = await renderMarkdown(
       "It costs $5 to $10 per seat. Escape \\$E=mc^2\\$ when you want literal TeX.",

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -83,13 +83,17 @@ const MARKDOWN_REMARK_PLUGINS: MarkdownRemarkPlugins = [
 ];
 const LITERAL_DOLLAR_PLACEHOLDER = "CHATMARKDOWNLITERALDOLLARPLACEHOLDER";
 
+function restoreLiteralDollarPlaceholders(value: string): string {
+  return value.replaceAll(LITERAL_DOLLAR_PLACEHOLDER, "$");
+}
+
 function restoreLiteralDollarsInNode(node: unknown): void {
   if (!node || typeof node !== "object") {
     return;
   }
 
   if ("type" in node && node.type === "text" && "value" in node && typeof node.value === "string") {
-    node.value = node.value.replaceAll(LITERAL_DOLLAR_PLACEHOLDER, "$");
+    node.value = restoreLiteralDollarPlaceholders(node.value);
   }
 
   if ("children" in node && Array.isArray(node.children)) {
@@ -292,6 +296,99 @@ function protectLiteralDollarsInPlainText(value: string): string {
   return result;
 }
 
+function findMarkdownBracketEnd(value: string, startIndex: number): number {
+  let depth = 0;
+  let cursor = startIndex;
+
+  while (cursor < value.length) {
+    if (value[cursor] === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (value[cursor] === "[") {
+      depth += 1;
+    } else if (value[cursor] === "]") {
+      depth -= 1;
+      if (depth === 0) {
+        return cursor;
+      }
+    }
+    cursor += 1;
+  }
+
+  return -1;
+}
+
+function findMarkdownParenEnd(value: string, startIndex: number): number {
+  let depth = 0;
+  let cursor = startIndex;
+
+  while (cursor < value.length) {
+    if (value[cursor] === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (value[cursor] === "(") {
+      depth += 1;
+    } else if (value[cursor] === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return cursor;
+      }
+    }
+    cursor += 1;
+  }
+
+  return -1;
+}
+
+function findInlineMarkdownLinkEnd(value: string, index: number): number {
+  const bracketStart = value[index] === "!" && value[index + 1] === "[" ? index + 1 : index;
+  if (value[bracketStart] !== "[") {
+    return -1;
+  }
+
+  const bracketEnd = findMarkdownBracketEnd(value, bracketStart);
+  if (bracketEnd === -1 || value[bracketEnd + 1] !== "(") {
+    return -1;
+  }
+
+  const parenEnd = findMarkdownParenEnd(value, bracketEnd + 1);
+  return parenEnd === -1 ? -1 : parenEnd + 1;
+}
+
+function protectLiteralDollarsInMarkdownLinks(value: string): string {
+  let result = "";
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    const isLinkStart =
+      value[cursor] === "[" || (value[cursor] === "!" && value[cursor + 1] === "[");
+    if (!isLinkStart) {
+      const nextLinkStart = value.indexOf("[", cursor);
+      const nextImageStart = value.indexOf("![", cursor);
+      const candidates = [nextLinkStart, nextImageStart].filter((candidate) => candidate >= 0);
+      const nextIndex = candidates.length > 0 ? Math.min(...candidates) : value.length;
+      result += protectLiteralDollarsInPlainText(value.slice(cursor, nextIndex));
+      cursor = nextIndex;
+      continue;
+    }
+
+    const linkEnd = findInlineMarkdownLinkEnd(value, cursor);
+    if (linkEnd === -1) {
+      result += protectLiteralDollarsInPlainText(value[cursor]);
+      cursor += 1;
+      continue;
+    }
+
+    // Inline links are parsed after math, so protect route params like `_chat.$threadId.tsx`.
+    result += value.slice(cursor, linkEnd).replaceAll("$", LITERAL_DOLLAR_PLACEHOLDER);
+    cursor = linkEnd;
+  }
+
+  return result;
+}
+
 // Tighten single-dollar math so currency and escaped dollars stay literal without touching code spans.
 function protectLiteralMarkdownDollars(value: string): string {
   let result = "";
@@ -330,7 +427,7 @@ function protectLiteralMarkdownDollars(value: string): string {
       nextCodeIndex += 1;
     }
 
-    result += protectLiteralDollarsInPlainText(value.slice(cursor, nextCodeIndex));
+    result += protectLiteralDollarsInMarkdownLinks(value.slice(cursor, nextCodeIndex));
     cursor = nextCodeIndex;
   }
 
@@ -519,20 +616,22 @@ function ChatMarkdown({
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
   const normalizedText = useMemo(() => protectLiteralMarkdownDollars(text), [text]);
   const markdownUrlTransform = useCallback((href: string) => {
-    return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
+    const restoredHref = restoreLiteralDollarPlaceholders(href);
+    return rewriteMarkdownFileUriHref(restoredHref) ?? defaultUrlTransform(restoredHref);
   }, []);
   const markdownComponents = useMemo<Components>(
     () => ({
       a({ node: _node, href, ...props }) {
-        const targetPath = resolveMarkdownFileLinkTarget(href, cwd);
+        const restoredHref = href ? restoreLiteralDollarPlaceholders(href) : href;
+        const targetPath = resolveMarkdownFileLinkTarget(restoredHref, cwd);
         if (!targetPath) {
-          return <a {...props} href={href} target="_blank" rel="noopener noreferrer" />;
+          return <a {...props} href={restoredHref} target="_blank" rel="noopener noreferrer" />;
         }
 
         return (
           <a
             {...props}
-            href={href}
+            href={restoredHref}
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -376,7 +376,7 @@ function protectLiteralDollarsInMarkdownLinks(value: string): string {
 
     const linkEnd = findInlineMarkdownLinkEnd(value, cursor);
     if (linkEnd === -1) {
-      result += protectLiteralDollarsInPlainText(value[cursor]);
+      result += protectLiteralDollarsInPlainText(value[cursor] ?? "");
       cursor += 1;
       continue;
     }

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -31,7 +31,7 @@ import {
 import { hasLiveTurnTailWork, type WorkLogEntry } from "../session-logic";
 import { localSubagentThreadId } from "./ChatView.selectors";
 
-export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
+export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "dpcode:last-invoked-script-by-project";
 const WORKTREE_NAME_PREFIX = "dpcode";
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -678,6 +678,7 @@ interface ChatViewProps {
   onOpenTurnDiffPanel?: (turnId: TurnId, filePath?: string) => void;
   onSplitSurface?: () => void;
   onMaximizeSurface?: () => void;
+  onChangeThreadInSplitPane?: () => void;
 }
 
 export default function ChatView({
@@ -691,6 +692,7 @@ export default function ChatView({
   onOpenTurnDiffPanel,
   onSplitSurface,
   onMaximizeSurface,
+  onChangeThreadInSplitPane,
 }: ChatViewProps) {
   const markThreadVisited = useStore((store) => store.markThreadVisited);
   const syncServerReadModel = useStore((store) => store.syncServerReadModel);
@@ -831,6 +833,7 @@ export default function ChatView({
   const [composerCommandPicker, setComposerCommandPicker] = useState<
     null | "fork-target" | "review-target"
   >(null);
+  const [secondaryChromePlaceholderHeight, setSecondaryChromePlaceholderHeight] = useState(88);
   // Tracks whether the user explicitly dismissed the sidebar for the active turn.
   const planSidebarDismissedForTurnRef = useRef<string | null>(null);
   // When set, the thread-change reset effect will open the sidebar instead of closing it.
@@ -892,6 +895,7 @@ export default function ChatView({
   }, [threadId]);
   const composerEditorRef = useRef<ComposerPromptEditorHandle>(null);
   const composerFormRef = useRef<HTMLFormElement>(null);
+  const pendingComposerFocusRef = useRef(false);
   const composerFormHeightRef = useRef(0);
   const composerImagesRef = useRef<ComposerImageAttachment[]>([]);
   const composerSelectLockRef = useRef(false);
@@ -2440,6 +2444,35 @@ export default function ChatView({
     terminalWorkspaceOpen &&
     (terminalState.workspaceLayout === "terminal-only" ||
       terminalState.workspaceActiveTab === "terminal");
+  const secondaryChromeThreadId = activeThread?.id ?? threadId;
+  const shouldDeferSecondaryChrome =
+    activeThread !== undefined && !isCenteredEmptyLanding && !terminalWorkspaceTerminalTabActive;
+  const [secondaryChromeState, setSecondaryChromeState] = useState(() => ({
+    threadId: secondaryChromeThreadId,
+    ready: true,
+  }));
+  const secondaryChromeReady =
+    !shouldDeferSecondaryChrome ||
+    (secondaryChromeState.threadId === secondaryChromeThreadId && secondaryChromeState.ready);
+
+  useEffect(() => {
+    if (!shouldDeferSecondaryChrome) {
+      setSecondaryChromeState((current) =>
+        current.threadId === secondaryChromeThreadId && current.ready
+          ? current
+          : { threadId: secondaryChromeThreadId, ready: true },
+      );
+      return;
+    }
+
+    setSecondaryChromeState({ threadId: secondaryChromeThreadId, ready: false });
+    const frame = window.requestAnimationFrame(() => {
+      setSecondaryChromeState({ threadId: secondaryChromeThreadId, ready: true });
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [secondaryChromeThreadId, shouldDeferSecondaryChrome]);
   const terminalWorkspaceChatTabActive =
     terminalWorkspaceOpen &&
     terminalState.workspaceLayout === "both" &&
@@ -2465,13 +2498,30 @@ export default function ChatView({
   );
 
   const focusComposer = useCallback(() => {
-    composerEditorRef.current?.focusAtEnd();
-  }, []);
+    // Secondary chrome is deferred during thread switches; replay focus once it mounts.
+    const editor = composerEditorRef.current;
+    if (!secondaryChromeReady || !editor) {
+      pendingComposerFocusRef.current = true;
+      return;
+    }
+    pendingComposerFocusRef.current = false;
+    editor.focusAtEnd();
+  }, [secondaryChromeReady]);
   const scheduleComposerFocus = useCallback(() => {
+    pendingComposerFocusRef.current = true;
     window.requestAnimationFrame(() => {
       focusComposer();
     });
   }, [focusComposer]);
+  useEffect(() => {
+    if (!secondaryChromeReady || !pendingComposerFocusRef.current) return;
+    const frame = window.requestAnimationFrame(() => {
+      focusComposer();
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [focusComposer, secondaryChromeReady, secondaryChromeThreadId]);
   // Keep the two composer picker menus mutually exclusive so shortcuts always open one surface.
   const handleModelPickerOpenChange = useCallback((open: boolean) => {
     setIsModelPickerOpen(open);
@@ -3445,7 +3495,13 @@ export default function ChatView({
     if (!composerForm) return;
     const measureComposerFormWidth = () => composerForm.clientWidth;
 
-    composerFormHeightRef.current = composerForm.getBoundingClientRect().height;
+    const measuredHeight = Math.ceil(composerForm.getBoundingClientRect().height);
+    composerFormHeightRef.current = measuredHeight;
+    if (measuredHeight > 0) {
+      setSecondaryChromePlaceholderHeight((current) =>
+        current === measuredHeight ? current : measuredHeight,
+      );
+    }
     setIsComposerFooterCompact(
       shouldUseCompactComposerFooter(measureComposerFormWidth(), {
         hasWideActions: composerFooterHasWideActions,
@@ -3465,6 +3521,12 @@ export default function ChatView({
       const nextHeight = entry.contentRect.height;
       const previousHeight = composerFormHeightRef.current;
       composerFormHeightRef.current = nextHeight;
+      const roundedNextHeight = Math.ceil(nextHeight);
+      if (roundedNextHeight > 0) {
+        setSecondaryChromePlaceholderHeight((current) =>
+          current === roundedNextHeight ? current : roundedNextHeight,
+        );
+      }
       if (previousHeight > 0 && Math.abs(nextHeight - previousHeight) < 0.5) {
         return;
       }
@@ -3484,6 +3546,7 @@ export default function ChatView({
 
   useEffect(() => {
     setPullRequestDialogState(null);
+    setRenameDialogOpen(false);
     isAtEndRef.current = true;
     showScrollDebouncer.current.cancel();
     setShowScrollToBottom(false);
@@ -3598,12 +3661,25 @@ export default function ChatView({
     setSelectedComposerMentions([]);
   }, [selectedProvider]);
 
+  useLayoutEffect(() => {
+    // ChatView stays mounted across thread switches, so clear thread-local overlays before paint.
+    setOptimisticUserMessages((existing) => {
+      if (existing.length === 0) return existing;
+      for (const message of existing) {
+        revokeUserMessagePreviewUrls(message);
+      }
+      return [];
+    });
+    setExpandedImage(null);
+  }, [threadId]);
+
   useEffect(() => {
     voiceTranscriptionRequestIdRef.current += 1;
     voiceRecordingStartedAtRef.current = null;
     void cancelVoiceRecording();
     setIsVoiceTranscribing(false);
     setOptimisticUserMessages((existing) => {
+      if (existing.length === 0) return existing;
       for (const message of existing) {
         revokeUserMessagePreviewUrls(message);
       }
@@ -6688,7 +6764,7 @@ export default function ChatView({
   // follow-up prompts and normal chat mode stay visually in sync.
   const planCardAboveComposer = Boolean(activePlan && !planSidebarOpen);
 
-  const composerSection = (
+  const composerSection = secondaryChromeReady ? (
     <>
       {activePlan && !planSidebarOpen ? (
         <div className="mx-auto w-full max-w-3xl">
@@ -7205,6 +7281,13 @@ export default function ChatView({
         </div>
       ) : null}
     </>
+  ) : (
+    <div
+      aria-hidden="true"
+      className="chat-composer-surface mx-auto w-full max-w-3xl rounded-2xl border border-[color:var(--color-border-light)] bg-background/65"
+      data-chat-composer-form="deferred"
+      style={{ height: secondaryChromePlaceholderHeight }}
+    />
   );
 
   return (
@@ -7220,6 +7303,7 @@ export default function ChatView({
         <ChatHeader
           activeThreadId={activeThread.id}
           activeThreadTitle={activeThreadDisplayTitle}
+          activeProvider={activeThread.modelSelection.provider}
           activeProjectName={activeProjectDisplayName}
           threadBreadcrumbs={threadBreadcrumbs}
           hideHandoffControls={terminalWorkspaceTerminalTabActive}
@@ -7264,6 +7348,14 @@ export default function ChatView({
                     onClick: onMaximizeSurface,
                   }
                 : null
+          }
+          changeThreadAction={
+            surfaceMode === "split" && isFocusedPane && onChangeThreadInSplitPane
+              ? {
+                  label: "Change thread",
+                  onClick: onChangeThreadInSplitPane,
+                }
+              : null
           }
           onRunProjectScript={onRunProjectScriptFromHeader}
           onAddProjectScript={saveProjectScript}
@@ -7925,17 +8017,19 @@ export default function ChatView({
                     </div>
                   </form>
                 </div>
-                {isGitRepo ? (
-                  <BranchToolbar {...branchToolbarProps} />
-                ) : (
-                  <div className="mx-auto flex w-full max-w-3xl items-center justify-end px-3 pb-3 pt-1">
-                    <RuntimeUsageControls {...runtimeUsageControlsProps} />
-                  </div>
-                )}
+                {secondaryChromeReady ? (
+                  isGitRepo ? (
+                    <BranchToolbar {...branchToolbarProps} />
+                  ) : (
+                    <div className="mx-auto flex w-full max-w-3xl items-center justify-end px-3 pb-3 pt-1">
+                      <RuntimeUsageControls {...runtimeUsageControlsProps} />
+                    </div>
+                  )
+                ) : null}
               </>
             ) : null}
 
-            {pullRequestDialogState ? (
+            {secondaryChromeReady && pullRequestDialogState ? (
               <PullRequestThreadDialog
                 key={pullRequestDialogState.key}
                 open

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -714,6 +714,7 @@ export default function ChatView({
   const { resolvedTheme } = useTheme();
   const queryClient = useQueryClient();
   const createWorktreeMutation = useMutation(gitCreateWorktreeMutationOptions({ queryClient }));
+  const isInactiveSplitPane = surfaceMode === "split" && !isFocusedPane;
   const composerDraft = useComposerThreadDraft(threadId);
   const prompt = composerDraft.prompt;
   const composerImages = composerDraft.images;
@@ -3418,7 +3419,11 @@ export default function ChatView({
     onMessagesWheel,
   } = useTranscriptAssistantSelectionAction({
     threadId,
-    enabled: Boolean(activeThread) && pendingUserInputs.length === 0 && !isComposerApprovalState,
+    enabled:
+      Boolean(activeThread) &&
+      !isInactiveSplitPane &&
+      pendingUserInputs.length === 0 &&
+      !isComposerApprovalState,
     composerImagesRef,
     composerAssistantSelectionsRef,
     addComposerAssistantSelectionToDraft,
@@ -3435,6 +3440,7 @@ export default function ChatView({
   });
 
   useLayoutEffect(() => {
+    if (isInactiveSplitPane) return;
     const composerForm = composerFormRef.current;
     if (!composerForm) return;
     const measureComposerFormWidth = () => composerForm.clientWidth;
@@ -3474,7 +3480,7 @@ export default function ChatView({
     return () => {
       observer.disconnect();
     };
-  }, [activeThread?.id, composerFooterHasWideActions, scrollToEnd]);
+  }, [activeThread?.id, composerFooterHasWideActions, isInactiveSplitPane, scrollToEnd]);
 
   useEffect(() => {
     setPullRequestDialogState(null);
@@ -3507,14 +3513,14 @@ export default function ChatView({
   }, [activeThread?.id]);
 
   useEffect(() => {
-    if (!activeThread?.id || terminalState.terminalOpen) return;
+    if (!activeThread?.id || terminalState.terminalOpen || isInactiveSplitPane) return;
     const frame = window.requestAnimationFrame(() => {
       focusComposer();
     });
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [activeThread?.id, focusComposer, terminalState.terminalOpen]);
+  }, [activeThread?.id, focusComposer, isInactiveSplitPane, terminalState.terminalOpen]);
 
   useEffect(() => {
     composerImagesRef.current = composerImages;
@@ -8028,10 +8034,12 @@ export default function ChatView({
         onOpenChange={setWorktreeHandoffDialogOpen}
         onConfirm={confirmWorktreeHandoff}
       />
-      <TranscriptSelectionActionLayer
-        action={pendingTranscriptSelectionAction}
-        onAddToChat={commitTranscriptAssistantSelection}
-      />
+      {isInactiveSplitPane ? null : (
+        <TranscriptSelectionActionLayer
+          action={pendingTranscriptSelectionAction}
+          onAddToChat={commitTranscriptAssistantSelection}
+        />
+      )}
 
       {expandedImage && expandedImageItem && (
         <div

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -21,10 +21,8 @@ import {
   hasUnseenCompletion,
   isDuplicateProjectCreateError,
   pruneExpandedProjectThreadListsForCollapsedProjects,
-  resolvePreferredSplitForCommand,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadEnvMode,
-  resolveThreadCommandActivation,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   shouldPrunePinnedThreads,
@@ -33,7 +31,6 @@ import {
   sortThreadsForSidebar,
 } from "./Sidebar.logic";
 import { ProjectId, ThreadId } from "@t3tools/contracts";
-import type { SplitView } from "../splitViewStore";
 import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
@@ -41,45 +38,6 @@ import {
   type SidebarThreadSummary,
   type Thread,
 } from "../types";
-
-const THREAD_A = ThreadId.makeUnsafe("thread-a");
-const THREAD_B = ThreadId.makeUnsafe("thread-b");
-const THREAD_C = ThreadId.makeUnsafe("thread-c");
-const PROJECT_ID = ProjectId.makeUnsafe("project-1");
-
-function makeSplitViewFixture(input: {
-  id: string;
-  sourceThreadId: ThreadId;
-  firstThreadId: ThreadId | null;
-  secondThreadId: ThreadId | null;
-  focusOn: "first" | "second";
-}): SplitView {
-  const firstId = `${input.id}-pane-first`;
-  const secondId = `${input.id}-pane-second`;
-  const panel = {
-    panel: null,
-    diffTurnId: null,
-    diffFilePath: null,
-    hasOpenedPanel: false,
-    lastOpenPanel: "browser" as const,
-  };
-  return {
-    id: input.id,
-    sourceThreadId: input.sourceThreadId,
-    ownerProjectId: PROJECT_ID,
-    focusedPaneId: input.focusOn === "first" ? firstId : secondId,
-    createdAt: "2026-01-01T00:00:00.000Z",
-    updatedAt: "2026-01-01T00:00:00.000Z",
-    root: {
-      kind: "split",
-      id: `${input.id}-root`,
-      direction: "horizontal",
-      ratio: 0.5,
-      first: { kind: "leaf", id: firstId, threadId: input.firstThreadId, panel },
-      second: { kind: "leaf", id: secondId, threadId: input.secondThreadId, panel },
-    },
-  };
-}
 
 function makeLatestTurn(overrides?: {
   completedAt?: string | null;
@@ -153,192 +111,6 @@ describe("resolveSidebarNewThreadEnvMode", () => {
         defaultEnvMode: "worktree",
       }),
     ).toBe("local");
-  });
-});
-
-describe("resolveThreadCommandActivation", () => {
-  it("opens the target thread inside the caller-provided active split", () => {
-    expect(
-      resolveThreadCommandActivation({
-        threadId: THREAD_A,
-        threadExists: true,
-        activeSidebarThreadId: THREAD_B,
-        preferredSplitViewId: "split-1",
-        splitPaneId: "pane-a",
-      }),
-    ).toEqual({
-      kind: "split",
-      threadId: THREAD_A,
-      splitViewId: "split-1",
-      paneId: "pane-a",
-    });
-  });
-
-  it("opens the target thread as single chat when it is not in a split", () => {
-    expect(
-      resolveThreadCommandActivation({
-        threadId: THREAD_A,
-        threadExists: true,
-        activeSidebarThreadId: THREAD_B,
-        preferredSplitViewId: null,
-        splitPaneId: null,
-      }),
-    ).toEqual({
-      kind: "single",
-      threadId: THREAD_A,
-    });
-  });
-
-  it("still opens the active sidebar thread split instead of ignoring it", () => {
-    expect(
-      resolveThreadCommandActivation({
-        threadId: THREAD_A,
-        threadExists: true,
-        activeSidebarThreadId: THREAD_A,
-        preferredSplitViewId: "split-1",
-        splitPaneId: "pane-a",
-      }),
-    ).toEqual({
-      kind: "split",
-      threadId: THREAD_A,
-      splitViewId: "split-1",
-      paneId: "pane-a",
-    });
-  });
-
-  it("ignores missing threads and already-active single chats", () => {
-    expect(
-      resolveThreadCommandActivation({
-        threadId: THREAD_A,
-        threadExists: false,
-        activeSidebarThreadId: THREAD_B,
-        preferredSplitViewId: null,
-        splitPaneId: null,
-      }),
-    ).toEqual({ kind: "ignore" });
-
-    expect(
-      resolveThreadCommandActivation({
-        threadId: THREAD_A,
-        threadExists: true,
-        activeSidebarThreadId: THREAD_A,
-        preferredSplitViewId: null,
-        splitPaneId: null,
-      }),
-    ).toEqual({ kind: "ignore" });
-  });
-});
-
-describe("resolvePreferredSplitForCommand", () => {
-  it("focuses the matching pane in the active split when the target lives there", () => {
-    const activeSplitView = makeSplitViewFixture({
-      id: "split-active",
-      sourceThreadId: THREAD_A,
-      firstThreadId: THREAD_A,
-      secondThreadId: THREAD_B,
-      focusOn: "first",
-    });
-
-    const result = resolvePreferredSplitForCommand({
-      activeSplitView,
-      splitViewsById: {},
-      restorableSplitViewId: null,
-      threadId: THREAD_B,
-    });
-
-    expect(result).toEqual({ splitViewId: "split-active", paneId: "split-active-pane-second" });
-  });
-
-  it("returns null inside an active split when the target is outside that split", () => {
-    const activeSplitView = makeSplitViewFixture({
-      id: "split-active",
-      sourceThreadId: THREAD_A,
-      firstThreadId: THREAD_A,
-      secondThreadId: THREAD_B,
-      focusOn: "first",
-    });
-    const result = resolvePreferredSplitForCommand({
-      activeSplitView,
-      splitViewsById: {},
-      restorableSplitViewId: null,
-      threadId: THREAD_C,
-    });
-
-    expect(result).toBeNull();
-  });
-
-  it("restores the last exited split when no split is active", () => {
-    const splitView = makeSplitViewFixture({
-      id: "split-background",
-      sourceThreadId: THREAD_A,
-      firstThreadId: THREAD_A,
-      secondThreadId: THREAD_B,
-      focusOn: "first",
-    });
-
-    const result = resolvePreferredSplitForCommand({
-      activeSplitView: null,
-      splitViewsById: { "split-background": splitView },
-      restorableSplitViewId: "split-background",
-      threadId: THREAD_B,
-    });
-
-    expect(result).toEqual({
-      splitViewId: "split-background",
-      paneId: "split-background-pane-second",
-    });
-  });
-
-  it("does not restore older persisted splits that are not the last exited split", () => {
-    const firstSplit = makeSplitViewFixture({
-      id: "split-first",
-      sourceThreadId: THREAD_A,
-      firstThreadId: THREAD_A,
-      secondThreadId: THREAD_B,
-      focusOn: "first",
-    });
-    const secondSplit = makeSplitViewFixture({
-      id: "split-second",
-      sourceThreadId: THREAD_C,
-      firstThreadId: THREAD_C,
-      secondThreadId: THREAD_B,
-      focusOn: "first",
-    });
-
-    expect(
-      resolvePreferredSplitForCommand({
-        activeSplitView: null,
-        splitViewsById: {
-          "split-first": firstSplit,
-          "split-second": secondSplit,
-        },
-        restorableSplitViewId: "split-first",
-        threadId: THREAD_B,
-      }),
-    ).toEqual({ splitViewId: "split-first", paneId: "split-first-pane-second" });
-
-    expect(
-      resolvePreferredSplitForCommand({
-        activeSplitView: null,
-        splitViewsById: {
-          "split-first": firstSplit,
-          "split-second": secondSplit,
-        },
-        restorableSplitViewId: "split-first",
-        threadId: THREAD_C,
-      }),
-    ).toBeNull();
-  });
-
-  it("returns null when no split is active and no persisted split owns the thread", () => {
-    expect(
-      resolvePreferredSplitForCommand({
-        activeSplitView: null,
-        splitViewsById: {},
-        restorableSplitViewId: null,
-        threadId: THREAD_A,
-      }),
-    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -21,9 +21,10 @@ import {
   hasUnseenCompletion,
   isDuplicateProjectCreateError,
   pruneExpandedProjectThreadListsForCollapsedProjects,
+  resolvePreferredSplitForCommand,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadEnvMode,
-  resolveSidebarRestorableThreadRoute,
+  resolveThreadCommandActivation,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   shouldPrunePinnedThreads,
@@ -32,6 +33,7 @@ import {
   sortThreadsForSidebar,
 } from "./Sidebar.logic";
 import { ProjectId, ThreadId } from "@t3tools/contracts";
+import type { SplitView } from "../splitViewStore";
 import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
@@ -39,6 +41,45 @@ import {
   type SidebarThreadSummary,
   type Thread,
 } from "../types";
+
+const THREAD_A = ThreadId.makeUnsafe("thread-a");
+const THREAD_B = ThreadId.makeUnsafe("thread-b");
+const THREAD_C = ThreadId.makeUnsafe("thread-c");
+const PROJECT_ID = ProjectId.makeUnsafe("project-1");
+
+function makeSplitViewFixture(input: {
+  id: string;
+  sourceThreadId: ThreadId;
+  firstThreadId: ThreadId | null;
+  secondThreadId: ThreadId | null;
+  focusOn: "first" | "second";
+}): SplitView {
+  const firstId = `${input.id}-pane-first`;
+  const secondId = `${input.id}-pane-second`;
+  const panel = {
+    panel: null,
+    diffTurnId: null,
+    diffFilePath: null,
+    hasOpenedPanel: false,
+    lastOpenPanel: "browser" as const,
+  };
+  return {
+    id: input.id,
+    sourceThreadId: input.sourceThreadId,
+    ownerProjectId: PROJECT_ID,
+    focusedPaneId: input.focusOn === "first" ? firstId : secondId,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    root: {
+      kind: "split",
+      id: `${input.id}-root`,
+      direction: "horizontal",
+      ratio: 0.5,
+      first: { kind: "leaf", id: firstId, threadId: input.firstThreadId, panel },
+      second: { kind: "leaf", id: secondId, threadId: input.secondThreadId, panel },
+    },
+  };
+}
 
 function makeLatestTurn(overrides?: {
   completedAt?: string | null;
@@ -115,29 +156,187 @@ describe("resolveSidebarNewThreadEnvMode", () => {
   });
 });
 
-describe("resolveSidebarRestorableThreadRoute", () => {
-  it("returns the last thread route when the thread still exists", () => {
+describe("resolveThreadCommandActivation", () => {
+  it("opens the target thread inside the caller-provided active split", () => {
     expect(
-      resolveSidebarRestorableThreadRoute({
-        lastThreadRoute: {
-          threadId: "thread-123",
-          splitViewId: "split-456",
-        },
-        availableThreadIds: new Set(["thread-123", "thread-789"]),
+      resolveThreadCommandActivation({
+        threadId: THREAD_A,
+        threadExists: true,
+        activeSidebarThreadId: THREAD_B,
+        preferredSplitViewId: "split-1",
+        splitPaneId: "pane-a",
       }),
     ).toEqual({
-      threadId: "thread-123",
-      splitViewId: "split-456",
+      kind: "split",
+      threadId: THREAD_A,
+      splitViewId: "split-1",
+      paneId: "pane-a",
     });
   });
 
-  it("returns null when the remembered thread no longer exists", () => {
+  it("opens the target thread as single chat when it is not in a split", () => {
     expect(
-      resolveSidebarRestorableThreadRoute({
-        lastThreadRoute: {
-          threadId: "thread-123",
+      resolveThreadCommandActivation({
+        threadId: THREAD_A,
+        threadExists: true,
+        activeSidebarThreadId: THREAD_B,
+        preferredSplitViewId: null,
+        splitPaneId: null,
+      }),
+    ).toEqual({
+      kind: "single",
+      threadId: THREAD_A,
+    });
+  });
+
+  it("still opens the active sidebar thread split instead of ignoring it", () => {
+    expect(
+      resolveThreadCommandActivation({
+        threadId: THREAD_A,
+        threadExists: true,
+        activeSidebarThreadId: THREAD_A,
+        preferredSplitViewId: "split-1",
+        splitPaneId: "pane-a",
+      }),
+    ).toEqual({
+      kind: "split",
+      threadId: THREAD_A,
+      splitViewId: "split-1",
+      paneId: "pane-a",
+    });
+  });
+
+  it("ignores missing threads and already-active single chats", () => {
+    expect(
+      resolveThreadCommandActivation({
+        threadId: THREAD_A,
+        threadExists: false,
+        activeSidebarThreadId: THREAD_B,
+        preferredSplitViewId: null,
+        splitPaneId: null,
+      }),
+    ).toEqual({ kind: "ignore" });
+
+    expect(
+      resolveThreadCommandActivation({
+        threadId: THREAD_A,
+        threadExists: true,
+        activeSidebarThreadId: THREAD_A,
+        preferredSplitViewId: null,
+        splitPaneId: null,
+      }),
+    ).toEqual({ kind: "ignore" });
+  });
+});
+
+describe("resolvePreferredSplitForCommand", () => {
+  it("focuses the matching pane in the active split when the target lives there", () => {
+    const activeSplitView = makeSplitViewFixture({
+      id: "split-active",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+
+    const result = resolvePreferredSplitForCommand({
+      activeSplitView,
+      splitViewsById: {},
+      restorableSplitViewId: null,
+      threadId: THREAD_B,
+    });
+
+    expect(result).toEqual({ splitViewId: "split-active", paneId: "split-active-pane-second" });
+  });
+
+  it("returns null inside an active split when the target is outside that split", () => {
+    const activeSplitView = makeSplitViewFixture({
+      id: "split-active",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const result = resolvePreferredSplitForCommand({
+      activeSplitView,
+      splitViewsById: {},
+      restorableSplitViewId: null,
+      threadId: THREAD_C,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("restores the last exited split when no split is active", () => {
+    const splitView = makeSplitViewFixture({
+      id: "split-background",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+
+    const result = resolvePreferredSplitForCommand({
+      activeSplitView: null,
+      splitViewsById: { "split-background": splitView },
+      restorableSplitViewId: "split-background",
+      threadId: THREAD_B,
+    });
+
+    expect(result).toEqual({
+      splitViewId: "split-background",
+      paneId: "split-background-pane-second",
+    });
+  });
+
+  it("does not restore older persisted splits that are not the last exited split", () => {
+    const firstSplit = makeSplitViewFixture({
+      id: "split-first",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const secondSplit = makeSplitViewFixture({
+      id: "split-second",
+      sourceThreadId: THREAD_C,
+      firstThreadId: THREAD_C,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+
+    expect(
+      resolvePreferredSplitForCommand({
+        activeSplitView: null,
+        splitViewsById: {
+          "split-first": firstSplit,
+          "split-second": secondSplit,
         },
-        availableThreadIds: new Set(["thread-789"]),
+        restorableSplitViewId: "split-first",
+        threadId: THREAD_B,
+      }),
+    ).toEqual({ splitViewId: "split-first", paneId: "split-first-pane-second" });
+
+    expect(
+      resolvePreferredSplitForCommand({
+        activeSplitView: null,
+        splitViewsById: {
+          "split-first": firstSplit,
+          "split-second": secondSplit,
+        },
+        restorableSplitViewId: "split-first",
+        threadId: THREAD_C,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when no split is active and no persisted split owns the thread", () => {
+    expect(
+      resolvePreferredSplitForCommand({
+        activeSplitView: null,
+        splitViewsById: {},
+        restorableSplitViewId: null,
+        threadId: THREAD_A,
       }),
     ).toBeNull();
   });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -14,7 +14,6 @@ import {
   getSidebarThreadIdsToPrewarm,
   getRenderedThreadsForSidebarProject,
   groupSidebarThreadsByProjectId,
-  groupSplitViewsByProjectId,
   getUnpinnedThreadsForSidebar,
   getVisibleSidebarThreadIds,
   getVisibleThreadsForProject,
@@ -40,7 +39,6 @@ import {
   type SidebarThreadSummary,
   type Thread,
 } from "../types";
-import type { SplitView } from "../splitViewStore";
 
 function makeLatestTurn(overrides?: {
   completedAt?: string | null;
@@ -876,6 +874,30 @@ describe("getSidebarThreadIdsToPrewarm", () => {
       }),
     ).toEqual([ThreadId.makeUnsafe("thread-1"), ThreadId.makeUnsafe("thread-2")]);
   });
+
+  it("prioritizes the active thread neighborhood before filling the limit", () => {
+    expect(
+      getSidebarThreadIdsToPrewarm({
+        visibleThreadIds: [
+          ThreadId.makeUnsafe("thread-1"),
+          ThreadId.makeUnsafe("thread-2"),
+          ThreadId.makeUnsafe("thread-3"),
+          ThreadId.makeUnsafe("thread-4"),
+          ThreadId.makeUnsafe("thread-5"),
+          ThreadId.makeUnsafe("thread-6"),
+        ],
+        activeThreadId: ThreadId.makeUnsafe("thread-5"),
+        limit: 5,
+        neighborRadius: 1,
+      }),
+    ).toEqual([
+      ThreadId.makeUnsafe("thread-4"),
+      ThreadId.makeUnsafe("thread-5"),
+      ThreadId.makeUnsafe("thread-6"),
+      ThreadId.makeUnsafe("thread-1"),
+      ThreadId.makeUnsafe("thread-2"),
+    ]);
+  });
 });
 
 function makeProject(overrides: Partial<Project> = {}): Project {
@@ -956,221 +978,25 @@ function makeSidebarThreadSummary(
   };
 }
 
-function makeSplitView(overrides: Partial<SplitView> = {}): SplitView {
-  const sourceThreadId = (overrides.sourceThreadId ?? ThreadId.makeUnsafe("thread-1")) as ThreadId;
-  const ownerProjectId = (overrides.ownerProjectId ??
-    ProjectId.makeUnsafe("project-1")) as ProjectId;
-  const firstLeaf = {
-    kind: "leaf" as const,
-    id: "pane-first",
-    threadId: sourceThreadId,
-    panel: {
-      panel: null,
-      diffTurnId: null,
-      diffFilePath: null,
-      hasOpenedPanel: false,
-      lastOpenPanel: "browser" as const,
-    },
-  };
-  const secondLeaf = {
-    kind: "leaf" as const,
-    id: "pane-second",
-    threadId: null,
-    panel: {
-      panel: null,
-      diffTurnId: null,
-      diffFilePath: null,
-      hasOpenedPanel: false,
-      lastOpenPanel: "browser" as const,
-    },
-  };
-  const root = {
-    kind: "split" as const,
-    id: "split-root",
-    direction: "horizontal" as const,
-    first: firstLeaf,
-    second: secondLeaf,
-    ratio: 0.5,
-  };
-
-  return {
-    id: "split-1",
-    sourceThreadId,
-    ownerProjectId,
-    root,
-    focusedPaneId: secondLeaf.id,
-    createdAt: "2026-03-09T10:00:00.000Z",
-    updatedAt: "2026-03-09T10:00:00.000Z",
-    ...overrides,
-  };
-}
-
 describe("deriveSidebarProjectData", () => {
-  it("replaces a thread row with its split view entry", () => {
+  it("shows split member threads as normal project rows", () => {
     const project = makeProject();
-    const threadOne = makeSidebarThreadSummary({
-      id: ThreadId.makeUnsafe("thread-1"),
-      title: "One",
-    });
-    const threadTwo = makeSidebarThreadSummary({
-      id: ThreadId.makeUnsafe("thread-2"),
-      title: "Two",
-      createdAt: "2026-03-09T10:05:00.000Z",
-      updatedAt: "2026-03-09T10:05:00.000Z",
-    });
-    const splitView = makeSplitView({
-      sourceThreadId: threadOne.id,
-      ownerProjectId: project.id,
-    });
-
-    const data = deriveSidebarProjectData({
-      projects: [project],
-      sortedSidebarThreadsByProjectId: groupSidebarThreadsByProjectId([threadOne, threadTwo]),
-      splitViewsByProjectId: groupSplitViewsByProjectId([splitView]),
-      splitViewBySourceThreadId: new Map([[splitView.sourceThreadId, splitView]]),
-      pinnedThreadIds: [],
-      pinnedThreadIdSet: new Set(),
-      expandedParentThreadIds: new Set(),
-      expandedThreadListProjectCwds: new Set(),
-      normalizeProjectCwd: (cwd) => cwd,
-      activeSidebarThreadId: undefined,
-      previewLimit: 5,
-    });
-
-    expect(data.get(project.id)?.visibleEntries).toEqual([
-      expect.objectContaining({
-        kind: "split",
-        rowId: splitView.sourceThreadId,
-      }),
-      expect.objectContaining({
-        kind: "thread",
-        rowId: threadTwo.id,
-      }),
-    ]);
-  });
-
-  it("keeps a split view visible after its source thread is gone", () => {
-    const project = makeProject();
-    const deletedSourceThreadId = ThreadId.makeUnsafe("thread-deleted-source");
-    const remainingThread = makeSidebarThreadSummary({
-      id: ThreadId.makeUnsafe("thread-remaining"),
-      title: "Remaining",
-    });
-    const splitView = makeSplitView({
-      sourceThreadId: deletedSourceThreadId,
-      ownerProjectId: project.id,
-    });
-
-    const data = deriveSidebarProjectData({
-      projects: [project],
-      sortedSidebarThreadsByProjectId: groupSidebarThreadsByProjectId([remainingThread]),
-      splitViewsByProjectId: groupSplitViewsByProjectId([splitView]),
-      splitViewBySourceThreadId: new Map(),
-      pinnedThreadIds: [],
-      pinnedThreadIdSet: new Set(),
-      expandedParentThreadIds: new Set(),
-      expandedThreadListProjectCwds: new Set(),
-      normalizeProjectCwd: (cwd) => cwd,
-      activeSidebarThreadId: undefined,
-      previewLimit: 5,
-    });
-
-    expect(data.get(project.id)?.visibleEntries).toEqual([
-      expect.objectContaining({
-        kind: "thread",
-        rowId: remainingThread.id,
-      }),
-      expect.objectContaining({
-        kind: "split",
-        rowId: deletedSourceThreadId,
-      }),
-    ]);
-  });
-
-  it("keeps an active orphaned split visible when the project preview is collapsed", () => {
-    const project = makeProject();
-    const deletedSourceThreadId = ThreadId.makeUnsafe("thread-deleted-source");
-    const firstThread = makeSidebarThreadSummary({
-      id: ThreadId.makeUnsafe("thread-first"),
-      title: "First",
-    });
-    const secondThread = makeSidebarThreadSummary({
-      id: ThreadId.makeUnsafe("thread-second"),
-      title: "Second",
-      createdAt: "2026-03-09T10:05:00.000Z",
-      updatedAt: "2026-03-09T10:05:00.000Z",
-    });
-    const splitView = makeSplitView({
-      sourceThreadId: deletedSourceThreadId,
-      ownerProjectId: project.id,
-    });
-
-    const data = deriveSidebarProjectData({
-      projects: [project],
-      sortedSidebarThreadsByProjectId: groupSidebarThreadsByProjectId([firstThread, secondThread]),
-      splitViewsByProjectId: groupSplitViewsByProjectId([splitView]),
-      splitViewBySourceThreadId: new Map(),
-      pinnedThreadIds: [],
-      pinnedThreadIdSet: new Set(),
-      expandedParentThreadIds: new Set(),
-      expandedThreadListProjectCwds: new Set(),
-      normalizeProjectCwd: (cwd) => cwd,
-      activeSidebarThreadId: deletedSourceThreadId,
-      previewLimit: 1,
-    });
-
-    expect(data.get(project.id)).toMatchObject({
-      activeEntryId: deletedSourceThreadId,
-      visibleEntries: expect.arrayContaining([
-        expect.objectContaining({
-          kind: "split",
-          rowId: deletedSourceThreadId,
-        }),
-      ]),
-    });
-  });
-
-  it("hides additional split-view leaf threads from the regular project list to avoid duplicates", () => {
-    // The split's `secondLeaf` is now bound to `threadTwo`, simulating a chat that the user
-    // dragged into the split. That thread must not also appear as a standalone row in the
-    // sidebar -- it lives only inside the split-chats group.
-    const project = makeProject();
-    const sourceThreadId = ThreadId.makeUnsafe("thread-source");
-    const droppedThreadId = ThreadId.makeUnsafe("thread-dropped");
-    const standaloneThreadId = ThreadId.makeUnsafe("thread-standalone");
     const sourceThread = makeSidebarThreadSummary({
-      id: sourceThreadId,
+      id: ThreadId.makeUnsafe("thread-source"),
       title: "Source",
     });
     const droppedThread = makeSidebarThreadSummary({
-      id: droppedThreadId,
+      id: ThreadId.makeUnsafe("thread-dropped"),
       title: "Dropped",
       createdAt: "2026-03-09T10:05:00.000Z",
       updatedAt: "2026-03-09T10:05:00.000Z",
     });
     const standaloneThread = makeSidebarThreadSummary({
-      id: standaloneThreadId,
+      id: ThreadId.makeUnsafe("thread-standalone"),
       title: "Standalone",
       createdAt: "2026-03-09T10:10:00.000Z",
       updatedAt: "2026-03-09T10:10:00.000Z",
     });
-    const baseSplitView = makeSplitView({
-      sourceThreadId,
-      ownerProjectId: project.id,
-    });
-    const splitView: SplitView = {
-      ...baseSplitView,
-      root:
-        baseSplitView.root.kind === "split"
-          ? {
-              ...baseSplitView.root,
-              second:
-                baseSplitView.root.second.kind === "leaf"
-                  ? { ...baseSplitView.root.second, threadId: droppedThreadId }
-                  : baseSplitView.root.second,
-            }
-          : baseSplitView.root,
-    };
 
     const data = deriveSidebarProjectData({
       projects: [project],
@@ -1179,42 +1005,7 @@ describe("deriveSidebarProjectData", () => {
         droppedThread,
         standaloneThread,
       ]),
-      splitViewsByProjectId: groupSplitViewsByProjectId([splitView]),
-      splitViewBySourceThreadId: new Map([[splitView.sourceThreadId, splitView]]),
       pinnedThreadIds: [],
-      pinnedThreadIdSet: new Set(),
-      expandedParentThreadIds: new Set(),
-      expandedThreadListProjectCwds: new Set(),
-      normalizeProjectCwd: (cwd) => cwd,
-      activeSidebarThreadId: undefined,
-      previewLimit: 5,
-    });
-
-    const visibleEntries = data.get(project.id)?.visibleEntries ?? [];
-    expect(visibleEntries).toEqual([
-      expect.objectContaining({ kind: "split", rowId: sourceThreadId }),
-      expect.objectContaining({ kind: "thread", rowId: standaloneThreadId }),
-    ]);
-    expect(
-      visibleEntries.some((entry) => entry.kind === "thread" && entry.rowId === droppedThreadId),
-    ).toBe(false);
-  });
-
-  it("does not hide orphaned splits because of stale pinned source state", () => {
-    const project = makeProject();
-    const deletedSourceThreadId = ThreadId.makeUnsafe("thread-deleted-source");
-    const splitView = makeSplitView({
-      sourceThreadId: deletedSourceThreadId,
-      ownerProjectId: project.id,
-    });
-
-    const data = deriveSidebarProjectData({
-      projects: [project],
-      sortedSidebarThreadsByProjectId: groupSidebarThreadsByProjectId([]),
-      splitViewsByProjectId: groupSplitViewsByProjectId([splitView]),
-      splitViewBySourceThreadId: new Map(),
-      pinnedThreadIds: [deletedSourceThreadId],
-      pinnedThreadIdSet: new Set([deletedSourceThreadId]),
       expandedParentThreadIds: new Set(),
       expandedThreadListProjectCwds: new Set(),
       normalizeProjectCwd: (cwd) => cwd,
@@ -1223,10 +1014,9 @@ describe("deriveSidebarProjectData", () => {
     });
 
     expect(data.get(project.id)?.visibleEntries).toEqual([
-      expect.objectContaining({
-        kind: "split",
-        rowId: deletedSourceThreadId,
-      }),
+      expect.objectContaining({ kind: "thread", rowId: sourceThread.id }),
+      expect.objectContaining({ kind: "thread", rowId: droppedThread.id }),
+      expect.objectContaining({ kind: "thread", rowId: standaloneThread.id }),
     ]);
   });
 
@@ -1256,10 +1046,7 @@ describe("deriveSidebarProjectData", () => {
         threadTwo,
         threadThree,
       ]),
-      splitViewsByProjectId: groupSplitViewsByProjectId([]),
-      splitViewBySourceThreadId: new Map(),
       pinnedThreadIds: [],
-      pinnedThreadIdSet: new Set(),
       expandedParentThreadIds: new Set(),
       expandedThreadListProjectCwds: new Set(),
       normalizeProjectCwd: (cwd) => cwd,
@@ -1289,10 +1076,7 @@ describe("deriveSidebarProjectData", () => {
     const data = deriveSidebarProjectData({
       projects: [project],
       sortedSidebarThreadsByProjectId: groupSidebarThreadsByProjectId([threadOne]),
-      splitViewsByProjectId: groupSplitViewsByProjectId([]),
-      splitViewBySourceThreadId: new Map(),
       pinnedThreadIds: [],
-      pinnedThreadIdSet: new Set(),
       expandedParentThreadIds: new Set(),
       expandedThreadListProjectCwds: new Set(),
       normalizeProjectCwd: (cwd) => cwd,

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -957,28 +957,48 @@ function makeSidebarThreadSummary(
 }
 
 function makeSplitView(overrides: Partial<SplitView> = {}): SplitView {
+  const sourceThreadId = (overrides.sourceThreadId ?? ThreadId.makeUnsafe("thread-1")) as ThreadId;
+  const ownerProjectId = (overrides.ownerProjectId ??
+    ProjectId.makeUnsafe("project-1")) as ProjectId;
+  const firstLeaf = {
+    kind: "leaf" as const,
+    id: "pane-first",
+    threadId: sourceThreadId,
+    panel: {
+      panel: null,
+      diffTurnId: null,
+      diffFilePath: null,
+      hasOpenedPanel: false,
+      lastOpenPanel: "browser" as const,
+    },
+  };
+  const secondLeaf = {
+    kind: "leaf" as const,
+    id: "pane-second",
+    threadId: null,
+    panel: {
+      panel: null,
+      diffTurnId: null,
+      diffFilePath: null,
+      hasOpenedPanel: false,
+      lastOpenPanel: "browser" as const,
+    },
+  };
+  const root = {
+    kind: "split" as const,
+    id: "split-root",
+    direction: "horizontal" as const,
+    first: firstLeaf,
+    second: secondLeaf,
+    ratio: 0.5,
+  };
+
   return {
     id: "split-1",
-    sourceThreadId: ThreadId.makeUnsafe("thread-1"),
-    ownerProjectId: ProjectId.makeUnsafe("project-1"),
-    leftThreadId: ThreadId.makeUnsafe("thread-1"),
-    rightThreadId: null,
-    focusedPane: "right",
-    ratio: 0.5,
-    leftPanel: {
-      panel: null,
-      diffTurnId: null,
-      diffFilePath: null,
-      hasOpenedPanel: false,
-      lastOpenPanel: "browser",
-    },
-    rightPanel: {
-      panel: null,
-      diffTurnId: null,
-      diffFilePath: null,
-      hasOpenedPanel: false,
-      lastOpenPanel: "browser",
-    },
+    sourceThreadId,
+    ownerProjectId,
+    root,
+    focusedPaneId: secondLeaf.id,
     createdAt: "2026-03-09T10:00:00.000Z",
     updatedAt: "2026-03-09T10:00:00.000Z",
     ...overrides,
@@ -1001,7 +1021,6 @@ describe("deriveSidebarProjectData", () => {
     const splitView = makeSplitView({
       sourceThreadId: threadOne.id,
       ownerProjectId: project.id,
-      leftThreadId: threadOne.id,
     });
 
     const data = deriveSidebarProjectData({
@@ -1026,6 +1045,117 @@ describe("deriveSidebarProjectData", () => {
       expect.objectContaining({
         kind: "thread",
         rowId: threadTwo.id,
+      }),
+    ]);
+  });
+
+  it("keeps a split view visible after its source thread is gone", () => {
+    const project = makeProject();
+    const deletedSourceThreadId = ThreadId.makeUnsafe("thread-deleted-source");
+    const remainingThread = makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe("thread-remaining"),
+      title: "Remaining",
+    });
+    const splitView = makeSplitView({
+      sourceThreadId: deletedSourceThreadId,
+      ownerProjectId: project.id,
+    });
+
+    const data = deriveSidebarProjectData({
+      projects: [project],
+      sortedSidebarThreadsByProjectId: groupSidebarThreadsByProjectId([remainingThread]),
+      splitViewsByProjectId: groupSplitViewsByProjectId([splitView]),
+      splitViewBySourceThreadId: new Map(),
+      pinnedThreadIds: [],
+      pinnedThreadIdSet: new Set(),
+      expandedParentThreadIds: new Set(),
+      expandedThreadListProjectCwds: new Set(),
+      normalizeProjectCwd: (cwd) => cwd,
+      activeSidebarThreadId: undefined,
+      previewLimit: 5,
+    });
+
+    expect(data.get(project.id)?.visibleEntries).toEqual([
+      expect.objectContaining({
+        kind: "thread",
+        rowId: remainingThread.id,
+      }),
+      expect.objectContaining({
+        kind: "split",
+        rowId: deletedSourceThreadId,
+      }),
+    ]);
+  });
+
+  it("keeps an active orphaned split visible when the project preview is collapsed", () => {
+    const project = makeProject();
+    const deletedSourceThreadId = ThreadId.makeUnsafe("thread-deleted-source");
+    const firstThread = makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe("thread-first"),
+      title: "First",
+    });
+    const secondThread = makeSidebarThreadSummary({
+      id: ThreadId.makeUnsafe("thread-second"),
+      title: "Second",
+      createdAt: "2026-03-09T10:05:00.000Z",
+      updatedAt: "2026-03-09T10:05:00.000Z",
+    });
+    const splitView = makeSplitView({
+      sourceThreadId: deletedSourceThreadId,
+      ownerProjectId: project.id,
+    });
+
+    const data = deriveSidebarProjectData({
+      projects: [project],
+      sortedSidebarThreadsByProjectId: groupSidebarThreadsByProjectId([firstThread, secondThread]),
+      splitViewsByProjectId: groupSplitViewsByProjectId([splitView]),
+      splitViewBySourceThreadId: new Map(),
+      pinnedThreadIds: [],
+      pinnedThreadIdSet: new Set(),
+      expandedParentThreadIds: new Set(),
+      expandedThreadListProjectCwds: new Set(),
+      normalizeProjectCwd: (cwd) => cwd,
+      activeSidebarThreadId: deletedSourceThreadId,
+      previewLimit: 1,
+    });
+
+    expect(data.get(project.id)).toMatchObject({
+      activeEntryId: deletedSourceThreadId,
+      visibleEntries: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "split",
+          rowId: deletedSourceThreadId,
+        }),
+      ]),
+    });
+  });
+
+  it("does not hide orphaned splits because of stale pinned source state", () => {
+    const project = makeProject();
+    const deletedSourceThreadId = ThreadId.makeUnsafe("thread-deleted-source");
+    const splitView = makeSplitView({
+      sourceThreadId: deletedSourceThreadId,
+      ownerProjectId: project.id,
+    });
+
+    const data = deriveSidebarProjectData({
+      projects: [project],
+      sortedSidebarThreadsByProjectId: groupSidebarThreadsByProjectId([]),
+      splitViewsByProjectId: groupSplitViewsByProjectId([splitView]),
+      splitViewBySourceThreadId: new Map(),
+      pinnedThreadIds: [deletedSourceThreadId],
+      pinnedThreadIdSet: new Set([deletedSourceThreadId]),
+      expandedParentThreadIds: new Set(),
+      expandedThreadListProjectCwds: new Set(),
+      normalizeProjectCwd: (cwd) => cwd,
+      activeSidebarThreadId: undefined,
+      previewLimit: 5,
+    });
+
+    expect(data.get(project.id)?.visibleEntries).toEqual([
+      expect.objectContaining({
+        kind: "split",
+        rowId: deletedSourceThreadId,
       }),
     ]);
   });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1130,6 +1130,76 @@ describe("deriveSidebarProjectData", () => {
     });
   });
 
+  it("hides additional split-view leaf threads from the regular project list to avoid duplicates", () => {
+    // The split's `secondLeaf` is now bound to `threadTwo`, simulating a chat that the user
+    // dragged into the split. That thread must not also appear as a standalone row in the
+    // sidebar -- it lives only inside the split-chats group.
+    const project = makeProject();
+    const sourceThreadId = ThreadId.makeUnsafe("thread-source");
+    const droppedThreadId = ThreadId.makeUnsafe("thread-dropped");
+    const standaloneThreadId = ThreadId.makeUnsafe("thread-standalone");
+    const sourceThread = makeSidebarThreadSummary({
+      id: sourceThreadId,
+      title: "Source",
+    });
+    const droppedThread = makeSidebarThreadSummary({
+      id: droppedThreadId,
+      title: "Dropped",
+      createdAt: "2026-03-09T10:05:00.000Z",
+      updatedAt: "2026-03-09T10:05:00.000Z",
+    });
+    const standaloneThread = makeSidebarThreadSummary({
+      id: standaloneThreadId,
+      title: "Standalone",
+      createdAt: "2026-03-09T10:10:00.000Z",
+      updatedAt: "2026-03-09T10:10:00.000Z",
+    });
+    const baseSplitView = makeSplitView({
+      sourceThreadId,
+      ownerProjectId: project.id,
+    });
+    const splitView: SplitView = {
+      ...baseSplitView,
+      root:
+        baseSplitView.root.kind === "split"
+          ? {
+              ...baseSplitView.root,
+              second:
+                baseSplitView.root.second.kind === "leaf"
+                  ? { ...baseSplitView.root.second, threadId: droppedThreadId }
+                  : baseSplitView.root.second,
+            }
+          : baseSplitView.root,
+    };
+
+    const data = deriveSidebarProjectData({
+      projects: [project],
+      sortedSidebarThreadsByProjectId: groupSidebarThreadsByProjectId([
+        sourceThread,
+        droppedThread,
+        standaloneThread,
+      ]),
+      splitViewsByProjectId: groupSplitViewsByProjectId([splitView]),
+      splitViewBySourceThreadId: new Map([[splitView.sourceThreadId, splitView]]),
+      pinnedThreadIds: [],
+      pinnedThreadIdSet: new Set(),
+      expandedParentThreadIds: new Set(),
+      expandedThreadListProjectCwds: new Set(),
+      normalizeProjectCwd: (cwd) => cwd,
+      activeSidebarThreadId: undefined,
+      previewLimit: 5,
+    });
+
+    const visibleEntries = data.get(project.id)?.visibleEntries ?? [];
+    expect(visibleEntries).toEqual([
+      expect.objectContaining({ kind: "split", rowId: sourceThreadId }),
+      expect.objectContaining({ kind: "thread", rowId: standaloneThreadId }),
+    ]);
+    expect(
+      visibleEntries.some((entry) => entry.kind === "thread" && entry.rowId === droppedThreadId),
+    ).toBe(false);
+  });
+
   it("does not hide orphaned splits because of stale pinned source state", () => {
     const project = makeProject();
     const deletedSourceThreadId = ThreadId.makeUnsafe("thread-deleted-source");

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -941,13 +941,16 @@ export function deriveSidebarProjectData(input: {
 
   for (const project of input.projects) {
     const allProjectThreads = input.sortedSidebarThreadsByProjectId.get(project.id) ?? [];
+    const allProjectThreadIds = new Set(allProjectThreads.map((thread) => thread.id));
     const projectThreads = getUnpinnedThreadsForSidebar(allProjectThreads, input.pinnedThreadIds);
     const projectThreadTree = buildProjectThreadTree({
       threads: projectThreads,
       expandedParentThreadIds: input.expandedParentThreadIds,
     });
     const projectSplitViews = (input.splitViewsByProjectId.get(project.id) ?? []).filter(
-      (splitView) => !input.pinnedThreadIdSet.has(splitView.sourceThreadId),
+      (splitView) =>
+        !input.pinnedThreadIdSet.has(splitView.sourceThreadId) ||
+        !allProjectThreadIds.has(splitView.sourceThreadId),
     );
     const projectStatus = resolveProjectStatusIndicator(
       allProjectThreads.map((thread) =>
@@ -963,9 +966,7 @@ export function deriveSidebarProjectData(input: {
     const isThreadListExpanded = input.expandedThreadListProjectCwds.has(
       input.normalizeProjectCwd(project.cwd),
     );
-    const replacedThreadIds = new Set(
-      projectSplitViews.map((splitView) => splitView.sourceThreadId),
-    );
+    const renderedSplitViewIds = new Set<SplitView["id"]>();
     const orderedEntries: SidebarProjectEntry[] = projectThreadTree.map(
       ({ thread, depth, rootThreadId, childCount, isExpanded }) => {
         const splitView = input.splitViewBySourceThreadId.get(thread.id);
@@ -980,6 +981,7 @@ export function deriveSidebarProjectData(input: {
             isExpanded,
           };
         }
+        renderedSplitViewIds.add(splitView.id);
         return {
           kind: "split",
           rowId: splitView.sourceThreadId,
@@ -990,7 +992,7 @@ export function deriveSidebarProjectData(input: {
     );
 
     for (const splitView of projectSplitViews) {
-      if (replacedThreadIds.has(splitView.sourceThreadId)) continue;
+      if (renderedSplitViewIds.has(splitView.id)) continue;
       orderedEntries.push({
         kind: "split",
         rowId: splitView.sourceThreadId,

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -9,6 +9,12 @@ import { cn } from "../lib/utils";
 import { isDuplicateProjectCreateError } from "../lib/projectCreateRecovery";
 import { workspaceRootsEqual } from "@t3tools/shared/threadWorkspace";
 import {
+  resolveSplitViewPaneIdForThread,
+  type PaneId,
+  type SplitView,
+  type SplitViewId,
+} from "../splitViewStore";
+import {
   hasLiveLatestTurn,
   findLatestProposedPlan,
   hasActionableProposedPlan,
@@ -23,10 +29,6 @@ export {
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 10;
 export type SidebarNewThreadEnvMode = "local" | "worktree";
-export type SidebarLastThreadRoute = {
-  threadId: string;
-  splitViewId?: string | undefined;
-};
 type SidebarProject = {
   id: string;
   name: string;
@@ -60,6 +62,11 @@ export type SidebarDerivedProjectData = {
   projectStatus: ReturnType<typeof resolveProjectStatusIndicator>;
 };
 
+export type ThreadCommandActivation =
+  | { kind: "ignore" }
+  | { kind: "single"; threadId: ThreadId }
+  | { kind: "split"; threadId: ThreadId; splitViewId: string; paneId: string };
+
 const THREAD_JUMP_COMMANDS = [
   "thread.jump.1",
   "thread.jump.2",
@@ -71,6 +78,67 @@ const THREAD_JUMP_COMMANDS = [
   "thread.jump.8",
   "thread.jump.9",
 ] as const satisfies readonly KeybindingCommand[];
+
+/**
+ * Decide what a keyboard/search activation should do for a given thread.
+ *
+ * Callers decide which split (if any) is "preferred". For command/search
+ * activation, that means the currently active split first; if no split is
+ * active, only the last exited split can be restored. When
+ * `preferredSplitViewId`/`splitPaneId` are set the activation focuses that
+ * split's pane; otherwise the thread is opened as a single chat.
+ */
+export function resolveThreadCommandActivation(input: {
+  threadId: ThreadId;
+  threadExists: boolean;
+  activeSidebarThreadId: ThreadId | null | undefined;
+  preferredSplitViewId: string | null;
+  splitPaneId: string | null;
+}): ThreadCommandActivation {
+  if (!input.threadExists) {
+    return { kind: "ignore" };
+  }
+
+  if (input.preferredSplitViewId && input.splitPaneId) {
+    return {
+      kind: "split",
+      threadId: input.threadId,
+      splitViewId: input.preferredSplitViewId,
+      paneId: input.splitPaneId,
+    };
+  }
+
+  if (input.threadId === input.activeSidebarThreadId) {
+    return { kind: "ignore" };
+  }
+
+  return { kind: "single", threadId: input.threadId };
+}
+
+/**
+ * Resolve whether command/search activation should land in a split.
+ *
+ * While a split is active, only that split's own panes count. From single chat,
+ * only the last exited split may be restored; older persisted pairings stay
+ * dormant so generic thread switching never resurrects random layouts.
+ */
+export function resolvePreferredSplitForCommand(input: {
+  activeSplitView: SplitView | null;
+  splitViewsById: Record<SplitViewId, SplitView | undefined>;
+  restorableSplitViewId: SplitViewId | null;
+  threadId: ThreadId;
+}): { splitViewId: SplitViewId; paneId: PaneId } | null {
+  if (input.activeSplitView) {
+    const paneId = resolveSplitViewPaneIdForThread(input.activeSplitView, input.threadId);
+    return paneId ? { splitViewId: input.activeSplitView.id, paneId } : null;
+  }
+
+  if (!input.restorableSplitViewId) return null;
+
+  const splitView = input.splitViewsById[input.restorableSplitViewId] ?? null;
+  const paneId = splitView ? resolveSplitViewPaneIdForThread(splitView, input.threadId) : null;
+  return splitView && paneId ? { splitViewId: splitView.id, paneId } : null;
+}
 
 export interface ThreadStatusPill {
   label:
@@ -148,19 +216,6 @@ export function resolveSidebarNewThreadEnvMode(input: {
   defaultEnvMode: SidebarNewThreadEnvMode;
 }): SidebarNewThreadEnvMode {
   return input.requestedEnvMode ?? input.defaultEnvMode;
-}
-
-// Reuses the last visited thread route when leaving special views like settings.
-export function resolveSidebarRestorableThreadRoute(input: {
-  lastThreadRoute: SidebarLastThreadRoute | null;
-  availableThreadIds: ReadonlySet<string>;
-}): SidebarLastThreadRoute | null {
-  const { lastThreadRoute, availableThreadIds } = input;
-  if (!lastThreadRoute) {
-    return null;
-  }
-
-  return availableThreadIds.has(lastThreadRoute.threadId) ? lastThreadRoute : null;
 }
 
 // Drops remembered "show more" state for projects that are currently collapsed.
@@ -947,10 +1002,7 @@ export function deriveSidebarProjectData(input: {
 
   for (const project of input.projects) {
     const allProjectThreads = input.sortedSidebarThreadsByProjectId.get(project.id) ?? [];
-    const projectThreads = getUnpinnedThreadsForSidebar(
-      allProjectThreads,
-      input.pinnedThreadIds,
-    );
+    const projectThreads = getUnpinnedThreadsForSidebar(allProjectThreads, input.pinnedThreadIds);
     const projectThreadTree = buildProjectThreadTree({
       threads: projectThreads,
       expandedParentThreadIds: input.expandedParentThreadIds,

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -14,8 +14,6 @@ import {
   hasActionableProposedPlan,
   isLatestTurnSettled,
 } from "../session-logic";
-import { collectLeaves } from "../splitView.logic";
-import type { SplitView } from "../splitViewStore";
 
 export {
   extractDuplicateProjectCreateProjectId,
@@ -42,22 +40,15 @@ type SidebarThreadSortInput = {
   messages?: ReadonlyArray<Pick<ChatMessage, "role" | "createdAt">> | undefined;
 };
 
-export type SidebarProjectEntry =
-  | {
-      kind: "thread";
-      rowId: ThreadId;
-      rootRowId: ThreadId;
-      thread: SidebarThreadSummary;
-      depth: number;
-      childCount: number;
-      isExpanded: boolean;
-    }
-  | {
-      kind: "split";
-      rowId: ThreadId;
-      rootRowId: ThreadId;
-      splitView: SplitView;
-    };
+export type SidebarProjectEntry = {
+  kind: "thread";
+  rowId: ThreadId;
+  rootRowId: ThreadId;
+  thread: SidebarThreadSummary;
+  depth: number;
+  childCount: number;
+  isExpanded: boolean;
+};
 
 export type SidebarDerivedProjectData = {
   projectThreads: SidebarThreadSummary[];
@@ -746,10 +737,43 @@ export function getSidebarThreadIdForJumpCommand(input: {
 
 export function getSidebarThreadIdsToPrewarm(input: {
   visibleThreadIds: readonly Thread["id"][];
+  activeThreadId?: Thread["id"] | null;
   limit?: number;
+  neighborRadius?: number;
 }): Thread["id"][] {
   const limit = Math.max(0, input.limit ?? SIDEBAR_THREAD_PREWARM_LIMIT);
-  return input.visibleThreadIds.slice(0, limit);
+  if (limit === 0) {
+    return [];
+  }
+  const prewarmedThreadIds = new Set<Thread["id"]>();
+  const neighborRadius = Math.max(0, input.neighborRadius ?? 2);
+  const activeIndex =
+    input.activeThreadId === undefined || input.activeThreadId === null
+      ? -1
+      : input.visibleThreadIds.indexOf(input.activeThreadId);
+
+  if (activeIndex >= 0) {
+    const start = Math.max(0, activeIndex - neighborRadius);
+    const end = Math.min(input.visibleThreadIds.length - 1, activeIndex + neighborRadius);
+    for (let index = start; index <= end; index += 1) {
+      if (prewarmedThreadIds.size >= limit) {
+        break;
+      }
+      const threadId = input.visibleThreadIds[index];
+      if (threadId) {
+        prewarmedThreadIds.add(threadId);
+      }
+    }
+  }
+
+  for (const threadId of input.visibleThreadIds) {
+    if (prewarmedThreadIds.size >= limit) {
+      break;
+    }
+    prewarmedThreadIds.add(threadId);
+  }
+
+  return [...prewarmedThreadIds];
 }
 
 function toSortableTimestamp(iso: string | undefined): number | null {
@@ -905,30 +929,11 @@ export function groupSidebarThreadsByProjectId(
   return byProjectId;
 }
 
-// Groups split views once so project renderers do not rescan the full split list every render.
-export function groupSplitViewsByProjectId(
-  splitViews: readonly SplitView[],
-): ReadonlyMap<ProjectId, SplitView[]> {
-  const byProjectId = new Map<ProjectId, SplitView[]>();
-  for (const splitView of splitViews) {
-    const existing = byProjectId.get(splitView.ownerProjectId);
-    if (existing) {
-      existing.push(splitView);
-    } else {
-      byProjectId.set(splitView.ownerProjectId, [splitView]);
-    }
-  }
-  return byProjectId;
-}
-
 // Centralizes the expensive per-project row derivation so Sidebar.tsx can mostly orchestrate UI state.
 export function deriveSidebarProjectData(input: {
   projects: readonly Pick<Project, "id" | "cwd" | "expanded">[];
   sortedSidebarThreadsByProjectId: ReadonlyMap<ProjectId, SidebarThreadSummary[]>;
-  splitViewsByProjectId: ReadonlyMap<ProjectId, SplitView[]>;
-  splitViewBySourceThreadId: ReadonlyMap<ThreadId, SplitView>;
   pinnedThreadIds: readonly ThreadId[];
-  pinnedThreadIdSet: ReadonlySet<ThreadId>;
   expandedParentThreadIds: ReadonlySet<ThreadId>;
   expandedThreadListProjectCwds: ReadonlySet<string>;
   normalizeProjectCwd: (cwd: string) => string;
@@ -942,28 +947,10 @@ export function deriveSidebarProjectData(input: {
 
   for (const project of input.projects) {
     const allProjectThreads = input.sortedSidebarThreadsByProjectId.get(project.id) ?? [];
-    const allProjectThreadIds = new Set(allProjectThreads.map((thread) => thread.id));
-    const projectSplitViews = (input.splitViewsByProjectId.get(project.id) ?? []).filter(
-      (splitView) =>
-        !input.pinnedThreadIdSet.has(splitView.sourceThreadId) ||
-        !allProjectThreadIds.has(splitView.sourceThreadId),
-    );
-    // Threads that already live inside a split-view group must not appear again as
-    // standalone rows in the regular project list. The split's source thread keeps its
-    // slot (it gets replaced in-place by the split entry below) so we only hide the
-    // additional panes that have been dropped into the split.
-    const threadIdsAdoptedBySplitGroups = new Set<ThreadId>();
-    for (const splitView of projectSplitViews) {
-      for (const leaf of collectLeaves(splitView.root)) {
-        if (leaf.threadId && leaf.threadId !== splitView.sourceThreadId) {
-          threadIdsAdoptedBySplitGroups.add(leaf.threadId);
-        }
-      }
-    }
     const projectThreads = getUnpinnedThreadsForSidebar(
       allProjectThreads,
       input.pinnedThreadIds,
-    ).filter((thread) => !threadIdsAdoptedBySplitGroups.has(thread.id));
+    );
     const projectThreadTree = buildProjectThreadTree({
       threads: projectThreads,
       expandedParentThreadIds: input.expandedParentThreadIds,
@@ -982,40 +969,17 @@ export function deriveSidebarProjectData(input: {
     const isThreadListExpanded = input.expandedThreadListProjectCwds.has(
       input.normalizeProjectCwd(project.cwd),
     );
-    const renderedSplitViewIds = new Set<SplitView["id"]>();
     const orderedEntries: SidebarProjectEntry[] = projectThreadTree.map(
-      ({ thread, depth, rootThreadId, childCount, isExpanded }) => {
-        const splitView = input.splitViewBySourceThreadId.get(thread.id);
-        if (!splitView) {
-          return {
-            kind: "thread",
-            rowId: thread.id,
-            rootRowId: rootThreadId,
-            thread,
-            depth,
-            childCount,
-            isExpanded,
-          };
-        }
-        renderedSplitViewIds.add(splitView.id);
-        return {
-          kind: "split",
-          rowId: splitView.sourceThreadId,
-          rootRowId: rootThreadId,
-          splitView,
-        };
-      },
+      ({ thread, depth, rootThreadId, childCount, isExpanded }) => ({
+        kind: "thread",
+        rowId: thread.id,
+        rootRowId: rootThreadId,
+        thread,
+        depth,
+        childCount,
+        isExpanded,
+      }),
     );
-
-    for (const splitView of projectSplitViews) {
-      if (renderedSplitViewIds.has(splitView.id)) continue;
-      orderedEntries.push({
-        kind: "split",
-        rowId: splitView.sourceThreadId,
-        rootRowId: splitView.sourceThreadId,
-        splitView,
-      });
-    }
 
     const activeEntry =
       input.activeSidebarThreadId === undefined

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -9,12 +9,6 @@ import { cn } from "../lib/utils";
 import { isDuplicateProjectCreateError } from "../lib/projectCreateRecovery";
 import { workspaceRootsEqual } from "@t3tools/shared/threadWorkspace";
 import {
-  resolveSplitViewPaneIdForThread,
-  type PaneId,
-  type SplitView,
-  type SplitViewId,
-} from "../splitViewStore";
-import {
   hasLiveLatestTurn,
   findLatestProposedPlan,
   hasActionableProposedPlan,
@@ -62,11 +56,6 @@ export type SidebarDerivedProjectData = {
   projectStatus: ReturnType<typeof resolveProjectStatusIndicator>;
 };
 
-export type ThreadCommandActivation =
-  | { kind: "ignore" }
-  | { kind: "single"; threadId: ThreadId }
-  | { kind: "split"; threadId: ThreadId; splitViewId: string; paneId: string };
-
 const THREAD_JUMP_COMMANDS = [
   "thread.jump.1",
   "thread.jump.2",
@@ -78,67 +67,6 @@ const THREAD_JUMP_COMMANDS = [
   "thread.jump.8",
   "thread.jump.9",
 ] as const satisfies readonly KeybindingCommand[];
-
-/**
- * Decide what a keyboard/search activation should do for a given thread.
- *
- * Callers decide which split (if any) is "preferred". For command/search
- * activation, that means the currently active split first; if no split is
- * active, only the last exited split can be restored. When
- * `preferredSplitViewId`/`splitPaneId` are set the activation focuses that
- * split's pane; otherwise the thread is opened as a single chat.
- */
-export function resolveThreadCommandActivation(input: {
-  threadId: ThreadId;
-  threadExists: boolean;
-  activeSidebarThreadId: ThreadId | null | undefined;
-  preferredSplitViewId: string | null;
-  splitPaneId: string | null;
-}): ThreadCommandActivation {
-  if (!input.threadExists) {
-    return { kind: "ignore" };
-  }
-
-  if (input.preferredSplitViewId && input.splitPaneId) {
-    return {
-      kind: "split",
-      threadId: input.threadId,
-      splitViewId: input.preferredSplitViewId,
-      paneId: input.splitPaneId,
-    };
-  }
-
-  if (input.threadId === input.activeSidebarThreadId) {
-    return { kind: "ignore" };
-  }
-
-  return { kind: "single", threadId: input.threadId };
-}
-
-/**
- * Resolve whether command/search activation should land in a split.
- *
- * While a split is active, only that split's own panes count. From single chat,
- * only the last exited split may be restored; older persisted pairings stay
- * dormant so generic thread switching never resurrects random layouts.
- */
-export function resolvePreferredSplitForCommand(input: {
-  activeSplitView: SplitView | null;
-  splitViewsById: Record<SplitViewId, SplitView | undefined>;
-  restorableSplitViewId: SplitViewId | null;
-  threadId: ThreadId;
-}): { splitViewId: SplitViewId; paneId: PaneId } | null {
-  if (input.activeSplitView) {
-    const paneId = resolveSplitViewPaneIdForThread(input.activeSplitView, input.threadId);
-    return paneId ? { splitViewId: input.activeSplitView.id, paneId } : null;
-  }
-
-  if (!input.restorableSplitViewId) return null;
-
-  const splitView = input.splitViewsById[input.restorableSplitViewId] ?? null;
-  const paneId = splitView ? resolveSplitViewPaneIdForThread(splitView, input.threadId) : null;
-  return splitView && paneId ? { splitViewId: splitView.id, paneId } : null;
-}
 
 export interface ThreadStatusPill {
   label:

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -14,6 +14,7 @@ import {
   hasActionableProposedPlan,
   isLatestTurnSettled,
 } from "../session-logic";
+import { collectLeaves } from "../splitView.logic";
 import type { SplitView } from "../splitViewStore";
 
 export {
@@ -942,16 +943,31 @@ export function deriveSidebarProjectData(input: {
   for (const project of input.projects) {
     const allProjectThreads = input.sortedSidebarThreadsByProjectId.get(project.id) ?? [];
     const allProjectThreadIds = new Set(allProjectThreads.map((thread) => thread.id));
-    const projectThreads = getUnpinnedThreadsForSidebar(allProjectThreads, input.pinnedThreadIds);
-    const projectThreadTree = buildProjectThreadTree({
-      threads: projectThreads,
-      expandedParentThreadIds: input.expandedParentThreadIds,
-    });
     const projectSplitViews = (input.splitViewsByProjectId.get(project.id) ?? []).filter(
       (splitView) =>
         !input.pinnedThreadIdSet.has(splitView.sourceThreadId) ||
         !allProjectThreadIds.has(splitView.sourceThreadId),
     );
+    // Threads that already live inside a split-view group must not appear again as
+    // standalone rows in the regular project list. The split's source thread keeps its
+    // slot (it gets replaced in-place by the split entry below) so we only hide the
+    // additional panes that have been dropped into the split.
+    const threadIdsAdoptedBySplitGroups = new Set<ThreadId>();
+    for (const splitView of projectSplitViews) {
+      for (const leaf of collectLeaves(splitView.root)) {
+        if (leaf.threadId && leaf.threadId !== splitView.sourceThreadId) {
+          threadIdsAdoptedBySplitGroups.add(leaf.threadId);
+        }
+      }
+    }
+    const projectThreads = getUnpinnedThreadsForSidebar(
+      allProjectThreads,
+      input.pinnedThreadIds,
+    ).filter((thread) => !threadIdsAdoptedBySplitGroups.has(thread.id));
+    const projectThreadTree = buildProjectThreadTree({
+      threads: projectThreads,
+      expandedParentThreadIds: input.expandedParentThreadIds,
+    });
     const projectStatus = resolveProjectStatusIndicator(
       allProjectThreads.map((thread) =>
         input.resolveThreadStatus

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -218,12 +218,15 @@ import {
 } from "../settingsNavigation";
 import {
   resolveSplitViewFocusedThreadId,
-  resolveSplitViewPaneForThread,
+  resolveSplitViewPaneIdForThread,
   selectSplitView,
+  type LeafPane,
+  type PaneId,
   type SplitView,
-  type SplitViewPane,
   useSplitViewStore,
 } from "../splitViewStore";
+import { collectLeaves, findLeafPaneById } from "../splitView.logic";
+import { THREAD_DRAG_MIME } from "./chat-drop-overlay/ChatPaneDropOverlay";
 import { useTemporaryThreadStore } from "../temporaryThreadStore";
 import { usePinnedThreadsStore } from "../pinnedThreadsStore";
 import { retainThreadDetailSubscription } from "../threadDetailSubscriptionRetention";
@@ -2202,7 +2205,7 @@ export default function Sidebar() {
       });
       const activeSplitViewId = routeSearch.splitViewId ?? null;
       const deletedPaneInActiveSplit = activeSplitView
-        ? resolveSplitViewPaneForThread(activeSplitView, threadId)
+        ? resolveSplitViewPaneIdForThread(activeSplitView, threadId)
         : null;
       await api.orchestration.dispatchCommand({
         type: "thread.delete",
@@ -2889,11 +2892,10 @@ export default function Sidebar() {
     ],
   );
   const returnSplitViewToSingleChat = useCallback(
-    (splitView: SplitView, pane: SplitViewPane) => {
+    (splitView: SplitView, paneId: PaneId) => {
+      const leaf = findLeafPaneById(splitView.root, paneId);
       const nextThreadId =
-        (pane === "left" ? splitView.leftThreadId : splitView.rightThreadId) ??
-        splitView.leftThreadId ??
-        splitView.rightThreadId;
+        leaf?.threadId ?? resolveSplitViewFocusedThreadId(splitView) ?? splitView.sourceThreadId;
       removeSplitView(splitView.id);
       if (!nextThreadId) {
         return;
@@ -2910,18 +2912,19 @@ export default function Sidebar() {
     [navigate, removeSplitView],
   );
   const handleSplitContextMenu = useCallback(
-    async (splitView: SplitView, pane: SplitViewPane, position: { x: number; y: number }) => {
+    async (splitView: SplitView, paneId: PaneId, position: { x: number; y: number }) => {
       const api = readNativeApi();
       if (!api) return;
 
-      const paneThreadId = pane === "left" ? splitView.leftThreadId : splitView.rightThreadId;
-      setSplitFocusedPane(splitView.id, pane);
+      const leaf = findLeafPaneById(splitView.root, paneId);
+      const paneThreadId = leaf?.threadId ?? null;
+      setSplitFocusedPane(splitView.id, paneId);
 
       if (paneThreadId) {
         await handleThreadContextMenu(paneThreadId, position, {
           extraItems: [{ id: "return-to-single-chat", label: "Return to single chat" }],
           onExtraAction: async () => {
-            returnSplitViewToSingleChat(splitView, pane);
+            returnSplitViewToSingleChat(splitView, paneId);
           },
         });
         return;
@@ -2932,7 +2935,7 @@ export default function Sidebar() {
         position,
       );
       if (clicked === "return-to-single-chat") {
-        returnSplitViewToSingleChat(splitView, pane);
+        returnSplitViewToSingleChat(splitView, paneId);
       }
     },
     [handleThreadContextMenu, returnSplitViewToSingleChat, setSplitFocusedPane],
@@ -3028,16 +3031,17 @@ export default function Sidebar() {
   );
 
   const activateSplitPane = useCallback(
-    (splitView: SplitView, pane: "left" | "right") => {
+    (splitView: SplitView, paneId: PaneId) => {
       if (selectedThreadIds.size > 0) {
         clearSelection();
       }
 
-      const paneThreadId = pane === "left" ? splitView.leftThreadId : splitView.rightThreadId;
-      const nextThreadId = paneThreadId ?? splitView.leftThreadId ?? splitView.rightThreadId;
+      const leaf = findLeafPaneById(splitView.root, paneId);
+      const paneThreadId = leaf?.threadId ?? null;
+      const nextThreadId = paneThreadId ?? resolveSplitViewFocusedThreadId(splitView);
 
       setSelectionAnchor(paneThreadId ?? splitView.sourceThreadId);
-      setSplitFocusedPane(splitView.id, pane);
+      setSplitFocusedPane(splitView.id, paneId);
 
       if (!nextThreadId) {
         return;
@@ -4124,6 +4128,23 @@ export default function Sidebar() {
             }),
             isSubagentThread ? "h-7 pr-7.5" : undefined,
           )}
+          draggable={renamingThreadId !== thread.id}
+          onDragStart={(event) => {
+            const dragImage = event.currentTarget as HTMLElement | null;
+            event.dataTransfer.effectAllowed = "move";
+            event.dataTransfer.setData(
+              THREAD_DRAG_MIME,
+              JSON.stringify({ threadId: thread.id, ownerProjectId: thread.projectId }),
+            );
+            if (dragImage) {
+              const rect = dragImage.getBoundingClientRect();
+              event.dataTransfer.setDragImage(
+                dragImage,
+                Math.max(0, event.clientX - rect.left),
+                Math.max(0, event.clientY - rect.top),
+              );
+            }
+          }}
           onClick={(event) =>
             handleThreadClick(event, thread.id, orderedProjectThreadIds, {
               isActive,
@@ -4352,8 +4373,7 @@ export default function Sidebar() {
       isThreadListExpanded,
     } = projectSidebarData;
     const renderSplitRow = (splitView: SplitView) => {
-      const leftPreview = resolveSplitPreview(splitView.leftThreadId);
-      const rightPreview = resolveSplitPreview(splitView.rightThreadId);
+      const leaves = collectLeaves(splitView.root);
       const isActive = routeSearch.splitViewId === splitView.id;
 
       return (
@@ -4366,10 +4386,10 @@ export default function Sidebar() {
               isActive,
               isSelected: false,
             })}
-            onClick={() => activateSplitPane(splitView, splitView.focusedPane)}
+            onClick={() => activateSplitPane(splitView, splitView.focusedPaneId)}
             onContextMenu={(event) => {
               event.preventDefault();
-              void handleSplitContextMenu(splitView, splitView.focusedPane, {
+              void handleSplitContextMenu(splitView, splitView.focusedPaneId, {
                 x: event.clientX,
                 y: event.clientY,
               });
@@ -4377,54 +4397,55 @@ export default function Sidebar() {
             onKeyDown={(event) => {
               if (event.key !== "Enter" && event.key !== " ") return;
               event.preventDefault();
-              activateSplitPane(splitView, splitView.focusedPane);
+              activateSplitPane(splitView, splitView.focusedPaneId);
             }}
           >
             <div className="-ml-1.5 flex min-w-0 flex-1 items-center gap-0.5">
-              {[
-                { pane: "left" as const, preview: leftPreview },
-                { pane: "right" as const, preview: rightPreview },
-              ].map(({ pane, preview }) => (
-                <div
-                  key={pane}
-                  role="button"
-                  tabIndex={0}
-                  className={cn(
-                    "flex min-w-0 flex-1 select-none items-center gap-1 rounded-md px-1.5 py-0.5 text-left outline-hidden transition-colors focus-visible:ring-1 focus-visible:ring-[color:var(--color-border-focus)]",
-                    splitView.focusedPane === pane
-                      ? "bg-[var(--color-background-button-secondary)] shadow-xs"
-                      : "hover:bg-[var(--sidebar-accent)]",
-                  )}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    activateSplitPane(splitView, pane);
-                  }}
-                  onContextMenu={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    void handleSplitContextMenu(splitView, pane, {
-                      x: event.clientX,
-                      y: event.clientY,
-                    });
-                  }}
-                  onMouseDown={(event) => {
-                    if (event.detail > 1) {
+              {leaves.map((leaf: LeafPane) => {
+                const preview = resolveSplitPreview(leaf.threadId);
+                const isPaneFocused = splitView.focusedPaneId === leaf.id;
+                return (
+                  <div
+                    key={leaf.id}
+                    role="button"
+                    tabIndex={0}
+                    className={cn(
+                      "flex min-w-0 flex-1 select-none items-center gap-1 rounded-md px-1.5 py-0.5 text-left outline-hidden transition-colors focus-visible:ring-1 focus-visible:ring-[color:var(--color-border-focus)]",
+                      isPaneFocused
+                        ? "bg-[var(--color-background-button-secondary)] shadow-xs"
+                        : "hover:bg-[var(--sidebar-accent)]",
+                    )}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      activateSplitPane(splitView, leaf.id);
+                    }}
+                    onContextMenu={(event) => {
                       event.preventDefault();
-                    }
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key !== "Enter" && event.key !== " ") return;
-                    event.preventDefault();
-                    event.stopPropagation();
-                    activateSplitPane(splitView, pane);
-                  }}
-                >
-                  <ProviderGlyph provider={preview.provider} className="size-3 shrink-0" />
-                  <span className="min-w-0 truncate text-[length:var(--app-font-size-ui-sm,11px)] leading-5 text-foreground/86">
-                    {preview.threadId ? preview.title : "Select chat"}
-                  </span>
-                </div>
-              ))}
+                      event.stopPropagation();
+                      void handleSplitContextMenu(splitView, leaf.id, {
+                        x: event.clientX,
+                        y: event.clientY,
+                      });
+                    }}
+                    onMouseDown={(event) => {
+                      if (event.detail > 1) {
+                        event.preventDefault();
+                      }
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Enter" && event.key !== " ") return;
+                      event.preventDefault();
+                      event.stopPropagation();
+                      activateSplitPane(splitView, leaf.id);
+                    }}
+                  >
+                    <ProviderGlyph provider={preview.provider} className="size-3 shrink-0" />
+                    <span className="min-w-0 truncate text-[length:var(--app-font-size-ui-sm,11px)] leading-5 text-foreground/86">
+                      {preview.threadId ? preview.title : "Select chat"}
+                    </span>
+                  </div>
+                );
+              })}
             </div>
             <div className="ml-auto flex shrink-0 items-center gap-1.5">
               <span className="text-[length:var(--app-font-size-ui-sm,11px)] text-muted-foreground/40">

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -20,12 +20,11 @@ import { autoAnimate } from "@formkit/auto-animate";
 import { FiGitBranch, FiPlus } from "react-icons/fi";
 import { GoRepoForked } from "react-icons/go";
 import { HiOutlineArchiveBox, HiOutlineCheckCircle, HiOutlineFolderOpen } from "react-icons/hi2";
-import { BsChat, BsLayoutSplit } from "react-icons/bs";
+import { BsChat } from "react-icons/bs";
 import { TbArrowsDiagonal, TbArrowsDiagonalMinimize2, TbCursorText } from "react-icons/tb";
 import { IoFilter } from "react-icons/io5";
 import { LuMessageSquareDashed, LuSplit } from "react-icons/lu";
 import {
-  Fragment,
   useCallback,
   useEffect,
   useMemo,
@@ -188,7 +187,6 @@ import {
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarEntriesForPreview,
   groupSidebarThreadsByProjectId,
-  groupSplitViewsByProjectId,
   pruneExpandedProjectThreadListsForCollapsedProjects,
   resolveSidebarNewThreadEnvMode,
   resolveSidebarRestorableThreadRoute,
@@ -221,12 +219,8 @@ import {
   resolveSplitViewFocusedThreadId,
   resolveSplitViewPaneIdForThread,
   selectSplitView,
-  type LeafPane,
-  type PaneId,
-  type SplitView,
   useSplitViewStore,
 } from "../splitViewStore";
-import { collectLeaves, findLeafPaneById } from "../splitView.logic";
 import { THREAD_DRAG_MIME } from "./chat-drop-overlay/ChatPaneDropOverlay";
 import { useTemporaryThreadStore } from "../temporaryThreadStore";
 import { usePinnedThreadsStore } from "../pinnedThreadsStore";
@@ -261,10 +255,10 @@ const SIDEBAR_LIST_ANIMATION_OPTIONS = {
 } as const;
 const EMPTY_THREAD_JUMP_LABELS = new Map<ThreadId, string>();
 const EMPTY_SHORTCUT_PARTS: readonly string[] = [];
-const EMPTY_THREAD_ID_LIST: readonly ThreadId[] = [];
 const DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY = "dpcode:show-debug-feature-flags-menu";
 const ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS = 6;
 const ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS = 50;
+const THREAD_INTENT_PREWARM_RELEASE_MS = 10_000;
 const ADD_PROJECT_EXISTING_SYNC_ERROR =
   "This folder is already linked, but the existing project has not synced into the sidebar yet. Try again in a moment.";
 
@@ -1114,9 +1108,7 @@ export default function Sidebar() {
   const settingsSectionSearch = useSearch({ strict: false }) as Record<string, unknown>;
   const activeSettingsSection = normalizeSettingsSection(settingsSectionSearch.section);
   const activeSplitView = useSplitViewStore(selectSplitView(routeSearch.splitViewId ?? null));
-  const splitViewsById = useSplitViewStore((store) => store.splitViewsById);
   const setSplitFocusedPane = useSplitViewStore((store) => store.setFocusedPane);
-  const removeSplitView = useSplitViewStore((store) => store.removeSplitView);
   const removeThreadFromSplitViews = useSplitViewStore((store) => store.removeThreadFromSplitViews);
   const { data: keybindings = EMPTY_KEYBINDINGS } = useQuery({
     ...serverConfigQueryOptions(),
@@ -1165,11 +1157,6 @@ export default function Sidebar() {
   const [expandedSubagentParentIds, setExpandedSubagentParentIds] = useState<ReadonlySet<ThreadId>>(
     () => new Set(),
   );
-  // Split chat groups default to expanded; we only track ids that the user has explicitly collapsed
-  // so newly-created splits open without any persisted state nudging them shut.
-  const [collapsedSplitViewGroupIds, setCollapsedSplitViewGroupIds] = useState<ReadonlySet<string>>(
-    () => new Set(),
-  );
   const autoRevealedSubagentThreadIdRef = useRef<ThreadId | null>(null);
   const renamingCommittedRef = useRef(false);
   const renamingInputRef = useRef<HTMLInputElement | null>(null);
@@ -1178,6 +1165,9 @@ export default function Sidebar() {
   const renamingProjectInputRef = useRef<HTMLInputElement | null>(null);
   const dragInProgressRef = useRef(false);
   const suppressProjectClickAfterDragRef = useRef(false);
+  const intentThreadRetentionByIdRef = useRef(
+    new Map<ThreadId, { release: () => void; timeoutId: number }>(),
+  );
   const [desktopUpdateState, setDesktopUpdateState] = useState<DesktopUpdateState | null>(null);
   const [renamingWorkspaceId, setRenamingWorkspaceId] = useState<string | null>(null);
   const [renamingWorkspaceTitle, setRenamingWorkspaceTitle] = useState("");
@@ -1191,10 +1181,9 @@ export default function Sidebar() {
   // Keep every platform on the same explicit submit path so desktop picker
   // results do not depend on a separate immediate-add branch.
   const shouldShowProjectPathEntry = addingProject;
-  const routeActiveSidebarThreadId = activeSplitView?.sourceThreadId ?? routeThreadId;
+  const routeActiveSidebarThreadId = routeThreadId;
   const activeSidebarThreadId = optimisticActiveThreadId ?? routeActiveSidebarThreadId;
-  const visualActiveSidebarThreadId =
-    optimisticActiveThreadId ?? (!activeSplitView ? routeThreadId : null);
+  const visualActiveSidebarThreadId = optimisticActiveThreadId ?? routeThreadId;
   const selectSidebarThreads = useMemo(() => createSidebarThreadSummariesSelector(), []);
   const selectSidebarDisplayThreads = useMemo(() => createSidebarDisplayThreadsSelector(), []);
   const sidebarThreads = useStore(selectSidebarThreads);
@@ -1291,13 +1280,6 @@ export default function Sidebar() {
     presentationMode: routeTerminalState?.presentationMode ?? "drawer",
     terminalOpen,
   });
-  const splitViews = useMemo(
-    () =>
-      Object.values(splitViewsById).filter(
-        (splitView): splitView is SplitView => splitView !== undefined,
-      ),
-    [splitViewsById],
-  );
   const pinnedThreadIdSet = useMemo(() => new Set(pinnedThreadIds), [pinnedThreadIds]);
   const pinnedThreads = useMemo(
     () => getPinnedThreadsForSidebar(sidebarDisplayThreads, pinnedThreadIds),
@@ -2128,14 +2110,44 @@ export default function Sidebar() {
     [openRenameThreadDialog],
   );
 
+  const prewarmThreadDetailForIntent = useCallback((threadId: ThreadId) => {
+    const previous = intentThreadRetentionByIdRef.current.get(threadId);
+    if (previous) {
+      window.clearTimeout(previous.timeoutId);
+      previous.release();
+    }
+
+    const release = retainThreadDetailSubscription(threadId);
+    const timeoutId = window.setTimeout(() => {
+      const current = intentThreadRetentionByIdRef.current.get(threadId);
+      if (!current || current.release !== release) return;
+      current.release();
+      intentThreadRetentionByIdRef.current.delete(threadId);
+    }, THREAD_INTENT_PREWARM_RELEASE_MS);
+
+    intentThreadRetentionByIdRef.current.set(threadId, { release, timeoutId });
+  }, []);
+
+  useEffect(
+    () => () => {
+      for (const entry of intentThreadRetentionByIdRef.current.values()) {
+        window.clearTimeout(entry.timeoutId);
+        entry.release();
+      }
+      intentThreadRetentionByIdRef.current.clear();
+    },
+    [],
+  );
+
   const primeThreadActivation = useCallback(
     (event: ReactPointerEvent<HTMLElement>, threadId: ThreadId) => {
       if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
         return;
       }
+      prewarmThreadDetailForIntent(threadId);
       setOptimisticActiveThreadId(threadId);
     },
-    [],
+    [prewarmThreadDetailForIntent],
   );
 
   /**
@@ -2898,56 +2910,6 @@ export default function Sidebar() {
       togglePinnedThread,
     ],
   );
-  const returnSplitViewToSingleChat = useCallback(
-    (splitView: SplitView, paneId: PaneId) => {
-      const leaf = findLeafPaneById(splitView.root, paneId);
-      const nextThreadId =
-        leaf?.threadId ?? resolveSplitViewFocusedThreadId(splitView) ?? splitView.sourceThreadId;
-      removeSplitView(splitView.id);
-      if (!nextThreadId) {
-        return;
-      }
-      void navigate({
-        to: "/$threadId",
-        params: { threadId: nextThreadId },
-        search: (previous) => ({
-          ...previous,
-          splitViewId: undefined,
-        }),
-      });
-    },
-    [navigate, removeSplitView],
-  );
-  const handleSplitContextMenu = useCallback(
-    async (splitView: SplitView, paneId: PaneId, position: { x: number; y: number }) => {
-      const api = readNativeApi();
-      if (!api) return;
-
-      const leaf = findLeafPaneById(splitView.root, paneId);
-      const paneThreadId = leaf?.threadId ?? null;
-      setSplitFocusedPane(splitView.id, paneId);
-
-      if (paneThreadId) {
-        await handleThreadContextMenu(paneThreadId, position, {
-          extraItems: [{ id: "return-to-single-chat", label: "Return to single chat" }],
-          onExtraAction: async () => {
-            returnSplitViewToSingleChat(splitView, paneId);
-          },
-        });
-        return;
-      }
-
-      const clicked = await api.contextMenu.show(
-        [{ id: "return-to-single-chat", label: "Return to single chat" }],
-        position,
-      );
-      if (clicked === "return-to-single-chat") {
-        returnSplitViewToSingleChat(splitView, paneId);
-      }
-    },
-    [handleThreadContextMenu, returnSplitViewToSingleChat, setSplitFocusedPane],
-  );
-
   const handleMultiSelectContextMenu = useCallback(
     async (position: { x: number; y: number }) => {
       const api = readNativeApi();
@@ -3024,59 +2986,15 @@ export default function Sidebar() {
   );
 
   // Keep clicks, keyboard activation, and Alt+Tab cycling aligned on the same thread-open path.
-  const navigateToSplitView = useCallback(
-    (splitView: SplitView, nextThreadId?: ThreadId | null) => {
-      const focusedThreadId = nextThreadId ?? resolveSplitViewFocusedThreadId(splitView);
-      if (!focusedThreadId) return;
-      void navigate({
-        to: "/$threadId",
-        params: { threadId: focusedThreadId },
-        search: () => ({ splitViewId: splitView.id }),
-      });
-    },
-    [navigate],
-  );
-
-  const activateSplitPane = useCallback(
-    (splitView: SplitView, paneId: PaneId) => {
-      if (selectedThreadIds.size > 0) {
-        clearSelection();
-      }
-
-      const leaf = findLeafPaneById(splitView.root, paneId);
-      const paneThreadId = leaf?.threadId ?? null;
-      const nextThreadId = paneThreadId ?? resolveSplitViewFocusedThreadId(splitView);
-
-      setSelectionAnchor(paneThreadId ?? splitView.sourceThreadId);
-      setSplitFocusedPane(splitView.id, paneId);
-
-      if (!nextThreadId) {
-        return;
-      }
-
-      void navigate({
-        to: "/$threadId",
-        params: { threadId: nextThreadId },
-        search: () => ({ splitViewId: splitView.id }),
-      });
-    },
-    [clearSelection, navigate, selectedThreadIds.size, setSelectionAnchor, setSplitFocusedPane],
-  );
-
   const activateThread = useCallback(
     (threadId: ThreadId) => {
       // Mark the row active immediately; route rendering can do heavier chat work after this.
+      prewarmThreadDetailForIntent(threadId);
       setOptimisticActiveThreadId(threadId);
       if (selectedThreadIds.size > 0) {
         clearSelection();
       }
       setSelectionAnchor(threadId);
-      const sourceSplitView = splitViews.find((splitView) => splitView.sourceThreadId === threadId);
-      if (sourceSplitView) {
-        navigateToSplitView(sourceSplitView);
-        return;
-      }
-
       const threadEntryPoint = selectThreadTerminalState(
         terminalStateByThreadId,
         threadId,
@@ -3089,19 +3007,62 @@ export default function Sidebar() {
       void navigate({
         to: "/$threadId",
         params: { threadId },
+        search: (previous) => ({
+          ...previous,
+          splitViewId: undefined,
+        }),
       });
     },
     [
       clearSelection,
       navigate,
-      navigateToSplitView,
       openChatThreadPage,
       openTerminalThreadPage,
+      prewarmThreadDetailForIntent,
       selectedThreadIds.size,
       setSelectionAnchor,
       setOptimisticActiveThreadId,
-      splitViews,
       terminalStateByThreadId,
+    ],
+  );
+  const activateThreadFromShortcut = useCallback(
+    (threadId: ThreadId) => {
+      const splitPaneId = activeSplitView
+        ? resolveSplitViewPaneIdForThread(activeSplitView, threadId)
+        : null;
+      if (!activeSplitView || !splitPaneId) {
+        activateThread(threadId);
+        return;
+      }
+
+      // Numeric/sidebar cycling shortcuts should switch panes when already inside a split.
+      // Pointer clicks still use activateThread above and intentionally return to single chat.
+      prewarmThreadDetailForIntent(threadId);
+      setOptimisticActiveThreadId(threadId);
+      if (selectedThreadIds.size > 0) {
+        clearSelection();
+      }
+      setSelectionAnchor(threadId);
+      setSplitFocusedPane(activeSplitView.id, splitPaneId);
+      void navigate({
+        to: "/$threadId",
+        params: { threadId },
+        search: (previous) => ({
+          ...previous,
+          splitViewId: activeSplitView.id,
+        }),
+      });
+    },
+    [
+      activateThread,
+      activeSplitView,
+      clearSelection,
+      navigate,
+      prewarmThreadDetailForIntent,
+      selectedThreadIds.size,
+      setOptimisticActiveThreadId,
+      setSelectionAnchor,
+      setSplitFocusedPane,
     ],
   );
 
@@ -3340,11 +3301,6 @@ export default function Sidebar() {
     autoAnimate(node, SIDEBAR_LIST_ANIMATION_OPTIONS);
     animatedThreadListsRef.current.add(node);
   }, []);
-  const splitViewBySourceThreadId = useMemo(
-    () => new Map(splitViews.map((splitView) => [splitView.sourceThreadId, splitView] as const)),
-    [splitViews],
-  );
-  const splitViewsByProjectId = useMemo(() => groupSplitViewsByProjectId(splitViews), [splitViews]);
   const sidebarThreadsByProjectId = useMemo(
     () => groupSidebarThreadsByProjectId(sidebarDisplayThreads),
     [sidebarDisplayThreads],
@@ -3465,10 +3421,7 @@ export default function Sidebar() {
       deriveSidebarProjectData({
         projects: standardProjects,
         sortedSidebarThreadsByProjectId,
-        splitViewsByProjectId,
-        splitViewBySourceThreadId,
         pinnedThreadIds,
-        pinnedThreadIdSet,
         expandedParentThreadIds: expandedSubagentParentIds,
         expandedThreadListProjectCwds: expandedThreadListsByProject,
         normalizeProjectCwd: normalizeSidebarProjectThreadListCwd,
@@ -3480,11 +3433,8 @@ export default function Sidebar() {
       activeSidebarThreadId,
       expandedSubagentParentIds,
       expandedThreadListsByProject,
-      pinnedThreadIdSet,
       pinnedThreadIds,
       sortedSidebarThreadsByProjectId,
-      splitViewBySourceThreadId,
-      splitViewsByProjectId,
       standardProjects,
       resolveThreadStatusForSidebar,
     ],
@@ -3609,36 +3559,6 @@ export default function Sidebar() {
     });
   }, []);
 
-  const toggleSplitViewGroupCollapsed = useCallback((splitViewId: string) => {
-    setCollapsedSplitViewGroupIds((previous) => {
-      const next = new Set(previous);
-      if (next.has(splitViewId)) {
-        next.delete(splitViewId);
-      } else {
-        next.add(splitViewId);
-      }
-      return next;
-    });
-  }, []);
-
-  // Prune collapsed-group entries for split views that no longer exist so the Set does not
-  // accumulate stale ids across long sessions.
-  useEffect(() => {
-    setCollapsedSplitViewGroupIds((previous) => {
-      if (previous.size === 0) return previous;
-      let changed = false;
-      const next = new Set<string>();
-      for (const splitViewId of previous) {
-        if (splitViewsById[splitViewId]) {
-          next.add(splitViewId);
-        } else {
-          changed = true;
-        }
-      }
-      return changed ? next : previous;
-    });
-  }, [splitViewsById]);
-
   const handleThreadClick = useCallback(
     (
       event: MouseEvent,
@@ -3665,18 +3585,31 @@ export default function Sidebar() {
         return;
       }
 
-      if (options?.isActive && options.canToggleSubagents) {
+      if (options?.isActive && options.canToggleSubagents && !routeSearch.splitViewId) {
         toggleSubagentParent(threadId);
         return;
       }
 
       activateThread(threadId);
     },
-    [activateThread, rangeSelectTo, toggleSubagentParent, toggleThreadSelection],
+    [
+      activateThread,
+      rangeSelectTo,
+      routeSearch.splitViewId,
+      toggleSubagentParent,
+      toggleThreadSelection,
+    ],
   );
 
   const visibleSidebarThreadIds = useMemo(() => {
-    const visibleThreadIds = pinnedThreads.map((thread) => thread.id);
+    const visibleThreadIdSet = new Set<ThreadId>();
+    const addVisibleThreadId = (threadId: ThreadId) => {
+      visibleThreadIdSet.add(threadId);
+    };
+
+    for (const thread of pinnedThreads) {
+      addVisibleThreadId(thread.id);
+    }
 
     for (const project of standardProjects) {
       const projectSidebarData = standardProjectSidebarDataById.get(project.id);
@@ -3686,15 +3619,17 @@ export default function Sidebar() {
 
       if (!project.expanded) {
         if (projectSidebarData.activeEntryId) {
-          visibleThreadIds.push(projectSidebarData.activeEntryId);
+          addVisibleThreadId(projectSidebarData.activeEntryId);
         }
         continue;
       }
 
-      visibleThreadIds.push(...projectSidebarData.visibleEntries.map((entry) => entry.rowId));
+      for (const entry of projectSidebarData.visibleEntries) {
+        addVisibleThreadId(entry.rowId);
+      }
     }
 
-    return visibleThreadIds;
+    return [...visibleThreadIdSet];
   }, [pinnedThreads, standardProjects, standardProjectSidebarDataById]);
   const isManualProjectSorting = appSettings.sidebarProjectSortOrder === "manual";
   const threadJumpCommandByThreadId = useMemo(() => {
@@ -3742,6 +3677,7 @@ export default function Sidebar() {
   useEffect(() => {
     const threadIdsToPrewarm = getSidebarThreadIdsToPrewarm({
       visibleThreadIds: visibleSidebarThreadIds,
+      activeThreadId: activeSidebarThreadId,
     });
     const releaseCallbacks = threadIdsToPrewarm.map((threadId) =>
       retainThreadDetailSubscription(threadId),
@@ -3752,7 +3688,7 @@ export default function Sidebar() {
         release();
       }
     };
-  }, [visibleSidebarThreadIds]);
+  }, [activeSidebarThreadId, visibleSidebarThreadIds]);
 
   // Pinned rows should show the user-facing project label, not the raw folder basename.
   function resolvePinnedThreadProjectLabel(projectId: ProjectId): string | null {
@@ -4052,18 +3988,11 @@ export default function Sidebar() {
     depth = 0,
     childCount = 0,
     isExpanded = false,
-    splitContext?: { splitView: SplitView; paneId: PaneId },
   ) {
     const threadTerminalState = selectThreadTerminalState(terminalStateByThreadId, thread.id);
     const threadEntryPoint = threadTerminalState.entryPoint;
     const isPendingArchiveConfirmation = pendingArchiveConfirmationThreadId === thread.id;
-    // When the row represents a leaf inside a split-chats group, "active" means the split is the
-    // routed surface AND this leaf is the focused pane. Falling back to the thread-id check would
-    // either over-highlight (same thread referenced in multiple splits) or under-highlight.
-    const isActive = splitContext
-      ? routeSearch.splitViewId === splitContext.splitView.id &&
-        splitContext.splitView.focusedPaneId === splitContext.paneId
-      : visualActiveSidebarThreadId === thread.id;
+    const isActive = visualActiveSidebarThreadId === thread.id;
     const isPinned = pinnedThreadIdSet.has(thread.id);
     const isSelected = selectedThreadIds.has(thread.id);
     const isHighlighted = isActive || isSelected;
@@ -4119,12 +4048,8 @@ export default function Sidebar() {
       ? "border-[color:var(--color-border)] bg-[var(--color-background-button-secondary)] text-[var(--color-text-foreground-secondary)] hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]"
       : "border-[color:var(--color-border-light)] bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground-secondary)] hover:border-[color:var(--color-border)] hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]";
 
-    const rowKey = splitContext
-      ? `split-leaf:${splitContext.splitView.id}:${splitContext.paneId}`
-      : thread.id;
-
     return (
-      <SidebarMenuSubItem key={rowKey} className="group/thread-row w-full" data-thread-item>
+      <SidebarMenuSubItem key={thread.id} className="group/thread-row w-full" data-thread-item>
         <ThreadPinToggleButton
           pinned={isPinned}
           presentation="overlay"
@@ -4194,11 +4119,6 @@ export default function Sidebar() {
             }
           }}
           onClick={(event) => {
-            if (splitContext) {
-              event.stopPropagation();
-              activateSplitPane(splitContext.splitView, splitContext.paneId);
-              return;
-            }
             handleThreadClick(event, thread.id, orderedProjectThreadIds, {
               isActive,
               canToggleSubagents,
@@ -4214,22 +4134,10 @@ export default function Sidebar() {
           onKeyDown={(event) => {
             if (event.key !== "Enter" && event.key !== " ") return;
             event.preventDefault();
-            if (splitContext) {
-              activateSplitPane(splitContext.splitView, splitContext.paneId);
-              return;
-            }
             activateThread(thread.id);
           }}
           onContextMenu={(event) => {
             event.preventDefault();
-            if (splitContext) {
-              event.stopPropagation();
-              void handleSplitContextMenu(splitContext.splitView, splitContext.paneId, {
-                x: event.clientX,
-                y: event.clientY,
-              });
-              return;
-            }
             if (selectedThreadIds.size > 0 && selectedThreadIds.has(thread.id)) {
               void handleMultiSelectContextMenu({
                 x: event.clientX,
@@ -4437,110 +4345,6 @@ export default function Sidebar() {
       hasHiddenThreads,
       isThreadListExpanded,
     } = projectSidebarData;
-    const renderSplitRow = (splitView: SplitView) => {
-      const leaves = collectLeaves(splitView.root);
-      const isActiveSplit = routeSearch.splitViewId === splitView.id;
-      const isCollapsed = collapsedSplitViewGroupIds.has(splitView.id);
-      const populatedLeafCount = leaves.reduce(
-        (count, leaf) => (leaf.threadId ? count + 1 : count),
-        0,
-      );
-      const collapseLabel = isCollapsed ? "Expand split chats" : "Collapse split chats";
-      // The split-chats header is styled like the project header (full width, px-2) rather than
-      // a thread row, so it matches the "section" that the user expects above the nested thread
-      // rows. Thread rows underneath keep their pl-8/pr-9 chrome unchanged.
-      const headerToneClass = isActiveSplit
-        ? "bg-[var(--color-background-button-secondary)] text-[var(--color-text-foreground)] hover:bg-[var(--color-background-button-secondary)]"
-        : "hover:bg-[var(--sidebar-accent)]";
-      const headerSecondaryToneClass = isActiveSplit
-        ? "text-foreground/54 dark:text-foreground/64"
-        : "text-muted-foreground/45";
-
-      return (
-        <Fragment key={`split-group:${splitView.id}`}>
-          <SidebarMenuSubItem className="group/thread-row w-full" data-thread-item>
-            <div
-              role="button"
-              tabIndex={0}
-              data-active={isActiveSplit ? "true" : undefined}
-              className={cn(
-                "flex h-8 w-full cursor-pointer items-center gap-2 rounded-md px-2 py-0.5 text-left text-[length:var(--app-font-size-ui,12px)] font-normal text-sidebar-foreground transition-colors select-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
-                headerToneClass,
-              )}
-              onClick={() => activateSplitPane(splitView, splitView.focusedPaneId)}
-              onContextMenu={(event) => {
-                event.preventDefault();
-                void handleSplitContextMenu(splitView, splitView.focusedPaneId, {
-                  x: event.clientX,
-                  y: event.clientY,
-                });
-              }}
-              onKeyDown={(event) => {
-                if (event.key !== "Enter" && event.key !== " ") return;
-                event.preventDefault();
-                activateSplitPane(splitView, splitView.focusedPaneId);
-              }}
-            >
-              <BsLayoutSplit
-                aria-hidden="true"
-                className={cn("size-3.5 shrink-0", headerSecondaryToneClass)}
-              />
-              <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                <span className="min-w-0 truncate leading-5 text-foreground/86">Split chats</span>
-                <span
-                  aria-label={`${populatedLeafCount} chat${populatedLeafCount === 1 ? "" : "s"} in this split`}
-                  className={cn(
-                    "shrink-0 text-[10px] leading-none tabular-nums",
-                    headerSecondaryToneClass,
-                  )}
-                >
-                  {populatedLeafCount}
-                </span>
-              </div>
-              {/* Collapse toggle stays inline with the rest of the header content; clicking it
-                  toggles the group only and never activates the split. */}
-              <button
-                type="button"
-                data-thread-selection-safe
-                aria-label={collapseLabel}
-                title={collapseLabel}
-                className={cn(
-                  "inline-flex size-4 shrink-0 items-center justify-center rounded-sm transition-colors hover:bg-[var(--sidebar-accent)] hover:text-foreground",
-                  headerSecondaryToneClass,
-                )}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  toggleSplitViewGroupCollapsed(splitView.id);
-                }}
-              >
-                {isCollapsed ? (
-                  <ChevronRightIcon className="size-3" />
-                ) : (
-                  <ChevronDownIcon className="size-3" />
-                )}
-              </button>
-            </div>
-          </SidebarMenuSubItem>
-          {!isCollapsed
-            ? leaves.flatMap((leaf) => {
-                // Empty/unknown panes don't get a placeholder row — keep the rule "reuse the
-                // existing thread row component, nothing else". Empty panes are still visible
-                // inside the split view itself when the user opens the group.
-                if (leaf.threadId === null) return [];
-                const thread = sidebarThreadSummaryById[leaf.threadId];
-                if (!thread) return [];
-                return [
-                  renderThreadRow(thread, EMPTY_THREAD_ID_LIST, 0, 0, false, {
-                    splitView,
-                    paneId: leaf.id,
-                  }),
-                ];
-              })
-            : null}
-        </Fragment>
-      );
-    };
 
     return (
       <div className="group/collapsible">
@@ -4738,15 +4542,13 @@ export default function Sidebar() {
               )}
             >
               {visibleEntries.map((entry) =>
-                entry.kind === "thread"
-                  ? renderThreadRow(
-                      entry.thread,
-                      orderedProjectThreadIds,
-                      entry.depth,
-                      entry.childCount,
-                      entry.isExpanded,
-                    )
-                  : renderSplitRow(entry.splitView),
+                renderThreadRow(
+                  entry.thread,
+                  orderedProjectThreadIds,
+                  entry.depth,
+                  entry.childCount,
+                  entry.isExpanded,
+                ),
               )}
 
               {hasHiddenThreads && !isThreadListExpanded && (
@@ -4939,7 +4741,7 @@ export default function Sidebar() {
         if (threadJumpTargetId === activeSidebarThreadId) return;
         event.preventDefault();
         event.stopPropagation();
-        activateThread(threadJumpTargetId);
+        activateThreadFromShortcut(threadJumpTargetId);
         return;
       }
       if (command !== "chat.visible.next" && command !== "chat.visible.previous") {
@@ -4955,7 +4757,7 @@ export default function Sidebar() {
 
       event.preventDefault();
       event.stopPropagation();
-      activateThread(nextThreadId);
+      activateThreadFromShortcut(nextThreadId);
     };
     const onKeyUp = (event: KeyboardEvent) => {
       if (shouldIgnoreThreadJumpHintUpdate(event)) {
@@ -4994,7 +4796,7 @@ export default function Sidebar() {
       window.removeEventListener("blur", onWindowBlur);
     };
   }, [
-    activateThread,
+    activateThreadFromShortcut,
     activeSidebarThreadId,
     keybindings,
     getCurrentSidebarShortcutContext,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -188,9 +188,7 @@ import {
   getVisibleSidebarEntriesForPreview,
   groupSidebarThreadsByProjectId,
   pruneExpandedProjectThreadListsForCollapsedProjects,
-  resolvePreferredSplitForCommand,
   resolveSidebarNewThreadEnvMode,
-  resolveThreadCommandActivation,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   isDuplicateProjectCreateError,
@@ -226,6 +224,7 @@ import {
 } from "../splitViewStore";
 import { THREAD_DRAG_MIME } from "./chat-drop-overlay/ChatPaneDropOverlay";
 import { useTemporaryThreadStore } from "../temporaryThreadStore";
+import { useThreadActivationController } from "../hooks/useThreadActivationController";
 import { usePinnedThreadsStore } from "../pinnedThreadsStore";
 import { retainThreadDetailSubscription } from "../threadDetailSubscriptionRetention";
 import { useWorkspaceStore, workspaceThreadId } from "../workspaceStore";
@@ -1158,7 +1157,6 @@ export default function Sidebar() {
     () => readSidebarUiState().lastThreadRoute,
   );
   const [optimisticActiveThreadId, setOptimisticActiveThreadId] = useState<ThreadId | null>(null);
-  const lastCommandRestorableSplitViewIdRef = useRef<SplitViewId | null>(null);
   const [expandedSubagentParentIds, setExpandedSubagentParentIds] = useState<ReadonlySet<ThreadId>>(
     () => new Set(),
   );
@@ -1183,6 +1181,7 @@ export default function Sidebar() {
   const clearSelection = useThreadSelectionStore((s) => s.clearSelection);
   const removeFromSelection = useThreadSelectionStore((s) => s.removeFromSelection);
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
+
   // Keep every platform on the same explicit submit path so desktop picker
   // results do not depend on a separate immediate-add branch.
   const shouldShowProjectPathEntry = addingProject;
@@ -2990,49 +2989,6 @@ export default function Sidebar() {
     ],
   );
 
-  // Opens a thread as a single chat. Split-aware entry points should use
-  // activateThreadFromCommand below so click/search/shortcuts stay consistent.
-  const activateThread = useCallback(
-    (threadId: ThreadId) => {
-      if (!sidebarThreadSummaryById[threadId]) return;
-      // Mark the row active immediately; route rendering can do heavier chat work after this.
-      prewarmThreadDetailForIntent(threadId);
-      setOptimisticActiveThreadId(threadId);
-      if (selectedThreadIds.size > 0) {
-        clearSelection();
-      }
-      setSelectionAnchor(threadId);
-      const threadEntryPoint = selectThreadTerminalState(
-        terminalStateByThreadId,
-        threadId,
-      ).entryPoint;
-      if (threadEntryPoint === "terminal") {
-        openTerminalThreadPage(threadId);
-      } else {
-        openChatThreadPage(threadId);
-      }
-      void navigate({
-        to: "/$threadId",
-        params: { threadId },
-        search: (previous) => ({
-          ...previous,
-          splitViewId: undefined,
-        }),
-      });
-    },
-    [
-      clearSelection,
-      navigate,
-      openChatThreadPage,
-      openTerminalThreadPage,
-      prewarmThreadDetailForIntent,
-      selectedThreadIds.size,
-      setSelectionAnchor,
-      setOptimisticActiveThreadId,
-      sidebarThreadSummaryById,
-      terminalStateByThreadId,
-    ],
-  );
   const rememberLastThreadRouteNow = useCallback(
     (nextLastThreadRoute: LastThreadRoute) => {
       setLastThreadRoute(nextLastThreadRoute);
@@ -3051,93 +3007,24 @@ export default function Sidebar() {
       expandedThreadListsByProject,
     ],
   );
-  const activateThreadFromCommand = useCallback(
-    (threadId: ThreadId) => {
-      // Active-split-aware activation rules for keyboard shortcuts / search picker:
-      //   1. While inside a split view, a shortcut targeting one of *that split's*
-      //      panes only swaps focus inside the split (no navigation churn).
-      //   2. While inside a split view, a shortcut targeting a thread that does
-      //      NOT belong to that split closes the split and opens the target as a
-      //      single chat — even if the target lives in some other persisted split.
-      //   3. While viewing a single chat (no active split), shortcuts can restore
-      //      only the last split the user actually left. Old persisted splits do
-      //      not get resurrected by generic 3/4-style switching.
-      const preferredSplit = resolvePreferredSplitForCommand({
-        activeSplitView,
-        splitViewsById,
-        restorableSplitViewId: lastCommandRestorableSplitViewIdRef.current,
-        threadId,
-      });
-      const activation = resolveThreadCommandActivation({
-        threadId,
-        threadExists: sidebarThreadSummaryById[threadId] !== undefined,
-        // Compare against the actual routed thread, not optimistic hover/click
-        // state. Pointer-down prewarms rows before click, and treating that as
-        // active makes normal clicks no-op while Cmd+number still works.
-        activeSidebarThreadId: routeThreadId,
-        preferredSplitViewId: preferredSplit?.splitViewId ?? null,
-        splitPaneId: preferredSplit?.paneId ?? null,
-      });
-
-      if (activation.kind === "ignore") {
-        return;
-      }
-
-      if (activation.kind === "single") {
-        if (activeSplitView) {
-          lastCommandRestorableSplitViewIdRef.current = activeSplitView.id;
-        }
-        activateThread(activation.threadId);
-        return;
-      }
-
-      // Skip the entire side-effect chain when the route already points at the
-      // exact (thread, split) the shortcut would land on — including the
-      // localStorage write below — so a "no-op" Cmd+N stays cheap.
-      if (
-        routeThreadId === activation.threadId &&
-        routeSearch.splitViewId === activation.splitViewId
-      ) {
-        return;
-      }
-
-      prewarmThreadDetailForIntent(activation.threadId);
-      setOptimisticActiveThreadId(activation.threadId);
-      if (selectedThreadIds.size > 0) {
-        clearSelection();
-      }
-      setSelectionAnchor(activation.threadId);
-      setSplitFocusedPane(activation.splitViewId, activation.paneId);
-      rememberLastThreadRouteNow({
-        threadId: activation.threadId,
-        splitViewId: activation.splitViewId,
-      });
-      void navigate({
-        to: "/$threadId",
-        params: { threadId: activation.threadId },
-        search: (previous) => ({
-          ...previous,
-          splitViewId: activation.splitViewId,
-        }),
-      });
-    },
-    [
-      activateThread,
-      activeSplitView,
-      clearSelection,
-      navigate,
-      prewarmThreadDetailForIntent,
-      rememberLastThreadRouteNow,
-      routeSearch.splitViewId,
-      routeThreadId,
-      selectedThreadIds.size,
-      setOptimisticActiveThreadId,
-      setSelectionAnchor,
-      setSplitFocusedPane,
-      sidebarThreadSummaryById,
-      splitViewsById,
-    ],
-  );
+  const { activateThreadFromSidebarIntent } = useThreadActivationController({
+    activeSplitView,
+    clearSelection,
+    navigate,
+    openChatThreadPage,
+    openTerminalThreadPage,
+    prewarmThreadDetailForIntent,
+    rememberLastThreadRouteNow,
+    routeSplitViewId: routeSearch.splitViewId,
+    routeThreadId,
+    selectedThreadCount: selectedThreadIds.size,
+    setOptimisticActiveThreadId,
+    setSelectionAnchor,
+    setSplitFocusedPane,
+    sidebarThreadSummaryById,
+    splitViewsById,
+    terminalStateByThreadId,
+  });
 
   const handleProjectContextMenu = useCallback(
     async (projectId: ProjectId, position: { x: number; y: number }) => {
@@ -3663,10 +3550,10 @@ export default function Sidebar() {
         return;
       }
 
-      activateThreadFromCommand(threadId);
+      activateThreadFromSidebarIntent(threadId);
     },
     [
-      activateThreadFromCommand,
+      activateThreadFromSidebarIntent,
       rangeSelectTo,
       routeThreadId,
       routeSearch.splitViewId,
@@ -3925,7 +3812,7 @@ export default function Sidebar() {
               : "text-foreground/72 hover:bg-[var(--sidebar-accent)]",
           )}
           onPointerDown={(event) => primeThreadActivation(event, thread.id)}
-          onClick={() => activateThreadFromCommand(thread.id)}
+          onClick={() => activateThreadFromSidebarIntent(thread.id)}
           onDoubleClick={(event) => {
             event.preventDefault();
             event.stopPropagation();
@@ -3935,7 +3822,7 @@ export default function Sidebar() {
           onKeyDown={(event) => {
             if (event.key === "Enter" || event.key === " ") {
               event.preventDefault();
-              activateThreadFromCommand(thread.id);
+              activateThreadFromSidebarIntent(thread.id);
             }
           }}
           onContextMenu={(event) => {
@@ -4208,7 +4095,7 @@ export default function Sidebar() {
           onKeyDown={(event) => {
             if (event.key !== "Enter" && event.key !== " ") return;
             event.preventDefault();
-            activateThreadFromCommand(thread.id);
+            activateThreadFromSidebarIntent(thread.id);
           }}
           onContextMenu={(event) => {
             event.preventDefault();
@@ -4812,7 +4699,7 @@ export default function Sidebar() {
         event.stopPropagation();
         const threadJumpTargetId = threadJumpThreadIds[jumpIndex];
         if (threadJumpTargetId) {
-          activateThreadFromCommand(threadJumpTargetId);
+          activateThreadFromSidebarIntent(threadJumpTargetId);
         }
         return;
       }
@@ -4828,7 +4715,7 @@ export default function Sidebar() {
         direction: command === "chat.visible.previous" ? "backward" : "forward",
       });
       if (nextThreadId && nextThreadId !== activeSidebarThreadId) {
-        activateThreadFromCommand(nextThreadId);
+        activateThreadFromSidebarIntent(nextThreadId);
       }
     };
     const onKeyUp = (event: KeyboardEvent) => {
@@ -4868,7 +4755,7 @@ export default function Sidebar() {
       window.removeEventListener("blur", onWindowBlur);
     };
   }, [
-    activateThreadFromCommand,
+    activateThreadFromSidebarIntent,
     activeSidebarThreadId,
     keybindings,
     getCurrentSidebarShortcutContext,
@@ -5897,7 +5784,7 @@ export default function Sidebar() {
           onOpenProject={handleOpenProjectFromSearch}
           onImportThread={handleImportThread}
           onOpenThread={(threadId) => {
-            activateThreadFromCommand(ThreadId.makeUnsafe(threadId));
+            activateThreadFromSidebarIntent(ThreadId.makeUnsafe(threadId));
           }}
         />
       ) : null}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -188,8 +188,9 @@ import {
   getVisibleSidebarEntriesForPreview,
   groupSidebarThreadsByProjectId,
   pruneExpandedProjectThreadListsForCollapsedProjects,
+  resolvePreferredSplitForCommand,
   resolveSidebarNewThreadEnvMode,
-  resolveSidebarRestorableThreadRoute,
+  resolveThreadCommandActivation,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   isDuplicateProjectCreateError,
@@ -199,6 +200,7 @@ import {
   sortProjectsForSidebar,
   sortThreadsForSidebar,
 } from "./Sidebar.logic";
+import { resolveRestorableThreadRoute, type LastThreadRoute } from "../chatRouteRestore";
 import { resolveSubagentPresentationForThread } from "../lib/subagentPresentation";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { cn } from "~/lib/utils";
@@ -219,6 +221,7 @@ import {
   resolveSplitViewFocusedThreadId,
   resolveSplitViewPaneIdForThread,
   selectSplitView,
+  type SplitViewId,
   useSplitViewStore,
 } from "../splitViewStore";
 import { THREAD_DRAG_MIME } from "./chat-drop-overlay/ChatPaneDropOverlay";
@@ -1108,6 +1111,7 @@ export default function Sidebar() {
   const settingsSectionSearch = useSearch({ strict: false }) as Record<string, unknown>;
   const activeSettingsSection = normalizeSettingsSection(settingsSectionSearch.section);
   const activeSplitView = useSplitViewStore(selectSplitView(routeSearch.splitViewId ?? null));
+  const splitViewsById = useSplitViewStore((store) => store.splitViewsById);
   const setSplitFocusedPane = useSplitViewStore((store) => store.setFocusedPane);
   const removeThreadFromSplitViews = useSplitViewStore((store) => store.removeThreadFromSplitViews);
   const { data: keybindings = EMPTY_KEYBINDINGS } = useQuery({
@@ -1154,6 +1158,7 @@ export default function Sidebar() {
     () => readSidebarUiState().lastThreadRoute,
   );
   const [optimisticActiveThreadId, setOptimisticActiveThreadId] = useState<ThreadId | null>(null);
+  const lastCommandRestorableSplitViewIdRef = useRef<SplitViewId | null>(null);
   const [expandedSubagentParentIds, setExpandedSubagentParentIds] = useState<ReadonlySet<ThreadId>>(
     () => new Set(),
   );
@@ -1674,7 +1679,7 @@ export default function Sidebar() {
         return;
       }
 
-      const restorableRoute = resolveSidebarRestorableThreadRoute({
+      const restorableRoute = resolveRestorableThreadRoute({
         lastThreadRoute,
         availableThreadIds: new Set(Object.keys(sidebarThreadSummaryById)),
       });
@@ -2985,9 +2990,11 @@ export default function Sidebar() {
     ],
   );
 
-  // Keep clicks, keyboard activation, and Alt+Tab cycling aligned on the same thread-open path.
+  // Opens a thread as a single chat. Split-aware entry points should use
+  // activateThreadFromCommand below so click/search/shortcuts stay consistent.
   const activateThread = useCallback(
     (threadId: ThreadId) => {
+      if (!sidebarThreadSummaryById[threadId]) return;
       // Mark the row active immediately; route rendering can do heavier chat work after this.
       prewarmThreadDetailForIntent(threadId);
       setOptimisticActiveThreadId(threadId);
@@ -3022,34 +3029,95 @@ export default function Sidebar() {
       selectedThreadIds.size,
       setSelectionAnchor,
       setOptimisticActiveThreadId,
+      sidebarThreadSummaryById,
       terminalStateByThreadId,
     ],
   );
-  const activateThreadFromShortcut = useCallback(
+  const rememberLastThreadRouteNow = useCallback(
+    (nextLastThreadRoute: LastThreadRoute) => {
+      setLastThreadRoute(nextLastThreadRoute);
+      persistSidebarUiState({
+        chatSectionExpanded,
+        chatThreadListExpanded,
+        expandedProjectThreadListCwds: [...expandedThreadListsByProject],
+        dismissedThreadStatusKeyByThreadId,
+        lastThreadRoute: nextLastThreadRoute,
+      });
+    },
+    [
+      chatSectionExpanded,
+      chatThreadListExpanded,
+      dismissedThreadStatusKeyByThreadId,
+      expandedThreadListsByProject,
+    ],
+  );
+  const activateThreadFromCommand = useCallback(
     (threadId: ThreadId) => {
-      const splitPaneId = activeSplitView
-        ? resolveSplitViewPaneIdForThread(activeSplitView, threadId)
-        : null;
-      if (!activeSplitView || !splitPaneId) {
-        activateThread(threadId);
+      // Active-split-aware activation rules for keyboard shortcuts / search picker:
+      //   1. While inside a split view, a shortcut targeting one of *that split's*
+      //      panes only swaps focus inside the split (no navigation churn).
+      //   2. While inside a split view, a shortcut targeting a thread that does
+      //      NOT belong to that split closes the split and opens the target as a
+      //      single chat — even if the target lives in some other persisted split.
+      //   3. While viewing a single chat (no active split), shortcuts can restore
+      //      only the last split the user actually left. Old persisted splits do
+      //      not get resurrected by generic 3/4-style switching.
+      const preferredSplit = resolvePreferredSplitForCommand({
+        activeSplitView,
+        splitViewsById,
+        restorableSplitViewId: lastCommandRestorableSplitViewIdRef.current,
+        threadId,
+      });
+      const activation = resolveThreadCommandActivation({
+        threadId,
+        threadExists: sidebarThreadSummaryById[threadId] !== undefined,
+        // Compare against the actual routed thread, not optimistic hover/click
+        // state. Pointer-down prewarms rows before click, and treating that as
+        // active makes normal clicks no-op while Cmd+number still works.
+        activeSidebarThreadId: routeThreadId,
+        preferredSplitViewId: preferredSplit?.splitViewId ?? null,
+        splitPaneId: preferredSplit?.paneId ?? null,
+      });
+
+      if (activation.kind === "ignore") {
         return;
       }
 
-      // Numeric/sidebar cycling shortcuts should switch panes when already inside a split.
-      // Pointer clicks still use activateThread above and intentionally return to single chat.
-      prewarmThreadDetailForIntent(threadId);
-      setOptimisticActiveThreadId(threadId);
+      if (activation.kind === "single") {
+        if (activeSplitView) {
+          lastCommandRestorableSplitViewIdRef.current = activeSplitView.id;
+        }
+        activateThread(activation.threadId);
+        return;
+      }
+
+      // Skip the entire side-effect chain when the route already points at the
+      // exact (thread, split) the shortcut would land on — including the
+      // localStorage write below — so a "no-op" Cmd+N stays cheap.
+      if (
+        routeThreadId === activation.threadId &&
+        routeSearch.splitViewId === activation.splitViewId
+      ) {
+        return;
+      }
+
+      prewarmThreadDetailForIntent(activation.threadId);
+      setOptimisticActiveThreadId(activation.threadId);
       if (selectedThreadIds.size > 0) {
         clearSelection();
       }
-      setSelectionAnchor(threadId);
-      setSplitFocusedPane(activeSplitView.id, splitPaneId);
+      setSelectionAnchor(activation.threadId);
+      setSplitFocusedPane(activation.splitViewId, activation.paneId);
+      rememberLastThreadRouteNow({
+        threadId: activation.threadId,
+        splitViewId: activation.splitViewId,
+      });
       void navigate({
         to: "/$threadId",
-        params: { threadId },
+        params: { threadId: activation.threadId },
         search: (previous) => ({
           ...previous,
-          splitViewId: activeSplitView.id,
+          splitViewId: activation.splitViewId,
         }),
       });
     },
@@ -3059,10 +3127,15 @@ export default function Sidebar() {
       clearSelection,
       navigate,
       prewarmThreadDetailForIntent,
+      rememberLastThreadRouteNow,
+      routeSearch.splitViewId,
+      routeThreadId,
       selectedThreadIds.size,
       setOptimisticActiveThreadId,
       setSelectionAnchor,
       setSplitFocusedPane,
+      sidebarThreadSummaryById,
+      splitViewsById,
     ],
   );
 
@@ -3585,16 +3658,17 @@ export default function Sidebar() {
         return;
       }
 
-      if (options?.isActive && options.canToggleSubagents && !routeSearch.splitViewId) {
+      if (threadId === routeThreadId && options?.canToggleSubagents && !routeSearch.splitViewId) {
         toggleSubagentParent(threadId);
         return;
       }
 
-      activateThread(threadId);
+      activateThreadFromCommand(threadId);
     },
     [
-      activateThread,
+      activateThreadFromCommand,
       rangeSelectTo,
+      routeThreadId,
       routeSearch.splitViewId,
       toggleSubagentParent,
       toggleThreadSelection,
@@ -3851,7 +3925,7 @@ export default function Sidebar() {
               : "text-foreground/72 hover:bg-[var(--sidebar-accent)]",
           )}
           onPointerDown={(event) => primeThreadActivation(event, thread.id)}
-          onClick={() => activateThread(thread.id)}
+          onClick={() => activateThreadFromCommand(thread.id)}
           onDoubleClick={(event) => {
             event.preventDefault();
             event.stopPropagation();
@@ -3861,7 +3935,7 @@ export default function Sidebar() {
           onKeyDown={(event) => {
             if (event.key === "Enter" || event.key === " ") {
               event.preventDefault();
-              activateThread(thread.id);
+              activateThreadFromCommand(thread.id);
             }
           }}
           onContextMenu={(event) => {
@@ -4134,7 +4208,7 @@ export default function Sidebar() {
           onKeyDown={(event) => {
             if (event.key !== "Enter" && event.key !== " ") return;
             event.preventDefault();
-            activateThread(thread.id);
+            activateThreadFromCommand(thread.id);
           }}
           onContextMenu={(event) => {
             event.preventDefault();
@@ -4734,30 +4808,28 @@ export default function Sidebar() {
       }
       const jumpIndex = threadJumpIndexFromCommand(command ?? "");
       if (jumpIndex !== null) {
-        const threadJumpTargetId = threadJumpThreadIds[jumpIndex];
-        if (!threadJumpTargetId) {
-          return;
-        }
-        if (threadJumpTargetId === activeSidebarThreadId) return;
         event.preventDefault();
         event.stopPropagation();
-        activateThreadFromShortcut(threadJumpTargetId);
+        const threadJumpTargetId = threadJumpThreadIds[jumpIndex];
+        if (threadJumpTargetId) {
+          activateThreadFromCommand(threadJumpTargetId);
+        }
         return;
       }
       if (command !== "chat.visible.next" && command !== "chat.visible.previous") {
         return;
       }
 
+      event.preventDefault();
+      event.stopPropagation();
       const nextThreadId = getNextVisibleSidebarThreadId({
         visibleThreadIds: visibleSidebarThreadIds,
         activeThreadId: activeSidebarThreadId ?? undefined,
         direction: command === "chat.visible.previous" ? "backward" : "forward",
       });
-      if (!nextThreadId || nextThreadId === activeSidebarThreadId) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-      activateThreadFromShortcut(nextThreadId);
+      if (nextThreadId && nextThreadId !== activeSidebarThreadId) {
+        activateThreadFromCommand(nextThreadId);
+      }
     };
     const onKeyUp = (event: KeyboardEvent) => {
       if (shouldIgnoreThreadJumpHintUpdate(event)) {
@@ -4796,7 +4868,7 @@ export default function Sidebar() {
       window.removeEventListener("blur", onWindowBlur);
     };
   }, [
-    activateThreadFromShortcut,
+    activateThreadFromCommand,
     activeSidebarThreadId,
     keybindings,
     getCurrentSidebarShortcutContext,
@@ -5825,7 +5897,7 @@ export default function Sidebar() {
           onOpenProject={handleOpenProjectFromSearch}
           onImportThread={handleImportThread}
           onOpenThread={(threadId) => {
-            activateThread(ThreadId.makeUnsafe(threadId));
+            activateThreadFromCommand(ThreadId.makeUnsafe(threadId));
           }}
         />
       ) : null}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -20,11 +20,12 @@ import { autoAnimate } from "@formkit/auto-animate";
 import { FiGitBranch, FiPlus } from "react-icons/fi";
 import { GoRepoForked } from "react-icons/go";
 import { HiOutlineArchiveBox, HiOutlineCheckCircle, HiOutlineFolderOpen } from "react-icons/hi2";
-import { BsChat } from "react-icons/bs";
+import { BsChat, BsLayoutSplit } from "react-icons/bs";
 import { TbArrowsDiagonal, TbArrowsDiagonalMinimize2, TbCursorText } from "react-icons/tb";
 import { IoFilter } from "react-icons/io5";
 import { LuMessageSquareDashed, LuSplit } from "react-icons/lu";
 import {
+  Fragment,
   useCallback,
   useEffect,
   useMemo,
@@ -260,6 +261,7 @@ const SIDEBAR_LIST_ANIMATION_OPTIONS = {
 } as const;
 const EMPTY_THREAD_JUMP_LABELS = new Map<ThreadId, string>();
 const EMPTY_SHORTCUT_PARTS: readonly string[] = [];
+const EMPTY_THREAD_ID_LIST: readonly ThreadId[] = [];
 const DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY = "dpcode:show-debug-feature-flags-menu";
 const ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS = 6;
 const ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS = 50;
@@ -1161,6 +1163,11 @@ export default function Sidebar() {
   );
   const [optimisticActiveThreadId, setOptimisticActiveThreadId] = useState<ThreadId | null>(null);
   const [expandedSubagentParentIds, setExpandedSubagentParentIds] = useState<ReadonlySet<ThreadId>>(
+    () => new Set(),
+  );
+  // Split chat groups default to expanded; we only track ids that the user has explicitly collapsed
+  // so newly-created splits open without any persisted state nudging them shut.
+  const [collapsedSplitViewGroupIds, setCollapsedSplitViewGroupIds] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
   const autoRevealedSubagentThreadIdRef = useRef<ThreadId | null>(null);
@@ -3602,6 +3609,36 @@ export default function Sidebar() {
     });
   }, []);
 
+  const toggleSplitViewGroupCollapsed = useCallback((splitViewId: string) => {
+    setCollapsedSplitViewGroupIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(splitViewId)) {
+        next.delete(splitViewId);
+      } else {
+        next.add(splitViewId);
+      }
+      return next;
+    });
+  }, []);
+
+  // Prune collapsed-group entries for split views that no longer exist so the Set does not
+  // accumulate stale ids across long sessions.
+  useEffect(() => {
+    setCollapsedSplitViewGroupIds((previous) => {
+      if (previous.size === 0) return previous;
+      let changed = false;
+      const next = new Set<string>();
+      for (const splitViewId of previous) {
+        if (splitViewsById[splitViewId]) {
+          next.add(splitViewId);
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : previous;
+    });
+  }, [splitViewsById]);
+
   const handleThreadClick = useCallback(
     (
       event: MouseEvent,
@@ -4015,11 +4052,18 @@ export default function Sidebar() {
     depth = 0,
     childCount = 0,
     isExpanded = false,
+    splitContext?: { splitView: SplitView; paneId: PaneId },
   ) {
     const threadTerminalState = selectThreadTerminalState(terminalStateByThreadId, thread.id);
     const threadEntryPoint = threadTerminalState.entryPoint;
     const isPendingArchiveConfirmation = pendingArchiveConfirmationThreadId === thread.id;
-    const isActive = visualActiveSidebarThreadId === thread.id;
+    // When the row represents a leaf inside a split-chats group, "active" means the split is the
+    // routed surface AND this leaf is the focused pane. Falling back to the thread-id check would
+    // either over-highlight (same thread referenced in multiple splits) or under-highlight.
+    const isActive = splitContext
+      ? routeSearch.splitViewId === splitContext.splitView.id &&
+        splitContext.splitView.focusedPaneId === splitContext.paneId
+      : visualActiveSidebarThreadId === thread.id;
     const isPinned = pinnedThreadIdSet.has(thread.id);
     const isSelected = selectedThreadIds.has(thread.id);
     const isHighlighted = isActive || isSelected;
@@ -4075,8 +4119,12 @@ export default function Sidebar() {
       ? "border-[color:var(--color-border)] bg-[var(--color-background-button-secondary)] text-[var(--color-text-foreground-secondary)] hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]"
       : "border-[color:var(--color-border-light)] bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground-secondary)] hover:border-[color:var(--color-border)] hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]";
 
+    const rowKey = splitContext
+      ? `split-leaf:${splitContext.splitView.id}:${splitContext.paneId}`
+      : thread.id;
+
     return (
-      <SidebarMenuSubItem key={thread.id} className="group/thread-row w-full" data-thread-item>
+      <SidebarMenuSubItem key={rowKey} className="group/thread-row w-full" data-thread-item>
         <ThreadPinToggleButton
           pinned={isPinned}
           presentation="overlay"
@@ -4145,12 +4193,17 @@ export default function Sidebar() {
               );
             }
           }}
-          onClick={(event) =>
+          onClick={(event) => {
+            if (splitContext) {
+              event.stopPropagation();
+              activateSplitPane(splitContext.splitView, splitContext.paneId);
+              return;
+            }
             handleThreadClick(event, thread.id, orderedProjectThreadIds, {
               isActive,
               canToggleSubagents,
-            })
-          }
+            });
+          }}
           onPointerDown={(event) => primeThreadActivation(event, thread.id)}
           onDoubleClick={(event) => {
             event.preventDefault();
@@ -4161,10 +4214,22 @@ export default function Sidebar() {
           onKeyDown={(event) => {
             if (event.key !== "Enter" && event.key !== " ") return;
             event.preventDefault();
+            if (splitContext) {
+              activateSplitPane(splitContext.splitView, splitContext.paneId);
+              return;
+            }
             activateThread(thread.id);
           }}
           onContextMenu={(event) => {
             event.preventDefault();
+            if (splitContext) {
+              event.stopPropagation();
+              void handleSplitContextMenu(splitContext.splitView, splitContext.paneId, {
+                x: event.clientX,
+                y: event.clientY,
+              });
+              return;
+            }
             if (selectedThreadIds.size > 0 && selectedThreadIds.has(thread.id)) {
               void handleMultiSelectContextMenu({
                 x: event.clientX,
@@ -4374,86 +4439,106 @@ export default function Sidebar() {
     } = projectSidebarData;
     const renderSplitRow = (splitView: SplitView) => {
       const leaves = collectLeaves(splitView.root);
-      const isActive = routeSearch.splitViewId === splitView.id;
+      const isActiveSplit = routeSearch.splitViewId === splitView.id;
+      const isCollapsed = collapsedSplitViewGroupIds.has(splitView.id);
+      const populatedLeafCount = leaves.reduce(
+        (count, leaf) => (leaf.threadId ? count + 1 : count),
+        0,
+      );
+      const collapseLabel = isCollapsed ? "Expand split chats" : "Collapse split chats";
+      // The split-chats header is styled like the project header (full width, px-2) rather than
+      // a thread row, so it matches the "section" that the user expects above the nested thread
+      // rows. Thread rows underneath keep their pl-8/pr-9 chrome unchanged.
+      const headerToneClass = isActiveSplit
+        ? "bg-[var(--color-background-button-secondary)] text-[var(--color-text-foreground)] hover:bg-[var(--color-background-button-secondary)]"
+        : "hover:bg-[var(--sidebar-accent)]";
+      const headerSecondaryToneClass = isActiveSplit
+        ? "text-foreground/54 dark:text-foreground/64"
+        : "text-muted-foreground/45";
 
       return (
-        <SidebarMenuSubItem key={`split:${splitView.id}`} className="w-full" data-thread-item>
-          <SidebarMenuSubButton
-            render={<div role="button" tabIndex={0} />}
-            size="sm"
-            isActive={isActive}
-            className={resolveThreadRowClassName({
-              isActive,
-              isSelected: false,
-            })}
-            onClick={() => activateSplitPane(splitView, splitView.focusedPaneId)}
-            onContextMenu={(event) => {
-              event.preventDefault();
-              void handleSplitContextMenu(splitView, splitView.focusedPaneId, {
-                x: event.clientX,
-                y: event.clientY,
-              });
-            }}
-            onKeyDown={(event) => {
-              if (event.key !== "Enter" && event.key !== " ") return;
-              event.preventDefault();
-              activateSplitPane(splitView, splitView.focusedPaneId);
-            }}
-          >
-            <div className="-ml-1.5 flex min-w-0 flex-1 items-center gap-0.5">
-              {leaves.map((leaf: LeafPane) => {
-                const preview = resolveSplitPreview(leaf.threadId);
-                const isPaneFocused = splitView.focusedPaneId === leaf.id;
-                return (
-                  <div
-                    key={leaf.id}
-                    role="button"
-                    tabIndex={0}
-                    className={cn(
-                      "flex min-w-0 flex-1 select-none items-center gap-1 rounded-md px-1.5 py-0.5 text-left outline-hidden transition-colors focus-visible:ring-1 focus-visible:ring-[color:var(--color-border-focus)]",
-                      isPaneFocused
-                        ? "bg-[var(--color-background-button-secondary)] shadow-xs"
-                        : "hover:bg-[var(--sidebar-accent)]",
-                    )}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      activateSplitPane(splitView, leaf.id);
-                    }}
-                    onContextMenu={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      void handleSplitContextMenu(splitView, leaf.id, {
-                        x: event.clientX,
-                        y: event.clientY,
-                      });
-                    }}
-                    onMouseDown={(event) => {
-                      if (event.detail > 1) {
-                        event.preventDefault();
-                      }
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key !== "Enter" && event.key !== " ") return;
-                      event.preventDefault();
-                      event.stopPropagation();
-                      activateSplitPane(splitView, leaf.id);
-                    }}
-                  >
-                    <ProviderGlyph provider={preview.provider} className="size-3 shrink-0" />
-                    <span className="min-w-0 truncate text-[length:var(--app-font-size-ui-sm,11px)] leading-5 text-foreground/86">
-                      {preview.threadId ? preview.title : "Select chat"}
-                    </span>
-                  </div>
-                );
-              })}
+        <Fragment key={`split-group:${splitView.id}`}>
+          <SidebarMenuSubItem className="group/thread-row w-full" data-thread-item>
+            <div
+              role="button"
+              tabIndex={0}
+              data-active={isActiveSplit ? "true" : undefined}
+              className={cn(
+                "flex h-8 w-full cursor-pointer items-center gap-2 rounded-md px-2 py-0.5 text-left text-[length:var(--app-font-size-ui,12px)] font-normal text-sidebar-foreground transition-colors select-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
+                headerToneClass,
+              )}
+              onClick={() => activateSplitPane(splitView, splitView.focusedPaneId)}
+              onContextMenu={(event) => {
+                event.preventDefault();
+                void handleSplitContextMenu(splitView, splitView.focusedPaneId, {
+                  x: event.clientX,
+                  y: event.clientY,
+                });
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter" && event.key !== " ") return;
+                event.preventDefault();
+                activateSplitPane(splitView, splitView.focusedPaneId);
+              }}
+            >
+              <BsLayoutSplit
+                aria-hidden="true"
+                className={cn("size-3.5 shrink-0", headerSecondaryToneClass)}
+              />
+              <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                <span className="min-w-0 truncate leading-5 text-foreground/86">Split chats</span>
+                <span
+                  aria-label={`${populatedLeafCount} chat${populatedLeafCount === 1 ? "" : "s"} in this split`}
+                  className={cn(
+                    "shrink-0 text-[10px] leading-none tabular-nums",
+                    headerSecondaryToneClass,
+                  )}
+                >
+                  {populatedLeafCount}
+                </span>
+              </div>
+              {/* Collapse toggle stays inline with the rest of the header content; clicking it
+                  toggles the group only and never activates the split. */}
+              <button
+                type="button"
+                data-thread-selection-safe
+                aria-label={collapseLabel}
+                title={collapseLabel}
+                className={cn(
+                  "inline-flex size-4 shrink-0 items-center justify-center rounded-sm transition-colors hover:bg-[var(--sidebar-accent)] hover:text-foreground",
+                  headerSecondaryToneClass,
+                )}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  toggleSplitViewGroupCollapsed(splitView.id);
+                }}
+              >
+                {isCollapsed ? (
+                  <ChevronRightIcon className="size-3" />
+                ) : (
+                  <ChevronDownIcon className="size-3" />
+                )}
+              </button>
             </div>
-            <div className="ml-auto flex shrink-0 items-center gap-1.5">
-              <span className="text-[length:var(--app-font-size-ui-sm,11px)] text-muted-foreground/40">
-                {formatRelativeTime(splitView.updatedAt)}
-              </span>
-            </div>
-          </SidebarMenuSubButton>
-        </SidebarMenuSubItem>
+          </SidebarMenuSubItem>
+          {!isCollapsed
+            ? leaves.flatMap((leaf) => {
+                // Empty/unknown panes don't get a placeholder row — keep the rule "reuse the
+                // existing thread row component, nothing else". Empty panes are still visible
+                // inside the split view itself when the user opens the group.
+                if (leaf.threadId === null) return [];
+                const thread = sidebarThreadSummaryById[leaf.threadId];
+                if (!thread) return [];
+                return [
+                  renderThreadRow(thread, EMPTY_THREAD_ID_LIST, 0, 0, false, {
+                    splitView,
+                    paneId: leaf.id,
+                  }),
+                ];
+              })
+            : null}
+        </Fragment>
       );
     };
 

--- a/apps/web/src/components/Sidebar.uiState.test.ts
+++ b/apps/web/src/components/Sidebar.uiState.test.ts
@@ -81,7 +81,7 @@ describe("Sidebar.uiState", () => {
 
   it("ignores malformed persisted project thread list entries", () => {
     window.localStorage.setItem(
-      "t3code:sidebar-ui:v1",
+      "dpcode:sidebar-ui:v1",
       JSON.stringify({
         chatSectionExpanded: true,
         chatThreadListExpanded: false,
@@ -115,7 +115,7 @@ describe("Sidebar.uiState", () => {
 
   it("drops malformed persisted last thread routes", () => {
     window.localStorage.setItem(
-      "t3code:sidebar-ui:v1",
+      "dpcode:sidebar-ui:v1",
       JSON.stringify({
         lastThreadRoute: {
           threadId: 42,

--- a/apps/web/src/components/Sidebar.uiState.ts
+++ b/apps/web/src/components/Sidebar.uiState.ts
@@ -1,16 +1,19 @@
-import { normalizeWorkspaceRootForComparison } from "@t3tools/shared/threadWorkspace";
+// FILE: Sidebar.uiState.ts
+// Purpose: Persists sidebar-only UI preferences plus the last chat route for restore flows.
+// Layer: Browser storage helper
+// Exports: sidebar UI state read/write helpers.
 
-const SIDEBAR_UI_STATE_STORAGE_KEY = "t3code:sidebar-ui:v1";
+import { normalizeWorkspaceRootForComparison } from "@t3tools/shared/threadWorkspace";
+import type { LastThreadRoute } from "../chatRouteRestore";
+
+const SIDEBAR_UI_STATE_STORAGE_KEY = "dpcode:sidebar-ui:v1";
 
 export type SidebarUiState = {
   chatSectionExpanded: boolean;
   chatThreadListExpanded: boolean;
   expandedProjectThreadListCwds: string[];
   dismissedThreadStatusKeyByThreadId: Record<string, string>;
-  lastThreadRoute: {
-    threadId: string;
-    splitViewId?: string | undefined;
-  } | null;
+  lastThreadRoute: LastThreadRoute | null;
 };
 
 const DEFAULT_SIDEBAR_UI_STATE: SidebarUiState = {

--- a/apps/web/src/components/chat-drop-overlay/ChatPaneDropOverlay.test.tsx
+++ b/apps/web/src/components/chat-drop-overlay/ChatPaneDropOverlay.test.tsx
@@ -1,0 +1,110 @@
+// FILE: ChatPaneDropOverlay.test.tsx
+// Purpose: Cover pure drop-zone helpers (hit-test + zone-to-direction mapping) used by the overlay.
+// Layer: UI helpers test
+// Targets: getDropZoneFromPointer, dropZoneToDirectionSide.
+
+import { describe, expect, it } from "vitest";
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+
+import {
+  dropZoneToDirectionSide,
+  getDropZoneFromPointer,
+  isThreadDragPayloadAllowed,
+} from "./ChatPaneDropOverlay";
+
+const RECT = { left: 0, top: 0, width: 100, height: 100 };
+const PROJECT_A = ProjectId.makeUnsafe("project-a");
+const PROJECT_B = ProjectId.makeUnsafe("project-b");
+const THREAD_A = ThreadId.makeUnsafe("thread-a");
+const THREAD_B = ThreadId.makeUnsafe("thread-b");
+
+describe("getDropZoneFromPointer", () => {
+  it("returns top when the pointer is near the top edge", () => {
+    expect(getDropZoneFromPointer(RECT, 50, 5)).toBe("top");
+  });
+
+  it("returns bottom when the pointer is near the bottom edge", () => {
+    expect(getDropZoneFromPointer(RECT, 50, 95)).toBe("bottom");
+  });
+
+  it("returns left when the pointer is near the left edge", () => {
+    expect(getDropZoneFromPointer(RECT, 5, 50)).toBe("left");
+  });
+
+  it("returns right when the pointer is near the right edge", () => {
+    expect(getDropZoneFromPointer(RECT, 95, 50)).toBe("right");
+  });
+
+  it("uses wide-pane regions that make left/right reliable", () => {
+    const wideRect = { left: 0, top: 0, width: 300, height: 100 };
+
+    expect(getDropZoneFromPointer(wideRect, 20, 5)).toBe("left");
+    expect(getDropZoneFromPointer(wideRect, 280, 95)).toBe("right");
+    expect(getDropZoneFromPointer(wideRect, 150, 10)).toBe("top");
+    expect(getDropZoneFromPointer(wideRect, 150, 90)).toBe("bottom");
+  });
+
+  it("uses tall-pane regions that make top/bottom reliable", () => {
+    const tallRect = { left: 0, top: 0, width: 100, height: 300 };
+
+    expect(getDropZoneFromPointer(tallRect, 5, 20)).toBe("top");
+    expect(getDropZoneFromPointer(tallRect, 95, 280)).toBe("bottom");
+    expect(getDropZoneFromPointer(tallRect, 10, 150)).toBe("left");
+    expect(getDropZoneFromPointer(tallRect, 90, 150)).toBe("right");
+  });
+
+  it("chooses the nearest allowed edge when some directions are disabled", () => {
+    const onlyVertical = (zone: "top" | "bottom" | "left" | "right") =>
+      zone === "top" || zone === "bottom";
+    const onlyHorizontal = (zone: "top" | "bottom" | "left" | "right") =>
+      zone === "left" || zone === "right";
+
+    expect(getDropZoneFromPointer(RECT, 5, 55, onlyVertical)).toBe("bottom");
+    expect(getDropZoneFromPointer(RECT, 60, 5, onlyHorizontal)).toBe("right");
+  });
+
+  it("returns null when every direction is disabled", () => {
+    expect(getDropZoneFromPointer(RECT, 50, 50, () => false)).toBeNull();
+  });
+
+  it("returns null for points outside the rectangle", () => {
+    expect(getDropZoneFromPointer(RECT, -5, 50)).toBeNull();
+    expect(getDropZoneFromPointer(RECT, 50, 200)).toBeNull();
+  });
+
+  it("returns null for degenerate rectangles", () => {
+    expect(getDropZoneFromPointer({ left: 0, top: 0, width: 0, height: 0 }, 0, 0)).toBeNull();
+  });
+});
+
+describe("dropZoneToDirectionSide", () => {
+  it("maps top/bottom to vertical splits and left/right to horizontal splits", () => {
+    expect(dropZoneToDirectionSide("top")).toEqual({ direction: "vertical", side: "first" });
+    expect(dropZoneToDirectionSide("bottom")).toEqual({ direction: "vertical", side: "second" });
+    expect(dropZoneToDirectionSide("left")).toEqual({ direction: "horizontal", side: "first" });
+    expect(dropZoneToDirectionSide("right")).toEqual({ direction: "horizontal", side: "second" });
+  });
+});
+
+describe("isThreadDragPayloadAllowed", () => {
+  it("rejects drops for already mounted threads or another project", () => {
+    expect(
+      isThreadDragPayloadAllowed(
+        { threadId: THREAD_A, ownerProjectId: PROJECT_A },
+        { excludedThreadIds: new Set([THREAD_A]), ownerProjectId: PROJECT_A },
+      ),
+    ).toBe(false);
+    expect(
+      isThreadDragPayloadAllowed(
+        { threadId: THREAD_B, ownerProjectId: PROJECT_B },
+        { excludedThreadIds: new Set([THREAD_A]), ownerProjectId: PROJECT_A },
+      ),
+    ).toBe(false);
+    expect(
+      isThreadDragPayloadAllowed(
+        { threadId: THREAD_B, ownerProjectId: PROJECT_A },
+        { excludedThreadIds: new Set([THREAD_A]), ownerProjectId: PROJECT_A },
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/components/chat-drop-overlay/ChatPaneDropOverlay.tsx
+++ b/apps/web/src/components/chat-drop-overlay/ChatPaneDropOverlay.tsx
@@ -37,7 +37,7 @@ const DROP_ZONE_PREVIEW_CLASS: Record<DropZone, string> = {
   right: "top-0 bottom-0 right-0 w-1/2",
 };
 const DROP_ZONE_PREVIEW_BASE_CLASS =
-  "absolute m-1 rounded-xl bg-info/18 ring-1 ring-inset ring-info/65";
+  "absolute m-1 rounded-md bg-info/18 ring-1 ring-inset ring-info/65";
 const EMPTY_RECT = { left: 0, top: 0, width: 0, height: 0 };
 const EDGE_REGION_FRACTION = 1 / 3;
 

--- a/apps/web/src/components/chat-drop-overlay/ChatPaneDropOverlay.tsx
+++ b/apps/web/src/components/chat-drop-overlay/ChatPaneDropOverlay.tsx
@@ -1,0 +1,330 @@
+// FILE: ChatPaneDropOverlay.tsx
+// Purpose: Renders the 4-quadrant drop-zone overlay used to split a chat surface by dragging a sidebar thread.
+// Layer: UI component (route surfaces wrap it around <ChatView /> or empty-state placeholders)
+// Exports: ChatPaneDropOverlay component, drag MIME constant, drop-zone helpers used by tests
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type DragEvent as ReactDragEvent,
+  type ReactNode,
+} from "react";
+import { type ProjectId, type ThreadId } from "@t3tools/contracts";
+
+import { type SplitDirection, type SplitDropSide } from "../../splitViewStore";
+import { cn } from "../../lib/utils";
+
+// Custom MIME so external file drops on the composer (which listen for `Files`) cannot trigger us.
+export const THREAD_DRAG_MIME = "application/x-t3-thread";
+
+export interface ThreadDragPayload {
+  threadId: ThreadId;
+  ownerProjectId: ProjectId;
+}
+
+export type DropZone = "top" | "bottom" | "left" | "right";
+
+export interface ThreadDropRules {
+  excludedThreadIds?: ReadonlySet<ThreadId>;
+  ownerProjectId?: ProjectId | null;
+}
+
+const DROP_ZONE_PREVIEW_CLASS: Record<DropZone, string> = {
+  top: "left-0 right-0 top-0 h-1/2",
+  bottom: "left-0 right-0 bottom-0 h-1/2",
+  left: "top-0 bottom-0 left-0 w-1/2",
+  right: "top-0 bottom-0 right-0 w-1/2",
+};
+const DROP_ZONE_PREVIEW_BASE_CLASS = "absolute m-1 rounded-xl bg-info/18 ring-1 ring-inset ring-info/65";
+const EMPTY_RECT = { left: 0, top: 0, width: 0, height: 0 };
+const EDGE_REGION_FRACTION = 1 / 3;
+
+function chooseAllowedZone(
+  primary: DropZone,
+  fallback: DropZone,
+  isZoneAllowed: (zone: DropZone) => boolean,
+): DropZone {
+  return isZoneAllowed(primary) ? primary : fallback;
+}
+
+interface ChatPaneDropOverlayProps {
+  // Centralized tree-aware predicate. Split panes use this to enforce the 2x2 depth cap.
+  canDropInDirection?: (direction: SplitDirection) => boolean;
+  // ThreadIds whose drops should be ignored (e.g. threads already mounted in this split view).
+  excludedThreadIds?: ReadonlySet<ThreadId>;
+  // Optional ProjectId restriction: drops from threads of other projects are silently ignored.
+  ownerProjectId?: ProjectId | null;
+  onDrop(payload: ThreadDragPayload & { direction: SplitDirection; side: SplitDropSide }): void;
+  // Outer wrapper className. Defaults to a layout-neutral filler that participates in flex containers.
+  className?: string;
+  children: ReactNode;
+  // Identifier used to reset internal state when the wrapped surface changes (e.g. pane id).
+  paneScopeId?: string;
+}
+
+export function getDropZoneFromPointer(
+  rect: { left: number; top: number; width: number; height: number },
+  clientX: number,
+  clientY: number,
+  isZoneAllowed: (zone: DropZone) => boolean = () => true,
+): DropZone | null {
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  const relX = (clientX - rect.left) / rect.width;
+  const relY = (clientY - rect.top) / rect.height;
+  if (relX < 0 || relX > 1 || relY < 0 || relY > 1) return null;
+
+  const horizontalAllowed = isZoneAllowed("left") || isZoneAllowed("right");
+  const verticalAllowed = isZoneAllowed("top") || isZoneAllowed("bottom");
+  if (!horizontalAllowed && !verticalAllowed) return null;
+
+  if (!horizontalAllowed) {
+    return relY < 0.5
+      ? chooseAllowedZone("top", "bottom", isZoneAllowed)
+      : chooseAllowedZone("bottom", "top", isZoneAllowed);
+  }
+  if (!verticalAllowed) {
+    return relX < 0.5
+      ? chooseAllowedZone("left", "right", isZoneAllowed)
+      : chooseAllowedZone("right", "left", isZoneAllowed);
+  }
+
+  // VS Code-style regions: favor left/right on wide panes, top/bottom on tall panes.
+  const preferHorizontal = rect.width >= rect.height;
+  const chooseHorizontal = () =>
+    relX < 0.5
+      ? chooseAllowedZone("left", "right", isZoneAllowed)
+      : chooseAllowedZone("right", "left", isZoneAllowed);
+  const chooseVertical = () =>
+    relY < 0.5
+      ? chooseAllowedZone("top", "bottom", isZoneAllowed)
+      : chooseAllowedZone("bottom", "top", isZoneAllowed);
+
+  if (preferHorizontal) {
+    if (relX < EDGE_REGION_FRACTION && isZoneAllowed("left")) return "left";
+    if (relX > 1 - EDGE_REGION_FRACTION && isZoneAllowed("right")) return "right";
+    return chooseVertical();
+  }
+
+  if (relY < EDGE_REGION_FRACTION && isZoneAllowed("top")) return "top";
+  if (relY > 1 - EDGE_REGION_FRACTION && isZoneAllowed("bottom")) return "bottom";
+  return chooseHorizontal();
+}
+
+export function dropZoneToDirectionSide(zone: DropZone): {
+  direction: SplitDirection;
+  side: SplitDropSide;
+} {
+  if (zone === "top") return { direction: "vertical", side: "first" };
+  if (zone === "bottom") return { direction: "vertical", side: "second" };
+  if (zone === "left") return { direction: "horizontal", side: "first" };
+  return { direction: "horizontal", side: "second" };
+}
+
+function isThreadDrag(event: ReactDragEvent): boolean {
+  const types = event.dataTransfer.types;
+  for (let index = 0; index < types.length; index += 1) {
+    if (types[index] === THREAD_DRAG_MIME) return true;
+  }
+  return false;
+}
+
+function parseThreadDragPayload(event: ReactDragEvent): ThreadDragPayload | null {
+  try {
+    const raw = event.dataTransfer.getData(THREAD_DRAG_MIME);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ThreadDragPayload>;
+    if (typeof parsed.threadId === "string" && typeof parsed.ownerProjectId === "string") {
+      return {
+        threadId: parsed.threadId as ThreadId,
+        ownerProjectId: parsed.ownerProjectId as ProjectId,
+      };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+// Applies the same thread/project constraints for hover feedback and the final drop.
+export function isThreadDragPayloadAllowed(
+  payload: ThreadDragPayload,
+  rules: ThreadDropRules,
+): boolean {
+  if (rules.excludedThreadIds?.has(payload.threadId)) return false;
+  if (rules.ownerProjectId && payload.ownerProjectId !== rules.ownerProjectId) return false;
+  return true;
+}
+
+export function ChatPaneDropOverlay(props: ChatPaneDropOverlayProps) {
+  const {
+    onDrop,
+    canDropInDirection,
+    excludedThreadIds,
+    ownerProjectId,
+    paneScopeId,
+    className,
+    children,
+  } = props;
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
+  const rectRef = useRef<DOMRect | null>(null);
+  const rectMeasuredAtRef = useRef(0);
+  const activeZoneRef = useRef<DropZone | null>(null);
+
+  const isZoneAllowed = useCallback(
+    (zone: DropZone): boolean => {
+      const { direction } = dropZoneToDirectionSide(zone);
+      return canDropInDirection ? canDropInDirection(direction) : true;
+    },
+    [canDropInDirection],
+  );
+
+  const setPreviewZone = useCallback((zone: DropZone | null) => {
+    const preview = previewRef.current;
+    if (!preview) return;
+    const nextClassName = zone
+      ? cn(DROP_ZONE_PREVIEW_BASE_CLASS, DROP_ZONE_PREVIEW_CLASS[zone])
+      : "";
+    if (activeZoneRef.current === zone && preview.className === nextClassName) return;
+    activeZoneRef.current = zone;
+    if (zone === null) {
+      preview.removeAttribute("data-chat-pane-drop-zone");
+      preview.className = "";
+      return;
+    }
+    preview.dataset.chatPaneDropZone = zone;
+    preview.className = nextClassName;
+  }, []);
+
+  const resetOverlayState = useCallback(() => {
+    rectRef.current = null;
+    rectMeasuredAtRef.current = 0;
+    setPreviewZone(null);
+  }, [setPreviewZone]);
+
+  const getCurrentRect = useCallback(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return null;
+    const now = performance.now();
+    if (!rectRef.current || now - rectMeasuredAtRef.current >= 16) {
+      rectRef.current = wrapper.getBoundingClientRect();
+      rectMeasuredAtRef.current = now;
+    }
+    return rectRef.current;
+  }, []);
+
+  const getZoneForEvent = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>) =>
+      getDropZoneFromPointer(
+        getCurrentRect() ?? EMPTY_RECT,
+        event.clientX,
+        event.clientY,
+        isZoneAllowed,
+      ),
+    [getCurrentRect, isZoneAllowed],
+  );
+
+  const getAllowedZoneForEvent = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>) => {
+      const zone = getZoneForEvent(event);
+      if (!zone) return null;
+      const payload = parseThreadDragPayload(event);
+      if (
+        payload &&
+        !isThreadDragPayloadAllowed(payload, {
+          excludedThreadIds,
+          ownerProjectId,
+        })
+      ) {
+        return null;
+      }
+      return zone;
+    },
+    [excludedThreadIds, getZoneForEvent, ownerProjectId],
+  );
+
+  const handleDragEnter = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>) => {
+      if (!isThreadDrag(event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      rectRef.current = wrapperRef.current?.getBoundingClientRect() ?? null;
+      rectMeasuredAtRef.current = performance.now();
+      const zone = getAllowedZoneForEvent(event);
+      event.dataTransfer.dropEffect = zone ? "move" : "none";
+      setPreviewZone(zone);
+    },
+    [getAllowedZoneForEvent, setPreviewZone],
+  );
+
+  const handleDragOver = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>) => {
+      if (!isThreadDrag(event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const zone = getAllowedZoneForEvent(event);
+      event.dataTransfer.dropEffect = zone ? "move" : "none";
+      setPreviewZone(zone);
+    },
+    [getAllowedZoneForEvent, setPreviewZone],
+  );
+
+  const handleDragLeave = useCallback((event: ReactDragEvent<HTMLDivElement>) => {
+    if (!isThreadDrag(event)) return;
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+    const related = event.relatedTarget as Node | null;
+    if (related && wrapper.contains(related)) return;
+    resetOverlayState();
+  }, [resetOverlayState]);
+
+  const handleDrop = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>) => {
+      if (!isThreadDrag(event)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const zone = getZoneForEvent(event);
+      const payload = parseThreadDragPayload(event);
+
+      resetOverlayState();
+
+      if (!zone || !payload) return;
+      if (!isThreadDragPayloadAllowed(payload, { excludedThreadIds, ownerProjectId })) return;
+      const { direction, side } = dropZoneToDirectionSide(zone);
+      onDrop({ ...payload, direction, side });
+    },
+    [
+      excludedThreadIds,
+      getZoneForEvent,
+      onDrop,
+      ownerProjectId,
+      resetOverlayState,
+    ],
+  );
+
+  useEffect(() => {
+    resetOverlayState();
+    return resetOverlayState;
+  }, [paneScopeId, resetOverlayState]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      data-chat-pane-drop-overlay="true"
+      className={cn("relative flex min-h-0 min-w-0 flex-1 flex-col", className)}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {children}
+      <div
+        className="pointer-events-none absolute inset-0 z-50"
+        data-chat-pane-drop-zones="true"
+      >
+        <div ref={previewRef} data-chat-pane-drop-zone-active="true" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat-drop-overlay/ChatPaneDropOverlay.tsx
+++ b/apps/web/src/components/chat-drop-overlay/ChatPaneDropOverlay.tsx
@@ -26,8 +26,8 @@ export interface ThreadDragPayload {
 export type DropZone = "top" | "bottom" | "left" | "right";
 
 export interface ThreadDropRules {
-  excludedThreadIds?: ReadonlySet<ThreadId>;
-  ownerProjectId?: ProjectId | null;
+  excludedThreadIds?: ReadonlySet<ThreadId> | undefined;
+  ownerProjectId?: ProjectId | null | undefined;
 }
 
 const DROP_ZONE_PREVIEW_CLASS: Record<DropZone, string> = {
@@ -36,7 +36,8 @@ const DROP_ZONE_PREVIEW_CLASS: Record<DropZone, string> = {
   left: "top-0 bottom-0 left-0 w-1/2",
   right: "top-0 bottom-0 right-0 w-1/2",
 };
-const DROP_ZONE_PREVIEW_BASE_CLASS = "absolute m-1 rounded-xl bg-info/18 ring-1 ring-inset ring-info/65";
+const DROP_ZONE_PREVIEW_BASE_CLASS =
+  "absolute m-1 rounded-xl bg-info/18 ring-1 ring-inset ring-info/65";
 const EMPTY_RECT = { left: 0, top: 0, width: 0, height: 0 };
 const EDGE_REGION_FRACTION = 1 / 3;
 
@@ -270,14 +271,17 @@ export function ChatPaneDropOverlay(props: ChatPaneDropOverlayProps) {
     [getAllowedZoneForEvent, setPreviewZone],
   );
 
-  const handleDragLeave = useCallback((event: ReactDragEvent<HTMLDivElement>) => {
-    if (!isThreadDrag(event)) return;
-    const wrapper = wrapperRef.current;
-    if (!wrapper) return;
-    const related = event.relatedTarget as Node | null;
-    if (related && wrapper.contains(related)) return;
-    resetOverlayState();
-  }, [resetOverlayState]);
+  const handleDragLeave = useCallback(
+    (event: ReactDragEvent<HTMLDivElement>) => {
+      if (!isThreadDrag(event)) return;
+      const wrapper = wrapperRef.current;
+      if (!wrapper) return;
+      const related = event.relatedTarget as Node | null;
+      if (related && wrapper.contains(related)) return;
+      resetOverlayState();
+    },
+    [resetOverlayState],
+  );
 
   const handleDrop = useCallback(
     (event: ReactDragEvent<HTMLDivElement>) => {
@@ -294,13 +298,7 @@ export function ChatPaneDropOverlay(props: ChatPaneDropOverlayProps) {
       const { direction, side } = dropZoneToDirectionSide(zone);
       onDrop({ ...payload, direction, side });
     },
-    [
-      excludedThreadIds,
-      getZoneForEvent,
-      onDrop,
-      ownerProjectId,
-      resetOverlayState,
-    ],
+    [excludedThreadIds, getZoneForEvent, onDrop, ownerProjectId, resetOverlayState],
   );
 
   useEffect(() => {
@@ -319,10 +317,7 @@ export function ChatPaneDropOverlay(props: ChatPaneDropOverlayProps) {
       onDrop={handleDrop}
     >
       {children}
-      <div
-        className="pointer-events-none absolute inset-0 z-50"
-        data-chat-pane-drop-zones="true"
-      >
+      <div className="pointer-events-none absolute inset-0 z-50" data-chat-pane-drop-zones="true">
         <div ref={previewRef} data-chat-pane-drop-zone-active="true" />
       </div>
     </div>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -16,7 +16,7 @@ import React, { memo, useEffect, useRef, useState } from "react";
 import { BsLayoutSplit, BsTerminal } from "react-icons/bs";
 import { FiGitBranch } from "react-icons/fi";
 import { HiMiniArrowsPointingOut } from "react-icons/hi2";
-import { TbLayoutSidebarRight } from "react-icons/tb";
+import { TbExchange, TbLayoutSidebarRight } from "react-icons/tb";
 import GitActionsControl from "../GitActionsControl";
 import { AppsIcon, ArrowRightIcon, GlobeIcon, PlusIcon } from "~/lib/icons";
 import { Button } from "../ui/button";
@@ -42,6 +42,7 @@ const HEADER_COMPACT_BREAKPOINT = 480;
 interface ChatHeaderProps {
   activeThreadId: ThreadId;
   activeThreadTitle: string;
+  activeProvider: ProviderKind;
   activeProjectName: string | undefined;
   threadBreadcrumbs: ReadonlyArray<{
     threadId: ThreadId;
@@ -77,6 +78,10 @@ interface ChatHeaderProps {
     shortcutLabel: string | null;
     onClick: () => void;
   } | null;
+  changeThreadAction?: {
+    label: string;
+    onClick: () => void;
+  } | null;
   onRunProjectScript: (script: ProjectScript) => void;
   onAddProjectScript: (input: NewProjectScriptInput) => Promise<void>;
   onUpdateProjectScript: (scriptId: string, input: NewProjectScriptInput) => Promise<void>;
@@ -92,6 +97,7 @@ interface ChatHeaderProps {
 export const ChatHeader = memo(function ChatHeader({
   activeThreadId,
   activeThreadTitle,
+  activeProvider,
   activeProjectName,
   threadBreadcrumbs,
   hideHandoffControls = false,
@@ -119,6 +125,7 @@ export const ChatHeader = memo(function ChatHeader({
   diffDisabledReason = null,
   surfaceMode = "single",
   chatLayoutAction = null,
+  changeThreadAction = null,
   onRunProjectScript,
   onAddProjectScript,
   onUpdateProjectScript,
@@ -202,6 +209,12 @@ export const ChatHeader = memo(function ChatHeader({
               </div>
             ) : null}
             <div className="flex min-w-0 items-center gap-2">
+              <span
+                className="inline-flex size-3.5 shrink-0 items-center justify-center"
+                title={PROVIDER_DISPLAY_NAMES[activeProvider]}
+              >
+                {renderProviderIcon(activeProvider, "size-3.5")}
+              </span>
               <h2
                 className="max-w-[clamp(16rem,50vw,40rem)] truncate text-sm font-medium text-foreground"
                 title={activeThreadTitle}
@@ -290,7 +303,11 @@ export const ChatHeader = memo(function ChatHeader({
 
         {/* Panel toggles menu — editor, terminal, browser, split chat. */}
         {!isDisposableThread &&
-        (terminalAvailable || activeProjectName || chatLayoutAction || isElectron) ? (
+        (terminalAvailable ||
+          activeProjectName ||
+          chatLayoutAction ||
+          changeThreadAction ||
+          isElectron) ? (
           <Menu modal={false}>
             <MenuTrigger
               render={
@@ -358,6 +375,12 @@ export const ChatHeader = memo(function ChatHeader({
                       {chatLayoutAction.shortcutLabel}
                     </span>
                   )}
+                </MenuItem>
+              ) : null}
+              {changeThreadAction ? (
+                <MenuItem onClick={changeThreadAction.onClick}>
+                  <TbExchange className="size-3.5 shrink-0" />
+                  <span>{changeThreadAction.label}</span>
                 </MenuItem>
               ) : null}
               {activeProjectScripts ? (

--- a/apps/web/src/components/ui/toastRouteVisibility.test.ts
+++ b/apps/web/src/components/ui/toastRouteVisibility.test.ts
@@ -12,28 +12,43 @@ const THREAD_A = ThreadId.makeUnsafe("thread-a");
 const THREAD_B = ThreadId.makeUnsafe("thread-b");
 
 function createSplitView(): SplitView {
-  return {
-    id: "split-1",
-    sourceThreadId: THREAD_A,
-    ownerProjectId: PROJECT_ID,
-    leftThreadId: THREAD_A,
-    rightThreadId: THREAD_B,
-    focusedPane: "right",
-    ratio: 0.5,
-    leftPanel: {
+  const firstLeaf = {
+    kind: "leaf" as const,
+    id: "pane-first",
+    threadId: THREAD_A,
+    panel: {
       panel: null,
       diffTurnId: null,
       diffFilePath: null,
       hasOpenedPanel: false,
-      lastOpenPanel: "browser",
+      lastOpenPanel: "browser" as const,
     },
-    rightPanel: {
-      panel: "browser",
+  };
+  const secondLeaf = {
+    kind: "leaf" as const,
+    id: "pane-second",
+    threadId: THREAD_B,
+    panel: {
+      panel: "browser" as const,
       diffTurnId: null,
       diffFilePath: null,
       hasOpenedPanel: true,
-      lastOpenPanel: "browser",
+      lastOpenPanel: "browser" as const,
     },
+  };
+  return {
+    id: "split-1",
+    sourceThreadId: THREAD_A,
+    ownerProjectId: PROJECT_ID,
+    root: {
+      kind: "split",
+      id: "split-root",
+      direction: "horizontal",
+      first: firstLeaf,
+      second: secondLeaf,
+      ratio: 0.5,
+    },
+    focusedPaneId: secondLeaf.id,
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
   };

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -46,7 +46,7 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { createDebouncedStorage, createMemoryStorage } from "./lib/storage";
 
-export const COMPOSER_DRAFT_STORAGE_KEY = "t3code:composer-drafts:v1";
+export const COMPOSER_DRAFT_STORAGE_KEY = "dpcode:composer-drafts:v1";
 const COMPOSER_DRAFT_STORAGE_VERSION = 4;
 const DraftThreadEnvModeSchema = Schema.Literals(["local", "worktree"]);
 export type DraftThreadEnvMode = typeof DraftThreadEnvModeSchema.Type;

--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -2,7 +2,7 @@ import { EDITORS, EditorId, NativeApi } from "@t3tools/contracts";
 import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "./hooks/useLocalStorage";
 import { useMemo } from "react";
 
-const LAST_EDITOR_KEY = "t3code:last-editor";
+const LAST_EDITOR_KEY = "dpcode:last-editor";
 
 export function usePreferredEditor(availableEditors: ReadonlyArray<EditorId>) {
   const [lastEditor, setLastEditor] = useLocalStorage(LAST_EDITOR_KEY, null, EditorId);

--- a/apps/web/src/focusedChatContext.test.ts
+++ b/apps/web/src/focusedChatContext.test.ts
@@ -72,32 +72,53 @@ function makeDraftThread(overrides: Partial<DraftThreadState> = {}): DraftThread
   };
 }
 
-function makeSplitView(overrides: Partial<SplitView> = {}): SplitView {
+interface SplitViewLayoutOverrides {
+  firstThreadId?: ThreadId | null;
+  secondThreadId?: ThreadId | null;
+  focusedSide?: "first" | "second";
+}
+
+function makeSplitView(overrides: SplitViewLayoutOverrides = {}): SplitView {
+  const firstLeaf = {
+    kind: "leaf" as const,
+    id: "pane-first",
+    threadId: overrides.firstThreadId === undefined ? THREAD_A : overrides.firstThreadId,
+    panel: {
+      panel: null,
+      diffTurnId: null,
+      diffFilePath: null,
+      hasOpenedPanel: false,
+      lastOpenPanel: "browser" as const,
+    },
+  };
+  const secondLeaf = {
+    kind: "leaf" as const,
+    id: "pane-second",
+    threadId: overrides.secondThreadId === undefined ? THREAD_B : overrides.secondThreadId,
+    panel: {
+      panel: null,
+      diffTurnId: null,
+      diffFilePath: null,
+      hasOpenedPanel: false,
+      lastOpenPanel: "browser" as const,
+    },
+  };
+  const focusedSide = overrides.focusedSide ?? "second";
   return {
     id: "split-1",
     sourceThreadId: THREAD_A,
     ownerProjectId: PROJECT_ID,
-    leftThreadId: THREAD_A,
-    rightThreadId: THREAD_B,
-    focusedPane: "right",
-    ratio: 0.5,
-    leftPanel: {
-      panel: null,
-      diffTurnId: null,
-      diffFilePath: null,
-      hasOpenedPanel: false,
-      lastOpenPanel: "browser",
+    root: {
+      kind: "split",
+      id: "split-root",
+      direction: "horizontal",
+      first: firstLeaf,
+      second: secondLeaf,
+      ratio: 0.5,
     },
-    rightPanel: {
-      panel: null,
-      diffTurnId: null,
-      diffFilePath: null,
-      hasOpenedPanel: false,
-      lastOpenPanel: "browser",
-    },
+    focusedPaneId: focusedSide === "first" ? firstLeaf.id : secondLeaf.id,
     createdAt: "2026-04-07T10:00:00.000Z",
     updatedAt: "2026-04-07T10:00:00.000Z",
-    ...overrides,
   };
 }
 
@@ -120,8 +141,8 @@ describe("resolveFocusedChatContext", () => {
     const context = resolveFocusedChatContext({
       routeThreadId: THREAD_A,
       splitView: makeSplitView({
-        rightThreadId: null,
-        focusedPane: "right",
+        secondThreadId: null,
+        focusedSide: "second",
       }),
       threads: [makeThread(THREAD_A)],
       projects: [makeProject()],
@@ -138,8 +159,8 @@ describe("resolveFocusedChatContext", () => {
     const context = resolveFocusedChatContext({
       routeThreadId: THREAD_A,
       splitView: makeSplitView({
-        rightThreadId: draftThreadId,
-        focusedPane: "right",
+        secondThreadId: draftThreadId,
+        focusedSide: "second",
       }),
       threads: [makeThread(THREAD_A)],
       projects: [makeProject()],

--- a/apps/web/src/hooks/useLocalStorage.ts
+++ b/apps/web/src/hooks/useLocalStorage.ts
@@ -39,7 +39,7 @@ export const removeLocalStorageItem = (key: string) => {
   isomorphicLocalStorage.removeItem(key);
 };
 
-const LOCAL_STORAGE_CHANGE_EVENT = "t3code:local_storage_change";
+const LOCAL_STORAGE_CHANGE_EVENT = "dpcode:local_storage_change";
 
 interface LocalStorageChangeDetail {
   key: string;

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -33,7 +33,7 @@ type ThemeSnapshot = {
   systemDark: boolean;
 };
 
-const STORAGE_KEY = "t3code:theme";
+const STORAGE_KEY = "dpcode:theme";
 const MEDIA_QUERY = "(prefers-color-scheme: dark)";
 
 let listeners: Array<() => void> = [];

--- a/apps/web/src/hooks/useThreadActivationController.test.ts
+++ b/apps/web/src/hooks/useThreadActivationController.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+import type { SplitView } from "../splitViewStore";
+import {
+  activateThreadFromSidebarIntent,
+  type ThreadActivationControllerInput,
+} from "./useThreadActivationController";
+
+const THREAD_A = ThreadId.makeUnsafe("thread-a");
+const THREAD_B = ThreadId.makeUnsafe("thread-b");
+const THREAD_C = ThreadId.makeUnsafe("thread-c");
+const PROJECT_ID = ProjectId.makeUnsafe("project-1");
+
+function makeSplitViewFixture(input: {
+  id: string;
+  sourceThreadId: ThreadId;
+  firstThreadId: ThreadId | null;
+  secondThreadId: ThreadId | null;
+  focusOn: "first" | "second";
+}): SplitView {
+  const firstId = `${input.id}-pane-first`;
+  const secondId = `${input.id}-pane-second`;
+  const panel = {
+    panel: null,
+    diffTurnId: null,
+    diffFilePath: null,
+    hasOpenedPanel: false,
+    lastOpenPanel: "browser" as const,
+  };
+  return {
+    id: input.id,
+    sourceThreadId: input.sourceThreadId,
+    ownerProjectId: PROJECT_ID,
+    focusedPaneId: input.focusOn === "first" ? firstId : secondId,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    root: {
+      kind: "split",
+      id: `${input.id}-root`,
+      direction: "horizontal",
+      ratio: 0.5,
+      first: { kind: "leaf", id: firstId, threadId: input.firstThreadId, panel },
+      second: { kind: "leaf", id: secondId, threadId: input.secondThreadId, panel },
+    },
+  };
+}
+
+function makeControllerInput(
+  overrides: Partial<ThreadActivationControllerInput> = {},
+): ThreadActivationControllerInput & {
+  navigate: ReturnType<typeof vi.fn>;
+  clearSelection: ReturnType<typeof vi.fn>;
+  openChatThreadPage: ReturnType<typeof vi.fn>;
+  openTerminalThreadPage: ReturnType<typeof vi.fn>;
+  prewarmThreadDetailForIntent: ReturnType<typeof vi.fn>;
+  rememberLastThreadRouteNow: ReturnType<typeof vi.fn>;
+  setOptimisticActiveThreadId: ReturnType<typeof vi.fn>;
+  setSelectionAnchor: ReturnType<typeof vi.fn>;
+  setSplitFocusedPane: ReturnType<typeof vi.fn>;
+} {
+  return {
+    activeSplitView: null,
+    clearSelection: vi.fn(),
+    navigate: vi.fn(),
+    openChatThreadPage: vi.fn(),
+    openTerminalThreadPage: vi.fn(),
+    prewarmThreadDetailForIntent: vi.fn(),
+    rememberLastThreadRouteNow: vi.fn(),
+    routeSplitViewId: undefined,
+    routeThreadId: THREAD_A,
+    selectedThreadCount: 0,
+    setOptimisticActiveThreadId: vi.fn(),
+    setSelectionAnchor: vi.fn(),
+    setSplitFocusedPane: vi.fn(),
+    sidebarThreadSummaryById: {
+      [THREAD_A]: {},
+      [THREAD_B]: {},
+      [THREAD_C]: {},
+    },
+    splitViewsById: {},
+    terminalStateByThreadId: {},
+    ...overrides,
+  } as ThreadActivationControllerInput & {
+    navigate: ReturnType<typeof vi.fn>;
+    clearSelection: ReturnType<typeof vi.fn>;
+    openChatThreadPage: ReturnType<typeof vi.fn>;
+    openTerminalThreadPage: ReturnType<typeof vi.fn>;
+    prewarmThreadDetailForIntent: ReturnType<typeof vi.fn>;
+    rememberLastThreadRouteNow: ReturnType<typeof vi.fn>;
+    setOptimisticActiveThreadId: ReturnType<typeof vi.fn>;
+    setSelectionAnchor: ReturnType<typeof vi.fn>;
+    setSplitFocusedPane: ReturnType<typeof vi.fn>;
+  };
+}
+
+function getFirstNavigateArgs(input: { navigate: ReturnType<typeof vi.fn> }) {
+  const [args] = input.navigate.mock.calls[0] ?? [];
+  if (!args) {
+    throw new Error("Expected navigate to be called");
+  }
+  return args as {
+    params: { threadId: ThreadId };
+    search: (previous: { splitViewId?: string; keep?: boolean }) => {
+      splitViewId?: string | undefined;
+      keep?: boolean;
+    };
+  };
+}
+
+describe("activateThreadFromSidebarIntent", () => {
+  it("focuses a target pane in the active split", () => {
+    const activeSplitView = makeSplitViewFixture({
+      id: "split-active",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const input = makeControllerInput({
+      activeSplitView,
+      routeSplitViewId: "split-active",
+      selectedThreadCount: 1,
+    });
+
+    activateThreadFromSidebarIntent(input, THREAD_B);
+
+    expect(input.prewarmThreadDetailForIntent).toHaveBeenCalledWith(THREAD_B);
+    expect(input.clearSelection).toHaveBeenCalledOnce();
+    expect(input.setSplitFocusedPane).toHaveBeenCalledWith(
+      "split-active",
+      "split-active-pane-second",
+    );
+    expect(input.rememberLastThreadRouteNow).toHaveBeenCalledWith({
+      threadId: THREAD_B,
+      splitViewId: "split-active",
+    });
+    expect(getFirstNavigateArgs(input).search({ keep: true })).toEqual({
+      keep: true,
+      splitViewId: "split-active",
+    });
+    expect(input.openChatThreadPage).not.toHaveBeenCalled();
+  });
+
+  it("exits an active split when the target thread is outside it", () => {
+    const activeSplitView = makeSplitViewFixture({
+      id: "split-active",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const input = makeControllerInput({
+      activeSplitView,
+      routeSplitViewId: "split-active",
+    });
+
+    activateThreadFromSidebarIntent(input, THREAD_C);
+
+    expect(input.openChatThreadPage).toHaveBeenCalledWith(THREAD_C);
+    expect(input.setSplitFocusedPane).not.toHaveBeenCalled();
+    expect(getFirstNavigateArgs(input).search({ keep: true, splitViewId: "split-active" })).toEqual(
+      {
+        keep: true,
+        splitViewId: undefined,
+      },
+    );
+  });
+
+  it("restores a persisted split from single-chat mode", () => {
+    const splitView = makeSplitViewFixture({
+      id: "split-background",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const input = makeControllerInput({
+      activeSplitView: null,
+      routeThreadId: THREAD_C,
+      splitViewsById: { "split-background": splitView },
+    });
+
+    activateThreadFromSidebarIntent(input, THREAD_B);
+
+    expect(input.setSplitFocusedPane).toHaveBeenCalledWith(
+      "split-background",
+      "split-background-pane-second",
+    );
+    expect(input.rememberLastThreadRouteNow).toHaveBeenCalledWith({
+      threadId: THREAD_B,
+      splitViewId: "split-background",
+    });
+    expect(getFirstNavigateArgs(input).search({ keep: true })).toEqual({
+      keep: true,
+      splitViewId: "split-background",
+    });
+  });
+
+  it("switches between two persisted split pairings without separating them", () => {
+    const firstSplit = makeSplitViewFixture({
+      id: "split-first",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const secondSplit = makeSplitViewFixture({
+      id: "split-second",
+      sourceThreadId: THREAD_C,
+      firstThreadId: THREAD_C,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const input = makeControllerInput({
+      activeSplitView: firstSplit,
+      routeSplitViewId: "split-first",
+      routeThreadId: THREAD_A,
+      splitViewsById: {
+        "split-first": firstSplit,
+        "split-second": secondSplit,
+      },
+    });
+
+    activateThreadFromSidebarIntent(input, THREAD_C);
+
+    expect(input.setSplitFocusedPane).toHaveBeenCalledWith(
+      "split-second",
+      "split-second-pane-first",
+    );
+    expect(input.openChatThreadPage).not.toHaveBeenCalled();
+    expect(getFirstNavigateArgs(input).search({ keep: true, splitViewId: "split-first" })).toEqual(
+      {
+        keep: true,
+        splitViewId: "split-second",
+      },
+    );
+  });
+
+  it("does nothing when the current route already targets the same split pane", () => {
+    const activeSplitView = makeSplitViewFixture({
+      id: "split-active",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "second",
+    });
+    const input = makeControllerInput({
+      activeSplitView,
+      routeSplitViewId: "split-active",
+      routeThreadId: THREAD_B,
+    });
+
+    activateThreadFromSidebarIntent(input, THREAD_B);
+
+    expect(input.navigate).not.toHaveBeenCalled();
+    expect(input.setSplitFocusedPane).not.toHaveBeenCalled();
+    expect(input.rememberLastThreadRouteNow).not.toHaveBeenCalled();
+  });
+
+  it("preserves terminal entry point when opening a single thread", () => {
+    const terminalStateByThreadId = {
+      [THREAD_C]: { entryPoint: "terminal" },
+    } as unknown as ThreadActivationControllerInput["terminalStateByThreadId"];
+    const input = makeControllerInput({
+      routeThreadId: THREAD_A,
+      terminalStateByThreadId,
+    });
+
+    activateThreadFromSidebarIntent(input, THREAD_C);
+
+    expect(input.openTerminalThreadPage).toHaveBeenCalledWith(THREAD_C);
+    expect(input.openChatThreadPage).not.toHaveBeenCalled();
+    expect(getFirstNavigateArgs(input).params).toEqual({ threadId: THREAD_C });
+  });
+});

--- a/apps/web/src/hooks/useThreadActivationController.ts
+++ b/apps/web/src/hooks/useThreadActivationController.ts
@@ -1,0 +1,212 @@
+// FILE: useThreadActivationController.ts
+// Purpose: Centralize sidebar thread activation side effects around the pure activation policy.
+// Exports: useThreadActivationController
+
+import { useCallback } from "react";
+import type { useNavigate } from "@tanstack/react-router";
+import type { ThreadId } from "@t3tools/contracts";
+import type { LastThreadRoute } from "../chatRouteRestore";
+import {
+  type PaneId,
+  type SplitView,
+  type SplitViewId,
+} from "../splitViewStore";
+import { selectThreadTerminalState } from "../terminalStateStore";
+import {
+  resolvePreferredSplitForCommand,
+  resolveThreadCommandActivation,
+} from "../threadActivation.logic";
+
+type Navigate = ReturnType<typeof useNavigate>;
+type ThreadTerminalStateById = Parameters<typeof selectThreadTerminalState>[0];
+
+export type ThreadActivationControllerInput = {
+  activeSplitView: SplitView | null;
+  clearSelection: () => void;
+  navigate: Navigate;
+  openChatThreadPage: (threadId: ThreadId) => void;
+  openTerminalThreadPage: (threadId: ThreadId) => void;
+  prewarmThreadDetailForIntent: (threadId: ThreadId) => void;
+  rememberLastThreadRouteNow: (nextLastThreadRoute: LastThreadRoute) => void;
+  routeSplitViewId: string | null | undefined;
+  routeThreadId: ThreadId | null | undefined;
+  selectedThreadCount: number;
+  setOptimisticActiveThreadId: (threadId: ThreadId) => void;
+  setSelectionAnchor: (threadId: ThreadId) => void;
+  setSplitFocusedPane: (splitViewId: SplitViewId, paneId: PaneId) => void;
+  sidebarThreadSummaryById: Readonly<Partial<Record<ThreadId, unknown>>>;
+  splitViewsById: Record<SplitViewId, SplitView | undefined>;
+  terminalStateByThreadId: ThreadTerminalStateById;
+};
+
+// Runs the complete sidebar activation side-effect chain for one thread intent.
+export function activateThreadFromSidebarIntent(
+  input: ThreadActivationControllerInput,
+  threadId: ThreadId,
+): void {
+  const {
+    activeSplitView,
+    clearSelection,
+    navigate,
+    openChatThreadPage,
+    openTerminalThreadPage,
+    prewarmThreadDetailForIntent,
+    rememberLastThreadRouteNow,
+    routeSplitViewId,
+    routeThreadId,
+    selectedThreadCount,
+    setOptimisticActiveThreadId,
+    setSelectionAnchor,
+    setSplitFocusedPane,
+    sidebarThreadSummaryById,
+    splitViewsById,
+    terminalStateByThreadId,
+  } = input;
+
+  // Active split wins first; otherwise every persisted split block can restore deterministically.
+  const preferredSplit = resolvePreferredSplitForCommand({
+    activeSplitView,
+    splitViewsById,
+    threadId,
+  });
+  const activation = resolveThreadCommandActivation({
+    threadId,
+    threadExists: sidebarThreadSummaryById[threadId] !== undefined,
+    activeSidebarThreadId: routeThreadId,
+    preferredSplitViewId: preferredSplit?.splitViewId ?? null,
+    splitPaneId: preferredSplit?.paneId ?? null,
+  });
+
+  if (activation.kind === "ignore") {
+    return;
+  }
+
+  if (activation.kind === "single") {
+    activateThreadSingle(input, activation.threadId);
+    return;
+  }
+
+  if (routeThreadId === activation.threadId && routeSplitViewId === activation.splitViewId) {
+    return;
+  }
+
+  prewarmThreadDetailForIntent(activation.threadId);
+  setOptimisticActiveThreadId(activation.threadId);
+  if (selectedThreadCount > 0) {
+    clearSelection();
+  }
+  setSelectionAnchor(activation.threadId);
+  setSplitFocusedPane(activation.splitViewId, activation.paneId);
+  rememberLastThreadRouteNow({
+    threadId: activation.threadId,
+    splitViewId: activation.splitViewId,
+  });
+  void navigate({
+    to: "/$threadId",
+    params: { threadId: activation.threadId },
+    search: (previous) => ({
+      ...previous,
+      splitViewId: activation.splitViewId,
+    }),
+  });
+}
+
+// Opens the target as a single chat while preserving chat-vs-terminal entry point.
+function activateThreadSingle(input: ThreadActivationControllerInput, threadId: ThreadId): void {
+  if (!input.sidebarThreadSummaryById[threadId]) return;
+
+  input.prewarmThreadDetailForIntent(threadId);
+  input.setOptimisticActiveThreadId(threadId);
+  if (input.selectedThreadCount > 0) {
+    input.clearSelection();
+  }
+  input.setSelectionAnchor(threadId);
+
+  const threadEntryPoint = selectThreadTerminalState(
+    input.terminalStateByThreadId,
+    threadId,
+  ).entryPoint;
+  if (threadEntryPoint === "terminal") {
+    input.openTerminalThreadPage(threadId);
+  } else {
+    input.openChatThreadPage(threadId);
+  }
+
+  void input.navigate({
+    to: "/$threadId",
+    params: { threadId },
+    search: (previous) => ({
+      ...previous,
+      splitViewId: undefined,
+    }),
+  });
+}
+
+export function useThreadActivationController(input: ThreadActivationControllerInput): {
+  activateThreadFromSidebarIntent: (threadId: ThreadId) => void;
+} {
+  const {
+    activeSplitView,
+    clearSelection,
+    navigate,
+    openChatThreadPage,
+    openTerminalThreadPage,
+    prewarmThreadDetailForIntent,
+    rememberLastThreadRouteNow,
+    routeSplitViewId,
+    routeThreadId,
+    selectedThreadCount,
+    setOptimisticActiveThreadId,
+    setSelectionAnchor,
+    setSplitFocusedPane,
+    sidebarThreadSummaryById,
+    splitViewsById,
+    terminalStateByThreadId,
+  } = input;
+
+  const activateThread = useCallback(
+    (threadId: ThreadId) => {
+      activateThreadFromSidebarIntent(
+        {
+          activeSplitView,
+          clearSelection,
+          navigate,
+          openChatThreadPage,
+          openTerminalThreadPage,
+          prewarmThreadDetailForIntent,
+          rememberLastThreadRouteNow,
+          routeSplitViewId,
+          routeThreadId,
+          selectedThreadCount,
+          setOptimisticActiveThreadId,
+          setSelectionAnchor,
+          setSplitFocusedPane,
+          sidebarThreadSummaryById,
+          splitViewsById,
+          terminalStateByThreadId,
+        },
+        threadId,
+      );
+    },
+    [
+      activeSplitView,
+      clearSelection,
+      navigate,
+      openChatThreadPage,
+      openTerminalThreadPage,
+      prewarmThreadDetailForIntent,
+      rememberLastThreadRouteNow,
+      routeSplitViewId,
+      routeThreadId,
+      selectedThreadCount,
+      setOptimisticActiveThreadId,
+      setSelectionAnchor,
+      setSplitFocusedPane,
+      sidebarThreadSummaryById,
+      splitViewsById,
+      terminalStateByThreadId,
+    ],
+  );
+
+  return { activateThreadFromSidebarIntent: activateThread };
+}

--- a/apps/web/src/latestProjectStore.ts
+++ b/apps/web/src/latestProjectStore.ts
@@ -2,7 +2,7 @@ import type { ProjectId } from "@t3tools/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
-const LATEST_PROJECT_STORAGE_KEY = "t3code:latest-project:v1";
+const LATEST_PROJECT_STORAGE_KEY = "dpcode:latest-project:v1";
 
 interface LatestProjectStore {
   latestProjectId: ProjectId | null;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,7 @@ import "@fontsource-variable/jetbrains-mono";
 import "katex/dist/katex.min.css";
 import "@xterm/xterm/css/xterm.css";
 import "./index.css";
+import "./storageKeyMigration";
 
 import { appHistory } from "./appNavigation";
 import { getRouter } from "./router";

--- a/apps/web/src/notifications/taskCompletion.tsx
+++ b/apps/web/src/notifications/taskCompletion.tsx
@@ -8,7 +8,6 @@ import { useEffect, useRef } from "react";
 import { toastManager } from "../components/ui/toast";
 import { useAppSettings } from "../appSettings";
 import { isElectron } from "../env";
-import { resolvePreferredSplitViewIdForThread, useSplitViewStore } from "../splitViewStore";
 import { useStore } from "../store";
 import { createAllThreadsSelector } from "../storeSelectors";
 import { useTerminalStateStore } from "../terminalStateStore";
@@ -70,15 +69,13 @@ interface ThreadNotificationCopy {
   body: string;
 }
 
-function focusThread(
-  threadId: Thread["id"],
-  navigate: ReturnType<typeof useNavigate>,
-  splitViewId: string | null,
-): void {
+// Notification opens are generic thread activations, so they clear splitViewId
+// instead of resurrecting a hidden split pairing.
+function focusThread(threadId: Thread["id"], navigate: ReturnType<typeof useNavigate>): void {
   void navigate({
     to: "/$threadId",
     params: { threadId },
-    ...(splitViewId ? { search: () => ({ splitViewId }) } : {}),
+    search: (previous) => ({ ...previous, splitViewId: undefined }),
   });
 }
 
@@ -86,7 +83,6 @@ async function showSystemThreadNotification(
   copy: ThreadNotificationCopy,
   threadId: Thread["id"],
   navigate: ReturnType<typeof useNavigate>,
-  splitViewId: string | null,
 ): Promise<boolean> {
   const { body, title } = copy;
 
@@ -108,7 +104,7 @@ async function showSystemThreadNotification(
   });
   notification.addEventListener("click", () => {
     window.focus();
-    focusThread(threadId, navigate, splitViewId);
+    focusThread(threadId, navigate);
   });
   return true;
 }
@@ -118,7 +114,6 @@ function showThreadToast(
   threadId: Thread["id"],
   tone: "success" | "warning",
   navigate: ReturnType<typeof useNavigate>,
-  splitViewId: string | null,
 ): void {
   const { body, title } = copy;
   toastManager.add({
@@ -132,7 +127,7 @@ function showThreadToast(
     },
     actionProps: {
       children: "Open",
-      onClick: () => focusThread(threadId, navigate, splitViewId),
+      onClick: () => focusThread(threadId, navigate),
     },
   });
 }
@@ -143,10 +138,6 @@ export function TaskCompletionNotifications() {
   const threads = useStore(useRef(createAllThreadsSelector()).current);
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const terminalStateByThreadId = useTerminalStateStore((store) => store.terminalStateByThreadId);
-  const splitViewsById = useSplitViewStore((store) => store.splitViewsById);
-  const splitViewIdBySourceThreadId = useSplitViewStore(
-    (store) => store.splitViewIdBySourceThreadId,
-  );
   const previousThreadsRef = useRef<readonly Thread[]>([]);
   const previousTerminalStateRef = useRef(terminalStateByThreadId);
   const readyRef = useRef(false);
@@ -166,18 +157,13 @@ export function TaskCompletionNotifications() {
       if (threadId.length === 0) {
         return;
       }
-      const preferredSplitViewId = resolvePreferredSplitViewIdForThread({
-        splitViewsById,
-        splitViewIdBySourceThreadId,
-        threadId: threadId as Thread["id"],
-      });
-      focusThread(threadId as Thread["id"], navigate, preferredSplitViewId);
+      focusThread(threadId as Thread["id"], navigate);
     });
 
     return () => {
       unsubscribe?.();
     };
-  }, [navigate, splitViewIdBySourceThreadId, splitViewsById]);
+  }, [navigate]);
 
   useEffect(() => {
     if (!threadsHydrated) {
@@ -221,76 +207,44 @@ export function TaskCompletionNotifications() {
       (window.desktopBridge ? true : !isWindowForeground());
 
     for (const completion of completions) {
-      const preferredSplitViewId = resolvePreferredSplitViewIdForThread({
-        splitViewsById,
-        splitViewIdBySourceThreadId,
-        threadId: completion.threadId,
-      });
       const copy = buildTaskCompletionCopy(completion);
       if (shouldAttemptSystemNotification) {
-        void showSystemThreadNotification(
-          copy,
-          completion.threadId,
-          navigate,
-          preferredSplitViewId,
-        );
+        void showSystemThreadNotification(copy, completion.threadId, navigate);
       }
     }
 
     for (const candidate of inputNeededCandidates) {
-      const preferredSplitViewId = resolvePreferredSplitViewIdForThread({
-        splitViewsById,
-        splitViewIdBySourceThreadId,
-        threadId: candidate.threadId,
-      });
       const copy = buildInputNeededCopy(candidate);
       if (settings.enableTaskCompletionToasts) {
-        showThreadToast(copy, candidate.threadId, "warning", navigate, preferredSplitViewId);
+        showThreadToast(copy, candidate.threadId, "warning", navigate);
       }
 
       if (shouldAttemptSystemNotification) {
-        void showSystemThreadNotification(copy, candidate.threadId, navigate, preferredSplitViewId);
+        void showSystemThreadNotification(copy, candidate.threadId, navigate);
       }
     }
 
     for (const completion of terminalCompletions) {
-      const preferredSplitViewId = resolvePreferredSplitViewIdForThread({
-        splitViewsById,
-        splitViewIdBySourceThreadId,
-        threadId: completion.threadId,
-      });
       const copy = buildTerminalCompletionCopy(completion);
       if (shouldAttemptSystemNotification) {
-        void showSystemThreadNotification(
-          copy,
-          completion.threadId,
-          navigate,
-          preferredSplitViewId,
-        );
+        void showSystemThreadNotification(copy, completion.threadId, navigate);
       }
     }
 
     for (const candidate of terminalAttentionCandidates) {
-      const preferredSplitViewId = resolvePreferredSplitViewIdForThread({
-        splitViewsById,
-        splitViewIdBySourceThreadId,
-        threadId: candidate.threadId,
-      });
       const copy = buildTerminalAttentionCopy(candidate);
       if (settings.enableTaskCompletionToasts) {
-        showThreadToast(copy, candidate.threadId, "warning", navigate, preferredSplitViewId);
+        showThreadToast(copy, candidate.threadId, "warning", navigate);
       }
 
       if (shouldAttemptSystemNotification) {
-        void showSystemThreadNotification(copy, candidate.threadId, navigate, preferredSplitViewId);
+        void showSystemThreadNotification(copy, candidate.threadId, navigate);
       }
     }
   }, [
     navigate,
     settings.enableSystemTaskCompletionNotifications,
     settings.enableTaskCompletionToasts,
-    splitViewIdBySourceThreadId,
-    splitViewsById,
     terminalStateByThreadId,
     threads,
     threadsHydrated,

--- a/apps/web/src/pinnedThreadsStore.ts
+++ b/apps/web/src/pinnedThreadsStore.ts
@@ -15,7 +15,7 @@ interface PinnedThreadsStoreState {
   prunePinnedThreads: (threadIds: readonly ThreadId[]) => void;
 }
 
-const PINNED_THREADS_STORAGE_KEY = "t3code:pinned-threads:v1";
+const PINNED_THREADS_STORAGE_KEY = "dpcode:pinned-threads:v1";
 
 function normalizePinnedThreadIds(threadIds: readonly ThreadId[]): ThreadId[] {
   const seen = new Set<ThreadId>();

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -14,7 +14,7 @@ import {
   useRouterState,
   useSearch,
 } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Throttler } from "@tanstack/react-pacer";
 
@@ -46,7 +46,10 @@ import { projectQueryKeys } from "../lib/projectReactQuery";
 import { collectActiveTerminalThreadIds } from "../lib/terminalStateCleanup";
 import { TaskCompletionNotifications } from "../notifications/taskCompletion";
 import { useWorkspaceStore, workspaceThreadId } from "../workspaceStore";
-import { useRetainedThreadDetailIds } from "../threadDetailSubscriptionRetention";
+import {
+  subscribeRetainedThreadDetailIdChanges,
+  useRetainedThreadDetailIds,
+} from "../threadDetailSubscriptionRetention";
 import { useAppTypography } from "../hooks/useAppTypography";
 import { useChatCodeFont } from "../hooks/useChatCodeFont";
 import { useTheme } from "../hooks/useTheme";
@@ -363,6 +366,7 @@ function EventRouter() {
   const workspacePagesRef = useRef(workspacePages);
   const pathnameRef = useRef(pathname);
   const handledBootstrapThreadIdRef = useRef<string | null>(null);
+  const routeVisibleThreadIdsRef = useRef(visibleThreadIds);
   const visibleThreadIdsRef = useRef(subscribedThreadIds);
   const reconcileThreadSubscriptionsRef = useRef<
     ((threadIds: readonly ThreadId[]) => Promise<void>) | null
@@ -370,6 +374,7 @@ function EventRouter() {
 
   workspacePagesRef.current = workspacePages;
   pathnameRef.current = pathname;
+  routeVisibleThreadIdsRef.current = visibleThreadIds;
   visibleThreadIdsRef.current = subscribedThreadIds;
 
   useEffect(() => {
@@ -440,18 +445,10 @@ function EventRouter() {
       const removals = [...subscribedThreadIds].filter((threadId) => !nextThreadIds.has(threadId));
       const additions = [...nextThreadIds].filter((threadId) => !subscribedThreadIds.has(threadId));
 
-      for (const threadId of removals) {
-        threadSnapshotSequenceById.delete(threadId);
-        pendingThreadEventsById.delete(threadId);
-        threadSnapshotRequestInFlight.delete(threadId);
-      }
-      await Promise.all(
-        removals.map((threadId) =>
-          api.orchestration.unsubscribeThread({ threadId }).catch(() => undefined),
-        ),
-      );
+      // Start new detail snapshots first so route changes can paint from the hot thread cache.
       for (const threadId of additions) {
         beginThreadSubscription(threadId);
+        subscribedThreadIds.add(threadId);
       }
       await Promise.all(
         additions.map((threadId) =>
@@ -459,10 +456,17 @@ function EventRouter() {
         ),
       );
 
-      subscribedThreadIds.clear();
-      for (const threadId of nextThreadIds) {
-        subscribedThreadIds.add(threadId);
+      for (const threadId of removals) {
+        threadSnapshotSequenceById.delete(threadId);
+        pendingThreadEventsById.delete(threadId);
+        threadSnapshotRequestInFlight.delete(threadId);
+        subscribedThreadIds.delete(threadId);
       }
+      await Promise.all(
+        removals.map((threadId) =>
+          api.orchestration.unsubscribeThread({ threadId }).catch(() => undefined),
+        ),
+      );
     };
 
     const enqueueThreadSubscriptionReconcile = (threadIds: readonly ThreadId[]) => {
@@ -472,6 +476,16 @@ function EventRouter() {
         .then(() => reconcileThreadSubscriptions(nextThreadIds));
       return reconcileThreadSubscriptionsChain;
     };
+
+    const unsubscribeRetainedThreadIdChanges = subscribeRetainedThreadDetailIdChanges(
+      (nextRetainedThreadIds) => {
+        const nextThreadIds = new Set(routeVisibleThreadIdsRef.current);
+        for (const threadId of nextRetainedThreadIds) {
+          nextThreadIds.add(threadId);
+        }
+        void enqueueThreadSubscriptionReconcile([...nextThreadIds]);
+      },
+    );
 
     const ensureScopedSubscriptions = async () => {
       shellSnapshotSequence = -1;
@@ -743,6 +757,7 @@ function EventRouter() {
           api.orchestration.unsubscribeThread({ threadId }).catch(() => undefined),
         ),
       );
+      unsubscribeRetainedThreadIdChanges();
       unsubShellEvent();
       unsubThreadEvent();
       unsubTerminalEvent();
@@ -762,7 +777,7 @@ function EventRouter() {
     syncServerThreadDetailHotPath,
   ]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const reconcile = reconcileThreadSubscriptionsRef.current;
     if (!reconcile) {
       return;

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -476,7 +476,7 @@ function SplitPaneEmptyState(props: {
     <div
       className={cn(
         "flex min-h-0 min-w-0 flex-1 flex-col items-center bg-background px-6 pt-16",
-        props.isFocused ? "ring-1 ring-inset ring-primary/25" : "",
+        props.isFocused ? "ring-2 ring-inset ring-primary/70" : "",
       )}
       onMouseDown={props.onFocus}
     >
@@ -804,9 +804,9 @@ function DeferredChatView(props: {
       onToggleDiffPanel={props.onToggleDiff}
       onToggleBrowserPanel={props.onToggleBrowser}
       onOpenTurnDiffPanel={props.onOpenTurnDiff}
-      onSplitSurface={props.onSplitSurface}
-      onMaximizeSurface={props.onMaximize}
-      onChangeThreadInSplitPane={props.onChangeThread}
+      {...(props.onSplitSurface ? { onSplitSurface: props.onSplitSurface } : {})}
+      {...(props.onMaximize ? { onMaximizeSurface: props.onMaximize } : {})}
+      {...(props.onChangeThread ? { onChangeThreadInSplitPane: props.onChangeThread } : {})}
     />
   );
 }
@@ -879,7 +879,7 @@ function SplitPaneSurface(props: {
         <SidebarInset
           className={cn(
             "min-h-0 min-w-0 overflow-hidden overscroll-y-none text-foreground transition-shadow",
-            props.isFocused ? "ring-1 ring-inset ring-primary/25" : "",
+            props.isFocused ? "ring-2 ring-inset ring-primary/70" : "",
           )}
           onMouseDown={props.onFocus}
         >
@@ -924,7 +924,7 @@ function SplitPaneSurface(props: {
       {!props.isFocused ? (
         <div
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 z-10 bg-foreground/[0.030] transition-opacity duration-150"
+          className="pointer-events-none absolute inset-0 z-10 bg-foreground/[0.060] transition-opacity duration-150"
         />
       ) : null}
     </div>
@@ -970,13 +970,14 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
     if (leaves.length <= 1) {
       const onlyThreadId = leaves[0]?.threadId ?? null;
       removeSplitView(activeSplitView.id);
-      if (!onlyThreadId) {
+      const fallbackThreadId = onlyThreadId ?? props.routeThreadId;
+      if (!fallbackThreadId) {
         void handleNewChat({ fresh: true });
         return;
       }
       void navigate({
         to: "/$threadId",
-        params: { threadId: onlyThreadId },
+        params: { threadId: fallbackThreadId },
         replace: true,
         search: (previous) => ({ ...stripDiffSearchParams(previous), splitViewId: undefined }),
       });
@@ -1538,9 +1539,7 @@ function SingleChatSurface(props: {
             surfaceMode="single"
             isFocusedPane
             panelState={panelState}
-            onToggleDiff={() =>
-              updatePanelState(resolveToggledChatPanelPatch(panelState, "diff"))
-            }
+            onToggleDiff={() => updatePanelState(resolveToggledChatPanelPatch(panelState, "diff"))}
             onToggleBrowser={() =>
               updatePanelState(resolveToggledChatPanelPatch(panelState, "browser"))
             }
@@ -1576,7 +1575,6 @@ function SingleChatSurface(props: {
 
 function ChatThreadRouteView() {
   const threadsHydrated = useStore((store) => store.threadsHydrated);
-  const { handleNewChat } = useHandleNewChat();
   const threadId = Route.useParams({
     select: (params) => ThreadId.makeUnsafe(params.threadId),
   });
@@ -1594,6 +1592,7 @@ function ChatThreadRouteView() {
   const draftThreadExists = draftThreadState !== null;
   const routeThreadExists = threadExists || draftThreadExists;
   const splitView = useSplitViewStore(selectSplitView(search.splitViewId ?? null));
+  const splitViewsHydrated = useSplitViewStore((store) => store.hasHydrated);
   const activeProjectId = resolveSingleProjectId({
     threadProjectId,
     draftProjectId: draftThreadState?.projectId ?? null,
@@ -1601,7 +1600,7 @@ function ChatThreadRouteView() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!threadsHydrated) {
+    if (!threadsHydrated || !splitViewsHydrated) {
       return;
     }
 
@@ -1618,11 +1617,19 @@ function ChatThreadRouteView() {
     }
 
     if (!routeThreadExists) {
-      void handleNewChat({ fresh: true });
+      void navigate({ to: "/", replace: true });
     }
-  }, [handleNewChat, navigate, routeThreadExists, search, splitView, threadId, threadsHydrated]);
+  }, [
+    navigate,
+    routeThreadExists,
+    search,
+    splitView,
+    splitViewsHydrated,
+    threadId,
+    threadsHydrated,
+  ]);
 
-  if (!threadsHydrated) {
+  if (!threadsHydrated || !splitViewsHydrated) {
     return <ChatMountSkeleton />;
   }
 

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -25,7 +25,6 @@ import {
   useState,
 } from "react";
 import { Schema } from "effect";
-import { TbExchange } from "react-icons/tb";
 
 import ChatView from "../components/ChatView";
 import BrowserPanel from "../components/BrowserPanel";
@@ -106,6 +105,7 @@ const SPLIT_RATIO_MIN = 0.25;
 const SPLIT_RATIO_MAX = 0.75;
 
 const allowAnySplitDirection = (_direction: SplitDirection) => true;
+const noop = () => {};
 
 function clampSplitRatio(value: number): number {
   if (!Number.isFinite(value)) return 0.5;
@@ -701,55 +701,87 @@ function PaneRenderer(props: {
   );
 }
 
-function SplitPaneChatMountSkeleton() {
+function ChatMountSkeleton() {
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background [contain:layout_style_paint]">
-      <div className="flex h-[52px] shrink-0 items-center border-b border-[color:var(--color-border-light)] px-4">
-        <div className="h-4 w-40 rounded-full bg-muted" />
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground [contain:layout_style_paint]">
+      {/* Mirrors the real chat shell so route changes paint immediately while ChatView mounts
+          on the next frames. */}
+      <div className="flex h-[52px] shrink-0 items-center gap-3 border-b border-[color:var(--color-border-light)] px-4">
+        <div className="size-5 rounded-full bg-muted" />
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="h-3.5 w-44 max-w-[48%] rounded-full bg-muted" />
+          <div className="h-2 w-24 max-w-[32%] rounded-full bg-muted/65" />
+        </div>
+        <div className="hidden items-center gap-1.5 sm:flex">
+          <div className="size-7 rounded-md border border-[color:var(--color-border-light)] bg-muted/35" />
+          <div className="size-7 rounded-md border border-[color:var(--color-border-light)] bg-muted/35" />
+        </div>
       </div>
       <div className="flex min-h-0 flex-1 flex-col justify-end gap-3 px-5 py-4">
-        <div className="h-12 w-4/5 rounded-xl bg-muted" />
-        <div className="ml-auto h-10 w-3/5 rounded-xl bg-muted" />
-        <div className="h-16 w-5/6 rounded-xl bg-muted" />
+        <div className="max-w-[82%] space-y-2 rounded-2xl border border-[color:var(--color-border-light)] bg-muted/22 p-3">
+          <div className="h-2.5 w-11/12 rounded-full bg-muted/75" />
+          <div className="h-2.5 w-7/12 rounded-full bg-muted/60" />
+        </div>
+        <div className="ml-auto max-w-[70%] space-y-2 rounded-2xl bg-muted/45 p-3">
+          <div className="h-2.5 w-48 max-w-full rounded-full bg-muted-foreground/14" />
+          <div className="h-2.5 w-32 max-w-[78%] rounded-full bg-muted-foreground/12" />
+        </div>
+        <div className="max-w-[88%] space-y-2 rounded-2xl border border-[color:var(--color-border-light)] bg-muted/22 p-3">
+          <div className="h-2.5 w-full rounded-full bg-muted/75" />
+          <div className="h-2.5 w-10/12 rounded-full bg-muted/60" />
+          <div className="h-2.5 w-5/12 rounded-full bg-muted/50" />
+        </div>
       </div>
       <div className="shrink-0 border-t border-[color:var(--color-border-light)] p-3">
-        <div className="h-16 rounded-2xl bg-muted" />
+        <div className="rounded-2xl border border-[color:var(--color-border-light)] bg-background p-3 shadow-xs">
+          <div className="h-3 w-40 max-w-[50%] rounded-full bg-muted" />
+          <div className="mt-8 flex items-center justify-between">
+            <div className="h-2.5 w-24 rounded-full bg-muted/65" />
+            <div className="size-7 rounded-full bg-muted" />
+          </div>
+        </div>
       </div>
     </div>
   );
 }
 
-function DeferredSplitPaneChatView(props: {
+function DeferredChatView(props: {
   threadId: ThreadIdType;
   paneScopeId: string;
-  deferInitialMount: boolean;
+  deferMount: boolean;
+  surfaceMode: "single" | "split";
   isFocusedPane: boolean;
   panelState: SplitViewPanePanelState;
   onToggleDiff: () => void;
   onToggleBrowser: () => void;
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
-  onMaximize: () => void;
-  onMounted: () => void;
+  onSplitSurface?: () => void;
+  onMaximize?: () => void;
+  onChangeThread?: () => void;
+  onMounted?: () => void;
 }) {
-  const onMounted = props.onMounted;
-  const [canMountChatView, setCanMountChatView] = useState(!props.deferInitialMount);
+  const onMounted = props.onMounted ?? noop;
+  const mountKey = `${props.paneScopeId}:${props.threadId}`;
+  const [readyMountKey, setReadyMountKey] = useState<string | null>(() =>
+    props.deferMount ? null : mountKey,
+  );
+  const canMountChatView = !props.deferMount || readyMountKey === mountKey;
 
   useEffect(() => {
-    if (!props.deferInitialMount) {
-      setCanMountChatView(true);
+    if (!props.deferMount) {
       return;
     }
-    setCanMountChatView(false);
+    setReadyMountKey(null);
     let firstFrame = 0;
     let secondFrame = 0;
     firstFrame = window.requestAnimationFrame(() => {
-      secondFrame = window.requestAnimationFrame(() => setCanMountChatView(true));
+      secondFrame = window.requestAnimationFrame(() => setReadyMountKey(mountKey));
     });
     return () => {
       window.cancelAnimationFrame(firstFrame);
       window.cancelAnimationFrame(secondFrame);
     };
-  }, [props.deferInitialMount, props.paneScopeId, props.threadId]);
+  }, [mountKey, props.deferMount]);
 
   useEffect(() => {
     if (canMountChatView) {
@@ -758,7 +790,7 @@ function DeferredSplitPaneChatView(props: {
   }, [canMountChatView, onMounted]);
 
   if (!canMountChatView) {
-    return <SplitPaneChatMountSkeleton />;
+    return <ChatMountSkeleton />;
   }
 
   return (
@@ -766,13 +798,15 @@ function DeferredSplitPaneChatView(props: {
       key={props.paneScopeId}
       threadId={props.threadId}
       paneScopeId={props.paneScopeId}
-      surfaceMode="split"
+      surfaceMode={props.surfaceMode}
       isFocusedPane={props.isFocusedPane}
       panelState={props.panelState}
       onToggleDiffPanel={props.onToggleDiff}
       onToggleBrowserPanel={props.onToggleBrowser}
       onOpenTurnDiffPanel={props.onOpenTurnDiff}
+      onSplitSurface={props.onSplitSurface}
       onMaximizeSurface={props.onMaximize}
+      onChangeThreadInSplitPane={props.onChangeThread}
     />
   );
 }
@@ -829,28 +863,11 @@ function SplitPaneSurface(props: {
   );
 
   return (
-    <div className="group relative flex min-h-0 min-w-0 flex-1 bg-background [contain:layout_style_paint]">
-      {props.threadId ? (
-        <div className="pointer-events-none absolute right-3 top-[3.75rem] z-20 sm:right-5 sm:top-[4.25rem]">
-          <Button
-            type="button"
-            size="icon-sm"
-            variant="outline"
-            aria-label={`Choose chat for split pane ${props.paneId}`}
-            title="Choose chat"
-            className={cn(
-              "pointer-events-auto transition-opacity",
-              !props.isFocused ? "opacity-0 group-hover:opacity-100" : "",
-            )}
-            onClick={(event) => {
-              event.stopPropagation();
-              props.onChooseThread();
-            }}
-          >
-            <TbExchange className="size-4" />
-          </Button>
-        </div>
-      ) : null}
+    <div
+      className={cn(
+        "group relative flex min-h-0 min-w-0 flex-1 bg-background [contain:layout_style_paint]",
+      )}
+    >
       <ChatPaneDropOverlay
         paneScopeId={paneScopeId}
         canDropInDirection={props.canDropInDirection}
@@ -867,16 +884,18 @@ function SplitPaneSurface(props: {
           onMouseDown={props.onFocus}
         >
           {props.threadId ? (
-            <DeferredSplitPaneChatView
+            <DeferredChatView
               threadId={props.threadId}
               paneScopeId={paneScopeId}
-              deferInitialMount={props.deferChatMount}
+              deferMount={props.deferChatMount}
+              surfaceMode="split"
               isFocusedPane={props.isFocused}
               panelState={props.panelState}
               onToggleDiff={props.onToggleDiff}
               onToggleBrowser={props.onToggleBrowser}
               onOpenTurnDiff={props.onOpenTurnDiff}
               onMaximize={props.onMaximize}
+              onChangeThread={props.onChooseThread}
               onMounted={props.onChatMounted}
             />
           ) : (
@@ -902,6 +921,12 @@ function SplitPaneSurface(props: {
         panelState={props.panelState}
         onUpdatePanelState={props.onUpdatePanelState}
       />
+      {!props.isFocused ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 z-10 bg-foreground/[0.030] transition-opacity duration-150"
+        />
+      ) : null}
     </div>
   );
 }
@@ -920,7 +945,6 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
   const dropThreadOnPane = useSplitViewStore((store) => store.dropThreadOnPane);
   const removeSplitView = useSplitViewStore((store) => store.removeSplitView);
   const [threadPickerPaneId, setThreadPickerPaneId] = useState<PaneId | null>(null);
-  const mountedChatPaneIdsRef = useRef(new Set<PaneId>());
   const {
     splitView: activeSplitView,
     focusedThreadId,
@@ -1154,7 +1178,7 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
   );
 
   if (!activeSplitView) {
-    return null;
+    return <ChatMountSkeleton />;
   }
 
   const chooseThreadForPane = (threadId: ThreadIdType, paneOverride?: PaneId) => {
@@ -1193,8 +1217,6 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
 
   const renderLeaf = ({ leaf }: { leaf: LeafPane }): ReactNode => {
     const isFocused = leaf.id === activeSplitView.focusedPaneId;
-    const shouldDeferChatMount =
-      isFocused && leaf.threadId !== null && !mountedChatPaneIdsRef.current.has(leaf.id);
     const excluded = new Set<ThreadIdType>(splitThreadIds);
     return (
       <SplitPaneSurface
@@ -1204,7 +1226,7 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
         threadId={leaf.threadId}
         panelState={leaf.panel}
         isFocused={isFocused}
-        deferChatMount={shouldDeferChatMount}
+        deferChatMount={false}
         canDropInDirection={(direction) =>
           canSubdividePane(activeSplitView.root, leaf.id, direction)
         }
@@ -1224,9 +1246,7 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
           setThreadPickerPaneId(leaf.id);
         }}
         onSelectThread={(threadId) => chooseThreadForPane(threadId, leaf.id)}
-        onChatMounted={() => {
-          mountedChatPaneIdsRef.current.add(leaf.id);
-        }}
+        onChatMounted={noop}
         onDropThread={(payload) => handleDropThreadOnPane(leaf.id, payload)}
       />
     );
@@ -1463,16 +1483,20 @@ function SingleChatSurface(props: {
           className="flex h-full min-h-0 min-w-0 flex-1"
         >
           <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none text-foreground">
-            <ChatView
+            <DeferredChatView
               threadId={props.threadId}
+              paneScopeId="single"
+              deferMount={false}
+              surfaceMode="single"
+              isFocusedPane
               panelState={panelState}
-              onToggleDiffPanel={() =>
+              onToggleDiff={() =>
                 updatePanelState(resolveToggledChatPanelPatch(panelState, "diff"))
               }
-              onToggleBrowserPanel={() =>
+              onToggleBrowser={() =>
                 updatePanelState(resolveToggledChatPanelPatch(panelState, "browser"))
               }
-              onOpenTurnDiffPanel={(turnId, filePath) =>
+              onOpenTurnDiff={(turnId, filePath) =>
                 updatePanelState({
                   panel: "diff",
                   diffTurnId: turnId,
@@ -1507,16 +1531,20 @@ function SingleChatSurface(props: {
         className="flex h-dvh min-h-0 min-w-0 flex-1"
       >
         <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none text-foreground">
-          <ChatView
+          <DeferredChatView
             threadId={props.threadId}
+            paneScopeId="single"
+            deferMount={false}
+            surfaceMode="single"
+            isFocusedPane
             panelState={panelState}
-            onToggleDiffPanel={() =>
+            onToggleDiff={() =>
               updatePanelState(resolveToggledChatPanelPatch(panelState, "diff"))
             }
-            onToggleBrowserPanel={() =>
+            onToggleBrowser={() =>
               updatePanelState(resolveToggledChatPanelPatch(panelState, "browser"))
             }
-            onOpenTurnDiffPanel={(turnId, filePath) =>
+            onOpenTurnDiff={(turnId, filePath) =>
               updatePanelState({
                 panel: "diff",
                 diffTurnId: turnId,
@@ -1595,7 +1623,7 @@ function ChatThreadRouteView() {
   }, [handleNewChat, navigate, routeThreadExists, search, splitView, threadId, threadsHydrated]);
 
   if (!threadsHydrated) {
-    return null;
+    return <ChatMountSkeleton />;
   }
 
   if (splitView && search.splitViewId) {
@@ -1603,7 +1631,7 @@ function ChatThreadRouteView() {
   }
 
   if (!routeThreadExists) {
-    return null;
+    return <ChatMountSkeleton />;
   }
 
   return <SingleChatSurface threadId={threadId} search={search} projectId={activeProjectId} />;

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -1,7 +1,7 @@
 // FILE: _chat.$threadId.tsx
 // Purpose: Resolves the active thread route into either a single chat surface or a persisted split view.
 // Layer: Route container
-// Depends on: ChatView, splitViewStore, and pane-scoped browser/diff panels
+// Depends on: ChatView, splitViewStore, splitView.logic, ChatPaneDropOverlay, and pane-scoped browser/diff panels
 
 import {
   type ProviderKind,
@@ -14,7 +14,9 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
   Suspense,
   lazy,
+  startTransition,
   type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -28,6 +30,7 @@ import { TbExchange } from "react-icons/tb";
 import ChatView from "../components/ChatView";
 import BrowserPanel from "../components/BrowserPanel";
 import { ClaudeAI, Gemini, OpenAI, OpenCodeIcon } from "../components/Icons";
+import { ChatPaneDropOverlay } from "../components/chat-drop-overlay/ChatPaneDropOverlay";
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
 import {
   DiffPanelHeaderSkeleton,
@@ -45,12 +48,19 @@ import {
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { useHandleNewChat } from "../hooks/useHandleNewChat";
 import { resolveActiveSplitView, isSplitRoute } from "../splitViewRoute";
+import { canSubdividePane, collectLeaves, findLeafPaneById } from "../splitView.logic";
 import {
   resolveSplitViewFocusedThreadId,
+  resolveSplitViewPaneIdForThread,
+  resolveSplitViewThreadIds,
   selectSplitView,
+  type LeafPane,
+  type Pane,
+  type PaneId,
+  type SplitDirection,
+  type SplitDropSide,
   type SplitView,
   type SplitViewId,
-  type SplitViewPane,
   type SplitViewPanePanelState,
   useSplitViewStore,
 } from "../splitViewStore";
@@ -92,6 +102,15 @@ const SINGLE_PANEL_MIN_WIDTH = 26 * 16;
 const BROWSER_PANEL_MIN_WIDTH = 30 * 16;
 const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
 const RIGHT_PANEL_SIDEBAR_WIDTH_STORAGE_KEY = "chat_right_panel_width";
+const SPLIT_RATIO_MIN = 0.25;
+const SPLIT_RATIO_MAX = 0.75;
+
+const allowAnySplitDirection = (_direction: SplitDirection) => true;
+
+function clampSplitRatio(value: number): number {
+  if (!Number.isFinite(value)) return 0.5;
+  return Math.min(SPLIT_RATIO_MAX, Math.max(SPLIT_RATIO_MIN, value));
+}
 
 const RightPanelSheet = (props: {
   children: ReactNode;
@@ -304,7 +323,7 @@ const PanePanelInlineSidebar = (props: {
 // against the viewport. This embedded shell keeps browser/diff content anchored to the pane.
 function SplitPaneEmbeddedPanel(props: {
   splitViewId: SplitViewId;
-  pane: SplitViewPane;
+  paneId: PaneId;
   paneScopeId: string;
   panelOpen: boolean;
   panel: ChatRightPanel | null | undefined;
@@ -318,7 +337,7 @@ function SplitPaneEmbeddedPanel(props: {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const panelWidthStorageKey =
     props.panel === "browser" ? "browser" : props.panel === "diff" ? "diff" : "panel";
-  const storageKey = `${RIGHT_PANEL_SIDEBAR_WIDTH_STORAGE_KEY}:${props.splitViewId}:${props.pane}:${panelWidthStorageKey}`;
+  const storageKey = `${RIGHT_PANEL_SIDEBAR_WIDTH_STORAGE_KEY}:${props.splitViewId}:${props.paneId}:${panelWidthStorageKey}`;
   const defaultPanelWidth =
     props.panel === "browser"
       ? BROWSER_SPLIT_PANE_PANEL_DEFAULT_WIDTH_PX
@@ -352,7 +371,7 @@ function SplitPaneEmbeddedPanel(props: {
   );
 
   const startResize = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
+    (event: ReactPointerEvent<HTMLDivElement>) => {
       const wrapper = wrapperRef.current;
       const parent = wrapper?.parentElement;
       if (!wrapper || !parent) return;
@@ -450,7 +469,7 @@ function SplitPaneEmptyState(props: {
     modelSelection: { provider: ProviderKind };
   }[];
   projects: readonly { id: ProjectId; name: string }[];
-  otherPaneThreadId: ThreadIdType | null;
+  excludedThreadIds: ReadonlySet<ThreadIdType>;
   onSelectThread: (threadId: ThreadIdType) => void;
 }) {
   return (
@@ -465,7 +484,7 @@ function SplitPaneEmptyState(props: {
         <p className="text-center text-sm font-medium text-foreground/70">Select a chat</p>
         <div className="max-h-[60vh] space-y-1 overflow-y-auto">
           {props.threads.map((thread) => {
-            const isUsed = thread.id === props.otherPaneThreadId;
+            const isUsed = props.excludedThreadIds.has(thread.id);
             const projectName =
               props.projects.find((p) => p.id === thread.projectId)?.name ?? "Project";
             return (
@@ -521,11 +540,253 @@ function PickerProviderGlyph(props: { provider: ProviderKind; className?: string
   return <OpenAI aria-hidden="true" className={cn("text-muted-foreground/60", props.className)} />;
 }
 
+function SplitDivider(props: {
+  splitNodeId: PaneId;
+  direction: SplitDirection;
+  onSetRatio: (nodeId: PaneId, ratio: number) => void;
+}) {
+  const { onSetRatio, splitNodeId, direction } = props;
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const target = event.currentTarget;
+      const parent = target.parentElement as HTMLElement | null;
+      if (!parent) return;
+      event.preventDefault();
+      const rect = parent.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return;
+
+      const computeRatio = (clientX: number, clientY: number) =>
+        clampSplitRatio(
+          direction === "horizontal"
+            ? (clientX - rect.left) / rect.width
+            : (clientY - rect.top) / rect.height,
+        );
+
+      let latestRatio = computeRatio(event.clientX, event.clientY);
+      let frameId = 0;
+      const previousParentPosition = parent.style.position;
+      const previousBodyCursor = document.body.style.cursor;
+      const previousBodyUserSelect = document.body.style.userSelect;
+      if (getComputedStyle(parent).position === "static") {
+        parent.style.position = "relative";
+      }
+      const resizeGuide = document.createElement("div");
+      resizeGuide.setAttribute("data-split-resize-guide", "true");
+      Object.assign(resizeGuide.style, {
+        position: "absolute",
+        zIndex: "50",
+        pointerEvents: "none",
+        borderRadius: "999px",
+        background: "var(--info)",
+        opacity: "0.75",
+        boxShadow: "0 0 0 1px color-mix(in srgb, var(--info) 70%, transparent)",
+      });
+      if (direction === "horizontal") {
+        Object.assign(resizeGuide.style, {
+          top: "0",
+          bottom: "0",
+          left: "0",
+          width: "2px",
+        });
+      } else {
+        Object.assign(resizeGuide.style, {
+          top: "0",
+          left: "0",
+          right: "0",
+          height: "2px",
+        });
+      }
+      parent.append(resizeGuide);
+
+      const applyGuide = () => {
+        frameId = 0;
+        const offsetPx =
+          direction === "horizontal" ? rect.width * latestRatio : rect.height * latestRatio;
+        resizeGuide.style.transform =
+          direction === "horizontal"
+            ? `translateX(${Math.round(offsetPx)}px)`
+            : `translateY(${Math.round(offsetPx)}px)`;
+      };
+
+      const onPointerMove = (moveEvent: PointerEvent) => {
+        latestRatio = computeRatio(moveEvent.clientX, moveEvent.clientY);
+        if (frameId === 0) {
+          frameId = window.requestAnimationFrame(applyGuide);
+        }
+      };
+      const onPointerUp = () => {
+        if (frameId !== 0) {
+          window.cancelAnimationFrame(frameId);
+          applyGuide();
+        }
+        document.body.style.userSelect = previousBodyUserSelect;
+        document.body.style.cursor = previousBodyCursor;
+        parent.style.position = previousParentPosition;
+        resizeGuide.remove();
+        window.removeEventListener("pointermove", onPointerMove);
+        window.removeEventListener("pointerup", onPointerUp);
+        window.removeEventListener("pointercancel", onPointerUp);
+        onSetRatio(splitNodeId, latestRatio);
+      };
+
+      document.body.style.userSelect = "none";
+      document.body.style.cursor = direction === "horizontal" ? "col-resize" : "row-resize";
+      applyGuide();
+      window.addEventListener("pointermove", onPointerMove);
+      window.addEventListener("pointerup", onPointerUp);
+      window.addEventListener("pointercancel", onPointerUp);
+    },
+    [direction, onSetRatio, splitNodeId],
+  );
+
+  return (
+    <div
+      data-split-divider="true"
+      data-split-node-id={splitNodeId}
+      data-split-direction={direction}
+      className={cn(
+        "relative z-10 shrink-0 bg-border/70",
+        direction === "horizontal"
+          ? "w-px cursor-col-resize before:absolute before:inset-y-0 before:-left-1 before:w-2 before:bg-transparent"
+          : "h-px cursor-row-resize before:absolute before:inset-x-0 before:-top-1 before:h-2 before:bg-transparent",
+      )}
+      onPointerDown={handlePointerDown}
+    />
+  );
+}
+
+function PaneRenderer(props: {
+  pane: Pane;
+  splitView: SplitView;
+  renderLeaf: (input: { leaf: LeafPane }) => ReactNode;
+  onSetRatio: (nodeId: PaneId, ratio: number) => void;
+}) {
+  if (props.pane.kind === "leaf") {
+    return <>{props.renderLeaf({ leaf: props.pane })}</>;
+  }
+  const node = props.pane;
+  const isRow = node.direction === "horizontal";
+  const firstBasis = `${node.ratio * 100}%`;
+  return (
+    <div
+      data-split-container="true"
+      data-split-direction={node.direction}
+      className={cn("flex min-h-0 min-w-0 flex-1 overflow-hidden", isRow ? "flex-row" : "flex-col")}
+    >
+      <div
+        className="flex min-h-0 min-w-0 overflow-hidden"
+        style={{ flexBasis: firstBasis, flexGrow: 0, flexShrink: 1 }}
+      >
+        <PaneRenderer
+          pane={node.first}
+          splitView={props.splitView}
+          renderLeaf={props.renderLeaf}
+          onSetRatio={props.onSetRatio}
+        />
+      </div>
+      <SplitDivider
+        splitNodeId={node.id}
+        direction={node.direction}
+        onSetRatio={props.onSetRatio}
+      />
+      <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+        <PaneRenderer
+          pane={node.second}
+          splitView={props.splitView}
+          renderLeaf={props.renderLeaf}
+          onSetRatio={props.onSetRatio}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SplitPaneChatMountSkeleton() {
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background [contain:layout_style_paint]">
+      <div className="flex h-[52px] shrink-0 items-center border-b border-[color:var(--color-border-light)] px-4">
+        <div className="h-4 w-40 rounded-full bg-muted" />
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col justify-end gap-3 px-5 py-4">
+        <div className="h-12 w-4/5 rounded-xl bg-muted" />
+        <div className="ml-auto h-10 w-3/5 rounded-xl bg-muted" />
+        <div className="h-16 w-5/6 rounded-xl bg-muted" />
+      </div>
+      <div className="shrink-0 border-t border-[color:var(--color-border-light)] p-3">
+        <div className="h-16 rounded-2xl bg-muted" />
+      </div>
+    </div>
+  );
+}
+
+function DeferredSplitPaneChatView(props: {
+  threadId: ThreadIdType;
+  paneScopeId: string;
+  deferInitialMount: boolean;
+  isFocusedPane: boolean;
+  panelState: SplitViewPanePanelState;
+  onToggleDiff: () => void;
+  onToggleBrowser: () => void;
+  onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
+  onMaximize: () => void;
+  onMounted: () => void;
+}) {
+  const onMounted = props.onMounted;
+  const [canMountChatView, setCanMountChatView] = useState(!props.deferInitialMount);
+
+  useEffect(() => {
+    if (!props.deferInitialMount) {
+      setCanMountChatView(true);
+      return;
+    }
+    setCanMountChatView(false);
+    let firstFrame = 0;
+    let secondFrame = 0;
+    firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => setCanMountChatView(true));
+    });
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      window.cancelAnimationFrame(secondFrame);
+    };
+  }, [props.deferInitialMount, props.paneScopeId, props.threadId]);
+
+  useEffect(() => {
+    if (canMountChatView) {
+      onMounted();
+    }
+  }, [canMountChatView, onMounted]);
+
+  if (!canMountChatView) {
+    return <SplitPaneChatMountSkeleton />;
+  }
+
+  return (
+    <ChatView
+      key={props.paneScopeId}
+      threadId={props.threadId}
+      paneScopeId={props.paneScopeId}
+      surfaceMode="split"
+      isFocusedPane={props.isFocusedPane}
+      panelState={props.panelState}
+      onToggleDiffPanel={props.onToggleDiff}
+      onToggleBrowserPanel={props.onToggleBrowser}
+      onOpenTurnDiffPanel={props.onOpenTurnDiff}
+      onMaximizeSurface={props.onMaximize}
+    />
+  );
+}
+
 function SplitPaneSurface(props: {
   splitView: SplitView;
-  pane: SplitViewPane;
+  paneId: PaneId;
   threadId: ThreadIdType | null;
+  panelState: SplitViewPanePanelState;
   isFocused: boolean;
+  deferChatMount: boolean;
+  canDropInDirection: (direction: SplitDirection) => boolean;
+  excludedThreadIds: ReadonlySet<ThreadIdType>;
+  ownerProjectId: ProjectId;
   threads: readonly {
     id: ThreadIdType;
     title: string | null;
@@ -544,23 +805,38 @@ function SplitPaneSurface(props: {
   onMaximize: () => void;
   onChooseThread: () => void;
   onSelectThread: (threadId: ThreadIdType) => void;
+  onChatMounted: () => void;
+  onDropThread: (payload: {
+    droppedThreadId: ThreadIdType;
+    direction: SplitDirection;
+    side: SplitDropSide;
+  }) => void;
 }) {
-  const paneScopeId = `${props.splitView.id}:${props.pane}`;
-  const panelState = props.pane === "left" ? props.splitView.leftPanel : props.splitView.rightPanel;
-  const panelOpen = panelState.panel !== null;
-  const shouldRenderPanelContent = panelOpen || panelState.hasOpenedPanel;
-  const otherPaneThreadId =
-    props.pane === "left" ? props.splitView.rightThreadId : props.splitView.leftThreadId;
+  const paneScopeId = `${props.splitView.id}:${props.paneId}`;
+  const panelOpen = props.panelState.panel !== null;
+  const shouldRenderPanelContent = panelOpen || props.panelState.hasOpenedPanel;
+
+  const onDropThread = props.onDropThread;
+  const handleDrop = useCallback(
+    (payload: { threadId: ThreadIdType; direction: SplitDirection; side: SplitDropSide }) => {
+      onDropThread({
+        droppedThreadId: payload.threadId,
+        direction: payload.direction,
+        side: payload.side,
+      });
+    },
+    [onDropThread],
+  );
 
   return (
-    <div className="group relative flex min-h-0 min-w-0 flex-1 bg-background">
+    <div className="group relative flex min-h-0 min-w-0 flex-1 bg-background [contain:layout_style_paint]">
       {props.threadId ? (
         <div className="pointer-events-none absolute right-3 top-[3.75rem] z-20 sm:right-5 sm:top-[4.25rem]">
           <Button
             type="button"
             size="icon-sm"
             variant="outline"
-            aria-label={`Choose chat for the ${props.pane} split pane`}
+            aria-label={`Choose chat for split pane ${props.paneId}`}
             title="Choose chat"
             className={cn(
               "pointer-events-auto transition-opacity",
@@ -575,45 +851,55 @@ function SplitPaneSurface(props: {
           </Button>
         </div>
       ) : null}
-      <SidebarInset
-        className={cn(
-          "min-h-0 min-w-0 overflow-hidden overscroll-y-none text-foreground transition-shadow",
-          props.isFocused ? "ring-1 ring-inset ring-primary/25" : "",
-        )}
-        onMouseDown={props.onFocus}
+      <ChatPaneDropOverlay
+        paneScopeId={paneScopeId}
+        canDropInDirection={props.canDropInDirection}
+        excludedThreadIds={props.excludedThreadIds}
+        ownerProjectId={props.ownerProjectId}
+        onDrop={handleDrop}
+        className="flex min-h-0 min-w-0 flex-1"
       >
-        {props.threadId ? (
-          <ChatView
-            threadId={props.threadId}
-            paneScopeId={paneScopeId}
-            surfaceMode="split"
-            isFocusedPane={props.isFocused}
-            panelState={panelState}
-            onToggleDiffPanel={props.onToggleDiff}
-            onToggleBrowserPanel={props.onToggleBrowser}
-            onOpenTurnDiffPanel={props.onOpenTurnDiff}
-            onMaximizeSurface={props.onMaximize}
-          />
-        ) : (
-          <SplitPaneEmptyState
-            isFocused={props.isFocused}
-            onFocus={props.onFocus}
-            threads={props.threads}
-            projects={props.projects}
-            otherPaneThreadId={otherPaneThreadId}
-            onSelectThread={props.onSelectThread}
-          />
-        )}
-      </SidebarInset>
+        <SidebarInset
+          className={cn(
+            "min-h-0 min-w-0 overflow-hidden overscroll-y-none text-foreground transition-shadow",
+            props.isFocused ? "ring-1 ring-inset ring-primary/25" : "",
+          )}
+          onMouseDown={props.onFocus}
+        >
+          {props.threadId ? (
+            <DeferredSplitPaneChatView
+              threadId={props.threadId}
+              paneScopeId={paneScopeId}
+              deferInitialMount={props.deferChatMount}
+              isFocusedPane={props.isFocused}
+              panelState={props.panelState}
+              onToggleDiff={props.onToggleDiff}
+              onToggleBrowser={props.onToggleBrowser}
+              onOpenTurnDiff={props.onOpenTurnDiff}
+              onMaximize={props.onMaximize}
+              onMounted={props.onChatMounted}
+            />
+          ) : (
+            <SplitPaneEmptyState
+              isFocused={props.isFocused}
+              onFocus={props.onFocus}
+              threads={props.threads}
+              projects={props.projects}
+              excludedThreadIds={props.excludedThreadIds}
+              onSelectThread={props.onSelectThread}
+            />
+          )}
+        </SidebarInset>
+      </ChatPaneDropOverlay>
       <SplitPaneEmbeddedPanel
         splitViewId={props.splitView.id}
-        pane={props.pane}
+        paneId={props.paneId}
         paneScopeId={paneScopeId}
         panelOpen={panelOpen && shouldRenderPanelContent}
-        panel={panelState.panel}
+        panel={props.panelState.panel}
         threadId={props.threadId}
         onClosePanel={props.onClosePanel}
-        panelState={panelState}
+        panelState={props.panelState}
         onUpdatePanelState={props.onUpdatePanelState}
       />
     </div>
@@ -628,16 +914,17 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
   const projects = useStore((store) => store.projects);
   const splitView = useSplitViewStore(selectSplitView(props.splitViewId));
   const setFocusedPane = useSplitViewStore((store) => store.setFocusedPane);
-  const setRatio = useSplitViewStore((store) => store.setRatio);
+  const setRatioForNode = useSplitViewStore((store) => store.setRatioForNode);
   const setPanePanelState = useSplitViewStore((store) => store.setPanePanelState);
   const replacePaneThread = useSplitViewStore((store) => store.replacePaneThread);
+  const dropThreadOnPane = useSplitViewStore((store) => store.dropThreadOnPane);
   const removeSplitView = useSplitViewStore((store) => store.removeSplitView);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [threadPickerPane, setThreadPickerPane] = useState<SplitViewPane | null>(null);
+  const [threadPickerPaneId, setThreadPickerPaneId] = useState<PaneId | null>(null);
+  const mountedChatPaneIdsRef = useRef(new Set<PaneId>());
   const {
     splitView: activeSplitView,
     focusedThreadId,
-    routePane,
+    routePaneId,
   } = resolveActiveSplitView({
     splitView,
     routeThreadId: props.routeThreadId,
@@ -654,26 +941,38 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
       return;
     }
 
+    // Single-leaf split views collapse back to the single chat surface.
+    const leaves = collectLeaves(activeSplitView.root);
+    if (leaves.length <= 1) {
+      const onlyThreadId = leaves[0]?.threadId ?? null;
+      removeSplitView(activeSplitView.id);
+      if (!onlyThreadId) {
+        void handleNewChat({ fresh: true });
+        return;
+      }
+      void navigate({
+        to: "/$threadId",
+        params: { threadId: onlyThreadId },
+        replace: true,
+        search: (previous) => ({ ...stripDiffSearchParams(previous), splitViewId: undefined }),
+      });
+      return;
+    }
+
+    // If the route threadId targets a non-focused pane, switch focus to that pane.
+    const focusedLeaf = findLeafPaneById(activeSplitView.root, activeSplitView.focusedPaneId);
     if (
-      activeSplitView.leftThreadId &&
-      activeSplitView.rightThreadId &&
-      activeSplitView.leftThreadId === activeSplitView.rightThreadId
+      routePaneId &&
+      routePaneId !== activeSplitView.focusedPaneId &&
+      focusedLeaf?.threadId !== null &&
+      focusedLeaf?.threadId !== undefined
     ) {
-      replacePaneThread(activeSplitView.id, "right", null);
-      setFocusedPane(activeSplitView.id, "left");
+      setFocusedPane(activeSplitView.id, routePaneId);
       return;
     }
 
-    const focusedPaneThreadId =
-      activeSplitView.focusedPane === "left"
-        ? activeSplitView.leftThreadId
-        : activeSplitView.rightThreadId;
+    // Sync the route threadId with the focused leaf's thread.
     const normalizedFocusedThreadId = resolveSplitViewFocusedThreadId(activeSplitView);
-    if (routePane && routePane !== activeSplitView.focusedPane && focusedPaneThreadId !== null) {
-      setFocusedPane(activeSplitView.id, routePane);
-      return;
-    }
-
     if (normalizedFocusedThreadId && props.routeThreadId !== normalizedFocusedThreadId) {
       void navigate({
         to: "/$threadId",
@@ -687,21 +986,20 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
     }
   }, [
     activeSplitView,
+    handleNewChat,
     navigate,
     props.routeThreadId,
-    replacePaneThread,
-    routePane,
+    removeSplitView,
+    routePaneId,
     setFocusedPane,
   ]);
 
   const setPaneFocus = useCallback(
-    (pane: SplitViewPane) => {
+    (paneId: PaneId) => {
       if (!activeSplitView) return;
-      setFocusedPane(activeSplitView.id, pane);
-      const nextThreadId =
-        pane === "left"
-          ? (activeSplitView.leftThreadId ?? activeSplitView.rightThreadId)
-          : (activeSplitView.rightThreadId ?? activeSplitView.leftThreadId);
+      const leaf = findLeafPaneById(activeSplitView.root, paneId);
+      const nextThreadId = leaf?.threadId ?? resolveSplitViewFocusedThreadId(activeSplitView);
+      setFocusedPane(activeSplitView.id, paneId);
       if (!nextThreadId || nextThreadId === props.routeThreadId) {
         return;
       }
@@ -720,36 +1018,33 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
 
   const updatePanePanelState = useCallback(
     (
-      pane: SplitViewPane,
+      paneId: PaneId,
       patch: Partial<Pick<SplitViewPanePanelState, "panel" | "diffTurnId" | "diffFilePath">>,
     ) => {
       if (!activeSplitView) return;
-      const previousState =
-        pane === "left" ? activeSplitView.leftPanel : activeSplitView.rightPanel;
-      setPanePanelState(activeSplitView.id, pane, {
+      const leaf = findLeafPaneById(activeSplitView.root, paneId);
+      if (!leaf) return;
+      const nextPanel = patch.panel ?? leaf.panel.panel;
+      setPanePanelState(activeSplitView.id, paneId, {
         ...patch,
-        hasOpenedPanel:
-          previousState.hasOpenedPanel || (patch.panel ?? previousState.panel) !== null,
+        hasOpenedPanel: leaf.panel.hasOpenedPanel || nextPanel !== null,
         lastOpenPanel:
           patch.panel === "browser" || patch.panel === "diff"
             ? patch.panel
-            : previousState.lastOpenPanel,
+            : leaf.panel.lastOpenPanel,
       });
     },
     [activeSplitView, setPanePanelState],
   );
 
   const togglePanePanel = useCallback(
-    (pane: SplitViewPane, panel: ChatRightPanel) => {
+    (paneId: PaneId, panel: ChatRightPanel) => {
       if (!activeSplitView) return;
-      const paneThreadId =
-        pane === "left" ? activeSplitView.leftThreadId : activeSplitView.rightThreadId;
-      if (!paneThreadId) {
+      const leaf = findLeafPaneById(activeSplitView.root, paneId);
+      if (!leaf?.threadId) {
         return;
       }
-      const previousState =
-        pane === "left" ? activeSplitView.leftPanel : activeSplitView.rightPanel;
-      updatePanePanelState(pane, resolveToggledChatPanelPatch(previousState, panel));
+      updatePanePanelState(paneId, resolveToggledChatPanelPatch(leaf.panel, panel));
     },
     [activeSplitView, updatePanePanelState],
   );
@@ -762,7 +1057,7 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
 
     const unsubscribe = onMenuAction((action) => {
       if (action !== "toggle-browser") return;
-      togglePanePanel(activeSplitView.focusedPane, "browser");
+      togglePanePanel(activeSplitView.focusedPaneId, "browser");
     });
 
     return () => {
@@ -771,17 +1066,15 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
   }, [activeSplitView, togglePanePanel]);
 
   const closePanePanel = useCallback(
-    (pane: SplitViewPane) => {
-      updatePanePanelState(pane, {
-        panel: null,
-      });
+    (paneId: PaneId) => {
+      updatePanePanelState(paneId, { panel: null });
     },
     [updatePanePanelState],
   );
 
   const openPaneTurnDiff = useCallback(
-    (pane: SplitViewPane, turnId: TurnId, filePath?: string) => {
-      updatePanePanelState(pane, {
+    (paneId: PaneId, turnId: TurnId, filePath?: string) => {
+      updatePanePanelState(paneId, {
         panel: "diff",
         diffTurnId: turnId,
         diffFilePath: filePath ?? null,
@@ -792,11 +1085,9 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
 
   const maximizeFocusedPane = useCallback(() => {
     if (!activeSplitView) return;
+    const focusedLeaf = findLeafPaneById(activeSplitView.root, activeSplitView.focusedPaneId);
+    const focusedPanelState = focusedLeaf?.panel ?? null;
     const nextThreadId = focusedThreadId;
-    const focusedPanelState =
-      activeSplitView.focusedPane === "left"
-        ? activeSplitView.leftPanel
-        : activeSplitView.rightPanel;
     removeSplitView(activeSplitView.id);
     if (!nextThreadId) {
       void handleNewChat({ fresh: true });
@@ -806,81 +1097,84 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
       to: "/$threadId",
       params: { threadId: nextThreadId },
       replace: true,
-      search: () => normalizeSingleSearchFromPane(focusedPanelState),
+      search: () => (focusedPanelState ? normalizeSingleSearchFromPane(focusedPanelState) : {}),
     });
   }, [activeSplitView, focusedThreadId, handleNewChat, navigate, removeSplitView]);
 
-  const activeSplitViewIdRef = useRef<SplitViewId | null>(null);
-  activeSplitViewIdRef.current = activeSplitView?.id ?? null;
+  const handleSetRatio = useCallback(
+    (nodeId: PaneId, ratio: number) => {
+      if (!activeSplitView) return;
+      setRatioForNode(activeSplitView.id, nodeId, ratio);
+    },
+    [activeSplitView, setRatioForNode],
+  );
 
-  useEffect(() => {
-    const root = rootRef.current;
-    const splitViewId = activeSplitViewIdRef.current;
-    if (!root || !splitViewId) return;
+  const handleDropThreadOnPane = useCallback(
+    (
+      paneId: PaneId,
+      payload: {
+        droppedThreadId: ThreadIdType;
+        direction: SplitDirection;
+        side: SplitDropSide;
+      },
+    ) => {
+      if (!activeSplitView) return;
+      const ok = dropThreadOnPane({
+        splitViewId: activeSplitView.id,
+        targetPaneId: paneId,
+        direction: payload.direction,
+        side: payload.side,
+        threadId: payload.droppedThreadId,
+      });
+      if (!ok) return;
+      startTransition(() => {
+        void navigate({
+          to: "/$threadId",
+          params: { threadId: payload.droppedThreadId },
+          replace: true,
+          search: () => ({ splitViewId: activeSplitView.id }),
+        });
+      });
+    },
+    [activeSplitView, dropThreadOnPane, navigate],
+  );
 
-    const divider = root.querySelector<HTMLElement>("[data-split-divider='true']");
-    if (!divider) return;
-
-    const handlePointerMove = (event: PointerEvent) => {
-      const rect = root.getBoundingClientRect();
-      if (!rect || rect.width <= 0) return;
-      const id = activeSplitViewIdRef.current;
-      if (!id) return;
-      setRatio(id, (event.clientX - rect.left) / rect.width);
-    };
-
-    const handlePointerUp = () => {
-      document.body.style.removeProperty("user-select");
-      window.removeEventListener("pointermove", handlePointerMove);
-      window.removeEventListener("pointerup", handlePointerUp);
-    };
-
-    const onPointerDown = (event: PointerEvent) => {
-      event.preventDefault();
-      document.body.style.userSelect = "none";
-      window.addEventListener("pointermove", handlePointerMove);
-      window.addEventListener("pointerup", handlePointerUp);
-    };
-
-    divider.addEventListener("pointerdown", onPointerDown);
-    return () => {
-      divider.removeEventListener("pointerdown", onPointerDown);
-      handlePointerUp();
-    };
-  }, [activeSplitView?.id, setRatio]);
+  const selectableThreads = useMemo(
+    () =>
+      threads.toSorted(
+        (left, right) =>
+          Date.parse(right.updatedAt ?? right.createdAt) -
+          Date.parse(left.updatedAt ?? left.createdAt),
+      ),
+    [threads],
+  );
+  const splitThreadIds = useMemo(
+    () => new Set(activeSplitView ? resolveSplitViewThreadIds(activeSplitView) : []),
+    [activeSplitView],
+  );
 
   if (!activeSplitView) {
     return null;
   }
 
-  const leftBasis = `${activeSplitView.ratio * 100}%`;
-  const rightBasis = `${(1 - activeSplitView.ratio) * 100}%`;
-  const selectableThreads = threads.toSorted(
-    (left, right) =>
-      Date.parse(right.updatedAt ?? right.createdAt) - Date.parse(left.updatedAt ?? left.createdAt),
-  );
-  const chooseThreadForPane = (threadId: ThreadIdType, paneOverride?: SplitViewPane) => {
-    const pane = paneOverride ?? threadPickerPane;
-    if (!pane) {
+  const chooseThreadForPane = (threadId: ThreadIdType, paneOverride?: PaneId) => {
+    const paneId = paneOverride ?? threadPickerPaneId;
+    if (!paneId) {
       return;
     }
-    const otherPane: SplitViewPane = pane === "left" ? "right" : "left";
-    const currentPaneThreadId =
-      pane === "left" ? activeSplitView.leftThreadId : activeSplitView.rightThreadId;
-    const otherPaneThreadId =
-      otherPane === "left" ? activeSplitView.leftThreadId : activeSplitView.rightThreadId;
+    setThreadPickerPaneId(null);
 
-    setThreadPickerPane(null);
-
-    if (threadId === otherPaneThreadId) {
-      setPaneFocus(otherPane);
+    const existingPaneIdForThread = resolveSplitViewPaneIdForThread(activeSplitView, threadId);
+    if (existingPaneIdForThread && existingPaneIdForThread !== paneId) {
+      setPaneFocus(existingPaneIdForThread);
       return;
     }
 
-    setFocusedPane(activeSplitView.id, pane);
-    if (threadId !== currentPaneThreadId) {
-      replacePaneThread(activeSplitView.id, pane, threadId);
-      setPanePanelState(activeSplitView.id, pane, {
+    const leaf = findLeafPaneById(activeSplitView.root, paneId);
+    setFocusedPane(activeSplitView.id, paneId);
+    if (leaf && leaf.threadId !== threadId) {
+      replacePaneThread(activeSplitView.id, paneId, threadId);
+      setPanePanelState(activeSplitView.id, paneId, {
         diffTurnId: null,
         diffFilePath: null,
       });
@@ -897,72 +1191,64 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
     });
   };
 
+  const renderLeaf = ({ leaf }: { leaf: LeafPane }): ReactNode => {
+    const isFocused = leaf.id === activeSplitView.focusedPaneId;
+    const shouldDeferChatMount =
+      isFocused && leaf.threadId !== null && !mountedChatPaneIdsRef.current.has(leaf.id);
+    const excluded = new Set<ThreadIdType>(splitThreadIds);
+    return (
+      <SplitPaneSurface
+        key={leaf.id}
+        splitView={activeSplitView}
+        paneId={leaf.id}
+        threadId={leaf.threadId}
+        panelState={leaf.panel}
+        isFocused={isFocused}
+        deferChatMount={shouldDeferChatMount}
+        canDropInDirection={(direction) => canSubdividePane(activeSplitView.root, leaf.id, direction)}
+        excludedThreadIds={excluded}
+        ownerProjectId={activeSplitView.ownerProjectId}
+        threads={selectableThreads}
+        projects={projects}
+        onFocus={() => setPaneFocus(leaf.id)}
+        onToggleDiff={() => togglePanePanel(leaf.id, "diff")}
+        onToggleBrowser={() => togglePanePanel(leaf.id, "browser")}
+        onOpenTurnDiff={(turnId, filePath) => openPaneTurnDiff(leaf.id, turnId, filePath)}
+        onClosePanel={() => closePanePanel(leaf.id)}
+        onUpdatePanelState={(patch) => updatePanePanelState(leaf.id, patch)}
+        onMaximize={maximizeFocusedPane}
+        onChooseThread={() => {
+          setPaneFocus(leaf.id);
+          setThreadPickerPaneId(leaf.id);
+        }}
+        onSelectThread={(threadId) => chooseThreadForPane(threadId, leaf.id)}
+        onChatMounted={() => {
+          mountedChatPaneIdsRef.current.add(leaf.id);
+        }}
+        onDropThread={(payload) => handleDropThreadOnPane(leaf.id, payload)}
+      />
+    );
+  };
+
+  const pickerLeaf = threadPickerPaneId
+    ? findLeafPaneById(activeSplitView.root, threadPickerPaneId)
+    : null;
+
   return (
     <>
-      <div
-        ref={rootRef}
-        className="flex h-dvh min-h-0 min-w-0 flex-1 overflow-hidden bg-background"
-      >
-        <div
-          className="flex min-h-0 min-w-0"
-          style={{ flexBasis: leftBasis, flexGrow: 0, flexShrink: 1 }}
-        >
-          <SplitPaneSurface
-            splitView={activeSplitView}
-            pane="left"
-            threadId={activeSplitView.leftThreadId}
-            isFocused={activeSplitView.focusedPane === "left"}
-            threads={selectableThreads}
-            projects={projects}
-            onFocus={() => setPaneFocus("left")}
-            onToggleDiff={() => togglePanePanel("left", "diff")}
-            onToggleBrowser={() => togglePanePanel("left", "browser")}
-            onOpenTurnDiff={(turnId, filePath) => openPaneTurnDiff("left", turnId, filePath)}
-            onClosePanel={() => closePanePanel("left")}
-            onUpdatePanelState={(patch) => updatePanePanelState("left", patch)}
-            onMaximize={maximizeFocusedPane}
-            onChooseThread={() => {
-              setPaneFocus("left");
-              setThreadPickerPane("left");
-            }}
-            onSelectThread={(threadId) => chooseThreadForPane(threadId, "left")}
-          />
-        </div>
-        <div
-          data-split-divider="true"
-          className="relative z-10 w-px shrink-0 cursor-col-resize bg-border/70 before:absolute before:inset-y-0 before:-left-1 before:w-2 before:bg-transparent"
+      <div className="flex h-dvh min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+        <PaneRenderer
+          pane={activeSplitView.root}
+          splitView={activeSplitView}
+          renderLeaf={renderLeaf}
+          onSetRatio={handleSetRatio}
         />
-        <div
-          className="flex min-h-0 min-w-0 flex-1"
-          style={{ flexBasis: rightBasis, flexGrow: 1, flexShrink: 1 }}
-        >
-          <SplitPaneSurface
-            splitView={activeSplitView}
-            pane="right"
-            threadId={activeSplitView.rightThreadId}
-            isFocused={activeSplitView.focusedPane === "right"}
-            threads={selectableThreads}
-            projects={projects}
-            onFocus={() => setPaneFocus("right")}
-            onToggleDiff={() => togglePanePanel("right", "diff")}
-            onToggleBrowser={() => togglePanePanel("right", "browser")}
-            onOpenTurnDiff={(turnId, filePath) => openPaneTurnDiff("right", turnId, filePath)}
-            onClosePanel={() => closePanePanel("right")}
-            onUpdatePanelState={(patch) => updatePanePanelState("right", patch)}
-            onMaximize={maximizeFocusedPane}
-            onChooseThread={() => {
-              setPaneFocus("right");
-              setThreadPickerPane("right");
-            }}
-            onSelectThread={(threadId) => chooseThreadForPane(threadId, "right")}
-          />
-        </div>
       </div>
       <Dialog
-        open={threadPickerPane !== null}
+        open={threadPickerPaneId !== null}
         onOpenChange={(open) => {
           if (!open) {
-            setThreadPickerPane(null);
+            setThreadPickerPaneId(null);
           }
         }}
       >
@@ -970,7 +1256,7 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
           <DialogHeader className="items-center text-center">
             <DialogTitle>Choose Chat</DialogTitle>
             <DialogDescription className="max-w-sm text-center">
-              Pick which chat should appear in the {threadPickerPane ?? "focused"} split pane.
+              Pick which chat should appear in the focused split pane.
             </DialogDescription>
           </DialogHeader>
           <DialogPanel className="space-y-3">
@@ -978,10 +1264,7 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
               {selectableThreads.map((thread) => {
                 const projectName =
                   projects.find((project) => project.id === thread.projectId)?.name ?? "Project";
-                const isSelected =
-                  threadPickerPane === "left"
-                    ? activeSplitView.leftThreadId === thread.id
-                    : activeSplitView.rightThreadId === thread.id;
+                const isSelected = pickerLeaf?.threadId === thread.id;
                 return (
                   <button
                     key={thread.id}
@@ -1009,7 +1292,7 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
               })}
             </div>
             <DialogFooter variant="bare">
-              <Button type="button" variant="outline" onClick={() => setThreadPickerPane(null)}>
+              <Button type="button" variant="outline" onClick={() => setThreadPickerPaneId(null)}>
                 Cancel
               </Button>
             </DialogFooter>
@@ -1028,6 +1311,7 @@ function SingleChatSurface(props: {
   const navigate = useNavigate();
   const shouldUseDiffSheet = useMediaQuery(DIFF_INLINE_LAYOUT_MEDIA_QUERY);
   const createSplitView = useSplitViewStore((store) => store.createFromThread);
+  const createSplitViewFromDrop = useSplitViewStore((store) => store.createFromDrop);
   const panelState = useSingleChatPanelStore(selectSingleChatPanelState(props.threadId));
   const setThreadPanelState = useSingleChatPanelStore((store) => store.setThreadPanelState);
   const activePanel = panelState.panel;
@@ -1073,13 +1357,38 @@ function SingleChatSurface(props: {
       sourceThreadId: props.threadId,
       ownerProjectId: props.projectId,
     });
-    void navigate({
-      to: "/$threadId",
-      params: { threadId: props.threadId },
-      replace: true,
-      search: () => ({ splitViewId }),
+    startTransition(() => {
+      void navigate({
+        to: "/$threadId",
+        params: { threadId: props.threadId },
+        replace: true,
+        search: () => ({ splitViewId }),
+      });
     });
   }, [createSplitView, navigate, props.projectId, props.threadId]);
+
+  const handleDropThread = useCallback(
+    (payload: { threadId: ThreadIdType; direction: SplitDirection; side: SplitDropSide }) => {
+      if (!props.projectId) return;
+      if (payload.threadId === props.threadId) return;
+      const splitViewId = createSplitViewFromDrop({
+        sourceThreadId: props.threadId,
+        ownerProjectId: props.projectId,
+        droppedThreadId: payload.threadId,
+        direction: payload.direction,
+        side: payload.side,
+      });
+      startTransition(() => {
+        void navigate({
+          to: "/$threadId",
+          params: { threadId: payload.threadId },
+          replace: true,
+          search: () => ({ splitViewId }),
+        });
+      });
+    },
+    [createSplitViewFromDrop, navigate, props.projectId, props.threadId],
+  );
 
   useEffect(() => {
     const { nextAppliedSearchKey, panelPatch } = resolveRoutePanelBootstrap({
@@ -1136,9 +1445,65 @@ function SingleChatSurface(props: {
 
   const shouldRenderPanelContent = activePanel !== null && (panelOpen || panelState.hasOpenedPanel);
 
+  const excludedThreadIds = useMemo(
+    () => new Set<ThreadIdType>([props.threadId]),
+    [props.threadId],
+  );
+
   if (!shouldUseDiffSheet) {
     return (
       <div className="flex h-dvh min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+        <ChatPaneDropOverlay
+          canDropInDirection={allowAnySplitDirection}
+          excludedThreadIds={excludedThreadIds}
+          ownerProjectId={props.projectId}
+          onDrop={handleDropThread}
+          className="flex h-full min-h-0 min-w-0 flex-1"
+        >
+          <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none text-foreground">
+            <ChatView
+              threadId={props.threadId}
+              panelState={panelState}
+              onToggleDiffPanel={() =>
+                updatePanelState(resolveToggledChatPanelPatch(panelState, "diff"))
+              }
+              onToggleBrowserPanel={() =>
+                updatePanelState(resolveToggledChatPanelPatch(panelState, "browser"))
+              }
+              onOpenTurnDiffPanel={(turnId, filePath) =>
+                updatePanelState({
+                  panel: "diff",
+                  diffTurnId: turnId,
+                  diffFilePath: filePath ?? null,
+                })
+              }
+              onSplitSurface={handleSplitSurface}
+            />
+          </SidebarInset>
+        </ChatPaneDropOverlay>
+        <PanePanelInlineSidebar
+          panelOpen={panelOpen}
+          onClosePanel={closePanel}
+          onOpenPanel={openPanel}
+          renderPanelContent={shouldRenderPanelContent}
+          panel={activePanel}
+          threadId={props.threadId}
+          panelState={panelState}
+          onUpdatePanelState={updatePanelState}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <ChatPaneDropOverlay
+        canDropInDirection={allowAnySplitDirection}
+        excludedThreadIds={excludedThreadIds}
+        ownerProjectId={props.projectId}
+        onDrop={handleDropThread}
+        className="flex h-dvh min-h-0 min-w-0 flex-1"
+      >
         <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none text-foreground">
           <ChatView
             threadId={props.threadId}
@@ -1159,42 +1524,7 @@ function SingleChatSurface(props: {
             onSplitSurface={handleSplitSurface}
           />
         </SidebarInset>
-        <PanePanelInlineSidebar
-          panelOpen={panelOpen}
-          onClosePanel={closePanel}
-          onOpenPanel={openPanel}
-          renderPanelContent={shouldRenderPanelContent}
-          panel={activePanel}
-          threadId={props.threadId}
-          panelState={panelState}
-          onUpdatePanelState={updatePanelState}
-        />
-      </div>
-    );
-  }
-
-  return (
-    <>
-      <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none text-foreground">
-        <ChatView
-          threadId={props.threadId}
-          panelState={panelState}
-          onToggleDiffPanel={() =>
-            updatePanelState(resolveToggledChatPanelPatch(panelState, "diff"))
-          }
-          onToggleBrowserPanel={() =>
-            updatePanelState(resolveToggledChatPanelPatch(panelState, "browser"))
-          }
-          onOpenTurnDiffPanel={(turnId, filePath) =>
-            updatePanelState({
-              panel: "diff",
-              diffTurnId: turnId,
-              diffFilePath: filePath ?? null,
-            })
-          }
-          onSplitSurface={handleSplitSurface}
-        />
-      </SidebarInset>
+      </ChatPaneDropOverlay>
       <RightPanelSheet panelOpen={panelOpen} onClosePanel={closePanel}>
         {shouldRenderPanelContent ? (
           activePanel === "browser" ? (

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -1205,7 +1205,9 @@ function SplitChatSurface(props: { splitViewId: SplitViewId; routeThreadId: Thre
         panelState={leaf.panel}
         isFocused={isFocused}
         deferChatMount={shouldDeferChatMount}
-        canDropInDirection={(direction) => canSubdividePane(activeSplitView.root, leaf.id, direction)}
+        canDropInDirection={(direction) =>
+          canSubdividePane(activeSplitView.root, leaf.id, direction)
+        }
         excludedThreadIds={excluded}
         ownerProjectId={activeSplitView.ownerProjectId}
         threads={selectableThreads}

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -1,24 +1,62 @@
 // FILE: _chat.index.tsx
-// Purpose: Open or resume the home-chat draft using the same bootstrap path as standard threads.
+// Purpose: Restores the last chat route on app launch, falling back to a fresh home-chat draft.
 // Layer: Routing
-// Depends on: shared new-chat handler so "/" stays a thin alias instead of a special chat surface.
+// Depends on: sidebar UI persistence plus shared new-chat handler for the empty-state fallback.
 
-import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { ThreadId } from "@t3tools/contracts";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect, useMemo, useState } from "react";
 
 import { SplashScreen } from "../components/SplashScreen";
+import { readSidebarUiState } from "../components/Sidebar.uiState";
+import { resolveRestorableThreadRoute } from "../chatRouteRestore";
 import { useHandleNewChat } from "../hooks/useHandleNewChat";
+import { useSplitViewStore } from "../splitViewStore";
+import { useStore } from "../store";
 
 function ChatIndexRouteView() {
   const { handleNewChat } = useHandleNewChat();
+  const navigate = useNavigate();
+  const threadsHydrated = useStore((store) => store.threadsHydrated);
+  const threadIds = useStore((state) => state.threadIds ?? []);
+  const splitViewsHydrated = useSplitViewStore((state) => state.hasHydrated);
+  const splitViewsById = useSplitViewStore((state) => state.splitViewsById);
+  const splitViewIds = useMemo(
+    () => Object.keys(splitViewsById).filter((splitViewId) => splitViewsById[splitViewId]),
+    [splitViewsById],
+  );
   const [attempt, setAttempt] = useState(0);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!threadsHydrated || !splitViewsHydrated) {
+      return;
+    }
+
     let cancelled = false;
     setErrorMessage(null);
 
     void (async () => {
+      const restorableRoute = resolveRestorableThreadRoute({
+        lastThreadRoute: readSidebarUiState().lastThreadRoute,
+        availableThreadIds: new Set(threadIds),
+        availableSplitViewIds: new Set(splitViewIds),
+      });
+      if (restorableRoute) {
+        if (cancelled) {
+          return;
+        }
+        await navigate({
+          to: "/$threadId",
+          params: { threadId: ThreadId.makeUnsafe(restorableRoute.threadId) },
+          replace: true,
+          search: () => ({
+            splitViewId: restorableRoute.splitViewId,
+          }),
+        });
+        return;
+      }
+
       const result = await handleNewChat({ fresh: true });
       if (cancelled || result.ok) {
         return;
@@ -29,7 +67,15 @@ function ChatIndexRouteView() {
     return () => {
       cancelled = true;
     };
-  }, [attempt, handleNewChat]);
+  }, [
+    attempt,
+    handleNewChat,
+    navigate,
+    splitViewIds,
+    splitViewsHydrated,
+    threadIds,
+    threadsHydrated,
+  ]);
 
   return (
     <SplashScreen

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -649,7 +649,7 @@ function SettingsRouteView() {
       return;
     }
 
-    const notification = new Notification(title, { body, tag: "t3code:test-notification" });
+    const notification = new Notification(title, { body, tag: "dpcode:test-notification" });
     notification.addEventListener("click", () => {
       window.focus();
     });

--- a/apps/web/src/singleChatPanelStore.ts
+++ b/apps/web/src/singleChatPanelStore.ts
@@ -22,7 +22,7 @@ interface SingleChatPanelStore {
   clearThreadPanelState: (threadId: ThreadId) => void;
 }
 
-const SINGLE_CHAT_PANEL_STORAGE_KEY = "t3code:single-chat-panel-state:v1";
+const SINGLE_CHAT_PANEL_STORAGE_KEY = "dpcode:single-chat-panel-state:v1";
 
 export function createDefaultSingleChatPanelState(): SingleChatPanelState {
   return {

--- a/apps/web/src/splitView.logic.test.ts
+++ b/apps/web/src/splitView.logic.test.ts
@@ -1,92 +1,286 @@
-import { ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
+// FILE: splitView.logic.test.ts
+// Purpose: Verify pure pane-tree helpers used by the store and chat surfaces.
+// Layer: UI state helpers test
+// Targets: tree traversal, immutable replace, leaf removal/collapse, depth-cap rule, legacy migration.
+
+import { ProjectId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { removeThreadFromSplitView } from "./splitView.logic";
-import type { SplitView } from "./splitViewStore";
+import {
+  canSubdivide,
+  canSubdividePane,
+  collectLeaves,
+  findLeafPaneById,
+  findPaneById,
+  findPaneDepth,
+  findParentSplitNode,
+  findSplitNodeById,
+  isLegacySplitViewLike,
+  removeLeafByThreadId,
+  replacePaneInTree,
+  resolveDefaultFocusLeafId,
+} from "./splitView.logic";
+import type { LeafPane, Pane, SplitNode, SplitViewPanePanelState } from "./splitViewStore";
 
-const PROJECT_ID = ProjectId.makeUnsafe("project-1");
 const THREAD_A = ThreadId.makeUnsafe("thread-a");
 const THREAD_B = ThreadId.makeUnsafe("thread-b");
-const TURN_ID = TurnId.makeUnsafe("turn-1");
+const THREAD_C = ThreadId.makeUnsafe("thread-c");
+const THREAD_D = ThreadId.makeUnsafe("thread-d");
+const PROJECT_ID = ProjectId.makeUnsafe("project-1");
 
-function createSplitView(overrides: Partial<SplitView> = {}): SplitView {
+function makePanel(): SplitViewPanePanelState {
   return {
-    id: "split-1",
-    sourceThreadId: THREAD_A,
-    ownerProjectId: PROJECT_ID,
-    leftThreadId: THREAD_A,
-    rightThreadId: THREAD_B,
-    focusedPane: "left",
-    ratio: 0.5,
-    leftPanel: {
-      panel: "diff",
-      diffTurnId: TURN_ID,
-      diffFilePath: "src/left.ts",
-      hasOpenedPanel: true,
-      lastOpenPanel: "diff",
-    },
-    rightPanel: {
-      panel: "browser",
-      diffTurnId: null,
-      diffFilePath: null,
-      hasOpenedPanel: true,
-      lastOpenPanel: "browser",
-    },
-    createdAt: "2026-01-01T00:00:00.000Z",
-    updatedAt: "2026-01-01T00:00:00.000Z",
-    ...overrides,
+    panel: null,
+    diffTurnId: null,
+    diffFilePath: null,
+    hasOpenedPanel: false,
+    lastOpenPanel: "browser",
   };
 }
 
-describe("removeThreadFromSplitView", () => {
-  it("clears the removed pane, resets its panel, and falls focus back to the remaining thread", () => {
-    const result = removeThreadFromSplitView(createSplitView(), THREAD_A);
+function makeLeaf(id: string, threadId: ThreadId | null): LeafPane {
+  return { kind: "leaf", id, threadId, panel: makePanel() };
+}
 
-    expect(result.removedPane).toBe("left");
-    expect(result.nextFocusedPane).toBe("right");
-    expect(result.nextFocusedThreadId).toBe(THREAD_B);
-    expect(result.nextSplitView).toMatchObject({
-      leftThreadId: null,
-      rightThreadId: THREAD_B,
-      focusedPane: "right",
-      leftPanel: {
-        panel: null,
-        diffTurnId: null,
-        diffFilePath: null,
-        hasOpenedPanel: true,
-        lastOpenPanel: "diff",
-      },
+function makeSplit(input: {
+  id: string;
+  direction: "horizontal" | "vertical";
+  first: Pane;
+  second: Pane;
+  ratio?: number;
+}): SplitNode {
+  return {
+    kind: "split",
+    id: input.id,
+    direction: input.direction,
+    first: input.first,
+    second: input.second,
+    ratio: input.ratio ?? 0.5,
+  };
+}
+
+describe("findPaneById / findLeafPaneById / findSplitNodeById", () => {
+  it("walks the tree and returns the matching node by id", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const leafB = makeLeaf("leaf-b", THREAD_B);
+    const root = makeSplit({ id: "root", direction: "horizontal", first: leafA, second: leafB });
+
+    expect(findPaneById(root, "leaf-a")).toBe(leafA);
+    expect(findLeafPaneById(root, "leaf-b")).toBe(leafB);
+    expect(findSplitNodeById(root, "root")).toBe(root);
+    expect(findLeafPaneById(root, "root")).toBeNull();
+    expect(findSplitNodeById(root, "leaf-a")).toBeNull();
+    expect(findPaneById(root, "missing")).toBeNull();
+  });
+});
+
+describe("findParentSplitNode", () => {
+  it("returns the SplitNode that directly contains a leaf", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const leafB = makeLeaf("leaf-b", THREAD_B);
+    const innerSplit = makeSplit({
+      id: "inner",
+      direction: "vertical",
+      first: leafA,
+      second: leafB,
     });
+    const leafC = makeLeaf("leaf-c", THREAD_C);
+    const root = makeSplit({
+      id: "root",
+      direction: "horizontal",
+      first: innerSplit,
+      second: leafC,
+    });
+
+    expect(findParentSplitNode(root, "leaf-a")).toBe(innerSplit);
+    expect(findParentSplitNode(root, "leaf-c")).toBe(root);
+    expect(findParentSplitNode(root, "root")).toBeNull();
+  });
+});
+
+describe("findPaneDepth", () => {
+  it("returns the depth of panes in the tree", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const leafB = makeLeaf("leaf-b", THREAD_B);
+    const innerSplit = makeSplit({
+      id: "inner",
+      direction: "vertical",
+      first: leafA,
+      second: leafB,
+    });
+    const leafC = makeLeaf("leaf-c", THREAD_C);
+    const root = makeSplit({
+      id: "root",
+      direction: "horizontal",
+      first: innerSplit,
+      second: leafC,
+    });
+
+    expect(findPaneDepth(root, "root")).toBe(0);
+    expect(findPaneDepth(root, "inner")).toBe(1);
+    expect(findPaneDepth(root, "leaf-a")).toBe(2);
+    expect(findPaneDepth(root, "leaf-c")).toBe(1);
+    expect(findPaneDepth(root, "missing")).toBeNull();
+  });
+});
+
+describe("collectLeaves", () => {
+  it("returns leaves in left-to-right (depth-first) order", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const leafB = makeLeaf("leaf-b", THREAD_B);
+    const inner = makeSplit({
+      id: "inner",
+      direction: "vertical",
+      first: leafA,
+      second: leafB,
+    });
+    const leafC = makeLeaf("leaf-c", THREAD_C);
+    const root = makeSplit({ id: "root", direction: "horizontal", first: inner, second: leafC });
+
+    expect(collectLeaves(root).map((leaf) => leaf.id)).toEqual(["leaf-a", "leaf-b", "leaf-c"]);
+  });
+});
+
+describe("replacePaneInTree", () => {
+  it("returns a new tree where the specified pane is replaced", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const leafB = makeLeaf("leaf-b", THREAD_B);
+    const root = makeSplit({ id: "root", direction: "horizontal", first: leafA, second: leafB });
+
+    const replacement: LeafPane = makeLeaf("leaf-a", THREAD_C);
+    const updated = replacePaneInTree(root, "leaf-a", replacement);
+
+    expect(updated).not.toBe(root);
+    expect((updated as SplitNode).first).toBe(replacement);
+    expect((updated as SplitNode).second).toBe(leafB);
   });
 
-  it("removes the split entirely when deleting the last remaining thread", () => {
-    const result = removeThreadFromSplitView(
-      createSplitView({
-        rightThreadId: null,
-        rightPanel: {
-          panel: null,
-          diffTurnId: null,
-          diffFilePath: null,
-          hasOpenedPanel: false,
-          lastOpenPanel: "browser",
-        },
-      }),
-      THREAD_A,
-    );
+  it("returns the same root when the pane is not found", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const leafB = makeLeaf("leaf-b", THREAD_B);
+    const root = makeSplit({ id: "root", direction: "horizontal", first: leafA, second: leafB });
+    expect(replacePaneInTree(root, "missing", makeLeaf("missing", THREAD_C))).toBe(root);
+  });
+});
 
-    expect(result.removedPane).toBe("left");
-    expect(result.nextFocusedPane).toBeNull();
-    expect(result.nextFocusedThreadId).toBeNull();
-    expect(result.nextSplitView).toBeNull();
+describe("removeLeafByThreadId", () => {
+  it("collapses a SplitNode to its surviving subtree when one side is removed", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const leafB = makeLeaf("leaf-b", THREAD_B);
+    const root = makeSplit({ id: "root", direction: "horizontal", first: leafA, second: leafB });
+
+    const result = removeLeafByThreadId(root, THREAD_A);
+    expect(result.removedLeafIds).toEqual(["leaf-a"]);
+    expect(result.nextRoot).toBe(leafB);
   });
 
-  it("leaves unrelated splits untouched", () => {
-    const splitView = createSplitView();
+  it("returns null when the only remaining leaf is removed", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const result = removeLeafByThreadId(leafA, THREAD_A);
+    expect(result.removedLeafIds).toEqual(["leaf-a"]);
+    expect(result.nextRoot).toBeNull();
+  });
 
-    const result = removeThreadFromSplitView(splitView, ThreadId.makeUnsafe("thread-z"));
+  it("removes leaves nested inside a perpendicular subtree", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const leafB = makeLeaf("leaf-b", THREAD_B);
+    const inner = makeSplit({
+      id: "inner",
+      direction: "vertical",
+      first: leafA,
+      second: leafB,
+    });
+    const leafC = makeLeaf("leaf-c", THREAD_C);
+    const root = makeSplit({ id: "root", direction: "horizontal", first: inner, second: leafC });
 
-    expect(result.nextSplitView).toBe(splitView);
-    expect(result.nextFocusedPane).toBe("left");
-    expect(result.nextFocusedThreadId).toBe(THREAD_A);
+    const result = removeLeafByThreadId(root, THREAD_B);
+    expect(result.removedLeafIds).toEqual(["leaf-b"]);
+    expect(result.nextRoot).not.toBe(root);
+    if (result.nextRoot && result.nextRoot.kind === "split") {
+      expect(result.nextRoot.first).toBe(leafA);
+      expect(result.nextRoot.second).toBe(leafC);
+    }
+  });
+
+  it("preserves identity when the threadId is not present", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const leafB = makeLeaf("leaf-b", THREAD_B);
+    const root = makeSplit({ id: "root", direction: "horizontal", first: leafA, second: leafB });
+    expect(removeLeafByThreadId(root, THREAD_C).nextRoot).toBe(root);
+  });
+});
+
+describe("canSubdivide", () => {
+  it("allows any direction when there is no parent split", () => {
+    expect(canSubdivide(null, "horizontal")).toBe(true);
+    expect(canSubdivide(null, "vertical")).toBe(true);
+  });
+
+  it("only allows perpendicular subdivisions", () => {
+    expect(canSubdivide("horizontal", "vertical")).toBe(true);
+    expect(canSubdivide("vertical", "horizontal")).toBe(true);
+    expect(canSubdivide("horizontal", "horizontal")).toBe(false);
+    expect(canSubdivide("vertical", "vertical")).toBe(false);
+  });
+});
+
+describe("canSubdividePane", () => {
+  it("allows root children to split perpendicularly but blocks leaves already at 2x2 depth", () => {
+    const topLeft = makeLeaf("top-left", THREAD_A);
+    const bottomLeft = makeLeaf("bottom-left", THREAD_B);
+    const leftSplit = makeSplit({
+      id: "left-split",
+      direction: "vertical",
+      first: topLeft,
+      second: bottomLeft,
+    });
+    const rightLeaf = makeLeaf("right", THREAD_C);
+    const root = makeSplit({
+      id: "root",
+      direction: "horizontal",
+      first: leftSplit,
+      second: rightLeaf,
+    });
+
+    expect(canSubdividePane(root, "right", "vertical")).toBe(true);
+    expect(canSubdividePane(root, "right", "horizontal")).toBe(false);
+    expect(canSubdividePane(root, "top-left", "horizontal")).toBe(false);
+    expect(canSubdividePane(root, "missing", "vertical")).toBe(false);
+  });
+
+  it("allows a root leaf to split in either direction", () => {
+    const root = makeLeaf("root-leaf", THREAD_D);
+    expect(canSubdividePane(root, "root-leaf", "horizontal")).toBe(true);
+    expect(canSubdividePane(root, "root-leaf", "vertical")).toBe(true);
+  });
+});
+
+describe("resolveDefaultFocusLeafId", () => {
+  it("returns the first leaf id in DFS order", () => {
+    const leafA = makeLeaf("leaf-a", THREAD_A);
+    const leafB = makeLeaf("leaf-b", THREAD_B);
+    const root = makeSplit({ id: "root", direction: "horizontal", first: leafA, second: leafB });
+    expect(resolveDefaultFocusLeafId(root)).toBe("leaf-a");
+  });
+});
+
+describe("isLegacySplitViewLike", () => {
+  it("matches the v1 persisted shape", () => {
+    const legacy = {
+      id: "split-1",
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      leftThreadId: THREAD_A,
+      rightThreadId: THREAD_B,
+      focusedPane: "left",
+      ratio: 0.5,
+      leftPanel: makePanel(),
+      rightPanel: makePanel(),
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    expect(isLegacySplitViewLike(legacy)).toBe(true);
+    expect(isLegacySplitViewLike(null)).toBe(false);
+    expect(isLegacySplitViewLike({})).toBe(false);
   });
 });

--- a/apps/web/src/splitView.logic.ts
+++ b/apps/web/src/splitView.logic.ts
@@ -1,17 +1,17 @@
 // FILE: splitView.logic.ts
-// Purpose: Centralizes split-surface fallback rules so deletion and cleanup flows stay consistent.
+// Purpose: Pure helpers for the split-view pane tree (find/replace/collapse leaves, depth caps, panel resets).
 // Layer: UI state helpers
-// Exports: split-view mutation helpers used by the store and split-aware navigation flows
+// Exports: tree traversal/mutation utilities and migration helpers consumed by the store and route surfaces
 
-import type { ThreadId } from "@t3tools/contracts";
-import type { SplitView, SplitViewPane, SplitViewPanePanelState } from "./splitViewStore";
-
-export interface SplitViewThreadRemovalResult {
-  removedPane: SplitViewPane | null;
-  nextFocusedPane: SplitViewPane | null;
-  nextFocusedThreadId: ThreadId | null;
-  nextSplitView: SplitView | null;
-}
+import type { ProjectId, ThreadId } from "@t3tools/contracts";
+import type {
+  LeafPane,
+  Pane,
+  PaneId,
+  SplitDirection,
+  SplitNode,
+  SplitViewPanePanelState,
+} from "./splitViewStore";
 
 export function clearSplitViewPanePanelState(
   panelState: SplitViewPanePanelState,
@@ -24,62 +24,180 @@ export function clearSplitViewPanePanelState(
   };
 }
 
-export function removeThreadFromSplitView(
-  splitView: SplitView,
-  threadId: ThreadId,
-): SplitViewThreadRemovalResult {
-  const leftMatches = splitView.leftThreadId === threadId;
-  const rightMatches = splitView.rightThreadId === threadId;
-  if (!leftMatches && !rightMatches) {
-    return {
-      removedPane: null,
-      nextFocusedPane: splitView.focusedPane,
-      nextFocusedThreadId:
-        splitView.focusedPane === "left"
-          ? (splitView.leftThreadId ?? splitView.rightThreadId)
-          : (splitView.rightThreadId ?? splitView.leftThreadId),
-      nextSplitView: splitView,
-    };
+// --- pane lookup ---
+
+export function findPaneById(root: Pane, paneId: PaneId): Pane | null {
+  if (root.id === paneId) {
+    return root;
+  }
+  if (root.kind === "leaf") {
+    return null;
+  }
+  return findPaneById(root.first, paneId) ?? findPaneById(root.second, paneId);
+}
+
+export function findLeafPaneById(root: Pane, paneId: PaneId): LeafPane | null {
+  const found = findPaneById(root, paneId);
+  return found?.kind === "leaf" ? found : null;
+}
+
+export function findSplitNodeById(root: Pane, paneId: PaneId): SplitNode | null {
+  const found = findPaneById(root, paneId);
+  return found?.kind === "split" ? found : null;
+}
+
+// Returns the SplitNode that directly contains the pane with paneId, or null if paneId is the root.
+export function findParentSplitNode(root: Pane, paneId: PaneId): SplitNode | null {
+  if (root.kind === "leaf") {
+    return null;
+  }
+  if (root.first.id === paneId || root.second.id === paneId) {
+    return root;
+  }
+  return findParentSplitNode(root.first, paneId) ?? findParentSplitNode(root.second, paneId);
+}
+
+export function findPaneDepth(root: Pane, paneId: PaneId): number | null {
+  if (root.id === paneId) {
+    return 0;
+  }
+  if (root.kind === "leaf") {
+    return null;
+  }
+  const firstDepth = findPaneDepth(root.first, paneId);
+  if (firstDepth !== null) {
+    return firstDepth + 1;
+  }
+  const secondDepth = findPaneDepth(root.second, paneId);
+  return secondDepth === null ? null : secondDepth + 1;
+}
+
+export function collectLeaves(root: Pane): LeafPane[] {
+  if (root.kind === "leaf") {
+    return [root];
+  }
+  return [...collectLeaves(root.first), ...collectLeaves(root.second)];
+}
+
+// --- pane mutation (immutable) ---
+
+// Returns a new tree where the pane with paneId is replaced. Preserves identity when nothing changes.
+export function replacePaneInTree(root: Pane, paneId: PaneId, replacement: Pane): Pane {
+  if (root.id === paneId) {
+    return replacement;
+  }
+  if (root.kind === "leaf") {
+    return root;
+  }
+  const first = replacePaneInTree(root.first, paneId, replacement);
+  const second = replacePaneInTree(root.second, paneId, replacement);
+  if (first === root.first && second === root.second) {
+    return root;
+  }
+  return { ...root, first, second };
+}
+
+export interface RemoveLeafResult {
+  nextRoot: Pane | null;
+  removedLeafIds: PaneId[];
+}
+
+// Walks the tree, removing every leaf whose threadId matches. SplitNodes whose subtree
+// loses every leaf collapse to null; nodes with one surviving subtree collapse to that subtree.
+export function removeLeafByThreadId(root: Pane, threadId: ThreadId): RemoveLeafResult {
+  if (root.kind === "leaf") {
+    if (root.threadId === threadId) {
+      return { nextRoot: null, removedLeafIds: [root.id] };
+    }
+    return { nextRoot: root, removedLeafIds: [] };
   }
 
-  const nextLeftThreadId = leftMatches ? null : splitView.leftThreadId;
-  const nextRightThreadId = rightMatches ? null : splitView.rightThreadId;
+  const firstResult = removeLeafByThreadId(root.first, threadId);
+  const secondResult = removeLeafByThreadId(root.second, threadId);
+  const removedLeafIds = [...firstResult.removedLeafIds, ...secondResult.removedLeafIds];
 
-  if (!nextLeftThreadId && !nextRightThreadId) {
-    return {
-      removedPane: leftMatches ? "left" : "right",
-      nextFocusedPane: null,
-      nextFocusedThreadId: null,
-      nextSplitView: null,
-    };
+  if (removedLeafIds.length === 0) {
+    return { nextRoot: root, removedLeafIds };
   }
 
-  const nextFocusedPane =
-    splitView.focusedPane === "left"
-      ? nextLeftThreadId
-        ? "left"
-        : "right"
-      : nextRightThreadId
-        ? "right"
-        : "left";
-  const nextFocusedThreadId = nextFocusedPane === "left" ? nextLeftThreadId : nextRightThreadId;
+  if (firstResult.nextRoot && secondResult.nextRoot) {
+    return {
+      nextRoot: { ...root, first: firstResult.nextRoot, second: secondResult.nextRoot },
+      removedLeafIds,
+    };
+  }
+  if (firstResult.nextRoot) {
+    return { nextRoot: firstResult.nextRoot, removedLeafIds };
+  }
+  if (secondResult.nextRoot) {
+    return { nextRoot: secondResult.nextRoot, removedLeafIds };
+  }
+  return { nextRoot: null, removedLeafIds };
+}
 
-  return {
-    removedPane: leftMatches ? "left" : "right",
-    nextFocusedPane,
-    nextFocusedThreadId,
-    nextSplitView: {
-      ...splitView,
-      leftThreadId: nextLeftThreadId,
-      rightThreadId: nextRightThreadId,
-      leftPanel: leftMatches
-        ? clearSplitViewPanePanelState(splitView.leftPanel)
-        : splitView.leftPanel,
-      rightPanel: rightMatches
-        ? clearSplitViewPanePanelState(splitView.rightPanel)
-        : splitView.rightPanel,
-      focusedPane: nextFocusedPane,
-      updatedAt: new Date().toISOString(),
-    },
-  };
+// --- structural rules ---
+
+// Returns true if a target leaf can be subdivided in the requested direction without exceeding
+// the depth-cap of 2 (root SplitNode + at most one perpendicular SplitNode under each side).
+// When parentDirection is null (root-level leaf), any direction is allowed.
+export function canSubdivide(
+  parentDirection: SplitDirection | null,
+  requestedDirection: SplitDirection,
+): boolean {
+  if (parentDirection === null) {
+    return true;
+  }
+  return parentDirection !== requestedDirection;
+}
+
+export function canSubdividePane(
+  root: Pane,
+  targetPaneId: PaneId,
+  requestedDirection: SplitDirection,
+): boolean {
+  if (!findLeafPaneById(root, targetPaneId)) {
+    return false;
+  }
+  const targetDepth = findPaneDepth(root, targetPaneId);
+  if (targetDepth === null || targetDepth >= 2) {
+    return false;
+  }
+  const parent = findParentSplitNode(root, targetPaneId);
+  return canSubdivide(parent?.direction ?? null, requestedDirection);
+}
+
+// Returns the first leaf id encountered in DFS order; falls back to root id when there are no leaves.
+export function resolveDefaultFocusLeafId(root: Pane): PaneId {
+  const leaves = collectLeaves(root);
+  return leaves[0]?.id ?? root.id;
+}
+
+// --- legacy split-view migration ---
+
+export interface LegacySplitViewLike {
+  id: string;
+  sourceThreadId: ThreadId;
+  ownerProjectId: ProjectId;
+  leftThreadId: ThreadId | null;
+  rightThreadId: ThreadId | null;
+  focusedPane: "left" | "right";
+  ratio: number;
+  leftPanel: SplitViewPanePanelState;
+  rightPanel: SplitViewPanePanelState;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function isLegacySplitViewLike(value: unknown): value is LegacySplitViewLike {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.sourceThreadId === "string" &&
+    "leftThreadId" in candidate &&
+    "rightThreadId" in candidate &&
+    typeof candidate.focusedPane === "string"
+  );
 }

--- a/apps/web/src/splitViewRoute.ts
+++ b/apps/web/src/splitViewRoute.ts
@@ -7,7 +7,8 @@ import { type ThreadId } from "@t3tools/contracts";
 import { type DiffRouteSearch } from "./diffRouteSearch";
 import {
   resolveSplitViewFocusedThreadId,
-  resolveSplitViewPaneForThread,
+  resolveSplitViewPaneIdForThread,
+  type PaneId,
   type SplitView,
 } from "./splitViewStore";
 
@@ -17,21 +18,21 @@ export function resolveActiveSplitView(input: {
 }): {
   splitView: SplitView | null;
   focusedThreadId: ThreadId | null;
-  routePane: "left" | "right" | null;
+  routePaneId: PaneId | null;
 } {
   const { routeThreadId, splitView } = input;
   if (!splitView) {
     return {
       splitView: null,
       focusedThreadId: routeThreadId,
-      routePane: null,
+      routePaneId: null,
     };
   }
 
   return {
     splitView,
     focusedThreadId: resolveSplitViewFocusedThreadId(splitView),
-    routePane: resolveSplitViewPaneForThread(splitView, routeThreadId),
+    routePaneId: resolveSplitViewPaneIdForThread(splitView, routeThreadId),
   };
 }
 

--- a/apps/web/src/splitViewStore.test.ts
+++ b/apps/web/src/splitViewStore.test.ts
@@ -390,6 +390,96 @@ describe("splitViewStore", () => {
     expect(snapshot(splitViewId).focusedPaneId).toBe(previousFocusedPaneId);
   });
 
+  it("replacePaneThread reanchors a split when clearing the source pane", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "second",
+    });
+    const sourcePaneId = findLeafIdForThread(snapshot(splitViewId), THREAD_A);
+
+    store.replacePaneThread(splitViewId, sourcePaneId, null);
+
+    const nextState = useSplitViewStore.getState();
+    const splitView = snapshot(splitViewId);
+    expect(splitView.sourceThreadId).toBe(THREAD_B);
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_A]).toBeUndefined();
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_B]).toBe(splitViewId);
+    expect(resolvePreferredSplitViewIdForThread({ ...nextState, threadId: THREAD_A })).toBeNull();
+  });
+
+  it("replacePaneThread reanchors a split when replacing the source pane", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "second",
+    });
+    const sourcePaneId = findLeafIdForThread(snapshot(splitViewId), THREAD_A);
+
+    store.replacePaneThread(splitViewId, sourcePaneId, THREAD_C);
+
+    const nextState = useSplitViewStore.getState();
+    const splitView = snapshot(splitViewId);
+    expect(splitView.sourceThreadId).toBe(THREAD_C);
+    expect(resolveSplitViewThreadIds(splitView).toSorted()).toEqual(
+      [THREAD_B, THREAD_C].toSorted(),
+    );
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_A]).toBeUndefined();
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_C]).toBe(splitViewId);
+    expect(resolvePreferredSplitViewIdForThread({ ...nextState, threadId: THREAD_C })).toBe(
+      splitViewId,
+    );
+  });
+
+  it("replacePaneThread does not steal another split's source mapping", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "second",
+    });
+    const otherSplitId = store.createFromThread({
+      sourceThreadId: THREAD_C,
+      ownerProjectId: PROJECT_ID,
+    });
+    const sourcePaneId = findLeafIdForThread(snapshot(splitViewId), THREAD_A);
+
+    store.replacePaneThread(splitViewId, sourcePaneId, THREAD_C);
+
+    const nextState = useSplitViewStore.getState();
+    const splitView = snapshot(splitViewId);
+    expect(splitView.sourceThreadId).toBe(THREAD_B);
+    expect(resolveSplitViewThreadIds(splitView).toSorted()).toEqual(
+      [THREAD_B, THREAD_C].toSorted(),
+    );
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_A]).toBeUndefined();
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_B]).toBe(splitViewId);
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_C]).toBe(otherSplitId);
+  });
+
+  it("replacePaneThread removes a split when clearing its last populated pane", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromThread({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+    });
+    const sourcePaneId = findLeafIdForThread(snapshot(splitViewId), THREAD_A);
+
+    store.replacePaneThread(splitViewId, sourcePaneId, null);
+
+    const nextState = useSplitViewStore.getState();
+    expect(nextState.splitViewsById[splitViewId]).toBeUndefined();
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_A]).toBeUndefined();
+  });
+
   it("removeThreadFromSplitViews collapses the tree, drops orphaned splits, and reseats focus", () => {
     const store = useSplitViewStore.getState();
     const firstSplitId = store.createFromThread({

--- a/apps/web/src/splitViewStore.test.ts
+++ b/apps/web/src/splitViewStore.test.ts
@@ -104,7 +104,7 @@ describe("splitViewStore", () => {
     expect(splitView.focusedPaneId).toBe(root.first.id);
   });
 
-  it("keeps writing split views to the v1 storage key so persisted state can migrate", async () => {
+  it("keeps writing split views to the DPCode v1 storage key so persisted state can migrate", async () => {
     vi.resetModules();
     globalThis.localStorage = createMemoryStorage();
     const { useSplitViewStore: freshSplitViewStore } = await import("./splitViewStore");
@@ -114,9 +114,9 @@ describe("splitViewStore", () => {
       ownerProjectId: PROJECT_ID,
     });
 
-    const persisted = globalThis.localStorage.getItem("t3code:split-view-state:v1");
+    const persisted = globalThis.localStorage.getItem("dpcode:split-view-state:v1");
     expect(persisted).not.toBeNull();
-    expect(globalThis.localStorage.getItem("t3code:split-view-state:v2")).toBeNull();
+    expect(globalThis.localStorage.getItem("dpcode:split-view-state:v2")).toBeNull();
     expect(JSON.parse(persisted ?? "{}")).toMatchObject({ version: 2 });
   });
 
@@ -149,7 +149,7 @@ describe("splitViewStore", () => {
     vi.resetModules();
     globalThis.localStorage = createMemoryStorage();
     globalThis.localStorage.setItem(
-      "t3code:split-view-state:v1",
+      "dpcode:split-view-state:v1",
       JSON.stringify({
         state: {
           splitViewsById: {
@@ -516,7 +516,9 @@ describe("splitViewStore", () => {
       // First split kept THREAD_B and dropped the THREAD_A leaf, so the tree collapses to a single leaf.
       expect(resolveSplitViewThreadIds(firstSplit)).toEqual([THREAD_B]);
       expect(resolveSplitViewFocusedThreadId(firstSplit)).toBe(THREAD_B);
+      expect(firstSplit.sourceThreadId).toBe(THREAD_B);
     }
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_B]).toBe(firstSplitId);
 
     const secondSplit = nextState.splitViewsById[secondSplitId];
     expect(secondSplit).toBeDefined();
@@ -581,7 +583,25 @@ describe("splitViewStore", () => {
     ).toBe(sourceSplitId);
   });
 
-  it("falls back to the most recently updated matching split for non-source threads", () => {
+  it("resolves the only matching split for non-source threads", () => {
+    const store = useSplitViewStore.getState();
+    const splitId = store.createFromThread({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+    });
+    const emptyId = findEmptyLeafId(snapshot(splitId));
+    store.replacePaneThread(splitId, emptyId, THREAD_B);
+
+    expect(
+      resolvePreferredSplitViewIdForThread({
+        splitViewsById: useSplitViewStore.getState().splitViewsById,
+        splitViewIdBySourceThreadId: useSplitViewStore.getState().splitViewIdBySourceThreadId,
+        threadId: THREAD_B,
+      }),
+    ).toBe(splitId);
+  });
+
+  it("returns null for ambiguous non-source split membership instead of guessing by recency", () => {
     const store = useSplitViewStore.getState();
     const olderSplitId = store.createFromThread({
       sourceThreadId: THREAD_A,
@@ -596,17 +616,6 @@ describe("splitViewStore", () => {
     });
     const newerEmptyId = findEmptyLeafId(snapshot(newerSplitId));
     store.replacePaneThread(newerSplitId, newerEmptyId, THREAD_B);
-    useSplitViewStore.setState((state) => ({
-      splitViewsById: {
-        ...state.splitViewsById,
-        [olderSplitId]: state.splitViewsById[olderSplitId]
-          ? { ...state.splitViewsById[olderSplitId], updatedAt: "2026-04-07T10:00:00.000Z" }
-          : undefined,
-        [newerSplitId]: state.splitViewsById[newerSplitId]
-          ? { ...state.splitViewsById[newerSplitId], updatedAt: "2026-04-07T10:01:00.000Z" }
-          : undefined,
-      },
-    }));
 
     expect(
       resolvePreferredSplitViewIdForThread({
@@ -614,6 +623,6 @@ describe("splitViewStore", () => {
         splitViewIdBySourceThreadId: useSplitViewStore.getState().splitViewIdBySourceThreadId,
         threadId: THREAD_B,
       }),
-    ).toBe(newerSplitId);
+    ).toBeNull();
   });
 });

--- a/apps/web/src/splitViewStore.test.ts
+++ b/apps/web/src/splitViewStore.test.ts
@@ -1,34 +1,78 @@
-import { ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+// FILE: splitViewStore.test.ts
+// Purpose: Verify tree-aware split view state operations: drop creation, perpendicular subdivision,
+// pane focus/ratio mutations, deleted-thread collapse semantics, and v1 -> v2 persisted-state migration.
 
-import { resolvePreferredSplitViewIdForThread, useSplitViewStore } from "./splitViewStore";
+import { ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { collectLeaves, findParentSplitNode } from "./splitView.logic";
+import {
+  resolvePreferredSplitViewIdForThread,
+  resolveSplitViewFocusedThreadId,
+  resolveSplitViewPaneIdForThread,
+  resolveSplitViewThreadIds,
+  useSplitViewStore,
+  type LeafPane,
+  type SplitNode,
+  type SplitView,
+} from "./splitViewStore";
 
 const PROJECT_ID = ProjectId.makeUnsafe("project-1");
 const THREAD_A = ThreadId.makeUnsafe("thread-a");
 const THREAD_B = ThreadId.makeUnsafe("thread-b");
 const THREAD_C = ThreadId.makeUnsafe("thread-c");
+const THREAD_D = ThreadId.makeUnsafe("thread-d");
 const TURN_ID = TurnId.makeUnsafe("turn-1");
 const ORIGINAL_LOCAL_STORAGE = globalThis.localStorage;
 
+function createMemoryStorage(): Storage {
+  const storage = new Map<string, string>();
+  return {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => {
+      storage.clear();
+    },
+    key: (index: number) => [...storage.keys()][index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  } as Storage;
+}
+
+function snapshot(splitViewId: string): SplitView {
+  const splitView = useSplitViewStore.getState().splitViewsById[splitViewId];
+  if (!splitView) throw new Error(`split view ${splitViewId} not found`);
+  return splitView;
+}
+
+function findRootSplitNode(splitView: SplitView): SplitNode {
+  if (splitView.root.kind !== "split") {
+    throw new Error("expected split root to be a SplitNode");
+  }
+  return splitView.root;
+}
+
+function findEmptyLeafId(splitView: SplitView): string {
+  const empty = collectLeaves(splitView.root).find((leaf) => leaf.threadId === null);
+  if (!empty) throw new Error("expected an empty leaf");
+  return empty.id;
+}
+
+function findLeafIdForThread(splitView: SplitView, threadId: ThreadId): string {
+  const paneId = resolveSplitViewPaneIdForThread(splitView, threadId);
+  if (!paneId) throw new Error(`expected leaf for thread ${threadId}`);
+  return paneId;
+}
+
 describe("splitViewStore", () => {
   beforeEach(() => {
-    const storage = new Map<string, string>();
-    globalThis.localStorage = {
-      getItem: (key: string) => storage.get(key) ?? null,
-      setItem: (key: string, value: string) => {
-        storage.set(key, value);
-      },
-      removeItem: (key: string) => {
-        storage.delete(key);
-      },
-      clear: () => {
-        storage.clear();
-      },
-      key: (index: number) => [...storage.keys()][index] ?? null,
-      get length() {
-        return storage.size;
-      },
-    } as Storage;
+    globalThis.localStorage = createMemoryStorage();
     useSplitViewStore.setState({
       splitViewsById: {},
       splitViewIdBySourceThreadId: {},
@@ -36,17 +80,326 @@ describe("splitViewStore", () => {
   });
 
   afterEach(() => {
+    vi.resetModules();
     globalThis.localStorage = ORIGINAL_LOCAL_STORAGE;
   });
 
-  it("removes a deleted thread from every split that references it", () => {
+  it("creates a horizontal drop split with the dropped leaf placed on the requested side", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "first",
+    });
+
+    const splitView = snapshot(splitViewId);
+    const root = findRootSplitNode(splitView);
+    expect(root.direction).toBe("horizontal");
+    expect(root.first.kind).toBe("leaf");
+    expect(root.second.kind).toBe("leaf");
+    expect((root.first as LeafPane).threadId).toBe(THREAD_B);
+    expect((root.second as LeafPane).threadId).toBe(THREAD_A);
+    expect(splitView.focusedPaneId).toBe(root.first.id);
+  });
+
+  it("keeps writing split views to the v1 storage key so persisted state can migrate", async () => {
+    vi.resetModules();
+    globalThis.localStorage = createMemoryStorage();
+    const { useSplitViewStore: freshSplitViewStore } = await import("./splitViewStore");
+
+    freshSplitViewStore.getState().createFromThread({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+    });
+
+    const persisted = globalThis.localStorage.getItem("t3code:split-view-state:v1");
+    expect(persisted).not.toBeNull();
+    expect(globalThis.localStorage.getItem("t3code:split-view-state:v2")).toBeNull();
+    expect(JSON.parse(persisted ?? "{}")).toMatchObject({ version: 2 });
+  });
+
+  it("replaces an existing source split when creating a drop split for the same source", () => {
     const store = useSplitViewStore.getState();
     const firstSplitId = store.createFromThread({
       sourceThreadId: THREAD_A,
       ownerProjectId: PROJECT_ID,
     });
-    store.replacePaneThread(firstSplitId, "right", THREAD_B);
-    store.setPanePanelState(firstSplitId, "left", {
+
+    const secondSplitId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "vertical",
+      side: "first",
+    });
+
+    const nextState = useSplitViewStore.getState();
+    expect(secondSplitId).toBe(firstSplitId);
+    expect(Object.keys(nextState.splitViewsById)).toEqual([firstSplitId]);
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_A]).toBe(firstSplitId);
+    expect(resolveSplitViewThreadIds(snapshot(firstSplitId)).toSorted()).toEqual(
+      [THREAD_A, THREAD_B].toSorted(),
+    );
+    expect(findRootSplitNode(snapshot(firstSplitId)).direction).toBe("vertical");
+  });
+
+  it("migrates legacy v1 flat split views from the stable storage key", async () => {
+    vi.resetModules();
+    globalThis.localStorage = createMemoryStorage();
+    globalThis.localStorage.setItem(
+      "t3code:split-view-state:v1",
+      JSON.stringify({
+        state: {
+          splitViewsById: {
+            "split-legacy": {
+              id: "split-legacy",
+              sourceThreadId: THREAD_A,
+              ownerProjectId: PROJECT_ID,
+              leftThreadId: THREAD_A,
+              rightThreadId: THREAD_B,
+              focusedPane: "right",
+              ratio: 0.6,
+              leftPanel: {
+                panel: null,
+                diffTurnId: null,
+                diffFilePath: null,
+                hasOpenedPanel: false,
+                lastOpenPanel: "browser",
+              },
+              rightPanel: {
+                panel: "diff",
+                diffTurnId: TURN_ID,
+                diffFilePath: "src/example.ts",
+                hasOpenedPanel: true,
+                lastOpenPanel: "diff",
+              },
+              createdAt: "2026-04-01T00:00:00.000Z",
+              updatedAt: "2026-04-01T00:00:00.000Z",
+            },
+          },
+        },
+        version: 0,
+      }),
+    );
+    const {
+      resolveSplitViewFocusedThreadId: resolveFreshFocusedThreadId,
+      resolveSplitViewThreadIds: resolveFreshThreadIds,
+      useSplitViewStore: freshSplitViewStore,
+    } = await import("./splitViewStore");
+
+    const migrated = freshSplitViewStore.getState().splitViewsById["split-legacy"];
+    expect(migrated).toBeDefined();
+    if (!migrated) return;
+    expect(migrated.root.kind).toBe("split");
+    expect(resolveFreshThreadIds(migrated).toSorted()).toEqual([THREAD_A, THREAD_B].toSorted());
+    expect(resolveFreshFocusedThreadId(migrated)).toBe(THREAD_B);
+  });
+
+  it("subdivides a target leaf perpendicular to its parent on dropThreadOnPane", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "second",
+    });
+
+    const targetLeafId = findLeafIdForThread(snapshot(splitViewId), THREAD_A);
+    const ok = useSplitViewStore.getState().dropThreadOnPane({
+      splitViewId,
+      targetPaneId: targetLeafId,
+      direction: "vertical",
+      side: "first",
+      threadId: THREAD_C,
+    });
+    expect(ok).toBe(true);
+
+    const splitView = snapshot(splitViewId);
+    expect(resolveSplitViewThreadIds(splitView).toSorted()).toEqual(
+      [THREAD_A, THREAD_B, THREAD_C].toSorted(),
+    );
+    const newLeaf = collectLeaves(splitView.root).find((leaf) => leaf.threadId === THREAD_C);
+    expect(newLeaf).toBeDefined();
+    expect(splitView.focusedPaneId).toBe(newLeaf?.id);
+    if (newLeaf) {
+      const parent = findParentSplitNode(splitView.root, newLeaf.id);
+      expect(parent?.direction).toBe("vertical");
+    }
+  });
+
+  it("rejects dropThreadOnPane when the dropped thread is already in the split view", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "second",
+    });
+
+    const targetLeafId = findLeafIdForThread(snapshot(splitViewId), THREAD_A);
+    const ok = useSplitViewStore.getState().dropThreadOnPane({
+      splitViewId,
+      targetPaneId: targetLeafId,
+      direction: "vertical",
+      side: "second",
+      threadId: THREAD_A,
+    });
+
+    expect(ok).toBe(false);
+    expect(resolveSplitViewThreadIds(snapshot(splitViewId)).toSorted()).toEqual(
+      [THREAD_A, THREAD_B].toSorted(),
+    );
+  });
+
+  it("rejects dropThreadOnPane when the requested direction matches the parent direction", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "first",
+    });
+
+    const targetLeafId = findLeafIdForThread(snapshot(splitViewId), THREAD_A);
+    const ok = useSplitViewStore.getState().dropThreadOnPane({
+      splitViewId,
+      targetPaneId: targetLeafId,
+      direction: "horizontal",
+      side: "second",
+      threadId: THREAD_C,
+    });
+    expect(ok).toBe(false);
+    expect(resolveSplitViewThreadIds(snapshot(splitViewId)).toSorted()).toEqual(
+      [THREAD_A, THREAD_B].toSorted(),
+    );
+  });
+
+  it("supports filling a 2x2 grid through perpendicular drops", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "first",
+    });
+
+    const leafAId = findLeafIdForThread(snapshot(splitViewId), THREAD_A);
+    expect(
+      useSplitViewStore.getState().dropThreadOnPane({
+        splitViewId,
+        targetPaneId: leafAId,
+        direction: "vertical",
+        side: "second",
+        threadId: THREAD_C,
+      }),
+    ).toBe(true);
+
+    const leafBId = findLeafIdForThread(snapshot(splitViewId), THREAD_B);
+    expect(
+      useSplitViewStore.getState().dropThreadOnPane({
+        splitViewId,
+        targetPaneId: leafBId,
+        direction: "vertical",
+        side: "second",
+        threadId: THREAD_D,
+      }),
+    ).toBe(true);
+
+    expect(resolveSplitViewThreadIds(snapshot(splitViewId)).toSorted()).toEqual(
+      [THREAD_A, THREAD_B, THREAD_C, THREAD_D].toSorted(),
+    );
+  });
+
+  it("rejects drops on leaves that are already inside a second-level split", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "first",
+    });
+
+    const leafAId = findLeafIdForThread(snapshot(splitViewId), THREAD_A);
+    expect(
+      useSplitViewStore.getState().dropThreadOnPane({
+        splitViewId,
+        targetPaneId: leafAId,
+        direction: "vertical",
+        side: "second",
+        threadId: THREAD_C,
+      }),
+    ).toBe(true);
+
+    const nestedLeafAId = findLeafIdForThread(snapshot(splitViewId), THREAD_A);
+    expect(
+      useSplitViewStore.getState().dropThreadOnPane({
+        splitViewId,
+        targetPaneId: nestedLeafAId,
+        direction: "horizontal",
+        side: "second",
+        threadId: THREAD_D,
+      }),
+    ).toBe(false);
+
+    expect(resolveSplitViewThreadIds(snapshot(splitViewId)).toSorted()).toEqual(
+      [THREAD_A, THREAD_B, THREAD_C].toSorted(),
+    );
+  });
+
+  it("setRatioForNode clamps to the allowed range and only writes when changed", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "first",
+    });
+    const root = findRootSplitNode(snapshot(splitViewId));
+
+    useSplitViewStore.getState().setRatioForNode(splitViewId, root.id, 0.99);
+    expect(findRootSplitNode(snapshot(splitViewId)).ratio).toBeCloseTo(0.75);
+
+    useSplitViewStore.getState().setRatioForNode(splitViewId, root.id, 0.01);
+    expect(findRootSplitNode(snapshot(splitViewId)).ratio).toBeCloseTo(0.25);
+  });
+
+  it("setFocusedPane refuses ids that do not point to a leaf", () => {
+    const store = useSplitViewStore.getState();
+    const splitViewId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "first",
+    });
+    const root = findRootSplitNode(snapshot(splitViewId));
+    const previousFocusedPaneId = snapshot(splitViewId).focusedPaneId;
+
+    useSplitViewStore.getState().setFocusedPane(splitViewId, root.id);
+    expect(snapshot(splitViewId).focusedPaneId).toBe(previousFocusedPaneId);
+
+    useSplitViewStore.getState().setFocusedPane(splitViewId, "non-existent");
+    expect(snapshot(splitViewId).focusedPaneId).toBe(previousFocusedPaneId);
+  });
+
+  it("removeThreadFromSplitViews collapses the tree, drops orphaned splits, and reseats focus", () => {
+    const store = useSplitViewStore.getState();
+    const firstSplitId = store.createFromThread({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+    });
+    const firstEmptyId = findEmptyLeafId(snapshot(firstSplitId));
+    store.replacePaneThread(firstSplitId, firstEmptyId, THREAD_B);
+    const firstThreadAPaneId = findLeafIdForThread(snapshot(firstSplitId), THREAD_A);
+    store.setPanePanelState(firstSplitId, firstThreadAPaneId, {
       panel: "diff",
       diffTurnId: TURN_ID,
       diffFilePath: "src/left.ts",
@@ -58,32 +411,51 @@ describe("splitViewStore", () => {
       sourceThreadId: THREAD_C,
       ownerProjectId: PROJECT_ID,
     });
-    store.replacePaneThread(secondSplitId, "right", THREAD_A);
-    store.setFocusedPane(secondSplitId, "right");
+    const secondEmptyId = findEmptyLeafId(snapshot(secondSplitId));
+    store.replacePaneThread(secondSplitId, secondEmptyId, THREAD_A);
+    store.setFocusedPane(secondSplitId, secondEmptyId);
 
     useSplitViewStore.getState().removeThreadFromSplitViews(THREAD_A);
 
     const nextState = useSplitViewStore.getState();
     expect(nextState.splitViewIdBySourceThreadId[THREAD_A]).toBeUndefined();
-    expect(nextState.splitViewsById[firstSplitId]).toMatchObject({
-      leftThreadId: null,
-      rightThreadId: THREAD_B,
-      focusedPane: "right",
-      leftPanel: {
-        panel: null,
-        diffTurnId: null,
-        diffFilePath: null,
-      },
-    });
-    expect(nextState.splitViewsById[secondSplitId]).toMatchObject({
-      leftThreadId: THREAD_C,
-      rightThreadId: null,
-      focusedPane: "left",
-    });
+
+    const firstSplit = nextState.splitViewsById[firstSplitId];
+    expect(firstSplit).toBeDefined();
+    if (firstSplit) {
+      // First split kept THREAD_B and dropped the THREAD_A leaf, so the tree collapses to a single leaf.
+      expect(resolveSplitViewThreadIds(firstSplit)).toEqual([THREAD_B]);
+      expect(resolveSplitViewFocusedThreadId(firstSplit)).toBe(THREAD_B);
+    }
+
+    const secondSplit = nextState.splitViewsById[secondSplitId];
+    expect(secondSplit).toBeDefined();
+    if (secondSplit) {
+      expect(resolveSplitViewThreadIds(secondSplit)).toEqual([THREAD_C]);
+      expect(resolveSplitViewFocusedThreadId(secondSplit)).toBe(THREAD_C);
+    }
     expect(nextState.splitViewIdBySourceThreadId[THREAD_C]).toBe(secondSplitId);
   });
 
-  it("removes an empty split entirely after deleting its last thread", () => {
+  it("removes an empty split entirely after deleting its source thread", () => {
+    const store = useSplitViewStore.getState();
+    const splitId = store.createFromDrop({
+      sourceThreadId: THREAD_A,
+      ownerProjectId: PROJECT_ID,
+      droppedThreadId: THREAD_B,
+      direction: "horizontal",
+      side: "first",
+    });
+
+    useSplitViewStore.getState().removeThreadFromSplitViews(THREAD_A);
+    useSplitViewStore.getState().removeThreadFromSplitViews(THREAD_B);
+
+    const nextState = useSplitViewStore.getState();
+    expect(nextState.splitViewsById[splitId]).toBeUndefined();
+    expect(nextState.splitViewIdBySourceThreadId[THREAD_A]).toBeUndefined();
+  });
+
+  it("removes a source-plus-empty split after deleting its only thread", () => {
     const store = useSplitViewStore.getState();
     const splitId = store.createFromThread({
       sourceThreadId: THREAD_A,
@@ -107,7 +479,8 @@ describe("splitViewStore", () => {
       sourceThreadId: THREAD_C,
       ownerProjectId: PROJECT_ID,
     });
-    store.replacePaneThread(otherSplitId, "right", THREAD_A);
+    const otherEmptyId = findEmptyLeafId(snapshot(otherSplitId));
+    store.replacePaneThread(otherSplitId, otherEmptyId, THREAD_A);
 
     expect(
       resolvePreferredSplitViewIdForThread({
@@ -124,13 +497,15 @@ describe("splitViewStore", () => {
       sourceThreadId: THREAD_A,
       ownerProjectId: PROJECT_ID,
     });
-    store.replacePaneThread(olderSplitId, "right", THREAD_B);
+    const olderEmptyId = findEmptyLeafId(snapshot(olderSplitId));
+    store.replacePaneThread(olderSplitId, olderEmptyId, THREAD_B);
 
     const newerSplitId = store.createFromThread({
       sourceThreadId: THREAD_C,
       ownerProjectId: PROJECT_ID,
     });
-    store.replacePaneThread(newerSplitId, "right", THREAD_B);
+    const newerEmptyId = findEmptyLeafId(snapshot(newerSplitId));
+    store.replacePaneThread(newerSplitId, newerEmptyId, THREAD_B);
     useSplitViewStore.setState((state) => ({
       splitViewsById: {
         ...state.splitViewsById,

--- a/apps/web/src/splitViewStore.ts
+++ b/apps/web/src/splitViewStore.ts
@@ -86,6 +86,7 @@ interface DropThreadOnPaneInput {
 }
 
 interface SplitViewStore {
+  hasHydrated: boolean;
   splitViewsById: Record<SplitViewId, SplitView | undefined>;
   splitViewIdBySourceThreadId: Record<string, SplitViewId | undefined>;
   createFromThread: (input: CreateFromThreadInput) => SplitViewId;
@@ -101,10 +102,14 @@ interface SplitViewStore {
     patch: Partial<SplitViewPanePanelState>,
   ) => void;
   removeThreadFromSplitViews: (threadId: ThreadId) => void;
+  setHasHydrated: (hasHydrated: boolean) => void;
 }
 
-// Keep the storage key stable so persisted v1 payloads can be read and migrated by Zustand.
-const SPLIT_VIEW_STORAGE_KEY = "t3code:split-view-state:v1";
+// Keep the v1 suffix stable while using the DPCode namespace; the legacy
+// `t3code:split-view-state:v1` key is copied over to this one by
+// `storageKeyMigration` before this store hydrates, so older payloads still
+// flow through the v1 -> v2 schema migration below.
+const SPLIT_VIEW_STORAGE_KEY = "dpcode:split-view-state:v1";
 const SPLIT_VIEW_STORAGE_VERSION = 2;
 const DEFAULT_RATIO = 0.5;
 const MIN_RATIO = 0.25;
@@ -357,6 +362,9 @@ export function selectSplitViewIdForSourceThread(threadId: ThreadId | null) {
     threadId ? (store.splitViewIdBySourceThreadId[threadId] ?? null) : null;
 }
 
+// Deterministic membership lookup: restore only if a thread has one clear split,
+// or if it is the source thread of one split. Ambiguous non-source membership
+// falls back to single-chat instead of guessing by recency.
 export function resolvePreferredSplitViewIdForThread(input: {
   splitViewsById: Record<SplitViewId, SplitView | undefined>;
   splitViewIdBySourceThreadId: Record<string, SplitViewId | undefined>;
@@ -366,19 +374,22 @@ export function resolvePreferredSplitViewIdForThread(input: {
     return null;
   }
 
-  const sourceSplitViewId = input.splitViewIdBySourceThreadId[input.threadId] ?? null;
-  if (sourceSplitViewId) {
-    return sourceSplitViewId;
-  }
-
   const matchingSplitViews = Object.values(input.splitViewsById)
     .filter((splitView): splitView is SplitView => splitView !== undefined)
     .filter((splitView) =>
       collectLeaves(splitView.root).some((leaf) => leaf.threadId === input.threadId),
-    )
-    .toSorted((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt));
+    );
 
-  return matchingSplitViews[0]?.id ?? null;
+  const sourceSplitViewId = input.splitViewIdBySourceThreadId[input.threadId] ?? null;
+  if (
+    sourceSplitViewId &&
+    matchingSplitViews.some((splitView) => splitView.id === sourceSplitViewId)
+  ) {
+    return sourceSplitViewId;
+  }
+
+  const onlyMatchingSplitView = matchingSplitViews.length === 1 ? matchingSplitViews[0] : null;
+  return onlyMatchingSplitView?.id ?? null;
 }
 
 // --- store ---
@@ -386,8 +397,10 @@ export function resolvePreferredSplitViewIdForThread(input: {
 export const useSplitViewStore = create<SplitViewStore>()(
   persist(
     (set, get) => ({
+      hasHydrated: false,
       splitViewsById: {},
       splitViewIdBySourceThreadId: {},
+      setHasHydrated: (hasHydrated) => set({ hasHydrated }),
       createFromThread: (input) => {
         const existingId = get().splitViewIdBySourceThreadId[input.sourceThreadId] ?? null;
         if (existingId) {
@@ -616,13 +629,29 @@ export const useSplitViewStore = create<SplitViewStore>()(
             const nextFocusedPaneId = focusedStillPresent
               ? splitView.focusedPaneId
               : resolveDefaultFocusLeafId(result.nextRoot);
+            const nextSourceThreadId =
+              splitView.sourceThreadId === threadId
+                ? resolveNextSourceThreadId({
+                    root: result.nextRoot,
+                    splitViewId,
+                    splitViewIdBySourceThreadId: nextSplitViewIdBySourceThreadId,
+                  })
+                : splitView.sourceThreadId;
 
             if (splitView.sourceThreadId === threadId) {
               delete nextSplitViewIdBySourceThreadId[splitView.sourceThreadId];
             }
+            if (!nextSourceThreadId) {
+              delete nextSplitViewsById[splitViewId];
+              continue;
+            }
+            if (nextSourceThreadId !== splitView.sourceThreadId) {
+              nextSplitViewIdBySourceThreadId[nextSourceThreadId] = splitViewId;
+            }
 
             nextSplitViewsById[splitViewId] = {
               ...splitView,
+              sourceThreadId: nextSourceThreadId,
               root: result.nextRoot,
               focusedPaneId: nextFocusedPaneId,
               updatedAt: resolveUpdatedAt(),
@@ -643,6 +672,20 @@ export const useSplitViewStore = create<SplitViewStore>()(
       name: SPLIT_VIEW_STORAGE_KEY,
       version: SPLIT_VIEW_STORAGE_VERSION,
       storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        splitViewsById: state.splitViewsById,
+        splitViewIdBySourceThreadId: state.splitViewIdBySourceThreadId,
+      }),
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...(persistedState as Partial<SplitViewStoreState>),
+        hasHydrated: currentState.hasHydrated,
+      }),
+      onRehydrateStorage: () => {
+        return (state) => {
+          state?.setHasHydrated(true);
+        };
+      },
       // Pre-v2 storage used a flat left/right pane shape. We migrate any persisted state to the
       // tree shape; if migration cannot recover anything, we silently drop it instead of crashing.
       migrate: (persistedState, version) => {

--- a/apps/web/src/splitViewStore.ts
+++ b/apps/web/src/splitViewStore.ts
@@ -282,6 +282,22 @@ function updateSplitView(
   };
 }
 
+// Re-anchor only to threads that are not already the source of another split view.
+function resolveNextSourceThreadId(input: {
+  root: Pane;
+  splitViewId: SplitViewId;
+  splitViewIdBySourceThreadId: Record<string, SplitViewId | undefined>;
+}): ThreadId | null {
+  for (const leaf of collectLeaves(input.root)) {
+    if (!leaf.threadId) continue;
+    const existingSourceSplitId = input.splitViewIdBySourceThreadId[leaf.threadId];
+    if (!existingSourceSplitId || existingSourceSplitId === input.splitViewId) {
+      return leaf.threadId;
+    }
+  }
+  return null;
+}
+
 // --- selectors ---
 
 // Returns the threadId of the focused leaf, falling back to the first non-empty leaf when the
@@ -421,19 +437,74 @@ export const useSplitViewStore = create<SplitViewStore>()(
           };
         }),
       replacePaneThread: (splitViewId, paneId, threadId) =>
-        set((state) =>
-          updateSplitView(state, splitViewId, (splitView) => {
+        set((state) => {
+          const existing = state.splitViewsById[splitViewId];
+          if (!existing) return state;
+          let nextSourceThreadId: ThreadId | null = existing.sourceThreadId;
+          let shouldRemoveSplitView = false;
+          const nextState = updateSplitView(state, splitViewId, (splitView) => {
             const leaf = findLeafPaneById(splitView.root, paneId);
             if (!leaf) return splitView;
             if (leaf.threadId === threadId) return splitView;
             const nextLeaf: LeafPane = { ...leaf, threadId };
+            const nextRoot = replacePaneInTree(splitView.root, paneId, nextLeaf);
+            const hasAnyThread = collectLeaves(nextRoot).some(
+              (nextLeaf) => nextLeaf.threadId !== null,
+            );
+            if (!hasAnyThread) {
+              shouldRemoveSplitView = true;
+            }
+            if (leaf.threadId === splitView.sourceThreadId) {
+              nextSourceThreadId = resolveNextSourceThreadId({
+                root: nextRoot,
+                splitViewId,
+                splitViewIdBySourceThreadId: state.splitViewIdBySourceThreadId,
+              });
+              if (nextSourceThreadId === null) {
+                shouldRemoveSplitView = true;
+              }
+            }
             return {
               ...splitView,
-              root: replacePaneInTree(splitView.root, paneId, nextLeaf),
+              sourceThreadId: nextSourceThreadId ?? splitView.sourceThreadId,
+              root: nextRoot,
               updatedAt: resolveUpdatedAt(),
             };
-          }),
-        ),
+          });
+          if (nextState === state) return state;
+
+          if (shouldRemoveSplitView) {
+            const nextSplitViewsById = { ...nextState.splitViewsById };
+            const nextSplitViewIdBySourceThreadId = { ...nextState.splitViewIdBySourceThreadId };
+            delete nextSplitViewsById[splitViewId];
+            if (nextSplitViewIdBySourceThreadId[existing.sourceThreadId] === splitViewId) {
+              delete nextSplitViewIdBySourceThreadId[existing.sourceThreadId];
+            }
+            return {
+              splitViewsById: nextSplitViewsById,
+              splitViewIdBySourceThreadId: nextSplitViewIdBySourceThreadId,
+            };
+          }
+
+          const updated = nextState.splitViewsById[splitViewId];
+          if (
+            !updated ||
+            nextSourceThreadId === null ||
+            nextSourceThreadId === existing.sourceThreadId
+          ) {
+            return nextState;
+          }
+
+          const nextSplitViewIdBySourceThreadId = { ...nextState.splitViewIdBySourceThreadId };
+          if (nextSplitViewIdBySourceThreadId[existing.sourceThreadId] === splitViewId) {
+            delete nextSplitViewIdBySourceThreadId[existing.sourceThreadId];
+          }
+          nextSplitViewIdBySourceThreadId[nextSourceThreadId] = splitViewId;
+          return {
+            ...nextState,
+            splitViewIdBySourceThreadId: nextSplitViewIdBySourceThreadId,
+          };
+        }),
       dropThreadOnPane: ({ splitViewId, targetPaneId, direction, side, threadId }) => {
         const stateBefore = get();
         const splitView = stateBefore.splitViewsById[splitViewId];

--- a/apps/web/src/splitViewStore.ts
+++ b/apps/web/src/splitViewStore.ts
@@ -1,17 +1,31 @@
 // FILE: splitViewStore.ts
-// Purpose: Persists split chat surfaces that replace one sidebar row with a two-pane view.
+// Purpose: Persists split chat surfaces as a recursive pane tree (depth-cap 2 = up to 2x2 grid).
 // Layer: UI state store
-// Exports: split view types, selectors, and mutation helpers used by sidebar and route surfaces
+// Exports: pane/split types, tree-aware selectors, and id-based mutation helpers used by sidebar and route surfaces
 
 import { type ProjectId, type ThreadId, type TurnId } from "@t3tools/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
-import { randomUUID } from "./lib/utils";
+
 import { type ChatRightPanel } from "./diffRouteSearch";
-import { removeThreadFromSplitView } from "./splitView.logic";
+import { randomUUID } from "./lib/utils";
+import {
+  canSubdividePane,
+  collectLeaves,
+  findLeafPaneById,
+  findSplitNodeById,
+  isLegacySplitViewLike,
+  removeLeafByThreadId as removeLeafByThreadIdInTree,
+  replacePaneInTree,
+  resolveDefaultFocusLeafId,
+  type LegacySplitViewLike,
+} from "./splitView.logic";
 
 export type SplitViewId = string;
-export type SplitViewPane = "left" | "right";
+export type PaneId = string;
+export type SplitDirection = "horizontal" | "vertical";
+// "first" maps to the top/left side of a split; "second" maps to the bottom/right side.
+export type SplitDropSide = "first" | "second";
 
 export interface SplitViewPanePanelState {
   panel: ChatRightPanel | null;
@@ -21,46 +35,77 @@ export interface SplitViewPanePanelState {
   lastOpenPanel: ChatRightPanel;
 }
 
+export interface LeafPane {
+  kind: "leaf";
+  id: PaneId;
+  threadId: ThreadId | null;
+  panel: SplitViewPanePanelState;
+}
+
+export interface SplitNode {
+  kind: "split";
+  id: PaneId;
+  direction: SplitDirection;
+  // first = left (horizontal) | top (vertical); second = right | bottom.
+  first: Pane;
+  second: Pane;
+  ratio: number;
+}
+
+export type Pane = LeafPane | SplitNode;
+
 export interface SplitView {
   id: SplitViewId;
   sourceThreadId: ThreadId;
   ownerProjectId: ProjectId;
-  leftThreadId: ThreadId | null;
-  rightThreadId: ThreadId | null;
-  focusedPane: SplitViewPane;
-  ratio: number;
-  leftPanel: SplitViewPanePanelState;
-  rightPanel: SplitViewPanePanelState;
+  root: Pane;
+  focusedPaneId: PaneId;
   createdAt: string;
   updatedAt: string;
 }
 
-interface CreateSplitViewInput {
+interface CreateFromThreadInput {
   sourceThreadId: ThreadId;
   ownerProjectId: ProjectId;
+}
+
+interface CreateFromDropInput {
+  sourceThreadId: ThreadId;
+  ownerProjectId: ProjectId;
+  droppedThreadId: ThreadId;
+  direction: SplitDirection;
+  side: SplitDropSide;
+}
+
+interface DropThreadOnPaneInput {
+  splitViewId: SplitViewId;
+  targetPaneId: PaneId;
+  direction: SplitDirection;
+  side: SplitDropSide;
+  threadId: ThreadId;
 }
 
 interface SplitViewStore {
   splitViewsById: Record<SplitViewId, SplitView | undefined>;
   splitViewIdBySourceThreadId: Record<string, SplitViewId | undefined>;
-  createFromThread: (input: CreateSplitViewInput) => SplitViewId;
+  createFromThread: (input: CreateFromThreadInput) => SplitViewId;
+  createFromDrop: (input: CreateFromDropInput) => SplitViewId;
   removeSplitView: (splitViewId: SplitViewId) => void;
-  replacePaneThread: (
-    splitViewId: SplitViewId,
-    pane: SplitViewPane,
-    threadId: ThreadId | null,
-  ) => void;
-  setFocusedPane: (splitViewId: SplitViewId, pane: SplitViewPane) => void;
-  setRatio: (splitViewId: SplitViewId, ratio: number) => void;
+  replacePaneThread: (splitViewId: SplitViewId, paneId: PaneId, threadId: ThreadId | null) => void;
+  dropThreadOnPane: (input: DropThreadOnPaneInput) => boolean;
+  setFocusedPane: (splitViewId: SplitViewId, paneId: PaneId) => void;
+  setRatioForNode: (splitViewId: SplitViewId, splitNodeId: PaneId, ratio: number) => void;
   setPanePanelState: (
     splitViewId: SplitViewId,
-    pane: SplitViewPane,
+    paneId: PaneId,
     patch: Partial<SplitViewPanePanelState>,
   ) => void;
   removeThreadFromSplitViews: (threadId: ThreadId) => void;
 }
 
+// Keep the storage key stable so persisted v1 payloads can be read and migrated by Zustand.
 const SPLIT_VIEW_STORAGE_KEY = "t3code:split-view-state:v1";
+const SPLIT_VIEW_STORAGE_VERSION = 2;
 const DEFAULT_RATIO = 0.5;
 const MIN_RATIO = 0.25;
 const MAX_RATIO = 0.75;
@@ -80,26 +125,144 @@ function createDefaultPanePanelState(): SplitViewPanePanelState {
   };
 }
 
-function createSplitView(input: CreateSplitViewInput): SplitView {
+function createLeafPane(threadId: ThreadId | null): LeafPane {
+  return {
+    kind: "leaf",
+    id: randomUUID(),
+    threadId,
+    panel: createDefaultPanePanelState(),
+  };
+}
+
+function createSplitNode(input: {
+  direction: SplitDirection;
+  first: Pane;
+  second: Pane;
+  ratio?: number;
+}): SplitNode {
+  return {
+    kind: "split",
+    id: randomUUID(),
+    direction: input.direction,
+    first: input.first,
+    second: input.second,
+    ratio: clampRatio(input.ratio ?? DEFAULT_RATIO),
+  };
+}
+
+function buildSplitViewFromThread(input: CreateFromThreadInput): SplitView {
   const now = new Date().toISOString();
+  const sourceLeaf = createLeafPane(input.sourceThreadId);
+  const emptyLeaf = createLeafPane(null);
+  const root = createSplitNode({
+    direction: "horizontal",
+    first: sourceLeaf,
+    second: emptyLeaf,
+  });
   return {
     id: randomUUID(),
     sourceThreadId: input.sourceThreadId,
     ownerProjectId: input.ownerProjectId,
-    leftThreadId: input.sourceThreadId,
-    rightThreadId: null,
-    focusedPane: "right",
-    ratio: DEFAULT_RATIO,
-    leftPanel: createDefaultPanePanelState(),
-    rightPanel: createDefaultPanePanelState(),
+    root,
+    focusedPaneId: emptyLeaf.id,
     createdAt: now,
     updatedAt: now,
+  };
+}
+
+function buildSplitViewFromDrop(
+  input: CreateFromDropInput,
+  existing?: Pick<SplitView, "id" | "createdAt"> | null,
+): SplitView {
+  const now = new Date().toISOString();
+  const sourceLeaf = createLeafPane(input.sourceThreadId);
+  const droppedLeaf = createLeafPane(input.droppedThreadId);
+  const root = createSplitNode(
+    input.side === "first"
+      ? { direction: input.direction, first: droppedLeaf, second: sourceLeaf }
+      : { direction: input.direction, first: sourceLeaf, second: droppedLeaf },
+  );
+  return {
+    id: existing?.id ?? randomUUID(),
+    sourceThreadId: input.sourceThreadId,
+    ownerProjectId: input.ownerProjectId,
+    root,
+    focusedPaneId: droppedLeaf.id,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now,
+  };
+}
+
+function migrateLegacySplitView(legacy: LegacySplitViewLike): SplitView | null {
+  const now = new Date().toISOString();
+  const leftLeaf: LeafPane = {
+    kind: "leaf",
+    id: randomUUID(),
+    threadId: legacy.leftThreadId ?? null,
+    panel: { ...legacy.leftPanel },
+  };
+  const rightLeaf: LeafPane = {
+    kind: "leaf",
+    id: randomUUID(),
+    threadId: legacy.rightThreadId ?? null,
+    panel: { ...legacy.rightPanel },
+  };
+
+  if (!leftLeaf.threadId && !rightLeaf.threadId) {
+    return null;
+  }
+
+  const root = createSplitNode({
+    direction: "horizontal",
+    first: leftLeaf,
+    second: rightLeaf,
+    ratio: legacy.ratio,
+  });
+  return {
+    id: legacy.id,
+    sourceThreadId: legacy.sourceThreadId,
+    ownerProjectId: legacy.ownerProjectId,
+    root,
+    focusedPaneId: legacy.focusedPane === "right" ? rightLeaf.id : leftLeaf.id,
+    createdAt: legacy.createdAt ?? now,
+    updatedAt: legacy.updatedAt ?? now,
+  };
+}
+
+function migrateLegacyPersistedState(state: unknown): SplitViewStoreState | null {
+  if (!state || typeof state !== "object") {
+    return null;
+  }
+  const legacyMap = (state as { splitViewsById?: Record<string, unknown> }).splitViewsById;
+  if (!legacyMap || typeof legacyMap !== "object") {
+    return null;
+  }
+  const splitViewsById: Record<SplitViewId, SplitView | undefined> = {};
+  const splitViewIdBySourceThreadId: Record<string, SplitViewId | undefined> = {};
+
+  for (const [splitViewId, value] of Object.entries(legacyMap)) {
+    if (!isLegacySplitViewLike(value)) {
+      continue;
+    }
+    const migrated = migrateLegacySplitView(value);
+    if (!migrated) {
+      continue;
+    }
+    splitViewsById[splitViewId] = migrated;
+    splitViewIdBySourceThreadId[migrated.sourceThreadId] = splitViewId;
+  }
+
+  return {
+    splitViewsById,
+    splitViewIdBySourceThreadId,
   };
 }
 
 function resolveUpdatedAt(): string {
   return new Date().toISOString();
 }
+
+type SplitViewStoreState = Pick<SplitViewStore, "splitViewsById" | "splitViewIdBySourceThreadId">;
 
 function updateSplitView(
   state: SplitViewStoreState,
@@ -119,41 +282,53 @@ function updateSplitView(
   };
 }
 
-type SplitViewStoreState = Pick<SplitViewStore, "splitViewsById" | "splitViewIdBySourceThreadId">;
+// --- selectors ---
 
+// Returns the threadId of the focused leaf, falling back to the first non-empty leaf when the
+// focused pane is empty (so the UI never shows an "empty" thread when something is open elsewhere).
 export function resolveSplitViewFocusedThreadId(splitView: SplitView): ThreadId | null {
-  if (splitView.focusedPane === "right") {
-    return splitView.rightThreadId ?? splitView.leftThreadId ?? null;
+  const focused = findLeafPaneById(splitView.root, splitView.focusedPaneId);
+  if (focused?.threadId) {
+    return focused.threadId;
   }
-  return splitView.leftThreadId ?? splitView.rightThreadId ?? null;
+  for (const leaf of collectLeaves(splitView.root)) {
+    if (leaf.threadId) return leaf.threadId;
+  }
+  return null;
+}
+
+// Strict variant: returns the focused leaf's threadId without any fallback (used for routing handoff).
+export function resolveSplitViewFocusedPaneThreadId(splitView: SplitView): ThreadId | null {
+  return findLeafPaneById(splitView.root, splitView.focusedPaneId)?.threadId ?? null;
 }
 
 export function resolveSplitViewPaneThreadId(
   splitView: SplitView,
-  pane: SplitViewPane,
+  paneId: PaneId,
 ): ThreadId | null {
-  return pane === "right" ? splitView.rightThreadId : splitView.leftThreadId;
-}
-
-export function resolveSplitViewFocusedPaneThreadId(splitView: SplitView): ThreadId | null {
-  return resolveSplitViewPaneThreadId(splitView, splitView.focusedPane);
+  return findLeafPaneById(splitView.root, paneId)?.threadId ?? null;
 }
 
 export function resolveSplitViewThreadIds(splitView: SplitView): ThreadId[] {
-  const ids = [splitView.leftThreadId, splitView.rightThreadId].filter(
-    (threadId): threadId is ThreadId => threadId !== null,
-  );
+  const ids = collectLeaves(splitView.root)
+    .map((leaf) => leaf.threadId)
+    .filter((threadId): threadId is ThreadId => threadId !== null);
   return [...new Set(ids)];
 }
 
-export function resolveSplitViewPaneForThread(
+export function resolveSplitViewPaneIdForThread(
   splitView: SplitView,
   threadId: ThreadId | null,
-): SplitViewPane | null {
+): PaneId | null {
   if (!threadId) return null;
-  if (splitView.leftThreadId === threadId) return "left";
-  if (splitView.rightThreadId === threadId) return "right";
+  for (const leaf of collectLeaves(splitView.root)) {
+    if (leaf.threadId === threadId) return leaf.id;
+  }
   return null;
+}
+
+export function resolveSplitViewLeaves(splitView: SplitView): LeafPane[] {
+  return collectLeaves(splitView.root);
 }
 
 export function selectSplitView(splitViewId: SplitViewId | null) {
@@ -182,14 +357,15 @@ export function resolvePreferredSplitViewIdForThread(input: {
 
   const matchingSplitViews = Object.values(input.splitViewsById)
     .filter((splitView): splitView is SplitView => splitView !== undefined)
-    .filter(
-      (splitView) =>
-        splitView.leftThreadId === input.threadId || splitView.rightThreadId === input.threadId,
+    .filter((splitView) =>
+      collectLeaves(splitView.root).some((leaf) => leaf.threadId === input.threadId),
     )
     .toSorted((left, right) => Date.parse(right.updatedAt) - Date.parse(left.updatedAt));
 
   return matchingSplitViews[0]?.id ?? null;
 }
+
+// --- store ---
 
 export const useSplitViewStore = create<SplitViewStore>()(
   persist(
@@ -202,7 +378,23 @@ export const useSplitViewStore = create<SplitViewStore>()(
           return existingId;
         }
 
-        const splitView = createSplitView(input);
+        const splitView = buildSplitViewFromThread(input);
+        set((state) => ({
+          splitViewsById: {
+            ...state.splitViewsById,
+            [splitView.id]: splitView,
+          },
+          splitViewIdBySourceThreadId: {
+            ...state.splitViewIdBySourceThreadId,
+            [input.sourceThreadId]: splitView.id,
+          },
+        }));
+        return splitView.id;
+      },
+      createFromDrop: (input) => {
+        const existingId = get().splitViewIdBySourceThreadId[input.sourceThreadId] ?? null;
+        const existing = existingId ? (get().splitViewsById[existingId] ?? null) : null;
+        const splitView = buildSplitViewFromDrop(input, existing);
         set((state) => ({
           splitViewsById: {
             ...state.splitViewsById,
@@ -228,63 +420,96 @@ export const useSplitViewStore = create<SplitViewStore>()(
             splitViewIdBySourceThreadId: nextSplitViewIdBySourceThreadId,
           };
         }),
-      replacePaneThread: (splitViewId, pane, threadId) =>
+      replacePaneThread: (splitViewId, paneId, threadId) =>
         set((state) =>
           updateSplitView(state, splitViewId, (splitView) => {
-            const key = pane === "left" ? "leftThreadId" : "rightThreadId";
-            if (splitView[key] === threadId) {
-              return splitView;
-            }
+            const leaf = findLeafPaneById(splitView.root, paneId);
+            if (!leaf) return splitView;
+            if (leaf.threadId === threadId) return splitView;
+            const nextLeaf: LeafPane = { ...leaf, threadId };
             return {
               ...splitView,
-              [key]: threadId,
+              root: replacePaneInTree(splitView.root, paneId, nextLeaf),
               updatedAt: resolveUpdatedAt(),
             };
           }),
         ),
-      setFocusedPane: (splitViewId, pane) =>
+      dropThreadOnPane: ({ splitViewId, targetPaneId, direction, side, threadId }) => {
+        const stateBefore = get();
+        const splitView = stateBefore.splitViewsById[splitViewId];
+        if (!splitView) return false;
+        const targetLeaf = findLeafPaneById(splitView.root, targetPaneId);
+        if (!targetLeaf) return false;
+        if (collectLeaves(splitView.root).some((leaf) => leaf.threadId === threadId)) {
+          return false;
+        }
+        if (!canSubdividePane(splitView.root, targetPaneId, direction)) {
+          return false;
+        }
+
+        const newLeaf = createLeafPane(threadId);
+        const newSplit = createSplitNode(
+          side === "first"
+            ? { direction, first: newLeaf, second: targetLeaf }
+            : { direction, first: targetLeaf, second: newLeaf },
+        );
+
+        set((state) =>
+          updateSplitView(state, splitViewId, (current) => ({
+            ...current,
+            root: replacePaneInTree(current.root, targetPaneId, newSplit),
+            focusedPaneId: newLeaf.id,
+            updatedAt: resolveUpdatedAt(),
+          })),
+        );
+        return true;
+      },
+      setFocusedPane: (splitViewId, paneId) =>
         set((state) =>
           updateSplitView(state, splitViewId, (splitView) => {
-            if (splitView.focusedPane === pane) return splitView;
+            if (splitView.focusedPaneId === paneId) return splitView;
+            if (!findLeafPaneById(splitView.root, paneId)) return splitView;
             return {
               ...splitView,
-              focusedPane: pane,
+              focusedPaneId: paneId,
               updatedAt: resolveUpdatedAt(),
             };
           }),
         ),
-      setRatio: (splitViewId, ratio) =>
+      setRatioForNode: (splitViewId, splitNodeId, ratio) =>
         set((state) =>
           updateSplitView(state, splitViewId, (splitView) => {
+            const node = findSplitNodeById(splitView.root, splitNodeId);
+            if (!node) return splitView;
             const nextRatio = clampRatio(ratio);
-            if (splitView.ratio === nextRatio) return splitView;
+            if (node.ratio === nextRatio) return splitView;
+            const nextNode: SplitNode = { ...node, ratio: nextRatio };
             return {
               ...splitView,
-              ratio: nextRatio,
+              root: replacePaneInTree(splitView.root, splitNodeId, nextNode),
               updatedAt: resolveUpdatedAt(),
             };
           }),
         ),
-      setPanePanelState: (splitViewId, pane, patch) =>
+      setPanePanelState: (splitViewId, paneId, patch) =>
         set((state) =>
           updateSplitView(state, splitViewId, (splitView) => {
-            const key = pane === "left" ? "leftPanel" : "rightPanel";
-            const nextPanel = {
-              ...splitView[key],
-              ...patch,
-            };
+            const leaf = findLeafPaneById(splitView.root, paneId);
+            if (!leaf) return splitView;
+            const nextPanel: SplitViewPanePanelState = { ...leaf.panel, ...patch };
             if (
-              splitView[key].panel === nextPanel.panel &&
-              splitView[key].diffTurnId === nextPanel.diffTurnId &&
-              splitView[key].diffFilePath === nextPanel.diffFilePath &&
-              splitView[key].hasOpenedPanel === nextPanel.hasOpenedPanel &&
-              splitView[key].lastOpenPanel === nextPanel.lastOpenPanel
+              leaf.panel.panel === nextPanel.panel &&
+              leaf.panel.diffTurnId === nextPanel.diffTurnId &&
+              leaf.panel.diffFilePath === nextPanel.diffFilePath &&
+              leaf.panel.hasOpenedPanel === nextPanel.hasOpenedPanel &&
+              leaf.panel.lastOpenPanel === nextPanel.lastOpenPanel
             ) {
               return splitView;
             }
+            const nextLeaf: LeafPane = { ...leaf, panel: nextPanel };
             return {
               ...splitView,
-              [key]: nextPanel,
+              root: replacePaneInTree(splitView.root, paneId, nextLeaf),
               updatedAt: resolveUpdatedAt(),
             };
           }),
@@ -299,21 +524,38 @@ export const useSplitViewStore = create<SplitViewStore>()(
             if (!splitView) {
               continue;
             }
-            const result = removeThreadFromSplitView(splitView, threadId);
-            if (result.nextSplitView === splitView) {
+            const result = removeLeafByThreadIdInTree(splitView.root, threadId);
+            if (result.removedLeafIds.length === 0) {
               continue;
             }
 
             didChange = true;
-            if (result.nextSplitView) {
-              nextSplitViewsById[splitViewId] = result.nextSplitView;
-            } else {
+            if (result.nextRoot === null) {
               delete nextSplitViewsById[splitViewId];
+              delete nextSplitViewIdBySourceThreadId[splitView.sourceThreadId];
+              continue;
+            }
+            if (!collectLeaves(result.nextRoot).some((leaf) => leaf.threadId !== null)) {
+              delete nextSplitViewsById[splitViewId];
+              delete nextSplitViewIdBySourceThreadId[splitView.sourceThreadId];
+              continue;
             }
 
-            if (splitView.sourceThreadId === threadId || result.nextSplitView === null) {
+            const focusedStillPresent = !result.removedLeafIds.includes(splitView.focusedPaneId);
+            const nextFocusedPaneId = focusedStillPresent
+              ? splitView.focusedPaneId
+              : resolveDefaultFocusLeafId(result.nextRoot);
+
+            if (splitView.sourceThreadId === threadId) {
               delete nextSplitViewIdBySourceThreadId[splitView.sourceThreadId];
             }
+
+            nextSplitViewsById[splitViewId] = {
+              ...splitView,
+              root: result.nextRoot,
+              focusedPaneId: nextFocusedPaneId,
+              updatedAt: resolveUpdatedAt(),
+            };
           }
 
           if (!didChange) {
@@ -328,7 +570,21 @@ export const useSplitViewStore = create<SplitViewStore>()(
     }),
     {
       name: SPLIT_VIEW_STORAGE_KEY,
+      version: SPLIT_VIEW_STORAGE_VERSION,
       storage: createJSONStorage(() => localStorage),
+      // Pre-v2 storage used a flat left/right pane shape. We migrate any persisted state to the
+      // tree shape; if migration cannot recover anything, we silently drop it instead of crashing.
+      migrate: (persistedState, version) => {
+        if (version >= SPLIT_VIEW_STORAGE_VERSION) {
+          return persistedState as SplitViewStoreState;
+        }
+        return (
+          migrateLegacyPersistedState(persistedState) ?? {
+            splitViewsById: {},
+            splitViewIdBySourceThreadId: {},
+          }
+        );
+      },
     },
   ),
 );

--- a/apps/web/src/storageKeyMigration.test.ts
+++ b/apps/web/src/storageKeyMigration.test.ts
@@ -1,0 +1,115 @@
+// FILE: storageKeyMigration.test.ts
+// Purpose: Verify legacy t3code:* localStorage keys are copied to dpcode:* without overwriting
+// existing dpcode values, so app boot never silently loses persisted state.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_LOCAL_STORAGE = globalThis.localStorage;
+
+function createMemoryStorage(): Storage {
+  const storage = new Map<string, string>();
+  return {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => {
+      storage.clear();
+    },
+    key: (index: number) => [...storage.keys()][index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  } as Storage;
+}
+
+async function importMigrationFresh() {
+  vi.resetModules();
+  return await import("./storageKeyMigration");
+}
+
+describe("storageKeyMigration", () => {
+  beforeEach(() => {
+    globalThis.localStorage = createMemoryStorage();
+  });
+
+  afterEach(() => {
+    globalThis.localStorage = ORIGINAL_LOCAL_STORAGE;
+    vi.resetModules();
+  });
+
+  it("copies a legacy t3code value to the dpcode key when missing", async () => {
+    globalThis.localStorage.setItem(
+      "t3code:split-view-state:v1",
+      JSON.stringify({ state: {}, version: 2 }),
+    );
+
+    await importMigrationFresh();
+
+    expect(globalThis.localStorage.getItem("dpcode:split-view-state:v1")).toBe(
+      JSON.stringify({ state: {}, version: 2 }),
+    );
+    // Legacy key is intentionally left in place so a downgrade still has its data.
+    expect(globalThis.localStorage.getItem("t3code:split-view-state:v1")).toBe(
+      JSON.stringify({ state: {}, version: 2 }),
+    );
+  });
+
+  it("does not overwrite an existing dpcode value when the legacy key still holds data", async () => {
+    globalThis.localStorage.setItem("t3code:theme", "dark");
+    globalThis.localStorage.setItem("dpcode:theme", "light");
+
+    await importMigrationFresh();
+
+    expect(globalThis.localStorage.getItem("dpcode:theme")).toBe("light");
+    expect(globalThis.localStorage.getItem("t3code:theme")).toBe("dark");
+  });
+
+  it("is a no-op when the legacy key is absent", async () => {
+    globalThis.localStorage.setItem("dpcode:renderer-state:v8", '{"projectNamesByCwd":{}}');
+
+    await importMigrationFresh();
+
+    expect(globalThis.localStorage.getItem("dpcode:renderer-state:v8")).toBe(
+      '{"projectNamesByCwd":{}}',
+    );
+    expect(globalThis.localStorage.getItem("t3code:renderer-state:v8")).toBeNull();
+  });
+
+  it("migrates several keys in one pass", async () => {
+    globalThis.localStorage.setItem("t3code:composer-drafts:v1", "drafts");
+    globalThis.localStorage.setItem("t3code:pinned-threads:v1", "pinned");
+    globalThis.localStorage.setItem("t3code:last-editor", "vscode");
+
+    await importMigrationFresh();
+
+    expect(globalThis.localStorage.getItem("dpcode:composer-drafts:v1")).toBe("drafts");
+    expect(globalThis.localStorage.getItem("dpcode:pinned-threads:v1")).toBe("pinned");
+    expect(globalThis.localStorage.getItem("dpcode:last-editor")).toBe("vscode");
+  });
+
+  it("swallows storage errors so the app can still boot", async () => {
+    const failingStorage = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+      removeItem: () => {
+        throw new Error("denied");
+      },
+      clear: () => {
+        throw new Error("denied");
+      },
+      key: () => null,
+      length: 0,
+    } as Storage;
+    globalThis.localStorage = failingStorage;
+
+    await expect(importMigrationFresh()).resolves.toBeDefined();
+  });
+});

--- a/apps/web/src/storageKeyMigration.ts
+++ b/apps/web/src/storageKeyMigration.ts
@@ -1,0 +1,52 @@
+// FILE: storageKeyMigration.ts
+// Purpose: Migrates legacy browser storage keys to the DPCode namespace.
+// Layer: Web bootstrap utility
+// Exports: migrateDpCodeLocalStorageKeys
+
+const STORAGE_KEY_MIGRATIONS = [
+  ["t3code:renderer-state:v8", "dpcode:renderer-state:v8"],
+  ["t3code:composer-drafts:v1", "dpcode:composer-drafts:v1"],
+  ["t3code:split-view-state:v1", "dpcode:split-view-state:v1"],
+  ["t3code:sidebar-ui:v1", "dpcode:sidebar-ui:v1"],
+  ["t3code:single-chat-panel-state:v1", "dpcode:single-chat-panel-state:v1"],
+  ["t3code:terminal-state:v1", "dpcode:terminal-state:v1"],
+  ["t3code:latest-project:v1", "dpcode:latest-project:v1"],
+  ["t3code:app-settings:v1", "dpcode:app-settings:v1"],
+  ["t3code:pinned-threads:v1", "dpcode:pinned-threads:v1"],
+  ["t3code:browser-state:v1", "dpcode:browser-state:v1"],
+  ["t3code:workspace-pages:v2", "dpcode:workspace-pages:v2"],
+  ["t3code:theme", "dpcode:theme"],
+  ["t3code:last-editor", "dpcode:last-editor"],
+  ["t3code:last-invoked-script-by-project", "dpcode:last-invoked-script-by-project"],
+] as const;
+
+export function migrateDpCodeLocalStorageKeys(): void {
+  // Prefer globalThis.localStorage so this works identically in browsers (where
+  // globalThis === window) and in node-based unit tests that stub the global.
+  let storage: Storage | null = null;
+  try {
+    storage = globalThis.localStorage ?? null;
+  } catch {
+    return;
+  }
+  if (!storage) {
+    return;
+  }
+
+  try {
+    for (const [legacyKey, nextKey] of STORAGE_KEY_MIGRATIONS) {
+      if (storage.getItem(nextKey) !== null) {
+        continue;
+      }
+      const legacyValue = storage.getItem(legacyKey);
+      if (legacyValue !== null) {
+        storage.setItem(nextKey, legacyValue);
+      }
+    }
+  } catch {
+    // Storage can be unavailable in private/sandboxed contexts; the app should still boot.
+  }
+}
+
+// Run during bootstrap before stores hydrate from localStorage.
+migrateDpCodeLocalStorageKeys();

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -2393,7 +2393,7 @@ describe("store read model sync", () => {
       addEventListener: vi.fn(),
     };
     storage.set(
-      "t3code:renderer-state:v8",
+      "dpcode:renderer-state:v8",
       JSON.stringify({
         projectNamesByCwd: {
           "/tmp/project": "dpcode",
@@ -2481,7 +2481,7 @@ describe("store read model sync", () => {
       freshStore.useStore.getState().renameProjectLocally(projectId, "dpcode");
 
       expect(setItem).toHaveBeenCalled();
-      expect(JSON.parse(storage.get("t3code:renderer-state:v8") ?? "{}")).toMatchObject({
+      expect(JSON.parse(storage.get("dpcode:renderer-state:v8") ?? "{}")).toMatchObject({
         projectNamesByCwd: {
           "/tmp/project": "dpcode",
         },

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -75,8 +75,9 @@ type ThreadUserInputResponseRequestedEvent = Extract<
   { type: "thread.user-input-response-requested" }
 >;
 
-const PERSISTED_STATE_KEY = "t3code:renderer-state:v8";
+const PERSISTED_STATE_KEY = "dpcode:renderer-state:v8";
 const LEGACY_PERSISTED_STATE_KEYS = [
+  "t3code:renderer-state:v8",
   "t3code:renderer-state:v7",
   "t3code:renderer-state:v6",
   "t3code:renderer-state:v5",

--- a/apps/web/src/terminalStateStore.ts
+++ b/apps/web/src/terminalStateStore.ts
@@ -53,7 +53,7 @@ interface ThreadTerminalState {
   activeTerminalGroupId: string;
 }
 
-const TERMINAL_STATE_STORAGE_KEY = "t3code:terminal-state:v1";
+const TERMINAL_STATE_STORAGE_KEY = "dpcode:terminal-state:v1";
 
 function normalizeTerminalIds(terminalIds: string[]): string[] {
   const ids = [...new Set(terminalIds.map((id) => id.trim()).filter((id) => id.length > 0))];

--- a/apps/web/src/threadActivation.logic.test.ts
+++ b/apps/web/src/threadActivation.logic.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+import type { SplitView } from "./splitViewStore";
+import {
+  resolvePreferredSplitForCommand,
+  resolveThreadCommandActivation,
+} from "./threadActivation.logic";
+
+const THREAD_A = ThreadId.makeUnsafe("thread-a");
+const THREAD_B = ThreadId.makeUnsafe("thread-b");
+const THREAD_C = ThreadId.makeUnsafe("thread-c");
+const PROJECT_ID = ProjectId.makeUnsafe("project-1");
+
+function makeSplitViewFixture(input: {
+  id: string;
+  sourceThreadId: ThreadId;
+  firstThreadId: ThreadId | null;
+  secondThreadId: ThreadId | null;
+  focusOn: "first" | "second";
+}): SplitView {
+  const firstId = `${input.id}-pane-first`;
+  const secondId = `${input.id}-pane-second`;
+  const panel = {
+    panel: null,
+    diffTurnId: null,
+    diffFilePath: null,
+    hasOpenedPanel: false,
+    lastOpenPanel: "browser" as const,
+  };
+  return {
+    id: input.id,
+    sourceThreadId: input.sourceThreadId,
+    ownerProjectId: PROJECT_ID,
+    focusedPaneId: input.focusOn === "first" ? firstId : secondId,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    root: {
+      kind: "split",
+      id: `${input.id}-root`,
+      direction: "horizontal",
+      ratio: 0.5,
+      first: { kind: "leaf", id: firstId, threadId: input.firstThreadId, panel },
+      second: { kind: "leaf", id: secondId, threadId: input.secondThreadId, panel },
+    },
+  };
+}
+
+describe("resolveThreadCommandActivation", () => {
+  it("opens the target thread inside the caller-provided active split", () => {
+    expect(
+      resolveThreadCommandActivation({
+        threadId: THREAD_A,
+        threadExists: true,
+        activeSidebarThreadId: THREAD_B,
+        preferredSplitViewId: "split-1",
+        splitPaneId: "pane-a",
+      }),
+    ).toEqual({
+      kind: "split",
+      threadId: THREAD_A,
+      splitViewId: "split-1",
+      paneId: "pane-a",
+    });
+  });
+
+  it("opens the target thread as single chat when it is not in a split", () => {
+    expect(
+      resolveThreadCommandActivation({
+        threadId: THREAD_A,
+        threadExists: true,
+        activeSidebarThreadId: THREAD_B,
+        preferredSplitViewId: null,
+        splitPaneId: null,
+      }),
+    ).toEqual({
+      kind: "single",
+      threadId: THREAD_A,
+    });
+  });
+
+  it("still opens the active sidebar thread split instead of ignoring it", () => {
+    expect(
+      resolveThreadCommandActivation({
+        threadId: THREAD_A,
+        threadExists: true,
+        activeSidebarThreadId: THREAD_A,
+        preferredSplitViewId: "split-1",
+        splitPaneId: "pane-a",
+      }),
+    ).toEqual({
+      kind: "split",
+      threadId: THREAD_A,
+      splitViewId: "split-1",
+      paneId: "pane-a",
+    });
+  });
+
+  it("ignores missing threads and already-active single chats", () => {
+    expect(
+      resolveThreadCommandActivation({
+        threadId: THREAD_A,
+        threadExists: false,
+        activeSidebarThreadId: THREAD_B,
+        preferredSplitViewId: null,
+        splitPaneId: null,
+      }),
+    ).toEqual({ kind: "ignore" });
+
+    expect(
+      resolveThreadCommandActivation({
+        threadId: THREAD_A,
+        threadExists: true,
+        activeSidebarThreadId: THREAD_A,
+        preferredSplitViewId: null,
+        splitPaneId: null,
+      }),
+    ).toEqual({ kind: "ignore" });
+  });
+});
+
+describe("resolvePreferredSplitForCommand", () => {
+  it("focuses the matching pane in the active split when the target lives there", () => {
+    const activeSplitView = makeSplitViewFixture({
+      id: "split-active",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+
+    const result = resolvePreferredSplitForCommand({
+      activeSplitView,
+      splitViewsById: {},
+      threadId: THREAD_B,
+    });
+
+    expect(result).toEqual({ splitViewId: "split-active", paneId: "split-active-pane-second" });
+  });
+
+  it("returns null inside an active split when the target is outside that split", () => {
+    const activeSplitView = makeSplitViewFixture({
+      id: "split-active",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const result = resolvePreferredSplitForCommand({
+      activeSplitView,
+      splitViewsById: {},
+      threadId: THREAD_C,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("restores a persisted split when no split is active", () => {
+    const splitView = makeSplitViewFixture({
+      id: "split-background",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+
+    const result = resolvePreferredSplitForCommand({
+      activeSplitView: null,
+      splitViewsById: { "split-background": splitView },
+      threadId: THREAD_B,
+    });
+
+    expect(result).toEqual({
+      splitViewId: "split-background",
+      paneId: "split-background-pane-second",
+    });
+  });
+
+  it("prefers source ownership when a thread appears in multiple split blocks", () => {
+    const firstSplit = makeSplitViewFixture({
+      id: "split-first",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const secondSplit = makeSplitViewFixture({
+      id: "split-second",
+      sourceThreadId: THREAD_C,
+      firstThreadId: THREAD_C,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+
+    expect(
+      resolvePreferredSplitForCommand({
+        activeSplitView: null,
+        splitViewsById: {
+          "split-first": firstSplit,
+          "split-second": secondSplit,
+        },
+        threadId: THREAD_B,
+      }),
+    ).toBeNull();
+
+    expect(
+      resolvePreferredSplitForCommand({
+        activeSplitView: null,
+        splitViewsById: {
+          "split-first": firstSplit,
+          "split-second": secondSplit,
+        },
+        threadId: THREAD_C,
+      }),
+    ).toEqual({ splitViewId: "split-second", paneId: "split-second-pane-first" });
+  });
+
+  it("switches from one active split to another persisted split", () => {
+    const activeSplit = makeSplitViewFixture({
+      id: "split-active",
+      sourceThreadId: THREAD_A,
+      firstThreadId: THREAD_A,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+    const otherSplit = makeSplitViewFixture({
+      id: "split-other",
+      sourceThreadId: THREAD_C,
+      firstThreadId: THREAD_C,
+      secondThreadId: THREAD_B,
+      focusOn: "first",
+    });
+
+    const result = resolvePreferredSplitForCommand({
+      activeSplitView: activeSplit,
+      splitViewsById: {
+        "split-active": activeSplit,
+        "split-other": otherSplit,
+      },
+      threadId: THREAD_C,
+    });
+
+    expect(result).toEqual({ splitViewId: "split-other", paneId: "split-other-pane-first" });
+  });
+
+  it("returns null when no split is active and no persisted split owns the thread", () => {
+    expect(
+      resolvePreferredSplitForCommand({
+        activeSplitView: null,
+        splitViewsById: {},
+        threadId: THREAD_A,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/threadActivation.logic.ts
+++ b/apps/web/src/threadActivation.logic.ts
@@ -1,0 +1,85 @@
+// FILE: threadActivation.logic.ts
+// Purpose: Pure routing decisions for opening threads as single chats or split panes.
+// Exports: split-aware activation resolvers shared by sidebar click, keyboard, and search flows.
+
+import type { ThreadId } from "@t3tools/contracts";
+import {
+  resolveSplitViewPaneIdForThread,
+  type PaneId,
+  type SplitView,
+  type SplitViewId,
+} from "./splitViewStore";
+
+export type ThreadCommandActivation =
+  | { kind: "ignore" }
+  | { kind: "single"; threadId: ThreadId }
+  | { kind: "split"; threadId: ThreadId; splitViewId: SplitViewId; paneId: PaneId };
+
+/**
+ * Decide what a sidebar/search/keyboard activation should do for a thread.
+ *
+ * Callers decide which split (if any) is "preferred". That means the currently
+ * active split first, then any persisted split block with deterministic ownership.
+ */
+export function resolveThreadCommandActivation(input: {
+  threadId: ThreadId;
+  threadExists: boolean;
+  activeSidebarThreadId: ThreadId | null | undefined;
+  preferredSplitViewId: SplitViewId | null;
+  splitPaneId: PaneId | null;
+}): ThreadCommandActivation {
+  if (!input.threadExists) {
+    return { kind: "ignore" };
+  }
+
+  if (input.preferredSplitViewId && input.splitPaneId) {
+    return {
+      kind: "split",
+      threadId: input.threadId,
+      splitViewId: input.preferredSplitViewId,
+      paneId: input.splitPaneId,
+    };
+  }
+
+  if (input.threadId === input.activeSidebarThreadId) {
+    return { kind: "ignore" };
+  }
+
+  return { kind: "single", threadId: input.threadId };
+}
+
+/**
+ * Resolve whether thread activation should land in a split.
+ *
+ * While a split is active, that split's panes win. Otherwise every persisted
+ * split block can be restored, but ambiguous non-source membership falls back to
+ * single chat instead of guessing by recency.
+ */
+export function resolvePreferredSplitForCommand(input: {
+  activeSplitView: SplitView | null;
+  splitViewsById: Record<SplitViewId, SplitView | undefined>;
+  threadId: ThreadId;
+}): { splitViewId: SplitViewId; paneId: PaneId } | null {
+  if (input.activeSplitView) {
+    const paneId = resolveSplitViewPaneIdForThread(input.activeSplitView, input.threadId);
+    if (paneId) {
+      return { splitViewId: input.activeSplitView.id, paneId };
+    }
+  }
+
+  const matchingSplits = Object.values(input.splitViewsById)
+    .filter((splitView): splitView is SplitView => splitView !== undefined)
+    .map((splitView) => ({
+      splitView,
+      paneId: resolveSplitViewPaneIdForThread(splitView, input.threadId),
+    }))
+    .filter(
+      (match): match is { splitView: SplitView; paneId: PaneId } => match.paneId !== null,
+    );
+
+  const sourceMatch = matchingSplits.find(
+    ({ splitView }) => splitView.sourceThreadId === input.threadId,
+  );
+  const match = sourceMatch ?? (matchingSplits.length === 1 ? matchingSplits[0] : null);
+  return match ? { splitViewId: match.splitView.id, paneId: match.paneId } : null;
+}

--- a/apps/web/src/threadDetailSubscriptionRetention.test.ts
+++ b/apps/web/src/threadDetailSubscriptionRetention.test.ts
@@ -49,7 +49,7 @@ describe("threadDetailSubscriptionRetention", () => {
   it("notifies imperative listeners when retained ids change", () => {
     vi.useFakeTimers();
     const threadId = ThreadId.makeUnsafe("thread-listener");
-    const snapshots: readonly ThreadId[][] = [];
+    const snapshots: ThreadId[][] = [];
     const unsubscribe = subscribeRetainedThreadDetailIdChanges((threadIds) => {
       snapshots.push([...threadIds]);
     });

--- a/apps/web/src/threadDetailSubscriptionRetention.test.ts
+++ b/apps/web/src/threadDetailSubscriptionRetention.test.ts
@@ -5,6 +5,7 @@ import {
   getRetainedThreadDetailIdsSnapshot,
   resetRetainedThreadDetailSubscriptionsForTests,
   retainThreadDetailSubscription,
+  subscribeRetainedThreadDetailIdChanges,
 } from "./threadDetailSubscriptionRetention";
 
 describe("threadDetailSubscriptionRetention", () => {
@@ -43,6 +44,22 @@ describe("threadDetailSubscriptionRetention", () => {
     vi.advanceTimersByTime(15 * 60 * 1000);
 
     expect(getRetainedThreadDetailIdsSnapshot()).toEqual([]);
+  });
+
+  it("notifies imperative listeners when retained ids change", () => {
+    vi.useFakeTimers();
+    const threadId = ThreadId.makeUnsafe("thread-listener");
+    const snapshots: readonly ThreadId[][] = [];
+    const unsubscribe = subscribeRetainedThreadDetailIdChanges((threadIds) => {
+      snapshots.push([...threadIds]);
+    });
+
+    const release = retainThreadDetailSubscription(threadId);
+    release();
+    vi.advanceTimersByTime(15 * 60 * 1000);
+    unsubscribe();
+
+    expect(snapshots).toEqual([[threadId], []]);
   });
 
   it("cancels eviction when a thread is retained again before timeout", () => {

--- a/apps/web/src/threadDetailSubscriptionRetention.ts
+++ b/apps/web/src/threadDetailSubscriptionRetention.ts
@@ -1,3 +1,8 @@
+// FILE: threadDetailSubscriptionRetention.ts
+// Purpose: Keep recently used thread-detail subscriptions warm across route/sidebar switches.
+// Layer: Web subscription retention utility
+// Exports: retain/release helpers plus React and imperative subscription listeners.
+
 import type { ThreadId } from "@t3tools/contracts";
 import { useSyncExternalStore } from "react";
 import { useStore } from "./store";
@@ -13,12 +18,16 @@ type RetainedThreadEntry = {
 
 const retainedThreadEntries = new Map<ThreadId, RetainedThreadEntry>();
 const listeners = new Set<() => void>();
+const retainedThreadIdChangeListeners = new Set<(threadIds: readonly ThreadId[]) => void>();
 let cachedSnapshot: readonly ThreadId[] = [];
 
 function emitChange(): void {
   cachedSnapshot = [...retainedThreadEntries.keys()];
   for (const listener of listeners) {
     listener();
+  }
+  for (const listener of retainedThreadIdChangeListeners) {
+    listener(cachedSnapshot);
   }
 }
 
@@ -171,6 +180,15 @@ export function subscribeRetainedThreadDetailIds(listener: () => void): () => vo
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
+  };
+}
+
+export function subscribeRetainedThreadDetailIdChanges(
+  listener: (threadIds: readonly ThreadId[]) => void,
+): () => void {
+  retainedThreadIdChangeListeners.add(listener);
+  return () => {
+    retainedThreadIdChangeListeners.delete(listener);
   };
 }
 

--- a/apps/web/src/workspaceStore.ts
+++ b/apps/web/src/workspaceStore.ts
@@ -31,7 +31,7 @@ interface WorkspaceStoreState {
   reorderWorkspace: (workspaceId: string, nextIndex: number) => void;
 }
 
-const WORKSPACE_STORE_STORAGE_KEY = "t3code:workspace-pages:v2";
+const WORKSPACE_STORE_STORAGE_KEY = "dpcode:workspace-pages:v2";
 
 function randomWorkspaceId(): string {
   if (typeof crypto.randomUUID === "function") {


### PR DESCRIPTION
## What Changed

- Add split chat routing and pane activation support for sidebar, keyboard shortcuts, search, and pinned rows.
- Centralize thread activation policy in `threadActivation.logic.ts` and side effects in `useThreadActivationController`.
- Add focused tests for split restore, pane focus, deterministic persisted split lookup, terminal entry preservation, and controller side effects.

## Why

Split chat activation was inconsistent across click, search, and `Cmd+number` flows. This keeps every persisted split block restorable while avoiding recency-based guessing when a thread belongs to multiple blocks.

## UI Changes

Interaction behavior changes only. No screenshots or video captured yet because this is opened as a draft.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Made with [Cursor](https://cursor.com)