### PR TITLE
Add Codex Imagen chat mode

### DIFF
--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -139,6 +139,19 @@ const isServerNotRunningError = (error: Error): boolean => {
   );
 };
 
+const WORKSPACE_IMAGE_PREVIEW_ROUTE = "/workspace-image-preview";
+const CODEX_TEMP_WORKSPACES_DIR_NAME = "dpcode-codex-workspaces";
+const PREVIEW_IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
+
+function isPathWithinRoot(input: { candidate: string; root: string; path: Path.Path }): boolean {
+  const candidate = input.path.normalize(input.candidate);
+  const root = input.path.normalize(input.root);
+  return (
+    candidate === root ||
+    candidate.startsWith(root.endsWith(input.path.sep) ? root : `${root}${input.path.sep}`)
+  );
+}
+
 const parseManagedWorktreeWorkspaceRoot = (input: {
   gitPointerFileContents: string;
   path: Path.Path;
@@ -1006,6 +1019,94 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         }
 
         if (tryHandleProjectFaviconRequest(url, res)) {
+          return;
+        }
+
+        if (url.pathname === WORKSPACE_IMAGE_PREVIEW_ROUTE) {
+          const cwd = url.searchParams.get("cwd")?.trim();
+          const rawPath = url.searchParams.get("path")?.trim();
+          if (!cwd || !rawPath || rawPath.includes("\0")) {
+            respond(400, { "Content-Type": "text/plain" }, "Invalid image preview path");
+            return;
+          }
+
+          const expandedCwd = expandHomePath(cwd);
+          const resolvedCwd = path.resolve(expandedCwd);
+          const resolvedImagePath = path.isAbsolute(rawPath)
+            ? path.resolve(expandHomePath(rawPath))
+            : path.resolve(resolvedCwd, rawPath);
+          const allowedRoots = [
+            resolvedCwd,
+            serverConfig.baseDir,
+            path.join(OS.tmpdir(), CODEX_TEMP_WORKSPACES_DIR_NAME),
+          ].map((root) => path.resolve(root));
+          if (
+            !allowedRoots.some((root) =>
+              isPathWithinRoot({ candidate: resolvedImagePath, root, path }),
+            )
+          ) {
+            respond(400, { "Content-Type": "text/plain" }, "Invalid image preview path");
+            return;
+          }
+
+          const contentType = Mime.getType(resolvedImagePath) ?? "application/octet-stream";
+          if (!PREVIEW_IMAGE_MIME_TYPES.has(contentType)) {
+            respond(415, { "Content-Type": "text/plain" }, "Unsupported image type");
+            return;
+          }
+
+          const fileInfo = yield* fileSystem
+            .stat(resolvedImagePath)
+            .pipe(Effect.catch(() => Effect.succeed(null)));
+          if (!fileInfo || fileInfo.type !== "File") {
+            respond(404, { "Content-Type": "text/plain" }, "Not Found");
+            return;
+          }
+
+          const realRoot = yield* Effect.sync(() => {
+            try {
+              return realpathSync(resolvedCwd);
+            } catch {
+              return null;
+            }
+          });
+          const realImagePath = yield* Effect.sync(() => {
+            try {
+              return realpathSync(resolvedImagePath);
+            } catch {
+              return null;
+            }
+          });
+          if (
+            !realImagePath ||
+            (realRoot && !isPathWithinRoot({ candidate: realImagePath, root: realRoot, path }))
+          ) {
+            respond(400, { "Content-Type": "text/plain" }, "Invalid image preview path");
+            return;
+          }
+
+          res.writeHead(200, {
+            "Content-Type": contentType,
+            "Cache-Control": "private, max-age=60",
+          });
+          const streamExit = yield* Stream.runForEach(
+            fileSystem.stream(resolvedImagePath),
+            (chunk) =>
+              Effect.sync(() => {
+                if (!res.destroyed) {
+                  res.write(chunk);
+                }
+              }),
+          ).pipe(Effect.exit);
+          if (Exit.isFailure(streamExit)) {
+            if (!res.destroyed) {
+              res.destroy();
+            }
+            return;
+          }
+          if (!res.writableEnded) {
+            res.end();
+          }
           return;
         }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -393,6 +393,53 @@ type ComposerPluginSuggestion = {
 };
 
 const EMPTY_COMPOSER_PLUGIN_SUGGESTIONS: ComposerPluginSuggestion[] = [];
+const IMAGEN_MODEL_SLUG = "imagen";
+const IMAGEN_SKILL_NAME = "codex-imagen";
+const IMAGEN_MODEL_OPTION = {
+  slug: IMAGEN_MODEL_SLUG,
+  name: "Imagen",
+  isCustom: false,
+} satisfies ProviderModelOption & { isCustom: false };
+
+function isCodexImagenModel(provider: ProviderKind, model: string | null | undefined): boolean {
+  return provider === "codex" && model === IMAGEN_MODEL_SLUG;
+}
+
+function resolveImagenModelSelectionForDispatch(input: {
+  provider: ProviderKind;
+  model: string | null | undefined;
+  modelSelection: ModelSelection;
+}): ModelSelection {
+  if (!isCodexImagenModel(input.provider, input.model)) {
+    return input.modelSelection;
+  }
+  return {
+    ...input.modelSelection,
+    model: DEFAULT_MODEL_BY_PROVIDER.codex,
+  };
+}
+
+function buildImagenSkillPrompt(prompt: string): string {
+  const trimmed = prompt.trim();
+  return trimmed.length > 0 ? `$${IMAGEN_SKILL_NAME} ${trimmed}` : `$${IMAGEN_SKILL_NAME}`;
+}
+
+function resolveImagenSkillReference(
+  skills: ReadonlyArray<ProviderSkillDescriptor>,
+): ProviderSkillReference | null {
+  const skill = skills.find((entry) => entry.name === IMAGEN_SKILL_NAME && entry.enabled);
+  return skill ? { name: skill.name, path: skill.path } : null;
+}
+
+function appendUniqueSkillReference(
+  skills: ReadonlyArray<ProviderSkillReference>,
+  skill: ProviderSkillReference | null,
+): ProviderSkillReference[] {
+  if (!skill || skills.some((entry) => entry.name === skill.name && entry.path === skill.path)) {
+    return [...skills];
+  }
+  return [...skills, skill];
+}
 
 function formatOutgoingPrompt(params: {
   provider: ProviderKind;
@@ -1292,12 +1339,15 @@ export default function ChatView({
   const codexDynamicAgentsQuery = useQuery(providerAgentsQueryOptions({ provider: "codex" }));
   const openCodeDynamicAgentsQuery = useQuery(providerAgentsQueryOptions({ provider: "opencode" }));
   const modelOptionsByProvider = useMemo(() => {
+    const codexModelOptions = getAppModelOptions(
+      "codex",
+      customModelsByProvider.codex,
+      composerModelHintByProvider.codex,
+    );
     const staticOptions: Record<ProviderKind, ReturnType<typeof getAppModelOptions>> = {
-      codex: getAppModelOptions(
-        "codex",
-        customModelsByProvider.codex,
-        composerModelHintByProvider.codex,
-      ),
+      codex: codexModelOptions.some((option) => option.slug === IMAGEN_MODEL_SLUG)
+        ? codexModelOptions
+        : [IMAGEN_MODEL_OPTION, ...codexModelOptions],
       claudeAgent: getAppModelOptions(
         "claudeAgent",
         customModelsByProvider.claudeAgent,
@@ -1363,6 +1413,7 @@ export default function ChatView({
     customModelsByProvider,
     availableModelOptionsByProvider: modelOptionsByProvider,
   });
+  const isImagenComposerMode = isCodexImagenModel(selectedProvider, selectedModel);
   const runtimeModelsByProvider = useMemo(
     () => ({
       claudeAgent: claudeDynamicModelsQuery.data?.models ?? [],
@@ -2023,7 +2074,7 @@ export default function ChatView({
       threadId,
       query: skillTriggerQuery,
       enabled:
-        isSkillTrigger &&
+        (isSkillTrigger || isImagenComposerMode) &&
         supportsSkillDiscovery(providerComposerCapabilitiesQuery.data) &&
         composerSkillCwd !== null,
     }),
@@ -4676,6 +4727,18 @@ export default function ChatView({
     const selectedPromptEffortForSend =
       queuedChatTurn?.selectedPromptEffort ?? selectedPromptEffort;
     const selectedModelSelectionForSend = queuedChatTurn?.modelSelection ?? selectedModelSelection;
+    const isImagenSend = isCodexImagenModel(selectedProviderForSend, selectedModelForSend);
+    const selectedModelSelectionForDispatch = resolveImagenModelSelectionForDispatch({
+      provider: selectedProviderForSend,
+      model: selectedModelForSend,
+      modelSelection: selectedModelSelectionForSend,
+    });
+    const selectedComposerSkillsForDispatch = isImagenSend
+      ? appendUniqueSkillReference(
+          selectedComposerSkillsForSend,
+          resolveImagenSkillReference(providerSkills),
+        )
+      : selectedComposerSkillsForSend;
     const providerOptionsForDispatchForSend =
       queuedChatTurn?.providerOptionsForDispatch ?? providerOptionsForDispatch;
     const runtimeModeForSend = queuedChatTurn?.runtimeMode ?? runtimeMode;
@@ -4818,7 +4881,7 @@ export default function ChatView({
         images: queuedImagesForPersistence,
         assistantSelections: composerAssistantSelectionsForSend,
         terminalContexts: sendableComposerTerminalContexts,
-        skills: selectedComposerSkillsForSend,
+        skills: selectedComposerSkillsForDispatch,
         mentions: selectedComposerMentionsForSend,
         selectedProvider: selectedProviderForSend,
         selectedModel: selectedModelForSend,
@@ -4948,7 +5011,7 @@ export default function ChatView({
     const composerImagesSnapshot = [...composerImagesForSend];
     const composerAssistantSelectionsSnapshot = [...composerAssistantSelectionsForSend];
     const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
-    const composerSkillsSnapshot = [...selectedComposerSkillsForSend];
+    const composerSkillsSnapshot = [...selectedComposerSkillsForDispatch];
     const composerMentionsSnapshot = [...selectedComposerMentionsForSend];
     const messageTextForSend = appendTerminalContextsToPrompt(
       appendAssistantSelectionsToPrompt(promptForSend, composerAssistantSelectionsSnapshot),
@@ -4956,13 +5019,16 @@ export default function ChatView({
     );
     const messageIdForSend = newMessageId();
     const messageCreatedAt = new Date().toISOString();
-    const outgoingMessageText = formatOutgoingPrompt({
+    const baseOutgoingMessageText = formatOutgoingPrompt({
       provider: selectedProviderForSend,
-      model: selectedModelForSend,
+      model: selectedModelSelectionForDispatch.model,
       effort: selectedPromptEffortForSend,
       text: messageTextForSend || IMAGE_ONLY_BOOTSTRAP_PROMPT,
     });
-    const mentionedSkillsForSend = selectedComposerSkillsForSend.filter((skill) =>
+    const outgoingMessageText = isImagenSend
+      ? buildImagenSkillPrompt(baseOutgoingMessageText)
+      : baseOutgoingMessageText;
+    const mentionedSkillsForSend = selectedComposerSkillsForDispatch.filter((skill) =>
       promptIncludesSkillMention(outgoingMessageText, skill.name, selectedProviderForSend),
     );
     const mentionedPluginMentionsForSend = resolvePromptPluginMentions({
@@ -5095,11 +5161,11 @@ export default function ChatView({
       // Keep the optimistic label short while the server asks Codex for a better summary.
       const title = buildPromptThreadTitleFallback(titleSeed);
       const threadCreateModelSelection: ModelSelection = buildModelSelection(
-        selectedProviderForSend,
-        selectedModelForSend ||
+        selectedModelSelectionForDispatch.provider,
+        selectedModelSelectionForDispatch.model ||
           targetProjectDefaultModelSelectionForSend?.model ||
           DEFAULT_MODEL_BY_PROVIDER.codex,
-        selectedModelSelectionForSend.options,
+        selectedModelSelectionForDispatch.options,
       );
 
       if (isLocalDraftThread) {
@@ -5158,7 +5224,7 @@ export default function ChatView({
         await persistThreadSettingsForNextTurn({
           threadId: threadIdForSend,
           createdAt: messageCreatedAt,
-          modelSelection: selectedModelSelectionForSend,
+          modelSelection: selectedModelSelectionForDispatch,
           runtimeMode: nextRuntimeModeForSend,
           interactionMode: interactionModeForSend,
         });
@@ -5180,7 +5246,7 @@ export default function ChatView({
             ? { mentions: mentionedPluginMentionsForSend }
             : {}),
         },
-        modelSelection: selectedModelSelectionForSend,
+        modelSelection: selectedModelSelectionForDispatch,
         ...(providerOptionsForDispatchForSend
           ? { providerOptions: providerOptionsForDispatchForSend }
           : {}),
@@ -6964,10 +7030,12 @@ export default function ChatView({
                       : showPlanFollowUpPrompt && activeProposedPlan
                         ? "Add feedback to refine the plan, or leave this blank to implement it"
                         : hasLiveTurn
-                          ? "Ask for follow-up changes"
-                          : phase === "disconnected"
-                            ? "Ask for follow-up changes or attach images"
-                            : "Ask anything, @tag files/folders, or use / to show available commands"
+                            ? "Ask for follow-up changes"
+                            : phase === "disconnected"
+                              ? "Ask for follow-up changes or attach images"
+                              : isImagenComposerMode
+                                ? "Describe the image you want to generate"
+                                : "Ask anything, @tag files/folders, or use / to show available commands"
                 }
                 disabled={isConnecting || isComposerApprovalState}
               />
@@ -7700,7 +7768,9 @@ export default function ChatView({
                                       ? "Ask for follow-up changes"
                                       : phase === "disconnected"
                                         ? "Ask for follow-up changes or attach images"
-                                        : "Ask anything, @tag files/folders, or use / to show available commands"
+                                        : isImagenComposerMode
+                                          ? "Describe the image you want to generate"
+                                          : "Ask anything, @tag files/folders, or use / to show available commands"
                             }
                             disabled={isConnecting || isComposerApprovalState}
                           />

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -24,6 +24,7 @@ import { type TurnDiffSummary } from "../../types";
 import ChatMarkdown from "../ChatMarkdown";
 import {
   BotIcon,
+  CameraIcon,
   CheckIcon,
   CircleAlertIcon,
   EyeIcon,
@@ -38,6 +39,10 @@ import {
   Undo2Icon,
   ZapIcon,
 } from "~/lib/icons";
+import {
+  type GeneratedImageArtifact,
+  extractGeneratedImageArtifacts,
+} from "~/lib/generatedImageArtifacts";
 import { Button } from "../ui/button";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
@@ -665,6 +670,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             showCopyButton: row.showAssistantCopyButton,
             streaming: row.message.streaming,
           });
+          const generatedImageArtifacts = extractGeneratedImageArtifacts({
+            text: row.message.text ?? "",
+            workspaceRoot,
+            messageId: row.message.id,
+          });
           const turnSummary = row.assistantTurnDiffSummary;
           const fileDiffStatByPath = new Map(
             (turnSummary?.files ?? []).map((file) => [
@@ -748,6 +758,28 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     style={chatTypographyStyle}
                   />
                 </div>
+                {generatedImageArtifacts.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {generatedImageArtifacts.map((artifact) => (
+                      <GeneratedImageArtifactCard
+                        key={artifact.id}
+                        artifact={artifact}
+                        onOpen={(artifact) => {
+                          onImageExpand({
+                            images: [
+                              {
+                                name: artifact.name,
+                                src: artifact.previewUrl,
+                              },
+                            ],
+                            index: 0,
+                          });
+                        }}
+                        onTimelineImageLoad={onTimelineImageLoad}
+                      />
+                    ))}
+                  </div>
+                )}
                 {visibleRenderableInlineToolEntries.length > 0 && (
                   <div className="mt-2.5">
                     <div className="space-y-px">
@@ -1209,6 +1241,46 @@ const UserImageAttachmentThumbnail = memo(function UserImageAttachmentThumbnail(
           />
         </div>
       )}
+    </button>
+  );
+});
+
+const GeneratedImageArtifactCard = memo(function GeneratedImageArtifactCard(props: {
+  artifact: GeneratedImageArtifact;
+  onOpen: (artifact: GeneratedImageArtifact) => void;
+  onTimelineImageLoad: () => void;
+}) {
+  const [imageLoadFailed, setImageLoadFailed] = useState(false);
+  return (
+    <button
+      type="button"
+      className="group flex min-w-0 overflow-hidden rounded-xl border border-border/70 bg-card/80 text-left shadow-sm transition-colors hover:bg-card"
+      onClick={() => props.onOpen(props.artifact)}
+      title={props.artifact.path}
+    >
+      <div className="flex size-24 shrink-0 items-center justify-center overflow-hidden bg-black/5 dark:bg-white/5">
+        {imageLoadFailed ? (
+          <CameraIcon className="size-5 text-muted-foreground/55" />
+        ) : (
+          <img
+            src={props.artifact.previewUrl}
+            alt=""
+            className="size-full object-cover transition-transform duration-200 group-hover:scale-[1.03]"
+            loading="lazy"
+            onLoad={props.onTimelineImageLoad}
+            onError={() => {
+              setImageLoadFailed(true);
+              props.onTimelineImageLoad();
+            }}
+          />
+        )}
+      </div>
+      <div className="min-w-0 px-3 py-2.5">
+        <div className="truncate font-medium text-sm">{props.artifact.name}</div>
+        <div className="mt-1 line-clamp-2 text-muted-foreground text-xs leading-snug">
+          {props.artifact.path}
+        </div>
+      </div>
     </button>
   );
 });

--- a/apps/web/src/lib/generatedImageArtifacts.test.ts
+++ b/apps/web/src/lib/generatedImageArtifacts.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWorkspaceImagePreviewUrl,
+  extractGeneratedImageArtifacts,
+} from "./generatedImageArtifacts";
+
+describe("generated image artifacts", () => {
+  it("extracts unique generated image paths from assistant text", () => {
+    const artifacts = extractGeneratedImageArtifacts({
+      text: `Saved image:\n/Users/dev/project/codex-imagen-output/result.png\nAlso ./out/hero.webp.`,
+      workspaceRoot: "/Users/dev/project",
+      messageId: "message-1",
+    });
+
+    expect(artifacts.map((artifact) => artifact.path)).toEqual([
+      "/Users/dev/project/codex-imagen-output/result.png",
+      "./out/hero.webp",
+    ]);
+    expect(artifacts[0]?.name).toBe("result.png");
+  });
+
+  it("builds workspace image preview URLs with encoded parameters", () => {
+    expect(
+      buildWorkspaceImagePreviewUrl({
+        workspaceRoot: "/Users/dev/My Project",
+        path: "./codex-imagen-output/result image.png",
+      }),
+    ).toBe(
+      "/workspace-image-preview?cwd=%2FUsers%2Fdev%2FMy+Project&path=.%2Fcodex-imagen-output%2Fresult+image.png",
+    );
+  });
+
+  it("uses the Codex temp workspace root for Codex-generated absolute image paths", () => {
+    const artifacts = extractGeneratedImageArtifacts({
+      text: `Generated: /private/tmp/dpcode-codex-workspaces/thread-123/codex-imagen-output/result.png`,
+      workspaceRoot: "/Users/dev/project",
+      messageId: "message-2",
+    });
+
+    expect(artifacts[0]?.previewUrl).toBe(
+      "/workspace-image-preview?cwd=%2Fprivate%2Ftmp%2Fdpcode-codex-workspaces%2Fthread-123&path=%2Fprivate%2Ftmp%2Fdpcode-codex-workspaces%2Fthread-123%2Fcodex-imagen-output%2Fresult.png",
+    );
+  });
+});

--- a/apps/web/src/lib/generatedImageArtifacts.ts
+++ b/apps/web/src/lib/generatedImageArtifacts.ts
@@ -1,0 +1,68 @@
+export interface GeneratedImageArtifact {
+  id: string;
+  path: string;
+  name: string;
+  previewUrl: string;
+}
+
+const IMAGE_PATH_REGEX = /(?:^|[\s"'`(])((?:~|\.|\.\.|\/|[A-Za-z]:[\\/])[^\s"'`<>)]+\.(?:png|jpe?g|webp|gif))(?:$|[\s"'`),.])/gi;
+const TRAILING_PATH_PUNCTUATION_REGEX = /[),.;:]+$/;
+const CODEX_WORKSPACE_SEGMENT = "/dpcode-codex-workspaces/";
+
+export function basenameOfGeneratedImagePath(path: string): string {
+  const normalized = path.replaceAll("\\", "/");
+  return normalized.split("/").filter(Boolean).at(-1) ?? path;
+}
+
+export function buildWorkspaceImagePreviewUrl(input: {
+  workspaceRoot: string;
+  path: string;
+}): string {
+  const params = new URLSearchParams({
+    cwd: input.workspaceRoot,
+    path: input.path,
+  });
+  return `/workspace-image-preview?${params.toString()}`;
+}
+
+function previewRootForGeneratedImagePath(path: string, fallbackWorkspaceRoot: string): string {
+  const normalized = path.replaceAll("\\", "/");
+  const markerIndex = normalized.indexOf(CODEX_WORKSPACE_SEGMENT);
+  if (markerIndex === -1) {
+    return fallbackWorkspaceRoot;
+  }
+
+  const workspaceIdStart = markerIndex + CODEX_WORKSPACE_SEGMENT.length;
+  const workspaceIdEnd = normalized.indexOf("/", workspaceIdStart);
+  if (workspaceIdEnd === -1) {
+    return fallbackWorkspaceRoot;
+  }
+  return path.slice(0, workspaceIdEnd);
+}
+
+export function extractGeneratedImageArtifacts(input: {
+  text: string;
+  workspaceRoot: string | undefined;
+  messageId: string;
+}): GeneratedImageArtifact[] {
+  if (!input.workspaceRoot) return [];
+
+  const seen = new Set<string>();
+  const artifacts: GeneratedImageArtifact[] = [];
+  for (const match of input.text.matchAll(IMAGE_PATH_REGEX)) {
+    const rawPath = match[1]?.trim().replace(TRAILING_PATH_PUNCTUATION_REGEX, "");
+    if (!rawPath || seen.has(rawPath)) continue;
+    seen.add(rawPath);
+    const previewWorkspaceRoot = previewRootForGeneratedImagePath(rawPath, input.workspaceRoot);
+    artifacts.push({
+      id: `${input.messageId}:${artifacts.length}:${rawPath}`,
+      path: rawPath,
+      name: basenameOfGeneratedImagePath(rawPath),
+      previewUrl: buildWorkspaceImagePreviewUrl({
+        workspaceRoot: previewWorkspaceRoot,
+        path: rawPath,
+      }),
+    });
+  }
+  return artifacts;
+}


### PR DESCRIPTION
## Summary
- Adds an `Imagen` option to the Codex model picker and automatically dispatches those chat prompts through the `codex-imagen` skill.
- Serves generated image artifacts through a constrained workspace preview route and renders detected image paths as transcript preview cards.
- Adds focused coverage for generated image path extraction, URL encoding, and Codex temp workspace previews.

## Verification
- `bun run test src/lib/generatedImageArtifacts.test.ts`

## Notes
- This is intentionally an integration handoff PR and not the final image-generation UX.
- The `Imagen` picker option still routes through the normal Codex model at dispatch time, so persisted thread model selections remain compatible.
- Direct native Codex `imageGeneration` event rendering is not complete yet; this PR previews generated files when assistant output includes image paths.