### PR TITLE
Fix Cursor model discovery loading state

### DIFF
--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -66,7 +66,6 @@ import {
 import { makeAcpNativeLoggers } from "../acp/AcpNativeLogging.ts";
 import {
   applyCursorAcpModelSelection,
-  buildCursorAcpModelDescriptors,
   makeCursorAcpRuntime,
   parseCursorCliModelList,
   resolveCursorAcpBaseModelId,
@@ -1076,52 +1075,46 @@ export function makeCursorAdapter(
       const binaryPath = input.binaryPath?.trim();
       const apiEndpoint = input.apiEndpoint?.trim();
       const effectiveBinaryPath = binaryPath || cursorSettings.binaryPath || "agent";
+      const effectiveApiEndpoint = apiEndpoint || cursorSettings.apiEndpoint;
       const runCursorModelListCommand = Effect.gen(function* () {
         const child = yield* childProcessSpawner.spawn(
-          ChildProcess.make(effectiveBinaryPath, ["models"], {
-            shell: process.platform === "win32",
-            env: process.env,
-          }),
+          ChildProcess.make(
+            effectiveBinaryPath,
+            [...(effectiveApiEndpoint ? (["-e", effectiveApiEndpoint] as const) : []), "models"],
+            {
+              shell: process.platform === "win32",
+              env: process.env,
+            },
+          ),
         );
-        const [stdout, exitCode] = yield* Effect.all(
-          [collectStreamAsString(child.stdout), child.exitCode.pipe(Effect.map(Number))],
+        const [stdout, stderr, exitCode] = yield* Effect.all(
+          [
+            collectStreamAsString(child.stdout),
+            collectStreamAsString(child.stderr),
+            child.exitCode.pipe(Effect.map(Number)),
+          ],
           { concurrency: "unbounded" },
         );
-        return exitCode === 0 ? parseCursorCliModelList(stdout) : [];
+        if (exitCode !== 0) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "model/list",
+            detail:
+              stderr.trim() ||
+              `Cursor model discovery failed because '${effectiveBinaryPath} models' exited with code ${exitCode}.`,
+          });
+        }
+        const models = parseCursorCliModelList(stdout);
+        if (models.length === 0) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "model/list",
+            detail: "Cursor model discovery returned no CLI models.",
+          });
+        }
+        return models;
       }).pipe(
         Effect.scoped,
-        Effect.catch(() => Effect.succeed([] as ProviderListModelsResult["models"])),
-      );
-      const discovery = Effect.scoped(
-        Effect.gen(function* () {
-          const acp = yield* makeCursorAcpRuntime({
-            cursorSettings: {
-              ...(cursorSettings.binaryPath !== undefined
-                ? { binaryPath: cursorSettings.binaryPath }
-                : {}),
-              ...(cursorSettings.apiEndpoint !== undefined
-                ? { apiEndpoint: cursorSettings.apiEndpoint }
-                : {}),
-              ...(binaryPath ? { binaryPath } : {}),
-              ...(apiEndpoint ? { apiEndpoint } : {}),
-            },
-            childProcessSpawner,
-            cwd: serverConfig.cwd || serverConfig.homeDir,
-            clientInfo: { name: "t3-code", version: "0.0.0" },
-          });
-          yield* acp.start();
-          const acpModels = buildCursorAcpModelDescriptors(yield* acp.getConfigOptions);
-          const cliModels = yield* runCursorModelListCommand;
-          const models = cliModels.length > 0 ? cliModels : acpModels;
-          return {
-            models,
-            source: cliModels.length > 0 ? "cursor.cli" : "cursor.acp",
-            cached: false,
-          } satisfies ProviderListModelsResult;
-        }),
-      );
-
-      return discovery.pipe(
         Effect.timeoutOption(CURSOR_MODEL_DISCOVERY_TIMEOUT_MS),
         Effect.flatMap(
           Option.match({
@@ -1130,19 +1123,31 @@ export function makeCursorAdapter(
                 new ProviderAdapterRequestError({
                   provider: PROVIDER,
                   method: "model/list",
-                  detail: "Timed out while discovering Cursor models via ACP.",
+                  detail: "Timed out while discovering Cursor models via CLI.",
                 }),
               ),
-            onSome: (result) => Effect.succeed(result),
+            onSome: (models) => Effect.succeed(models),
           }),
         ),
+      );
+      const discovery =
+        Effect.gen(function* () {
+          const cliModels = yield* runCursorModelListCommand;
+          return {
+            models: cliModels,
+            source: "cursor.cli",
+            cached: false,
+          } satisfies ProviderListModelsResult;
+        });
+
+      return discovery.pipe(
         Effect.mapError((cause) =>
           cause instanceof ProviderAdapterRequestError
             ? cause
             : new ProviderAdapterRequestError({
                 provider: PROVIDER,
                 method: "model/list",
-                detail: "Failed to discover Cursor models via ACP.",
+                detail: "Failed to discover Cursor models via CLI.",
                 cause,
               }),
         ),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -189,8 +189,10 @@ import {
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  CircleAlertIcon,
   EllipsisIcon,
   QueueArrow,
+  RefreshCwIcon,
   Trash2,
   XIcon,
 } from "~/lib/icons";
@@ -667,6 +669,48 @@ function ComposerControlSkeleton(props: { widthClassName: string }) {
     >
       <Skeleton className="h-3.5 w-full rounded-full" />
     </div>
+  );
+}
+
+function ComposerModelLoadingControl(props: { widthClassName: string }) {
+  return (
+    <div
+      aria-label="Loading models"
+      className={cn(
+        "flex h-8 shrink-0 items-center gap-2 rounded-md border border-border/50 px-2 text-muted-foreground",
+        props.widthClassName,
+      )}
+    >
+      <RefreshCwIcon aria-hidden="true" className="size-3.5 animate-spin" />
+      <span className="truncate text-[length:var(--app-font-size-ui-xs,11px)]">Loading models</span>
+    </div>
+  );
+}
+
+function ComposerModelErrorControl(props: {
+  widthClassName: string;
+  onRetry: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className={cn(
+        "h-8 shrink-0 justify-start gap-2 px-2 text-destructive hover:text-destructive",
+        props.widthClassName,
+      )}
+      disabled={props.disabled ?? false}
+      onClick={props.onRetry}
+    >
+      {props.disabled ? (
+        <RefreshCwIcon aria-hidden="true" className="size-3.5 animate-spin" />
+      ) : (
+        <CircleAlertIcon aria-hidden="true" className="size-3.5" />
+      )}
+      <span className="truncate text-[length:var(--app-font-size-ui-xs,11px)]">Retry models</span>
+    </Button>
   );
 }
 
@@ -1306,6 +1350,21 @@ export default function ChatView({
         : collapseCursorModelVariants(cursorDynamicModelsQuery.data?.models ?? []),
     [cursorDynamicModelsQuery.data?.models, showExpandedCursorModelVariants],
   );
+  const cursorModelDiscoveryEnabled = selectedProvider === "cursor" || lockedProvider === "cursor";
+  const hasResolvedCursorModelDiscovery =
+    cursorDynamicModelsQuery.data?.source === "cursor.cli" &&
+    (cursorDynamicModelsQuery.data.models.length ?? 0) > 0;
+  const cursorModelDiscoveryPending =
+    cursorModelDiscoveryEnabled &&
+    !hasResolvedCursorModelDiscovery &&
+    (cursorDynamicModelsQuery.isLoading || cursorDynamicModelsQuery.isFetching);
+  const cursorModelDiscoveryError =
+    cursorModelDiscoveryEnabled &&
+    !cursorModelDiscoveryPending &&
+    !hasResolvedCursorModelDiscovery &&
+    cursorDynamicModelsQuery.isError
+      ? cursorDynamicModelsQuery.error
+      : null;
   const modelOptionsByProvider = useMemo(() => {
     const staticOptions: Record<ProviderKind, ReturnType<typeof getAppModelOptions>> = {
       codex: getAppModelOptions(
@@ -1452,9 +1511,11 @@ export default function ChatView({
     composerDraft.modelSelectionByProvider[selectedProvider] ?? null;
   const selectedProviderModelsQuery = providerModelsQueryByProvider[selectedProvider];
   const providerModelsLoading =
-    selectedProviderModelsQuery !== undefined &&
-    (selectedProviderModelsQuery.isLoading ||
-      (selectedProviderModelsQuery.isFetching && selectedProviderModelsQuery.data === undefined));
+    selectedProvider === "cursor"
+      ? cursorModelDiscoveryPending
+      : selectedProviderModelsQuery !== undefined &&
+        (selectedProviderModelsQuery.isLoading ||
+          (selectedProviderModelsQuery.isFetching && selectedProviderModelsQuery.data === undefined));
   const showComposerModelBootstrapSkeleton = shouldShowComposerModelBootstrapSkeleton({
     selectedProvider,
     selectedModel,
@@ -5868,8 +5929,22 @@ export default function ChatView({
     shortcutLabel: traitsPickerShortcutLabel,
     onPromptChange: setPromptFromTraits,
   });
-  const composerModelPickerControl = showComposerModelBootstrapSkeleton ? (
-    <ComposerControlSkeleton widthClassName={isComposerFooterCompact ? "w-28" : "w-32 sm:w-36"} />
+  const composerModelPickerWidthClassName = isComposerFooterCompact ? "w-28" : "w-32 sm:w-36";
+  const composerTraitsPickerWidthClassName = isComposerFooterCompact ? "w-16" : "w-20";
+  const composerModelPickerControl = cursorModelDiscoveryError ? (
+    <ComposerModelErrorControl
+      widthClassName={composerModelPickerWidthClassName}
+      disabled={cursorDynamicModelsQuery.isFetching}
+      onRetry={() => {
+        void cursorDynamicModelsQuery.refetch();
+      }}
+    />
+  ) : showComposerModelBootstrapSkeleton ? (
+    cursorModelDiscoveryPending ? (
+      <ComposerModelLoadingControl widthClassName={composerModelPickerWidthClassName} />
+    ) : (
+      <ComposerControlSkeleton widthClassName={composerModelPickerWidthClassName} />
+    )
   ) : (
     <ProviderModelPicker
       compact={isComposerFooterCompact}
@@ -5889,8 +5964,12 @@ export default function ChatView({
       onProviderModelChange={onProviderModelSelect}
     />
   );
-  const composerTraitsPickerControl = showComposerModelBootstrapSkeleton ? (
-    <ComposerControlSkeleton widthClassName={isComposerFooterCompact ? "w-16" : "w-20"} />
+  const composerTraitsPickerControl = cursorModelDiscoveryError ? null : showComposerModelBootstrapSkeleton ? (
+    cursorModelDiscoveryPending ? (
+      <ComposerModelLoadingControl widthClassName={composerTraitsPickerWidthClassName} />
+    ) : (
+      <ComposerControlSkeleton widthClassName={composerTraitsPickerWidthClassName} />
+    )
   ) : (
     providerTraitsPicker
   );

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -145,6 +145,7 @@ export function providerModelsQueryOptions(input: {
       });
     },
     enabled: input.enabled ?? true,
+    retry: input.provider === "cursor" ? 1 : 3,
     staleTime: 60_000,
     placeholderData: (previous) => previous ?? EMPTY_MODELS_RESULT,
   });


### PR DESCRIPTION
## Summary

- require Cursor CLI model discovery to return the full CLI model list instead of falling back to the short ACP model set
- show a loading state while Cursor models are still being discovered
- show a retry control when initial Cursor model discovery fails

## Validation

- bun run --cwd apps/server test src/provider/acp/CursorAcpSupport.test.ts
- bun run --cwd apps/web test src/components/ChatView.logic.test.ts src/cursorModelVariants.test.ts
