### PR TITLE
Add dpcode branch naming and assistant item reuse

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -222,22 +222,39 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           checkpoint_status,
           checkpoint_files_json
         )
-        VALUES (
-          'thread-1',
-          'turn-1',
-          NULL,
-          'thread-1',
-          'plan-1',
-          'message-1',
-          'completed',
-          '2026-02-24T00:00:08.000Z',
-          '2026-02-24T00:00:08.000Z',
-          '2026-02-24T00:00:08.000Z',
-          1,
-          'checkpoint-1',
-          'ready',
-          '[{"path":"README.md","kind":"modified","additions":2,"deletions":1}]'
-        )
+        VALUES
+          (
+            'thread-1',
+            'turn-1',
+            NULL,
+            'thread-1',
+            'plan-1',
+            'message-1',
+            'completed',
+            '2026-02-24T00:00:08.000Z',
+            '2026-02-24T00:00:08.000Z',
+            '2026-02-24T00:00:08.000Z',
+            1,
+            'checkpoint-1',
+            'ready',
+            '[{"path":"README.md","kind":"modified","additions":2,"deletions":1}]'
+          ),
+          (
+            'thread-1',
+            'turn-placeholder',
+            NULL,
+            NULL,
+            NULL,
+            NULL,
+            'running',
+            '2026-02-24T00:00:07.500Z',
+            '2026-02-24T00:00:07.500Z',
+            NULL,
+            2,
+            'provider-diff:placeholder',
+            'missing',
+            '[]'
+          )
       `;
 
       let sequence = 5;

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2071,6 +2071,98 @@ describe("ProviderRuntimeIngestion", () => {
     expect(assistantMessages[0]?.text).toBe("Come together");
   });
 
+  it("reuses the live assistant message when item.completed supplies a late item id", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-late-completion-item-id"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("message-late-completion-item-id"),
+          role: "user",
+          text: "stream please",
+          attachments: [],
+        },
+        assistantDeliveryMode: "streaming",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await harness.drain();
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-late-completion-item-id"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-late-completion-item-id"),
+    });
+
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" &&
+        thread.session?.activeTurnId === "turn-late-completion-item-id",
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-assistant-delta-late-completion-item-id"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-late-completion-item-id"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "same answer",
+      },
+    });
+
+    await waitForThread(harness.engine, (thread) =>
+      thread.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:turn-late-completion-item-id" &&
+          message.streaming &&
+          message.text === "same answer",
+      ),
+    );
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-assistant-completed-late-completion-item-id"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-late-completion-item-id"),
+      itemId: asItemId("item-late-completion-item-id"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "same answer",
+      },
+    });
+
+    const finalizedThread = await waitForThread(harness.engine, (thread) =>
+      thread.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:turn-late-completion-item-id" && !message.streaming,
+      ),
+    );
+
+    const assistantMessages = finalizedThread.messages.filter(
+      (message: ProviderRuntimeTestMessage) =>
+        message.role === "assistant" && message.turnId === "turn-late-completion-item-id",
+    );
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0]?.id).toBe("assistant:turn-late-completion-item-id");
+    expect(assistantMessages[0]?.text).toBe("same answer");
+  });
+
   it("maps canonical request events into approval activities with requestKind", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1032,10 +1032,6 @@ const make = Effect.gen(function* () {
     turnId?: TurnId;
   }) =>
     Effect.gen(function* () {
-      if (input.event.itemId) {
-        return MessageId.makeUnsafe(`assistant:${input.event.itemId}`);
-      }
-
       if (input.turnId) {
         const knownAssistantMessageIds = yield* getAssistantMessageIdsForTurn(
           input.thread.id,
@@ -1072,7 +1068,13 @@ const make = Effect.gen(function* () {
             return preferredKnownMessage.id;
           }
         }
-        return MessageId.makeUnsafe(`assistant:${input.turnId}`);
+        return input.event.itemId
+          ? MessageId.makeUnsafe(`assistant:${input.event.itemId}`)
+          : MessageId.makeUnsafe(`assistant:${input.turnId}`);
+      }
+
+      if (input.event.itemId) {
+        return MessageId.makeUnsafe(`assistant:${input.event.itemId}`);
       }
 
       return MessageId.makeUnsafe(`assistant:${input.event.eventId}`);

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -7,7 +7,7 @@ import {
   type ThreadId as ThreadIdType,
 } from "@t3tools/contracts";
 import { normalizeModelSlug } from "@t3tools/shared/model";
-import { sanitizeBranchFragment } from "@t3tools/shared/git";
+import { buildDpcodeBranchName } from "@t3tools/shared/git";
 import { isGenericChatThreadTitle } from "@t3tools/shared/chatThreads";
 import { isGenericTerminalThreadTitle } from "@t3tools/shared/terminalThreads";
 import {
@@ -32,7 +32,6 @@ import { hasLiveTurnTailWork, type WorkLogEntry } from "../session-logic";
 import { localSubagentThreadId } from "./ChatView.selectors";
 
 export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "dpcode:last-invoked-script-by-project";
-const WORKTREE_NAME_PREFIX = "dpcode";
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 
@@ -356,15 +355,7 @@ export function buildSuggestedWorktreeName(input: {
   associatedWorktreeBranch?: string | null;
   title?: string | null;
 }): string {
-  const normalizedExisting =
-    input.associatedWorktreeBranch?.trim().replace(/^(codex|t3code|dpcode)\//i, "") ?? "";
-  const preferred =
-    normalizedExisting ||
-    `${WORKTREE_NAME_PREFIX}/${sanitizeBranchFragment(input.title ?? "update")}`;
-  const normalized = preferred.toLowerCase();
-  return normalized.startsWith(`${WORKTREE_NAME_PREFIX}/`)
-    ? normalized
-    : `${WORKTREE_NAME_PREFIX}/${sanitizeBranchFragment(normalized)}`;
+  return buildDpcodeBranchName(input.associatedWorktreeBranch ?? input.title);
 }
 
 export function cloneComposerImageForRetry(

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -6,6 +6,7 @@ import {
   requiresFeatureBranchForDefaultBranchAction,
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
+  resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveLiveThreadBranchUpdate,
   resolveQuickAction,
@@ -1190,6 +1191,36 @@ describe("resolveAutoFeatureBranchName", () => {
   it("falls back to feature/update when no preferred name is provided", () => {
     const branch = resolveAutoFeatureBranchName(["main"]);
     assert.equal(branch, "feature/update");
+  });
+});
+
+describe("resolveDefaultCreateBranchName", () => {
+  it("uses dpcode as the default namespace", () => {
+    const branch = resolveDefaultCreateBranchName(["main"], "fix toast copy");
+    assert.equal(branch, "dpcode/fix-toast-copy");
+  });
+
+  it("keeps an existing dpcode namespace", () => {
+    const branch = resolveDefaultCreateBranchName(["main"], "dpcode/refine-toolbar-actions");
+    assert.equal(branch, "dpcode/refine-toolbar-actions");
+  });
+
+  it("preserves nested namespaces under dpcode", () => {
+    const branch = resolveDefaultCreateBranchName(["main"], "feature/refine-toolbar-actions");
+    assert.equal(branch, "dpcode/feature/refine-toolbar-actions");
+  });
+
+  it("increments suffix when the dpcode branch already exists", () => {
+    const branch = resolveDefaultCreateBranchName(
+      ["main", "dpcode/fix-toast-copy", "dpcode/fix-toast-copy-2"],
+      "fix toast copy",
+    );
+    assert.equal(branch, "dpcode/fix-toast-copy-3");
+  });
+
+  it("falls back to dpcode/update when no preferred name is provided", () => {
+    const branch = resolveDefaultCreateBranchName(["main"]);
+    assert.equal(branch, "dpcode/update");
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -3,7 +3,10 @@ import type {
   GitStackedAction,
   GitStatusResult,
 } from "@t3tools/contracts";
-import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
+import {
+  isTemporaryWorktreeBranch,
+  resolveUniqueDpcodeBranchName,
+} from "@t3tools/shared/git";
 
 export type GitActionIconName = "commit" | "push" | "pr";
 
@@ -60,6 +63,13 @@ function truncateText(
   if (value.length <= maxLength) return value;
   if (maxLength <= 3) return "...".slice(0, maxLength);
   return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+export function resolveDefaultCreateBranchName(
+  existingBranchNames: readonly string[],
+  preferredBranch?: string,
+): string {
+  return resolveUniqueDpcodeBranchName(existingBranchNames, preferredBranch);
 }
 
 export function buildGitActionProgressStages(input: {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -28,6 +28,7 @@ import {
   requiresFeatureBranchForDefaultBranchAction,
   requiresDefaultBranchConfirmation,
   resolveLiveThreadBranchUpdate,
+  resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveQuickAction,
   shouldOfferCreateBranchPrompt,
@@ -117,11 +118,11 @@ interface RunGitActionWithToastInput {
 }
 
 interface GitPickerMenuItem {
-  id: "push" | "pr" | "sync" | "commit";
+  id: "push" | "pr" | "sync" | "commit" | "create_branch";
   label: string;
   disabled: boolean;
   disabledReason: string | null;
-  icon: GitActionIconName | "sync";
+  icon: GitActionIconName | "sync" | "branch";
   onSelect: () => void;
 }
 
@@ -229,7 +230,8 @@ function GitActionItemIcon({ icon }: { icon: GitActionIconName }) {
   return <GitHubIcon />;
 }
 
-function GitPickerItemIcon({ icon }: { icon: GitActionIconName | "sync" }) {
+function GitPickerItemIcon({ icon }: { icon: GitActionIconName | "sync" | "branch" }) {
+  if (icon === "branch") return <GoGitBranch />;
   if (icon === "sync") return <RefreshCwIcon />;
   if (icon === "pr") return <GitHubIcon />;
   return <GitActionItemIcon icon={icon} />;
@@ -390,9 +392,21 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
   }, [activeThread?.createBranchFlowCompleted, activeThread?.worktreePath, gitStatusForActions]);
   const currentBranchName =
     gitStatusForActions?.branch ?? currentBranch ?? activeThread?.branch ?? null;
+  const existingBranchNames = useMemo(
+    () => (branchList?.branches ?? []).map((branch) => branch.name),
+    [branchList?.branches],
+  );
+  const branchNames = useMemo(
+    () => new Set(existingBranchNames.map((branchName) => branchName.toLowerCase())),
+    [existingBranchNames],
+  );
   const suggestedCreateBranchName = useMemo(
-    () => activeThread?.associatedWorktreeBranch ?? currentBranchName ?? "",
-    [activeThread?.associatedWorktreeBranch, currentBranchName],
+    () =>
+      resolveDefaultCreateBranchName(
+        existingBranchNames,
+        activeThread?.associatedWorktreeBranch ?? activeThread?.title,
+      ),
+    [activeThread?.associatedWorktreeBranch, activeThread?.title, existingBranchNames],
   );
 
   const quickAction = useMemo(
@@ -855,10 +869,6 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
     setIsCommitDialogOpen(true);
   }, []);
 
-  const branchNames = useMemo(
-    () => new Set((branchList?.branches ?? []).map((b) => b.name.toLowerCase())),
-    [branchList?.branches],
-  );
   const normalizedCurrentBranchName = currentBranchName?.trim().toLowerCase() ?? "";
   const normalizedCreateBranchName = createBranchName.trim().toLowerCase();
   const createBranchNameConflicts =
@@ -996,6 +1006,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
     const commitMenuItem = gitActionMenuItems.find((item) => item.id === "commit");
     const pushMenuItem = gitActionMenuItems.find((item) => item.id === "push");
     const prMenuItem = gitActionMenuItems.find((item) => item.id === "pr");
+    const createBranchDisabled = isGitActionRunning || !gitStatusForActions;
 
     if (commitMenuItem) {
       items.push({
@@ -1045,12 +1056,26 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
       });
     }
 
+    items.push({
+      id: "create_branch",
+      label: "Create Branch",
+      disabled: createBranchDisabled,
+      disabledReason: createBranchDisabled
+        ? isGitActionRunning
+          ? "Git action in progress."
+          : "Git status is unavailable."
+        : null,
+      icon: "branch",
+      onSelect: openCreateBranchDialog,
+    });
+
     return items;
   }, [
     gitActionMenuItems,
     gitStatusForActions,
     hasOriginRemote,
     isGitActionRunning,
+    openCreateBranchDialog,
     openDialogForMenuItem,
   ]);
 
@@ -1450,7 +1475,8 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
           <DialogHeader>
             <DialogTitle>Create Branch</DialogTitle>
             <DialogDescription>
-              Create a permanent branch for this worktree. The temporary branch will be replaced.
+              Create and switch to a branch from the current HEAD. Future commits, pushes, and PRs
+              will use it.
             </DialogDescription>
           </DialogHeader>
           <DialogPanel className="space-y-3">

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   WORKTREE_BRANCH_PREFIX,
+  buildDpcodeBranchName,
   buildTemporaryWorktreeBranchName,
   isTemporaryWorktreeBranch,
+  resolveUniqueDpcodeBranchName,
   resolveThreadBranchRegressionGuard,
 } from "./git";
 
@@ -49,5 +51,38 @@ describe("resolveThreadBranchRegressionGuard", () => {
         nextBranch: null,
       }),
     ).toBeNull();
+  });
+});
+
+describe("buildDpcodeBranchName", () => {
+  it("uses dpcode as the branch namespace", () => {
+    expect(buildDpcodeBranchName("fix toast copy")).toBe("dpcode/fix-toast-copy");
+  });
+
+  it("keeps non-dpcode namespaces inside the dpcode branch", () => {
+    expect(buildDpcodeBranchName("feature/refine-toolbar-actions")).toBe(
+      "dpcode/feature/refine-toolbar-actions",
+    );
+  });
+
+  it("normalizes legacy dpcode-style prefixes before rebuilding the branch", () => {
+    expect(buildDpcodeBranchName("t3code/refine toolbar actions")).toBe(
+      "dpcode/refine-toolbar-actions",
+    );
+  });
+
+  it("falls back to dpcode/update when no preferred name is provided", () => {
+    expect(buildDpcodeBranchName()).toBe("dpcode/update");
+  });
+});
+
+describe("resolveUniqueDpcodeBranchName", () => {
+  it("increments suffix when the dpcode branch already exists", () => {
+    expect(
+      resolveUniqueDpcodeBranchName(
+        ["main", "dpcode/fix-toast-copy", "dpcode/fix-toast-copy-2"],
+        "fix toast copy",
+      ),
+    ).toBe("dpcode/fix-toast-copy-3");
   });
 });

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -36,6 +36,7 @@ export function sanitizeFeatureBranchName(raw: string): string {
 }
 
 const AUTO_FEATURE_BRANCH_FALLBACK = "feature/update";
+const DPCODE_BRANCH_FALLBACK = "update";
 
 /**
  * Resolve a unique `feature/…` branch name that doesn't collide with
@@ -49,6 +50,33 @@ export function resolveAutoFeatureBranchName(
   const resolvedBase = sanitizeFeatureBranchName(
     preferred && preferred.length > 0 ? preferred : AUTO_FEATURE_BRANCH_FALLBACK,
   );
+  const existingNames = new Set(existingBranchNames.map((branch) => branch.toLowerCase()));
+
+  if (!existingNames.has(resolvedBase)) {
+    return resolvedBase;
+  }
+
+  let suffix = 2;
+  while (existingNames.has(`${resolvedBase}-${suffix}`)) {
+    suffix += 1;
+  }
+
+  return `${resolvedBase}-${suffix}`;
+}
+
+export function buildDpcodeBranchName(preferredBranch?: string | null): string {
+  const normalizedExisting =
+    preferredBranch?.trim().replace(/^(codex|t3code|dpcode)\//i, "") ?? "";
+  return `${WORKTREE_BRANCH_PREFIX}/${sanitizeBranchFragment(
+    normalizedExisting || DPCODE_BRANCH_FALLBACK,
+  )}`;
+}
+
+export function resolveUniqueDpcodeBranchName(
+  existingBranchNames: readonly string[],
+  preferredBranch?: string | null,
+): string {
+  const resolvedBase = buildDpcodeBranchName(preferredBranch);
   const existingNames = new Set(existingBranchNames.map((branch) => branch.toLowerCase()));
 
   if (!existingNames.has(resolvedBase)) {


### PR DESCRIPTION
## Summary
- Standardize suggested worktree/branch creation on the `dpcode/` namespace, including legacy prefix normalization and collision-safe suffixing.
- Add a dedicated Create Branch menu action in the Git controls and update the dialog copy to match the new flow.
- Improve provider ingestion so a late `item.completed` event can reuse the live assistant message instead of creating a duplicate.
- Expand projection, git, and runtime tests to cover the new branch naming and late-item reuse behavior.

## Testing
- Not run (not requested).
- Added/updated unit coverage for shared git branch helpers.
- Added/updated unit coverage for Git action branch-name resolution.
- Added/updated runtime ingestion coverage for late assistant item completion reuse.