### PR TITLE
[codex] Fix legacy schema reconciliation

### DIFF
--- a/apps/server/src/persistence/Migrations/032_ReconcileLegacyT3SchemaImport.test.ts
+++ b/apps/server/src/persistence/Migrations/032_ReconcileLegacyT3SchemaImport.test.ts
@@ -17,13 +17,18 @@ const projectionThreadMessagesColumnNames = (sql: SqlClient.SqlClient) =>
     SELECT name FROM pragma_table_info('projection_thread_messages')
   `.pipe(Effect.map((rows) => rows.map((row) => row.name)));
 
+const projectionProjectsColumnNames = (sql: SqlClient.SqlClient) =>
+  sql<{ readonly name: string }>`
+    SELECT name FROM pragma_table_info('projection_projects')
+  `.pipe(Effect.map((rows) => rows.map((row) => row.name)));
+
 layer("032_ReconcileLegacyT3SchemaImport", (it) => {
   // Simulates a legacy ~/.t3 import where the imported `effect_sql_migrations`
-  // tracker has IDs 17-31 recorded under unrelated T3 Code names. The 17-23
+  // tracker has IDs 17-31 recorded under unrelated T3 Code names. The 17-31
   // body never ran, so the columns those migrations would have added are
   // missing. Without #032, the server crashes on the first SELECT that
   // references env_mode.
-  it.effect("heals an imported T3 Code DB whose tracker skipped 17-23", () =>
+  it.effect("heals an imported T3 Code DB whose tracker skipped 17-31", () =>
     Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient;
 
@@ -79,12 +84,92 @@ layer("032_ReconcileLegacyT3SchemaImport", (it) => {
           'Legacy thread',
           'feature/legacy',
           '/tmp/legacy-worktree',
-          NULL,
+          'turn-1',
           '2026-01-01T00:00:00.000Z',
           '2026-01-01T00:00:00.000Z',
           NULL,
           'full-access',
           'default'
+        )
+      `;
+      yield* sql`
+        INSERT INTO projection_thread_messages (
+          message_id,
+          thread_id,
+          turn_id,
+          role,
+          text,
+          is_streaming,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          'message-user-1',
+          'thread-legacy',
+          'turn-1',
+          'user',
+          'Please make this change',
+          0,
+          '2026-01-01T00:00:01.000Z',
+          '2026-01-01T00:00:01.000Z'
+        )
+      `;
+      yield* sql`
+        INSERT INTO projection_thread_activities (
+          activity_id,
+          thread_id,
+          turn_id,
+          tone,
+          kind,
+          summary,
+          payload_json,
+          created_at,
+          sequence
+        )
+        VALUES
+          (
+            'activity-approval-1',
+            'thread-legacy',
+            'turn-1',
+            'info',
+            'approval.requested',
+            'Approval requested',
+            '{"requestId":"approval-1"}',
+            '2026-01-01T00:00:02.000Z',
+            1
+          ),
+          (
+            'activity-input-1',
+            'thread-legacy',
+            'turn-1',
+            'info',
+            'user-input.requested',
+            'User input requested',
+            '{"requestId":"input-1"}',
+            '2026-01-01T00:00:03.000Z',
+            2
+          )
+      `;
+      yield* sql`
+        INSERT INTO projection_thread_proposed_plans (
+          plan_id,
+          thread_id,
+          turn_id,
+          plan_markdown,
+          created_at,
+          updated_at,
+          implemented_at,
+          implementation_thread_id
+        )
+        VALUES (
+          'plan-1',
+          'thread-legacy',
+          'turn-1',
+          '- Do the thing',
+          '2026-01-01T00:00:04.000Z',
+          '2026-01-01T00:00:04.000Z',
+          NULL,
+          NULL
         )
       `;
 
@@ -97,6 +182,7 @@ layer("032_ReconcileLegacyT3SchemaImport", (it) => {
 
       const afterThreadsColumns = yield* projectionThreadsColumnNames(sql);
       const afterMessagesColumns = yield* projectionThreadMessagesColumnNames(sql);
+      const afterProjectsColumns = yield* projectionProjectsColumnNames(sql);
 
       // #017 + #018 columns
       assert.include(afterThreadsColumns, "handoff_json");
@@ -111,6 +197,22 @@ layer("032_ReconcileLegacyT3SchemaImport", (it) => {
       assert.include(afterThreadsColumns, "associated_worktree_branch");
       assert.include(afterThreadsColumns, "associated_worktree_ref");
 
+      // #024-#031 columns can be skipped by the same max-ID gate and must be
+      // healed before read-model queries touch them on startup.
+      assert.include(afterThreadsColumns, "archived_at");
+      assert.include(afterThreadsColumns, "parent_thread_id");
+      assert.include(afterThreadsColumns, "subagent_agent_id");
+      assert.include(afterThreadsColumns, "subagent_nickname");
+      assert.include(afterThreadsColumns, "subagent_role");
+      assert.include(afterThreadsColumns, "latest_user_message_at");
+      assert.include(afterThreadsColumns, "pending_approval_count");
+      assert.include(afterThreadsColumns, "pending_user_input_count");
+      assert.include(afterThreadsColumns, "has_actionable_proposed_plan");
+      assert.include(afterProjectsColumns, "kind");
+      assert.include(afterThreadsColumns, "last_known_pr_json");
+      assert.include(afterMessagesColumns, "dispatch_mode");
+      assert.include(afterThreadsColumns, "create_branch_flow_completed");
+
       // Data-rewrite branches: env_mode derived from worktree_path,
       // associated_* mirrored from existing branch / worktree fields.
       const [seeded] = yield* sql<{
@@ -118,8 +220,20 @@ layer("032_ReconcileLegacyT3SchemaImport", (it) => {
         readonly associated_worktree_path: string | null;
         readonly associated_worktree_branch: string | null;
         readonly associated_worktree_ref: string | null;
+        readonly latest_user_message_at: string | null;
+        readonly pending_approval_count: number;
+        readonly pending_user_input_count: number;
+        readonly has_actionable_proposed_plan: number;
       }>`
-        SELECT env_mode, associated_worktree_path, associated_worktree_branch, associated_worktree_ref
+        SELECT
+          env_mode,
+          associated_worktree_path,
+          associated_worktree_branch,
+          associated_worktree_ref,
+          latest_user_message_at,
+          pending_approval_count,
+          pending_user_input_count,
+          has_actionable_proposed_plan
         FROM projection_threads
         WHERE thread_id = 'thread-legacy'
       `;
@@ -127,6 +241,17 @@ layer("032_ReconcileLegacyT3SchemaImport", (it) => {
       assert.strictEqual(seeded?.associated_worktree_path, "/tmp/legacy-worktree");
       assert.strictEqual(seeded?.associated_worktree_branch, "feature/legacy");
       assert.strictEqual(seeded?.associated_worktree_ref, "feature/legacy");
+      assert.strictEqual(seeded?.latest_user_message_at, "2026-01-01T00:00:01.000Z");
+      assert.strictEqual(seeded?.pending_approval_count, 1);
+      assert.strictEqual(seeded?.pending_user_input_count, 1);
+      assert.strictEqual(seeded?.has_actionable_proposed_plan, 1);
+
+      const [pendingApproval] = yield* sql<{ readonly status: string }>`
+        SELECT status
+        FROM projection_pending_approvals
+        WHERE request_id = 'approval-1'
+      `;
+      assert.strictEqual(pendingApproval?.status, "pending");
     }),
   );
 
@@ -147,7 +272,9 @@ layer("032_ReconcileLegacyT3SchemaImport", (it) => {
       // confirming #032 didn't try to ADD COLUMN on top of existing ones.
       assert.include(threadsColumns, "env_mode");
       assert.include(threadsColumns, "associated_worktree_ref");
+      assert.include(threadsColumns, "create_branch_flow_completed");
       assert.include(messagesColumns, "skills_json");
+      assert.include(messagesColumns, "dispatch_mode");
     }),
   );
 });

--- a/apps/server/src/persistence/Migrations/032_ReconcileLegacyT3SchemaImport.ts
+++ b/apps/server/src/persistence/Migrations/032_ReconcileLegacyT3SchemaImport.ts
@@ -1,8 +1,8 @@
 /**
  * Reconciles schema after a legacy ~/.t3 import where the imported
- * `effect_sql_migrations` tracker already records IDs 17–23 under unrelated
+ * `effect_sql_migrations` tracker already records IDs 17-31 under unrelated
  * T3 Code names. Because the migrator skips by ID, the renumbered DP Code
- * migrations 17–23 never run on those imports, leaving columns like
+ * migrations 17-31 never run on those imports, leaving columns like
  * `env_mode` missing and crashing the server on first query.
  *
  * Migration #023 previously held this self-healing logic, but legacy DBs
@@ -11,10 +11,12 @@
  * any T3 Code migration, guaranteeing it runs on import.
  *
  * Idempotent and a no-op for fresh DP Code installs (every column already
- * exists from the in-order runs of 17–23).
+ * exists from the in-order runs of 17-31).
  */
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as Effect from "effect/Effect";
+
+import BackfillProjectionThreadShellSummary from "./027_BackfillProjectionThreadShellSummary.ts";
 
 export default Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
@@ -44,6 +46,27 @@ export default Effect.gen(function* () {
       }
       yield* sql.unsafe(`
         ALTER TABLE projection_threads
+        ADD COLUMN ${definition}
+      `);
+      return true;
+    });
+
+  const ensureProjectionProjectsColumn = (columnName: string, definition: string) =>
+    Effect.gen(function* () {
+      const exists = yield* sql<{ readonly exists: number }>`
+        SELECT EXISTS(
+          SELECT 1
+          FROM pragma_table_info('projection_projects')
+          WHERE name = ${columnName}
+        ) AS "exists"
+      `.pipe(Effect.map(([row]) => row?.exists === 1));
+
+      if (exists) {
+        return false;
+      }
+
+      yield* sql.unsafe(`
+        ALTER TABLE projection_projects
         ADD COLUMN ${definition}
       `);
       return true;
@@ -118,4 +141,47 @@ export default Effect.gen(function* () {
         AND COALESCE(associated_worktree_branch, branch) IS NOT NULL
     `;
   }
+
+  yield* ensureProjectionThreadsColumn("archived_at", "archived_at TEXT");
+  yield* ensureProjectionThreadsColumn("parent_thread_id", "parent_thread_id TEXT");
+  yield* ensureProjectionThreadsColumn("subagent_agent_id", "subagent_agent_id TEXT");
+  yield* ensureProjectionThreadsColumn("subagent_nickname", "subagent_nickname TEXT");
+  yield* ensureProjectionThreadsColumn("subagent_role", "subagent_role TEXT");
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_threads_parent_thread_id
+    ON projection_threads(parent_thread_id)
+  `;
+
+  const addedLatestUserMessageAt = yield* ensureProjectionThreadsColumn(
+    "latest_user_message_at",
+    "latest_user_message_at TEXT",
+  );
+  const addedPendingApprovalCount = yield* ensureProjectionThreadsColumn(
+    "pending_approval_count",
+    "pending_approval_count INTEGER NOT NULL DEFAULT 0",
+  );
+  const addedPendingUserInputCount = yield* ensureProjectionThreadsColumn(
+    "pending_user_input_count",
+    "pending_user_input_count INTEGER NOT NULL DEFAULT 0",
+  );
+  const addedHasActionableProposedPlan = yield* ensureProjectionThreadsColumn(
+    "has_actionable_proposed_plan",
+    "has_actionable_proposed_plan INTEGER NOT NULL DEFAULT 0",
+  );
+  if (
+    addedLatestUserMessageAt ||
+    addedPendingApprovalCount ||
+    addedPendingUserInputCount ||
+    addedHasActionableProposedPlan
+  ) {
+    yield* BackfillProjectionThreadShellSummary;
+  }
+
+  yield* ensureProjectionProjectsColumn("kind", "kind TEXT NOT NULL DEFAULT 'project'");
+  yield* ensureProjectionThreadsColumn("last_known_pr_json", "last_known_pr_json TEXT");
+  yield* ensureProjectionThreadMessagesColumn("dispatch_mode", "dispatch_mode TEXT");
+  yield* ensureProjectionThreadsColumn(
+    "create_branch_flow_completed",
+    "create_branch_flow_completed INTEGER NOT NULL DEFAULT 0",
+  );
 });


### PR DESCRIPTION
## Summary\n\n- extend migration 032 so legacy T3 imports reconcile skipped DP Code migrations 24-31\n- rerun the existing projection thread shell-summary backfill when 032 adds those summary columns\n- expand the migration regression test to cover pending approvals, user-input counts, actionable plans, project kind, dispatch mode, and create-branch completion columns\n\n## Root cause\n\nLegacy imported databases can already have migration IDs 17-31 recorded under old T3 Code names. DP Code then skips its own migrations with those IDs, leaving columns and denormalized sidebar state missing after update.\n\n## Validation\n\n- `cd apps/server && bun run test src/persistence/Migrations/032_ReconcileLegacyT3SchemaImport.test.ts`\n\nCloses #80