### PR TITLE
Heal legacy T3 Code imports stuck on missing env_mode column

### DIFF
--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -44,6 +44,7 @@ import Migration0028 from "./Migrations/028_ProjectionProjectsKind.ts";
 import Migration0029 from "./Migrations/029_ProjectionThreadsLastKnownPr.ts";
 import Migration0030 from "./Migrations/030_ProjectionThreadMessagesDispatchMode.ts";
 import Migration0031 from "./Migrations/031_ProjectionThreadsCreateBranchFlowCompleted.ts";
+import Migration0032 from "./Migrations/032_ReconcileLegacyT3SchemaImport.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -87,6 +88,7 @@ export const migrationEntries = [
   [29, "ProjectionThreadsLastKnownPr", Migration0029],
   [30, "ProjectionThreadMessagesDispatchMode", Migration0030],
   [31, "ProjectionThreadsCreateBranchFlowCompleted", Migration0031],
+  [32, "ReconcileLegacyT3SchemaImport", Migration0032],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/032_ReconcileLegacyT3SchemaImport.test.ts
+++ b/apps/server/src/persistence/Migrations/032_ReconcileLegacyT3SchemaImport.test.ts
@@ -1,0 +1,153 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+const projectionThreadsColumnNames = (sql: SqlClient.SqlClient) =>
+  sql<{ readonly name: string }>`
+    SELECT name FROM pragma_table_info('projection_threads')
+  `.pipe(Effect.map((rows) => rows.map((row) => row.name)));
+
+const projectionThreadMessagesColumnNames = (sql: SqlClient.SqlClient) =>
+  sql<{ readonly name: string }>`
+    SELECT name FROM pragma_table_info('projection_thread_messages')
+  `.pipe(Effect.map((rows) => rows.map((row) => row.name)));
+
+layer("032_ReconcileLegacyT3SchemaImport", (it) => {
+  // Simulates a legacy ~/.t3 import where the imported `effect_sql_migrations`
+  // tracker has IDs 17-31 recorded under unrelated T3 Code names. The 17-23
+  // body never ran, so the columns those migrations would have added are
+  // missing. Without #032, the server crashes on the first SELECT that
+  // references env_mode.
+  it.effect("heals an imported T3 Code DB whose tracker skipped 17-23", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      // Bring the schema to where T3 Code and DP Code last agreed.
+      yield* runMigrations({ toMigrationInclusive: 16 });
+
+      // Mark IDs 17-31 applied under T3 Code's old names so the migrator
+      // skips DP Code's renumbered 17-23. Names are illustrative; only the
+      // IDs matter to the migrator's "run anything past max(id)" gate.
+      const legacyT3MigrationNames: ReadonlyArray<readonly [number, string]> = [
+        [17, "ProjectionThreadsArchivedAt"],
+        [18, "ProjectionThreadsArchivedAtIndex"],
+        [19, "ProjectionSnapshotLookupIndexes"],
+        [20, "AuthAccessManagement"],
+        [21, "AuthSessionClientMetadata"],
+        [22, "AuthSessionLastConnectedAt"],
+        [23, "ProjectionThreadShellSummary"],
+        [24, "BackfillProjectionThreadShellSummary"],
+        [25, "ProjectionThreadsSubagents"],
+        [26, "ProjectionThreadShellSummary"],
+        [27, "BackfillProjectionThreadShellSummary"],
+        [28, "ProjectionProjectsKind"],
+        [29, "ProjectionThreadsLastKnownPr"],
+        [30, "ProjectionThreadMessagesDispatchMode"],
+        [31, "ProjectionThreadsCreateBranchFlowCompleted"],
+      ];
+      for (const [id, name] of legacyT3MigrationNames) {
+        yield* sql`
+          INSERT INTO effect_sql_migrations (migration_id, name)
+          VALUES (${id}, ${name})
+        `;
+      }
+
+      // Seed a thread row with the T3 Code-era column set so the data-rewrite
+      // branches in #032 have something to operate on.
+      yield* sql`
+        INSERT INTO projection_threads (
+          thread_id,
+          project_id,
+          title,
+          branch,
+          worktree_path,
+          latest_turn_id,
+          created_at,
+          updated_at,
+          deleted_at,
+          runtime_mode,
+          interaction_mode
+        )
+        VALUES (
+          'thread-legacy',
+          'project-legacy',
+          'Legacy thread',
+          'feature/legacy',
+          '/tmp/legacy-worktree',
+          NULL,
+          '2026-01-01T00:00:00.000Z',
+          '2026-01-01T00:00:00.000Z',
+          NULL,
+          'full-access',
+          'default'
+        )
+      `;
+
+      // Sanity check: env_mode shouldn't exist yet.
+      const beforeColumns = yield* projectionThreadsColumnNames(sql);
+      assert.notInclude(beforeColumns, "env_mode");
+
+      // This is what runs on next launch.
+      yield* runMigrations();
+
+      const afterThreadsColumns = yield* projectionThreadsColumnNames(sql);
+      const afterMessagesColumns = yield* projectionThreadMessagesColumnNames(sql);
+
+      // #017 + #018 columns
+      assert.include(afterThreadsColumns, "handoff_json");
+      assert.include(afterMessagesColumns, "source");
+      assert.include(afterMessagesColumns, "skills_json");
+      assert.include(afterMessagesColumns, "mentions_json");
+
+      // #019 + the columns from #020-#023
+      assert.include(afterThreadsColumns, "env_mode");
+      assert.include(afterThreadsColumns, "fork_source_thread_id");
+      assert.include(afterThreadsColumns, "associated_worktree_path");
+      assert.include(afterThreadsColumns, "associated_worktree_branch");
+      assert.include(afterThreadsColumns, "associated_worktree_ref");
+
+      // Data-rewrite branches: env_mode derived from worktree_path,
+      // associated_* mirrored from existing branch / worktree fields.
+      const [seeded] = yield* sql<{
+        readonly env_mode: string;
+        readonly associated_worktree_path: string | null;
+        readonly associated_worktree_branch: string | null;
+        readonly associated_worktree_ref: string | null;
+      }>`
+        SELECT env_mode, associated_worktree_path, associated_worktree_branch, associated_worktree_ref
+        FROM projection_threads
+        WHERE thread_id = 'thread-legacy'
+      `;
+      assert.strictEqual(seeded?.env_mode, "worktree");
+      assert.strictEqual(seeded?.associated_worktree_path, "/tmp/legacy-worktree");
+      assert.strictEqual(seeded?.associated_worktree_branch, "feature/legacy");
+      assert.strictEqual(seeded?.associated_worktree_ref, "feature/legacy");
+    }),
+  );
+
+  it.effect("is a no-op on a fresh DP Code install", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      // Run the entire chain in order, the way a fresh install would.
+      yield* runMigrations();
+
+      // Nothing should blow up if we run it again.
+      yield* runMigrations();
+
+      const threadsColumns = yield* projectionThreadsColumnNames(sql);
+      const messagesColumns = yield* projectionThreadMessagesColumnNames(sql);
+
+      // Columns from the regular in-order runs of 17-23 are still there,
+      // confirming #032 didn't try to ADD COLUMN on top of existing ones.
+      assert.include(threadsColumns, "env_mode");
+      assert.include(threadsColumns, "associated_worktree_ref");
+      assert.include(messagesColumns, "skills_json");
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/032_ReconcileLegacyT3SchemaImport.ts
+++ b/apps/server/src/persistence/Migrations/032_ReconcileLegacyT3SchemaImport.ts
@@ -1,0 +1,121 @@
+/**
+ * Reconciles schema after a legacy ~/.t3 import where the imported
+ * `effect_sql_migrations` tracker already records IDs 17–23 under unrelated
+ * T3 Code names. Because the migrator skips by ID, the renumbered DP Code
+ * migrations 17–23 never run on those imports, leaving columns like
+ * `env_mode` missing and crashing the server on first query.
+ *
+ * Migration #023 previously held this self-healing logic, but legacy DBs
+ * also have a row for ID 23 (T3 Code's `ProjectionThreadShellSummary`),
+ * so the migrator skipped it too. This migration is at a fresh ID beyond
+ * any T3 Code migration, guaranteeing it runs on import.
+ *
+ * Idempotent and a no-op for fresh DP Code installs (every column already
+ * exists from the in-order runs of 17–23).
+ */
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as Effect from "effect/Effect";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const projectionThreadsColumnExists = (columnName: string) =>
+    sql<{ readonly exists: number }>`
+      SELECT EXISTS(
+        SELECT 1
+        FROM pragma_table_info('projection_threads')
+        WHERE name = ${columnName}
+      ) AS "exists"
+    `.pipe(Effect.map(([row]) => row?.exists === 1));
+
+  const projectionThreadMessagesColumnExists = (columnName: string) =>
+    sql<{ readonly exists: number }>`
+      SELECT EXISTS(
+        SELECT 1
+        FROM pragma_table_info('projection_thread_messages')
+        WHERE name = ${columnName}
+      ) AS "exists"
+    `.pipe(Effect.map(([row]) => row?.exists === 1));
+
+  const ensureProjectionThreadsColumn = (columnName: string, definition: string) =>
+    Effect.gen(function* () {
+      if (yield* projectionThreadsColumnExists(columnName)) {
+        return false;
+      }
+      yield* sql.unsafe(`
+        ALTER TABLE projection_threads
+        ADD COLUMN ${definition}
+      `);
+      return true;
+    });
+
+  const ensureProjectionThreadMessagesColumn = (columnName: string, definition: string) =>
+    Effect.gen(function* () {
+      if (yield* projectionThreadMessagesColumnExists(columnName)) {
+        return false;
+      }
+      yield* sql.unsafe(`
+        ALTER TABLE projection_thread_messages
+        ADD COLUMN ${definition}
+      `);
+      return true;
+    });
+
+  yield* ensureProjectionThreadsColumn("handoff_json", "handoff_json TEXT");
+  yield* ensureProjectionThreadMessagesColumn("source", "source TEXT NOT NULL DEFAULT 'native'");
+  yield* ensureProjectionThreadMessagesColumn("skills_json", "skills_json TEXT");
+  yield* ensureProjectionThreadMessagesColumn("mentions_json", "mentions_json TEXT");
+
+  const addedEnvMode = yield* ensureProjectionThreadsColumn(
+    "env_mode",
+    "env_mode TEXT NOT NULL DEFAULT 'local'",
+  );
+  if (addedEnvMode) {
+    yield* sql`
+      UPDATE projection_threads
+      SET env_mode = CASE
+        WHEN worktree_path IS NOT NULL THEN 'worktree'
+        ELSE 'local'
+      END
+    `;
+  }
+
+  yield* ensureProjectionThreadsColumn("fork_source_thread_id", "fork_source_thread_id TEXT");
+
+  const addedAssociatedWorktreePath = yield* ensureProjectionThreadsColumn(
+    "associated_worktree_path",
+    "associated_worktree_path TEXT",
+  );
+  if (addedAssociatedWorktreePath) {
+    yield* sql`
+      UPDATE projection_threads
+      SET associated_worktree_path = worktree_path
+      WHERE associated_worktree_path IS NULL
+    `;
+  }
+
+  const addedAssociatedWorktreeBranch = yield* ensureProjectionThreadsColumn(
+    "associated_worktree_branch",
+    "associated_worktree_branch TEXT",
+  );
+  if (addedAssociatedWorktreeBranch) {
+    yield* sql`
+      UPDATE projection_threads
+      SET associated_worktree_branch = branch
+      WHERE associated_worktree_branch IS NULL
+    `;
+  }
+
+  const addedAssociatedWorktreeRef = yield* ensureProjectionThreadsColumn(
+    "associated_worktree_ref",
+    "associated_worktree_ref TEXT",
+  );
+  if (addedAssociatedWorktreeRef) {
+    yield* sql`
+      UPDATE projection_threads
+      SET associated_worktree_ref = COALESCE(associated_worktree_branch, branch)
+      WHERE associated_worktree_ref IS NULL
+        AND COALESCE(associated_worktree_branch, branch) IS NOT NULL
+    `;
+  }
+});


### PR DESCRIPTION
Closes #68.

**Symptom**

Packaged backend exits with `code=1` on launch in a restart loop; UI never appears. Real error lives in `~/.dpcode/userdata/logs/server-child.log`:

```
Error: no such column: env_mode
    at ProjectionThreadRepository.getById:query
```

**Cause**

`homeMigration.ts` imports an existing `~/.t3` SQLite DB via `VACUUM INTO`, which copies the `effect_sql_migrations` tracker byte-for-byte. T3 Code's tracker has IDs 17–23 recorded under unrelated names (`ProjectionSnapshotLookupIndexes`, `AuthAccessManagement`, etc.). The migrator only checks IDs, so DP Code's renumbered 17–23 never run on a legacy import. The columns they would have added — `env_mode`, `handoff_json`, `fork_source_thread_id`, `associated_worktree_{path,branch,ref}`, `source`, `skills_json`, `mentions_json` — stay missing.

Migration `#023` was previously updated with self-healing `ensureProjectionThreadsColumn` logic exactly for this case, but it itself is gated by the colliding ID 23, so it never triggers on the affected DBs.

**Fix**

Move the ensure-column body to a new migration `#032`, past T3 Code's max ID. Runs once on legacy imports, no-op on fresh installs.

**Verification**

- New unit test seeds T3 Code-era tracker rows (IDs 17–31 under old names) and a T3-era schema, then asserts all 9 missing columns appear and `env_mode` derives correctly from `worktree_path`.
- Second test confirms `#032` is a no-op on a fresh chain.
- Verified against a real broken DB: backend boots cleanly under 0.0.39 after `#032` runs.

Same crash signature reported in #68 (0.0.37, 0.0.38) — likely identical root cause; that user can confirm by checking `~/.dpcode/userdata/logs/server-child.log` for `no such column: env_mode`.