### PR TITLE
feat: copy proposed plans as markdown

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -18,7 +18,7 @@ import {
   shell,
   systemPreferences,
 } from "electron";
-import type { IpcMainEvent, MenuItemConstructorOptions } from "electron";
+import type { FileFilter, IpcMainEvent, MenuItemConstructorOptions } from "electron";
 import * as Effect from "effect/Effect";
 import type {
   DesktopTheme,
@@ -78,6 +78,7 @@ import {
 syncShellEnvironment();
 
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
+const SAVE_FILE_CHANNEL = "desktop:save-file";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const SET_THEME_CHANNEL = "desktop:set-theme";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
@@ -257,6 +258,38 @@ function getSafeTheme(rawTheme: unknown): DesktopTheme | null {
   }
 
   return null;
+}
+
+function isSaveFileInput(input: unknown): input is {
+  defaultFilename: string;
+  contents: string;
+  filters?: FileFilter[];
+} {
+  if (!input || typeof input !== "object") {
+    return false;
+  }
+  const record = input as Record<string, unknown>;
+  if (typeof record.defaultFilename !== "string" || record.defaultFilename.trim().length === 0) {
+    return false;
+  }
+  if (typeof record.contents !== "string") {
+    return false;
+  }
+  if (record.filters === undefined) {
+    return true;
+  }
+  if (!Array.isArray(record.filters)) {
+    return false;
+  }
+  return record.filters.every((filter) => {
+    if (!filter || typeof filter !== "object") return false;
+    const filterRecord = filter as Record<string, unknown>;
+    return (
+      typeof filterRecord.name === "string" &&
+      Array.isArray(filterRecord.extensions) &&
+      filterRecord.extensions.every((extension) => typeof extension === "string")
+    );
+  });
 }
 
 async function waitForBackendHttpReady(
@@ -1564,6 +1597,29 @@ function registerIpcHandlers(): void {
         });
     if (result.canceled) return null;
     return result.filePaths[0] ?? null;
+  });
+
+  ipcMain.removeHandler(SAVE_FILE_CHANNEL);
+  ipcMain.handle(SAVE_FILE_CHANNEL, async (_event, input: unknown) => {
+    if (!isSaveFileInput(input)) {
+      throw new Error("Invalid save file input.");
+    }
+
+    const owner = BrowserWindow.getFocusedWindow() ?? mainWindow;
+    const options = {
+      defaultPath: input.defaultFilename,
+      ...(input.filters ? { filters: input.filters } : {}),
+    };
+    const result = owner
+      ? await dialog.showSaveDialog(owner, options)
+      : await dialog.showSaveDialog(options);
+
+    if (result.canceled || !result.filePath) {
+      return null;
+    }
+
+    await FS.promises.writeFile(result.filePath, input.contents, "utf8");
+    return result.filePath;
   });
 
   ipcMain.removeHandler(CONFIRM_CHANNEL);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -9,6 +9,7 @@ import {
 import { SERVER_TRANSCRIBE_VOICE_CHANNEL } from "./voiceTranscription";
 
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
+const SAVE_FILE_CHANNEL = "desktop:save-file";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const SET_THEME_CHANNEL = "desktop:set-theme";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
@@ -35,6 +36,7 @@ function getDesktopWsUrl(): string | null {
 contextBridge.exposeInMainWorld("desktopBridge", {
   getWsUrl: getDesktopWsUrl,
   pickFolder: () => ipcRenderer.invoke(PICK_FOLDER_CHANNEL),
+  saveFile: (input) => ipcRenderer.invoke(SAVE_FILE_CHANNEL, input),
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(SET_THEME_CHANNEL, theme),
   showContextMenu: (items, position) => ipcRenderer.invoke(CONTEXT_MENU_CHANNEL, items, position),

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useCallback } from "react";
+import { memo, useState } from "react";
 import { type TimestampFormat } from "../appSettings";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
@@ -8,7 +8,6 @@ import {
   CheckIcon,
   ChevronDownIcon,
   ChevronRightIcon,
-  EllipsisIcon,
   LoaderIcon,
   PanelRightCloseIcon,
 } from "~/lib/icons";
@@ -16,17 +15,8 @@ import { cn } from "~/lib/utils";
 import type { ActiveTaskListState } from "../session-logic";
 import type { LatestProposedPlanState } from "../session-logic";
 import { formatTimestamp } from "../timestampFormat";
-import {
-  proposedPlanTitle,
-  buildProposedPlanMarkdownFilename,
-  normalizePlanMarkdownForExport,
-  downloadPlanAsTextFile,
-  stripDisplayedPlanMarkdown,
-} from "../proposedPlan";
-import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu";
-import { readNativeApi } from "~/nativeApi";
-import { toastManager } from "./ui/toast";
-import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { proposedPlanTitle, stripDisplayedPlanMarkdown } from "../proposedPlan";
+import { ProposedPlanActions } from "./chat/ProposedPlanActions";
 
 function stepStatusIcon(status: string): React.ReactNode {
   if (status === "completed") {
@@ -68,54 +58,9 @@ const PlanSidebar = memo(function PlanSidebar({
   onClose,
 }: PlanSidebarProps) {
   const [proposedPlanExpanded, setProposedPlanExpanded] = useState(false);
-  const [isSavingToWorkspace, setIsSavingToWorkspace] = useState(false);
-  const { copyToClipboard, isCopied } = useCopyToClipboard();
-
   const planMarkdown = activeProposedPlan?.planMarkdown ?? null;
   const displayedPlanMarkdown = planMarkdown ? stripDisplayedPlanMarkdown(planMarkdown) : null;
   const planTitle = planMarkdown ? proposedPlanTitle(planMarkdown) : null;
-
-  const handleCopyPlan = useCallback(() => {
-    if (!planMarkdown) return;
-    copyToClipboard(planMarkdown);
-  }, [planMarkdown, copyToClipboard]);
-
-  const handleDownload = useCallback(() => {
-    if (!planMarkdown) return;
-    const filename = buildProposedPlanMarkdownFilename(planMarkdown);
-    downloadPlanAsTextFile(filename, normalizePlanMarkdownForExport(planMarkdown));
-  }, [planMarkdown]);
-
-  const handleSaveToWorkspace = useCallback(() => {
-    const api = readNativeApi();
-    if (!api || !workspaceRoot || !planMarkdown) return;
-    const filename = buildProposedPlanMarkdownFilename(planMarkdown);
-    setIsSavingToWorkspace(true);
-    void api.projects
-      .writeFile({
-        cwd: workspaceRoot,
-        relativePath: filename,
-        contents: normalizePlanMarkdownForExport(planMarkdown),
-      })
-      .then((result) => {
-        toastManager.add({
-          type: "success",
-          title: "Plan saved",
-          description: result.relativePath,
-        });
-      })
-      .catch((error) => {
-        toastManager.add({
-          type: "error",
-          title: "Could not save plan",
-          description: error instanceof Error ? error.message : "An error occurred.",
-        });
-      })
-      .then(
-        () => setIsSavingToWorkspace(false),
-        () => setIsSavingToWorkspace(false),
-      );
-  }, [planMarkdown, workspaceRoot]);
 
   return (
     <div className="flex h-full w-[340px] shrink-0 flex-col border-l border-border/70 bg-card/50">
@@ -136,32 +81,12 @@ const PlanSidebar = memo(function PlanSidebar({
         </div>
         <div className="flex items-center gap-1">
           {planMarkdown ? (
-            <Menu>
-              <MenuTrigger
-                render={
-                  <Button
-                    size="icon-xs"
-                    variant="ghost"
-                    className="text-muted-foreground/50 hover:text-foreground/70"
-                    aria-label="Plan actions"
-                  />
-                }
-              >
-                <EllipsisIcon className="size-3.5" />
-              </MenuTrigger>
-              <MenuPopup align="end">
-                <MenuItem onClick={handleCopyPlan}>
-                  {isCopied ? "Copied!" : "Copy to clipboard"}
-                </MenuItem>
-                <MenuItem onClick={handleDownload}>Download as markdown</MenuItem>
-                <MenuItem
-                  onClick={handleSaveToWorkspace}
-                  disabled={!workspaceRoot || isSavingToWorkspace}
-                >
-                  Save to workspace
-                </MenuItem>
-              </MenuPopup>
-            </Menu>
+            <ProposedPlanActions
+              planMarkdown={planMarkdown}
+              workspaceRoot={workspaceRoot}
+              variant="ghost"
+              buttonClassName="text-muted-foreground/50 hover:text-foreground/70"
+            />
           ) : null}
           <Button
             size="icon-xs"

--- a/apps/web/src/components/chat/ProposedPlanActions.tsx
+++ b/apps/web/src/components/chat/ProposedPlanActions.tsx
@@ -1,0 +1,193 @@
+import { memo, useMemo, useState, type ReactNode } from "react";
+import {
+  buildProposedPlanMarkdownFilename,
+  normalizePlanMarkdownForExport,
+} from "../../proposedPlan";
+import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { ArrowDownIcon, ArrowUpIcon, CopyIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import { Button } from "../ui/button";
+import { toastManager } from "../ui/toast";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+
+type PlanActionVariant = "outline" | "ghost";
+
+interface ProposedPlanActionsProps {
+  planMarkdown: string;
+  workspaceRoot: string | undefined;
+  variant?: PlanActionVariant;
+  className?: string;
+  buttonClassName?: string;
+  iconClassName?: string;
+}
+
+export const ProposedPlanActions = memo(function ProposedPlanActions({
+  planMarkdown,
+  workspaceRoot,
+  variant = "outline",
+  className,
+  buttonClassName,
+  iconClassName,
+}: ProposedPlanActionsProps) {
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const filename = useMemo(() => buildProposedPlanMarkdownFilename(planMarkdown), [planMarkdown]);
+  const markdown = useMemo(() => normalizePlanMarkdownForExport(planMarkdown), [planMarkdown]);
+  const { copyToClipboard, isCopied } = useCopyToClipboard<void>({
+    onCopy: () => {
+      toastManager.add({ type: "success", title: "Plan copied as markdown" });
+    },
+    onError: (error) => {
+      toastManager.add({
+        type: "error",
+        title: "Could not copy plan",
+        description: error.message,
+      });
+    },
+  });
+
+  const handleCopy = () => {
+    copyToClipboard(markdown, undefined);
+  };
+
+  const handleDownload = () => {
+    const api = readNativeApi();
+    if (!api || !workspaceRoot) {
+      toastManager.add({
+        type: "error",
+        title: "Workspace path is unavailable",
+        description: "This thread does not have a workspace path to download into.",
+      });
+      return;
+    }
+
+    setIsDownloading(true);
+    void api.projects
+      .writeFile({
+        cwd: workspaceRoot,
+        relativePath: `.plan/${filename}`,
+        contents: markdown,
+      })
+      .then((result) => {
+        toastManager.add({
+          type: "success",
+          title: "Plan downloaded",
+          description: result.relativePath,
+        });
+      })
+      .catch((error) => {
+        toastManager.add({
+          type: "error",
+          title: "Could not download plan",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        });
+      })
+      .finally(() => setIsDownloading(false));
+  };
+
+  const handleExport = () => {
+    const api = readNativeApi();
+    if (!api) return;
+
+    if (!api.dialogs.saveFile) {
+      toastManager.add({
+        type: "error",
+        title: "Export is unavailable",
+        description: "Exporting plans requires the desktop app.",
+      });
+      return;
+    }
+
+    setIsExporting(true);
+    void api.dialogs
+      .saveFile({
+        defaultFilename: filename,
+        contents: markdown,
+        filters: [{ name: "Markdown", extensions: ["md"] }],
+      })
+      .then((filePath) => {
+        if (!filePath) return;
+        toastManager.add({
+          type: "success",
+          title: "Plan exported",
+          description: filePath,
+        });
+      })
+      .catch((error) => {
+        toastManager.add({
+          type: "error",
+          title: "Could not export plan",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        });
+      })
+      .finally(() => setIsExporting(false));
+  };
+
+  return (
+    <div className={cn("flex items-center gap-1", className)}>
+      <PlanActionButton
+        label="Download to .plan folder"
+        onClick={handleDownload}
+        variant={variant}
+        className={buttonClassName}
+        busy={isDownloading}
+      >
+        <ArrowDownIcon className={cn("size-3.5", iconClassName)} />
+      </PlanActionButton>
+      <PlanActionButton
+        label="Export markdown file"
+        onClick={handleExport}
+        variant={variant}
+        className={buttonClassName}
+        busy={isExporting}
+      >
+        <ArrowUpIcon className={cn("size-3.5", iconClassName)} />
+      </PlanActionButton>
+      <PlanActionButton
+        label={isCopied ? "Copied" : "Copy as markdown"}
+        onClick={handleCopy}
+        variant={variant}
+        className={buttonClassName}
+      >
+        <CopyIcon className={cn("size-3.5", iconClassName)} />
+      </PlanActionButton>
+    </div>
+  );
+});
+
+function PlanActionButton({
+  label,
+  onClick,
+  variant,
+  className,
+  busy = false,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  variant: PlanActionVariant;
+  className: string | undefined;
+  busy?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            aria-label={label}
+            className={cn("shrink-0", className)}
+            disabled={busy}
+            size="icon-xs"
+            variant={variant}
+            onClick={onClick}
+          />
+        }
+      >
+        {children}
+      </TooltipTrigger>
+      <TooltipPopup>{label}</TooltipPopup>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/chat/ProposedPlanCard.tsx
+++ b/apps/web/src/components/chat/ProposedPlanCard.tsx
@@ -1,30 +1,15 @@
-import { memo, useState, useId, type CSSProperties } from "react";
+import { memo, useState, type CSSProperties } from "react";
 import {
   buildCollapsedProposedPlanPreviewMarkdown,
-  buildProposedPlanMarkdownFilename,
-  downloadPlanAsTextFile,
-  normalizePlanMarkdownForExport,
   proposedPlanTitle,
   stripDisplayedPlanMarkdown,
 } from "../../proposedPlan";
 import ChatMarkdown from "../ChatMarkdown";
-import { EllipsisIcon } from "~/lib/icons";
 import { Button } from "../ui/button";
-import { Input } from "../ui/input";
-import { Menu, MenuItem, MenuPopup, MenuTrigger } from "../ui/menu";
 import { cn } from "~/lib/utils";
 import { Badge } from "../ui/badge";
-import {
-  Dialog,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogPanel,
-  DialogPopup,
-  DialogTitle,
-} from "../ui/dialog";
-import { toastManager } from "../ui/toast";
-import { readNativeApi } from "~/nativeApi";
+import { ProposedPlanActions } from "./ProposedPlanActions";
+
 export const ProposedPlanCard = memo(function ProposedPlanCard({
   planMarkdown,
   cwd,
@@ -37,10 +22,6 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
   chatTypographyStyle?: CSSProperties;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
-  const [savePath, setSavePath] = useState("");
-  const [isSavingToWorkspace, setIsSavingToWorkspace] = useState(false);
-  const savePathInputId = useId();
   const title = proposedPlanTitle(planMarkdown) ?? "Proposed plan";
   const lineCount = planMarkdown.split("\n").length;
   const canCollapse = planMarkdown.length > 900 || lineCount > 20;
@@ -48,72 +29,6 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
   const collapsedPreview = canCollapse
     ? buildCollapsedProposedPlanPreviewMarkdown(planMarkdown, { maxLines: 10 })
     : null;
-  const downloadFilename = buildProposedPlanMarkdownFilename(planMarkdown);
-  const saveContents = normalizePlanMarkdownForExport(planMarkdown);
-
-  const handleDownload = () => {
-    downloadPlanAsTextFile(downloadFilename, saveContents);
-  };
-
-  const openSaveDialog = () => {
-    if (!workspaceRoot) {
-      toastManager.add({
-        type: "error",
-        title: "Workspace path is unavailable",
-        description: "This thread does not have a workspace path to save into.",
-      });
-      return;
-    }
-    setSavePath((existing) => (existing.length > 0 ? existing : downloadFilename));
-    setIsSaveDialogOpen(true);
-  };
-
-  const handleSaveToWorkspace = () => {
-    const api = readNativeApi();
-    const relativePath = savePath.trim();
-    if (!api || !workspaceRoot) {
-      return;
-    }
-    if (!relativePath) {
-      toastManager.add({
-        type: "warning",
-        title: "Enter a workspace path",
-      });
-      return;
-    }
-
-    setIsSavingToWorkspace(true);
-    void api.projects
-      .writeFile({
-        cwd: workspaceRoot,
-        relativePath,
-        contents: saveContents,
-      })
-      .then((result) => {
-        setIsSaveDialogOpen(false);
-        toastManager.add({
-          type: "success",
-          title: "Plan saved to workspace",
-          description: result.relativePath,
-        });
-      })
-      .catch((error) => {
-        toastManager.add({
-          type: "error",
-          title: "Could not save plan",
-          description: error instanceof Error ? error.message : "An error occurred while saving.",
-        });
-      })
-      .then(
-        () => {
-          setIsSavingToWorkspace(false);
-        },
-        () => {
-          setIsSavingToWorkspace(false);
-        },
-      );
-  };
-
   return (
     <div className="rounded-[24px] border border-border/80 bg-card/70 p-4 sm:p-5">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -121,19 +36,7 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
           <Badge variant="secondary">Plan</Badge>
           <p className="truncate text-sm font-medium text-foreground">{title}</p>
         </div>
-        <Menu>
-          <MenuTrigger
-            render={<Button aria-label="Plan actions" size="icon-xs" variant="outline" />}
-          >
-            <EllipsisIcon aria-hidden="true" className="size-4" />
-          </MenuTrigger>
-          <MenuPopup align="end">
-            <MenuItem onClick={handleDownload}>Download as markdown</MenuItem>
-            <MenuItem onClick={openSaveDialog} disabled={!workspaceRoot || isSavingToWorkspace}>
-              Save to workspace
-            </MenuItem>
-          </MenuPopup>
-        </Menu>
+        <ProposedPlanActions planMarkdown={planMarkdown} workspaceRoot={workspaceRoot} />
       </div>
       <div className="mt-4">
         <div className={cn("relative", canCollapse && !expanded && "max-h-104 overflow-hidden")}>
@@ -169,54 +72,6 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
           </div>
         ) : null}
       </div>
-
-      <Dialog
-        open={isSaveDialogOpen}
-        onOpenChange={(open) => {
-          if (!isSavingToWorkspace) {
-            setIsSaveDialogOpen(open);
-          }
-        }}
-      >
-        <DialogPopup className="max-w-xl">
-          <DialogHeader>
-            <DialogTitle>Save plan to workspace</DialogTitle>
-            <DialogDescription>
-              Enter a path relative to <code>{workspaceRoot ?? "the workspace"}</code>.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogPanel className="space-y-3">
-            <label htmlFor={savePathInputId} className="grid gap-1.5">
-              <span className="text-xs font-medium text-foreground">Workspace path</span>
-              <Input
-                id={savePathInputId}
-                value={savePath}
-                onChange={(event) => setSavePath(event.target.value)}
-                placeholder={downloadFilename}
-                spellCheck={false}
-                disabled={isSavingToWorkspace}
-              />
-            </label>
-          </DialogPanel>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setIsSaveDialogOpen(false)}
-              disabled={isSavingToWorkspace}
-            >
-              Cancel
-            </Button>
-            <Button
-              size="sm"
-              onClick={() => void handleSaveToWorkspace()}
-              disabled={isSavingToWorkspace}
-            >
-              {isSavingToWorkspace ? "Saving..." : "Save"}
-            </Button>
-          </DialogFooter>
-        </DialogPopup>
-      </Dialog>
     </div>
   );
 });

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -289,6 +289,22 @@ export function createWsNativeApi(): NativeApi {
         if (!window.desktopBridge) return null;
         return window.desktopBridge.pickFolder();
       },
+      saveFile: async (input) => {
+        if (window.desktopBridge?.saveFile) {
+          return window.desktopBridge.saveFile(input);
+        }
+        const blob = new Blob([input.contents], { type: "text/markdown;charset=utf-8" });
+        const url = URL.createObjectURL(blob);
+        try {
+          const anchor = document.createElement("a");
+          anchor.href = url;
+          anchor.download = input.defaultFilename;
+          anchor.click();
+        } finally {
+          URL.revokeObjectURL(url);
+        }
+        return null;
+      },
       confirm: async (message) => {
         return showConfirmDialogFallback(message);
       },

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -227,6 +227,11 @@ export interface DesktopNotificationInput {
 export interface DesktopBridge {
   getWsUrl: () => string | null;
   pickFolder: () => Promise<string | null>;
+  saveFile?: (input: {
+    defaultFilename: string;
+    contents: string;
+    filters?: ReadonlyArray<{ name: string; extensions: ReadonlyArray<string> }>;
+  }) => Promise<string | null>;
   confirm: (message: string) => Promise<boolean>;
   setTheme: (theme: DesktopTheme) => Promise<void>;
   showContextMenu: <T extends string>(
@@ -277,6 +282,11 @@ export interface DesktopBridge {
 export interface NativeApi {
   dialogs: {
     pickFolder: () => Promise<string | null>;
+    saveFile?: (input: {
+      defaultFilename: string;
+      contents: string;
+      filters?: ReadonlyArray<{ name: string; extensions: ReadonlyArray<string> }>;
+    }) => Promise<string | null>;
     confirm: (message: string) => Promise<boolean>;
   };
   terminal: {


### PR DESCRIPTION
## Change description

Updates proposed plan actions so users can access each markdown operation directly instead of opening the ellipsis menu.

- Adds separate icon buttons with hover tooltips for:
  - copy markdown
  - download markdown into `.plan/` under the workspace
  - export markdown through the native file explorer/save dialog
- Shares the action UI between the inline proposed plan card and the plan sidebar.
- Copies/exports/downloads normalized markdown so all output paths match.
- Adds desktop save-file bridge plumbing for native export.

## Test results

- `bun fmt` completed.
- `bun lint` completed with existing warnings and 0 errors.
- `bun typecheck` passed.

## Deployment impact

No migration impact. Frontend/desktop bridge UX change only.

## Review focus

Please check:

- proposed-plan action layout and tooltips
- `.plan/<filename>.md` workspace download behavior
- native export save dialog behavior
- desktop bridge compatibility around optional `saveFile`

Relevant files:

- `apps/web/src/components/chat/ProposedPlanActions.tsx`
- `apps/web/src/components/chat/ProposedPlanCard.tsx`
- `apps/web/src/components/PlanSidebar.tsx`
- `apps/web/src/wsNativeApi.ts`
- `apps/desktop/src/main.ts`
- `apps/desktop/src/preload.ts`
- `packages/contracts/src/ipc.ts`
