### PR TITLE
Fix Cursor provider reliability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,15 @@ Long term maintainability is a core priority. If you add new functionality, firs
 - `packages/contracts`: Shared effect/Schema schemas and TypeScript contracts for provider events, WebSocket protocol, and model/session types. Keep this package schema-only — no runtime logic.
 - `packages/shared`: Shared runtime utilities consumed by both server and web. Uses explicit subpath exports (e.g. `@t3tools/shared/git`) — no barrel index.
 
+## Local Dev Instance Isolation
+
+- Never start the default `bun run dev` while another DP Code instance is running unless the user explicitly wants shared ports/state.
+- Use an isolated home dir and non-default ports when running alongside the user's own DP Code instance, for example: `env -u T3CODE_AUTH_TOKEN T3CODE_PORT_OFFSET=3158 T3CODE_NO_BROWSER=1 bun run dev -- --home-dir ./.dpcode-pr84 --port 58090`.
+- Always dry-run first when avoiding conflicts: `env -u T3CODE_AUTH_TOKEN T3CODE_PORT_OFFSET=3158 bun run dev -- --home-dir ./.dpcode-pr84 --port 58090 --dry-run`.
+- Unset `T3CODE_AUTH_TOKEN` for browser dev instances unless the web app is also configured to connect with that token. If auth is accidentally inherited, the browser WebSocket can be rejected and the UI will show no threads even though SQLite has projects/threads.
+- Check both server and web ports with `lsof -nP -iTCP:<port> -sTCP:LISTEN`. A desktop app can bind `127.0.0.1:<port>` while the dev server binds IPv6 `*:<port>`, and `localhost` may still hit the wrong process.
+- If the UI shows no threads, verify the server path before changing SQL: inspect the isolated `state.sqlite`, then probe `orchestration.getSnapshot` over WebSocket. A healthy snapshot with projects/threads means the issue is client connection/hydration, not empty history.
+
 ## Codex App Server (Important)
 
 DP Code is currently Codex-first. The server starts `codex app-server` (JSON-RPC over stdio) per provider session, then streams structured events to the browser through WebSocket push messages.

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -78,6 +78,7 @@ import {
   extractAskQuestions,
   extractPlanMarkdown,
   extractTodosAsPlan,
+  formatCursorPlanUpdateMarkdown,
 } from "../acp/CursorAcpExtension.ts";
 import { CursorAdapter, type CursorAdapterShape } from "../Services/CursorAdapter.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
@@ -88,6 +89,12 @@ const CURSOR_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 const ACP_PLAN_MODE_ALIASES = ["plan", "architect"];
 const ACP_IMPLEMENT_MODE_ALIASES = ["code", "agent", "default", "chat", "implement"];
 const ACP_APPROVAL_MODE_ALIASES = ["ask"];
+const CURSOR_PLAN_MODE_PROMPT_PREFIX = [
+  "DP Code Cursor plan mode is active.",
+  "Do not implement or mutate files in this turn.",
+  "Do not ask follow-up questions or wait for confirmation; if scope is ambiguous, choose a reasonable default and state the assumption in the plan.",
+  "When ready, create the final implementation plan.",
+].join("\n");
 
 const collectStreamAsString = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
   Stream.runFold(
@@ -120,8 +127,24 @@ interface CursorSessionContext {
   readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
   readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
   lastPlanFingerprint: string | undefined;
+  completedPlanFingerprint: string | undefined;
+  activeInteractionMode: ProviderInteractionMode | undefined;
   activeTurnId: TurnId | undefined;
+  activePromptFiber: Fiber.Fiber<void, never> | undefined;
   stopped: boolean;
+}
+
+function clearCursorActiveTurn(ctx: CursorSessionContext, turnId: TurnId): boolean {
+  if (ctx.activeTurnId !== turnId) {
+    return false;
+  }
+
+  ctx.activeTurnId = undefined;
+  ctx.activePromptFiber = undefined;
+  ctx.activeInteractionMode = undefined;
+  const { activeTurnId: _activeTurnId, ...session } = ctx.session;
+  ctx.session = session;
+  return true;
 }
 
 function settlePendingApprovalsAsCancelled(
@@ -135,6 +158,20 @@ function settlePendingApprovalsAsCancelled(
       discard: true,
     },
   );
+}
+
+function withCursorPlanModePrompt(input: {
+  readonly text: string;
+  readonly interactionMode?: ProviderInteractionMode;
+}): string {
+  if (input.interactionMode !== "plan") {
+    return input.text;
+  }
+
+  const text = input.text.trim();
+  return text.length > 0
+    ? `${CURSOR_PLAN_MODE_PROMPT_PREFIX}\n\nUser request:\n${text}`
+    : CURSOR_PLAN_MODE_PROMPT_PREFIX;
 }
 
 function settlePendingUserInputsAsEmptyAnswers(
@@ -414,6 +451,49 @@ export function makeCursorAdapter(
             rawPayload,
           }),
         );
+
+        if (ctx.activeInteractionMode !== "plan" || ctx.activeTurnId === undefined) {
+          return;
+        }
+
+        const planMarkdown = formatCursorPlanUpdateMarkdown(payload);
+        if (!planMarkdown || ctx.completedPlanFingerprint === fingerprint) {
+          return;
+        }
+        ctx.completedPlanFingerprint = fingerprint;
+        const turnId = ctx.activeTurnId;
+        const activePromptFiber = ctx.activePromptFiber;
+        yield* offerRuntimeEvent({
+          type: "turn.proposed.completed",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          turnId,
+          payload: { planMarkdown },
+          raw: { source, method, payload: rawPayload },
+        });
+
+        if (!clearCursorActiveTurn(ctx, turnId)) {
+          return;
+        }
+        const { lastError: _lastError, ...sessionWithoutLastError } = ctx.session;
+        ctx.session = {
+          ...sessionWithoutLastError,
+          status: "ready",
+          updatedAt: yield* nowIso,
+        };
+        yield* offerRuntimeEvent({
+          type: "turn.completed",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          turnId,
+          payload: { state: "completed", stopReason: null },
+        });
+        yield* Effect.ignore(ctx.acp.cancel);
+        if (activePromptFiber) {
+          yield* Fiber.interrupt(activePromptFiber);
+        }
       });
 
     const requireSession = (
@@ -720,7 +800,10 @@ export function makeCursorAdapter(
             pendingUserInputs,
             turns: [],
             lastPlanFingerprint: undefined,
+            completedPlanFingerprint: undefined,
+            activeInteractionMode: undefined,
             activeTurnId: undefined,
+            activePromptFiber: undefined,
             stopped: false,
           };
 
@@ -864,9 +947,13 @@ export function makeCursorAdapter(
             mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
         });
         ctx.activeTurnId = turnId;
+        ctx.activeInteractionMode = input.interactionMode;
         ctx.lastPlanFingerprint = undefined;
+        ctx.completedPlanFingerprint = undefined;
+        const { lastError: _lastError, ...sessionWithoutLastError } = ctx.session;
         ctx.session = {
-          ...ctx.session,
+          ...sessionWithoutLastError,
+          status: "running",
           activeTurnId: turnId,
           updatedAt: yield* nowIso,
         };
@@ -882,7 +969,13 @@ export function makeCursorAdapter(
 
         const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
         if (input.input?.trim()) {
-          promptParts.push({ type: "text", text: input.input.trim() });
+          promptParts.push({
+            type: "text",
+            text: withCursorPlanModePrompt({
+              text: input.input.trim(),
+              interactionMode: input.interactionMode,
+            }),
+          });
         }
         if (input.attachments && input.attachments.length > 0) {
           for (const attachment of input.attachments) {
@@ -931,35 +1024,94 @@ export function makeCursorAdapter(
           });
         }
 
-        const result = yield* ctx.acp
-          .prompt({
-            prompt: promptParts,
-          })
-          .pipe(
+        const runPrompt = ctx.acp.prompt({ prompt: promptParts }).pipe(
             Effect.mapError((error) =>
               mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
             ),
+            Effect.matchEffect({
+              onFailure: (error) =>
+                Effect.gen(function* () {
+                  if (!clearCursorActiveTurn(ctx, turnId)) {
+                    return;
+                  }
+                  ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, error }] });
+                  const detail = error.message;
+                  ctx.session = {
+                    ...ctx.session,
+                    status: "error",
+                    updatedAt: yield* nowIso,
+                    model: resolvedModel,
+                    lastError: detail,
+                  };
+                  yield* offerRuntimeEvent({
+                    type: "turn.completed",
+                    ...(yield* makeEventStamp()),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId,
+                    payload: {
+                      state: "failed",
+                      stopReason: null,
+                      errorMessage: detail,
+                    },
+                  });
+                }),
+              onSuccess: (result) =>
+                Effect.gen(function* () {
+                  if (!clearCursorActiveTurn(ctx, turnId)) {
+                    return;
+                  }
+                  ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
+                  const { lastError: _lastError, ...sessionWithoutLastError } = ctx.session;
+                  ctx.session = {
+                    ...sessionWithoutLastError,
+                    status: "ready",
+                    updatedAt: yield* nowIso,
+                    model: resolvedModel,
+                  };
+                  yield* offerRuntimeEvent({
+                    type: "turn.completed",
+                    ...(yield* makeEventStamp()),
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    turnId,
+                    payload: {
+                      state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+                      stopReason: result.stopReason ?? null,
+                    },
+                  });
+                }),
+            }),
+            Effect.onInterrupt(() =>
+              Effect.gen(function* () {
+                if (!clearCursorActiveTurn(ctx, turnId)) {
+                  return;
+                }
+                ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, interrupted: true }] });
+                const { lastError: _lastError, ...sessionWithoutLastError } = ctx.session;
+                ctx.session = {
+                  ...sessionWithoutLastError,
+                  status: "ready",
+                  updatedAt: yield* nowIso,
+                  model: resolvedModel,
+                };
+                yield* offerRuntimeEvent({
+                  type: "turn.completed",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId,
+                  payload: {
+                    state: "cancelled",
+                    stopReason: "cancelled",
+                  },
+                });
+              }),
+            ),
+            Effect.ignoreCause({ log: true }),
+            Effect.forkIn(ctx.scope),
           );
-
-        ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
-        ctx.session = {
-          ...ctx.session,
-          activeTurnId: turnId,
-          updatedAt: yield* nowIso,
-          model: resolvedModel,
-        };
-
-        yield* offerRuntimeEvent({
-          type: "turn.completed",
-          ...(yield* makeEventStamp()),
-          provider: PROVIDER,
-          threadId: input.threadId,
-          turnId,
-          payload: {
-            state: result.stopReason === "cancelled" ? "cancelled" : "completed",
-            stopReason: result.stopReason ?? null,
-          },
-        });
+        ctx.activePromptFiber = yield* runPrompt;
 
         return {
           threadId: input.threadId,
@@ -973,6 +1125,7 @@ export function makeCursorAdapter(
         const ctx = yield* requireSession(threadId);
         yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
         yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        const activePromptFiber = ctx.activePromptFiber;
         yield* Effect.ignore(
           ctx.acp.cancel.pipe(
             Effect.mapError((error) =>
@@ -980,6 +1133,9 @@ export function makeCursorAdapter(
             ),
           ),
         );
+        if (activePromptFiber) {
+          yield* Fiber.interrupt(activePromptFiber);
+        }
       });
 
     const respondToRequest: CursorAdapterShape["respondToRequest"] = (

--- a/apps/server/src/provider/acp/CursorAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpExtension.test.ts
@@ -4,6 +4,7 @@ import {
   extractAskQuestions,
   extractPlanMarkdown,
   extractTodosAsPlan,
+  formatCursorPlanUpdateMarkdown,
 } from "./CursorAcpExtension.ts";
 
 describe("CursorAcpExtension", () => {
@@ -104,5 +105,25 @@ describe("CursorAcpExtension", () => {
         { step: "Unknown status", status: "pending" },
       ],
     });
+  });
+
+  it("formats Cursor ACP plan updates as proposed plan markdown", () => {
+    expect(
+      formatCursorPlanUpdateMarkdown({
+        explanation: "Assume a static hub page first.",
+        plan: [
+          { step: "Add /blogs route metadata", status: "pending" },
+          { step: "Link /blogs from footer", status: "pending" },
+        ],
+      }),
+    ).toBe("Assume a static hub page first.\n\n1. Add /blogs route metadata\n2. Link /blogs from footer");
+  });
+
+  it("does not format empty Cursor plan updates", () => {
+    expect(
+      formatCursorPlanUpdateMarkdown({
+        plan: [{ step: "   ", status: "pending" }],
+      }),
+    ).toBeUndefined();
   });
 });

--- a/apps/server/src/provider/acp/CursorAcpExtension.ts
+++ b/apps/server/src/provider/acp/CursorAcpExtension.ts
@@ -97,3 +97,22 @@ export function extractTodosAsPlan(params: typeof CursorUpdateTodosRequest.Type)
   });
   return { plan };
 }
+
+export function formatCursorPlanUpdateMarkdown(input: {
+  readonly explanation?: string | null;
+  readonly plan: ReadonlyArray<{
+    readonly step: string;
+    readonly status: "pending" | "inProgress" | "completed";
+  }>;
+}): string | undefined {
+  const steps = input.plan
+    .map((entry) => entry.step.trim())
+    .filter((step) => step.length > 0);
+  if (steps.length === 0) {
+    return undefined;
+  }
+
+  const explanation = input.explanation?.trim();
+  const body = steps.map((step, index) => `${index + 1}. ${step}`).join("\n");
+  return explanation && explanation.length > 0 ? `${explanation}\n\n${body}` : body;
+}

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -283,14 +283,26 @@ describe("buildCursorAcpModelDescriptors", () => {
 });
 
 describe("applyCursorAcpModelSelection", () => {
-  it("leaves Cursor's runtime default model unchanged for auto", async () => {
+  it("selects Cursor auto explicitly when the ACP model picker exposes it", async () => {
     const calls: Array<
       | { readonly type: "model"; readonly value: string }
       | { readonly type: "config"; readonly configId: string; readonly value: string | boolean }
     > = [];
 
     const runtime = {
-      getConfigOptions: Effect.succeed(parameterizedGpt54ConfigOptions),
+      getConfigOptions: Effect.succeed([
+        {
+          id: "model",
+          name: "Model",
+          category: "model",
+          type: "select",
+          currentValue: "composer-2[fast=true]",
+          options: [
+            { value: "auto", name: "Auto" },
+            { value: "composer-2[fast=true]", name: "Composer 2" },
+          ],
+        },
+      ] satisfies ReadonlyArray<EffectAcpSchema.SessionConfigOption>),
       setModel: (value: string) =>
         Effect.sync(() => {
           calls.push({ type: "model", value });
@@ -310,7 +322,49 @@ describe("applyCursorAcpModelSelection", () => {
       }),
     );
 
-    expect(calls).toEqual([]);
+    expect(calls).toEqual([{ type: "model", value: "auto" }]);
+  });
+
+  it("maps Cursor auto to legacy ACP default model values named Auto", async () => {
+    const calls: Array<
+      | { readonly type: "model"; readonly value: string }
+      | { readonly type: "config"; readonly configId: string; readonly value: string | boolean }
+    > = [];
+
+    const runtime = {
+      getConfigOptions: Effect.succeed([
+        {
+          id: "model",
+          name: "Model",
+          category: "model",
+          type: "select",
+          currentValue: "composer-2[fast=true]",
+          options: [
+            { value: "default[]", name: "Auto" },
+            { value: "composer-2[fast=true]", name: "Composer 2" },
+          ],
+        },
+      ] satisfies ReadonlyArray<EffectAcpSchema.SessionConfigOption>),
+      setModel: (value: string) =>
+        Effect.sync(() => {
+          calls.push({ type: "model", value });
+        }),
+      setConfigOption: (configId: string, value: string | boolean) =>
+        Effect.sync(() => {
+          calls.push({ type: "config", configId, value });
+        }),
+    };
+
+    await Effect.runPromise(
+      applyCursorAcpModelSelection({
+        runtime,
+        model: "auto",
+        options: undefined,
+        mapError: ({ cause }) => cause,
+      }),
+    );
+
+    expect(calls).toEqual([{ type: "model", value: "default[]" }]);
   });
 
   it("maps legacy Cursor base slugs to parameterized ACP model values", async () => {
@@ -353,6 +407,48 @@ describe("applyCursorAcpModelSelection", () => {
     );
 
     expect(calls).toEqual([{ type: "model", value: "composer-2[fast=true]" }]);
+  });
+
+  it("maps unsupported false boolean parameters to an available Cursor ACP model value", async () => {
+    const calls: Array<
+      | { readonly type: "model"; readonly value: string }
+      | { readonly type: "config"; readonly configId: string; readonly value: string | boolean }
+    > = [];
+
+    const runtime = {
+      getConfigOptions: Effect.succeed([
+        {
+          id: "model",
+          name: "Model",
+          category: "model",
+          type: "select",
+          currentValue: "grok-4-20[thinking=true]",
+          options: [
+            { value: "default[]", name: "Auto" },
+            { value: "grok-4-20[thinking=true]", name: "Grok 4.20" },
+          ],
+        },
+      ] satisfies ReadonlyArray<EffectAcpSchema.SessionConfigOption>),
+      setModel: (value: string) =>
+        Effect.sync(() => {
+          calls.push({ type: "model", value });
+        }),
+      setConfigOption: (configId: string, value: string | boolean) =>
+        Effect.sync(() => {
+          calls.push({ type: "config", configId, value });
+        }),
+    };
+
+    await Effect.runPromise(
+      applyCursorAcpModelSelection({
+        runtime,
+        model: "grok-4-20[thinking=false]",
+        options: undefined,
+        mapError: ({ cause }) => cause,
+      }),
+    );
+
+    expect(calls).toEqual([{ type: "model", value: "grok-4-20[thinking=true]" }]);
   });
 
   it("sets the base model before applying separate config options", async () => {

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -889,17 +889,60 @@ function findCursorModelChoiceIgnoringFast(
   )?.slug;
 }
 
+function cursorModelChoiceSupportsRequestedParameters(
+  choice: string,
+  requested: string,
+): boolean {
+  if (stripCursorParameterizedSuffix(choice) !== stripCursorParameterizedSuffix(requested)) {
+    return false;
+  }
+
+  const choiceParams = parseCursorModelParameters(choice);
+  const requestedParams = parseCursorModelParameters(requested);
+  for (const [key, requestedValue] of requestedParams) {
+    const choiceValue = choiceParams.get(key);
+    if (choiceValue === requestedValue) {
+      continue;
+    }
+    if ((key === "fast" || key === "thinking") && requestedValue === "false") {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+function findCursorModelChoiceWithSupportedParameters(
+  choices: ReadonlyArray<CursorAcpModelChoice>,
+  model: string,
+): string | undefined {
+  return choices.find((choice) => cursorModelChoiceSupportsRequestedParameters(choice.slug, model))?.slug;
+}
+
+function resolveCursorAutoModelValue(
+  choices: ReadonlyArray<CursorAcpModelChoice>,
+): string | undefined {
+  return (
+    choices.find((choice) => choice.slug.trim().toLowerCase() === "auto")?.slug ??
+    choices.find((choice) => normalizedText(choice.name) === "auto")?.slug
+  );
+}
+
 function resolveCursorAcpModelValue(
   configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption>,
   model: string | null | undefined,
   options: CursorModelOptions | null | undefined,
 ): string | undefined {
   const trimmed = model?.trim();
-  if (!trimmed || trimmed === "auto") {
+  if (!trimmed) {
     return undefined;
   }
 
   const choices = flattenCursorAcpModelChoices(configOptions);
+  if (trimmed === "auto") {
+    return resolveCursorAutoModelValue(choices);
+  }
+
   const exactChoice = choices.find((choice) => choice.slug === trimmed);
   if (exactChoice) {
     return exactChoice.slug;
@@ -929,7 +972,11 @@ function resolveCursorAcpModelValue(
   if (choices.some((choice) => choice.slug === resolvedModel)) {
     return resolvedModel;
   }
-  return findCursorModelChoiceIgnoringFast(choices, resolvedModel) ?? resolvedModel;
+  return (
+    findCursorModelChoiceIgnoringFast(choices, resolvedModel) ??
+    findCursorModelChoiceWithSupportedParameters(choices, resolvedModel) ??
+    resolvedModel
+  );
 }
 
 export function applyCursorAcpModelSelection<E>(input: {

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1846,7 +1846,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
           const planButton = Array.from(
             document.querySelectorAll<HTMLButtonElement>("button"),
           ).find((button) => button.textContent?.trim() === "Plan");
-          expect(planButton?.title).toContain("return to normal chat mode");
+          expect(planButton?.title).toContain("return to normal build mode");
         },
         { timeout: 8_000, interval: 16 },
       );

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -120,6 +120,32 @@ describe("voice helpers", () => {
 });
 
 describe("shouldShowComposerModelBootstrapSkeleton", () => {
+  it("shows a skeleton while a provider requires runtime-discovered models", () => {
+    expect(
+      shouldShowComposerModelBootstrapSkeleton({
+        selectedProvider: "cursor",
+        selectedModel: "auto",
+        persistedModelSelection: null,
+        draftModelSelection: null,
+        providerModelsLoading: true,
+        requiresDiscoveredModels: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the skeleton for a provider requiring discovered models after loading completes", () => {
+    expect(
+      shouldShowComposerModelBootstrapSkeleton({
+        selectedProvider: "cursor",
+        selectedModel: "auto",
+        persistedModelSelection: null,
+        draftModelSelection: null,
+        providerModelsLoading: false,
+        requiresDiscoveredModels: true,
+      }),
+    ).toBe(false);
+  });
+
   it("shows a skeleton while provider discovery is still resolving a persisted thread model", () => {
     expect(
       shouldShowComposerModelBootstrapSkeleton({

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -204,7 +204,12 @@ export function shouldShowComposerModelBootstrapSkeleton(input: {
   persistedModelSelection: ModelSelection | null | undefined;
   draftModelSelection: ModelSelection | null | undefined;
   providerModelsLoading: boolean;
+  requiresDiscoveredModels?: boolean;
 }): boolean {
+  if (input.requiresDiscoveredModels === true && input.providerModelsLoading) {
+    return true;
+  }
+
   const draftSelection = input.draftModelSelection;
   if (draftSelection && draftSelection.provider === input.selectedProvider) {
     return false;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1322,7 +1322,7 @@ export default function ChatView({
       provider: "cursor",
       binaryPath: settings.cursorBinaryPath || null,
       apiEndpoint: settings.cursorApiEndpoint || null,
-      enabled: selectedProvider === "cursor" || lockedProvider === "cursor",
+      enabled: selectedProvider === "cursor" || lockedProvider === "cursor" || isModelPickerOpen,
     }),
   );
   const geminiModelsQuery = useQuery(
@@ -1350,7 +1350,8 @@ export default function ChatView({
         : collapseCursorModelVariants(cursorDynamicModelsQuery.data?.models ?? []),
     [cursorDynamicModelsQuery.data?.models, showExpandedCursorModelVariants],
   );
-  const cursorModelDiscoveryEnabled = selectedProvider === "cursor" || lockedProvider === "cursor";
+  const cursorModelDiscoveryEnabled =
+    selectedProvider === "cursor" || lockedProvider === "cursor" || isModelPickerOpen;
   const hasResolvedCursorModelDiscovery =
     cursorDynamicModelsQuery.data?.source === "cursor.cli" &&
     (cursorDynamicModelsQuery.data.models.length ?? 0) > 0;
@@ -1522,6 +1523,7 @@ export default function ChatView({
     persistedModelSelection: persistedComposerModelSelection,
     draftModelSelection: draftModelSelectionForSelectedProvider,
     providerModelsLoading,
+    requiresDiscoveredModels: selectedProvider === "cursor",
   });
   const searchableModelOptions = useMemo(
     () =>
@@ -5953,6 +5955,7 @@ export default function ChatView({
       lockedProvider={lockedProvider}
       providers={providerStatuses}
       modelOptionsByProvider={modelOptionsByProvider}
+      loadingModelProviders={{ cursor: cursorModelDiscoveryPending }}
       open={isModelPickerOpen}
       onOpenChange={handleModelPickerOpenChange}
       shortcutLabel={modelPickerShortcutLabel}
@@ -7073,7 +7076,7 @@ export default function ChatView({
                             size="sm"
                             type="button"
                             onClick={toggleInteractionMode}
-                            title="Plan mode — click to return to normal chat mode"
+                            title="Plan mode — click to return to normal build mode"
                           >
                             <GoTasklist className="size-3.5" />
                             <span className="sr-only sm:not-sr-only">Plan</span>
@@ -7792,7 +7795,7 @@ export default function ChatView({
                                         size="sm"
                                         type="button"
                                         onClick={toggleInteractionMode}
-                                        title="Plan mode — click to return to normal chat mode"
+                                        title="Plan mode — click to return to normal build mode"
                                       >
                                         <GoTasklist className="size-3.5" />
                                         <span className="sr-only sm:not-sr-only">Plan</span>

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
@@ -105,8 +105,8 @@ describe("CompactComposerControlsMenu", () => {
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
       expect(text).toContain("Fast Mode");
-      expect(text).toContain("off");
-      expect(text).toContain("on");
+      expect(text).toContain("Default");
+      expect(text).toContain("Fast");
     });
   });
 
@@ -178,14 +178,14 @@ describe("CompactComposerControlsMenu", () => {
     });
   });
 
-  it("shows both chat and plan mode options", async () => {
+  it("shows both build and plan mode options", async () => {
     await using _ = await mountMenu();
 
     await page.getByLabelText("More composer controls").click();
 
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
-      expect(text).toContain("Chat");
+      expect(text).toContain("Build");
       expect(text).toContain("Plan");
     });
   });

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -51,7 +51,7 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
             props.onToggleInteractionMode();
           }}
         >
-          <MenuRadioItem value="default">Chat</MenuRadioItem>
+          <MenuRadioItem value="default">Build</MenuRadioItem>
           <MenuRadioItem value="plan">Plan</MenuRadioItem>
         </MenuRadioGroup>
         {props.activePlan ? (

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -59,6 +59,7 @@ async function mountPicker(props: {
   model: ModelSlug;
   lockedProvider: ProviderKind | null;
   providers?: ReadonlyArray<ServerProviderStatus>;
+  loadingModelProviders?: Partial<Record<ProviderKind, boolean>>;
   modelOptionsByProvider?: Record<
     ProviderKind,
     ReadonlyArray<ProviderModelOption & { slug: ModelSlug }>
@@ -73,6 +74,7 @@ async function mountPicker(props: {
       model={props.model}
       lockedProvider={props.lockedProvider}
       modelOptionsByProvider={props.modelOptionsByProvider ?? MODEL_OPTIONS_BY_PROVIDER}
+      {...(props.loadingModelProviders ? { loadingModelProviders: props.loadingModelProviders } : {})}
       {...(props.providers ? { providers: props.providers } : {})}
       onProviderModelChange={onProviderModelChange}
     />,
@@ -251,6 +253,29 @@ describe("ProviderModelPicker", () => {
         .toBeInTheDocument();
       await expect
         .element(page.getByRole("menuitemradio", { name: "GPT Cursor 1" }))
+        .not.toBeInTheDocument();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows a loading skeleton instead of fallback models for loading providers", async () => {
+    const mounted = await mountPicker({
+      provider: "cursor",
+      model: "auto",
+      lockedProvider: "cursor",
+      loadingModelProviders: { cursor: true },
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await expect.element(page.getByLabelText("Loading models")).toBeInTheDocument();
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "Auto" }))
+        .not.toBeInTheDocument();
+      await expect
+        .element(page.getByRole("menuitemradio", { name: "Composer 2" }))
         .not.toBeInTheDocument();
     } finally {
       await mounted.cleanup();

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -29,6 +29,7 @@ import { PickerTriggerButton } from "./PickerTriggerButton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { ShortcutKbd } from "../ui/shortcut-kbd";
 import { groupProviderModelOptions, type ProviderModelOption } from "../../providerModelOptions";
+import { Skeleton } from "../ui/skeleton";
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {
   value: ProviderKind;
@@ -130,6 +131,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   lockedProvider: ProviderKind | null;
   providers?: ReadonlyArray<ServerProviderStatus>;
   modelOptionsByProvider: Record<ProviderKind, ReadonlyArray<ProviderModelOption>>;
+  loadingModelProviders?: Partial<Record<ProviderKind, boolean>>;
   activeProviderIconClassName?: string;
   compact?: boolean;
   disabled?: boolean;
@@ -177,6 +179,21 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   };
 
   const renderModelRadioGroup = (provider: ProviderKind) => {
+    if (props.loadingModelProviders?.[provider]) {
+      return (
+        <div className="w-60 space-y-2 px-2 py-2" aria-label="Loading models">
+          {Array.from({ length: 6 }, (_, index) => (
+            <div key={index} className="flex items-center gap-2 rounded-md px-2 py-1.5">
+              <Skeleton className="size-3.5 rounded-full" />
+              <Skeleton
+                className={cn("h-3.5 rounded-full", index % 3 === 0 ? "w-24" : "w-32")}
+              />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
     const providerOptions = props.modelOptionsByProvider[provider];
     const shouldShowSearch =
       (provider === "opencode" || provider === "cursor") &&

--- a/apps/web/src/components/chat/TraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.browser.tsx
@@ -149,8 +149,8 @@ describe("TraitsPicker (Claude)", () => {
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
       expect(text).toContain("Fast Mode");
-      expect(text).toContain("off");
-      expect(text).toContain("on");
+      expect(text).toContain("Default");
+      expect(text).toContain("Fast");
     });
   });
 
@@ -379,8 +379,8 @@ describe("TraitsPicker (Codex)", () => {
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
       expect(text).toContain("Fast Mode");
-      expect(text).toContain("off");
-      expect(text).toContain("on");
+      expect(text).toContain("Default");
+      expect(text).toContain("Fast");
     });
   });
 
@@ -434,11 +434,85 @@ describe("TraitsPicker (Codex)", () => {
     });
 
     await page.getByRole("button").click();
-    await page.getByRole("menuitemradio", { name: "on" }).click();
+    await page.getByRole("menuitemradio", { name: "Fast" }).click();
 
     expect(useComposerDraftStore.getState().stickyModelSelectionByProvider.codex).toMatchObject({
       provider: "codex",
       options: { fastMode: true },
+    });
+  });
+});
+
+// ── Cursor TraitsPicker tests ─────────────────────────────────────────
+
+async function mountCursorPicker(props: {
+  runtimeModel: ProviderModelDescriptor;
+  options?: { fastMode?: boolean };
+}) {
+  const threadId = ThreadId.makeUnsafe("thread-cursor-traits");
+  const host = document.createElement("div");
+  document.body.append(host);
+  const screen = await render(
+    <TraitsPicker
+      provider="cursor"
+      threadId={threadId}
+      model={props.runtimeModel.slug}
+      runtimeModel={props.runtimeModel}
+      prompt=""
+      modelOptions={props.options}
+      onPromptChange={() => {}}
+    />,
+    { container: host },
+  );
+
+  const cleanup = async () => {
+    await screen.unmount();
+    host.remove();
+  };
+
+  return {
+    [Symbol.asyncDispose]: cleanup,
+    cleanup,
+  };
+}
+
+describe("TraitsPicker (Cursor)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  const fastOnlyComposerRuntimeModel: ProviderModelDescriptor = {
+    slug: "composer-2[fast=false]",
+    name: "Composer 2",
+    supportsFastMode: true,
+  };
+
+  it("shows Default instead of an empty trigger for fast-only models", async () => {
+    await using _ = await mountCursorPicker({
+      runtimeModel: fastOnlyComposerRuntimeModel,
+      options: { fastMode: false },
+    });
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent ?? "").toContain("Default");
+    });
+  });
+
+  it("shows only fast mode labels for fast-only models", async () => {
+    await using _ = await mountCursorPicker({
+      runtimeModel: fastOnlyComposerRuntimeModel,
+      options: { fastMode: false },
+    });
+
+    await page.getByRole("button").click();
+
+    await vi.waitFor(() => {
+      const text = document.body.textContent ?? "";
+      expect(text).toContain("Fast Mode");
+      expect(text).toContain("Default");
+      expect(text).toContain("Fast");
+      expect(text).not.toMatch(/\bThinking\b/u);
+      expect(text).not.toContain("Effort");
     });
   });
 });

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -70,6 +70,8 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
     { caps, effortLevels, thinkingEnabled, contextWindowOptions },
     { includeFastMode },
   );
+  const hasPriorFastModeSection =
+    effortLevels.length > 0 || thinkingEnabled !== null || contextWindowOptions.length > 1;
 
   const handleEffortChange = useCallback(
     (value: string) => {
@@ -187,7 +189,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
       ) : null}
       {includeFastMode && caps.supportsFastMode ? (
         <>
-          <MenuDivider />
+          {hasPriorFastModeSection ? <MenuDivider /> : null}
           <MenuGroup>
             <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Fast Mode</div>
             <MenuRadioGroup
@@ -203,10 +205,10 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
               }}
             >
               <MenuRadioItem value="off" onClick={() => onSelectionComplete?.()}>
-                off
+                Default
               </MenuRadioItem>
               <MenuRadioItem value="on" onClick={() => onSelectionComplete?.()}>
-                on
+                Fast
               </MenuRadioItem>
             </MenuRadioGroup>
           </MenuGroup>
@@ -304,14 +306,23 @@ export const TraitsPicker = memo(function TraitsPicker({
     contextWindowOptions.length > 1 && contextWindow !== defaultContextWindow
       ? (contextWindowOptions.find((option) => option.value === contextWindow)?.label ?? null)
       : null;
+  const isFastOnlyControl =
+    caps.supportsFastMode &&
+    effortLevels.length === 0 &&
+    thinkingEnabled === null &&
+    contextWindowOptions.length <= 1;
   const primaryTriggerLabel = ultrathinkPromptControlled
     ? "Ultrathink"
     : effortLabel
       ? effortLabel
-      : thinkingEnabled === null
-        ? null
-        : `Thinking ${thinkingEnabled ? "On" : "Off"}`;
-  const showsFastBadge = caps.supportsFastMode && fastModeEnabled;
+      : thinkingEnabled !== null
+        ? `Thinking ${thinkingEnabled ? "On" : "Off"}`
+        : isFastOnlyControl
+          ? fastModeEnabled
+            ? "Fast"
+            : "Default"
+          : null;
+  const showsFastBadge = caps.supportsFastMode && fastModeEnabled && !isFastOnlyControl;
 
   const isCodexStyle = provider === "codex";
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -334,6 +334,7 @@ function EventRouter() {
   );
   const setWorkspaceHomeDir = useWorkspaceStore((store) => store.setHomeDir);
   const workspacePages = useWorkspaceStore((store) => store.workspacePages);
+  const serverThreads = useStore((store) => store.threads);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
@@ -353,13 +354,24 @@ function EventRouter() {
     return routeThreadId ? [routeThreadId] : [];
   }, [activeSplitView, routeThreadId]);
   const retainedThreadIds = useRetainedThreadDetailIds();
+  const serverThreadIds = useMemo(
+    () => new Set(serverThreads.map((thread) => thread.id)),
+    [serverThreads],
+  );
   const subscribedThreadIds = useMemo(() => {
-    const nextThreadIds = new Set<ThreadId>(visibleThreadIds);
+    const nextThreadIds = new Set<ThreadId>();
+    for (const threadId of visibleThreadIds) {
+      if (serverThreadIds.has(threadId)) {
+        nextThreadIds.add(threadId);
+      }
+    }
     for (const threadId of retainedThreadIds) {
-      nextThreadIds.add(threadId);
+      if (serverThreadIds.has(threadId)) {
+        nextThreadIds.add(threadId);
+      }
     }
     return [...nextThreadIds];
-  }, [retainedThreadIds, visibleThreadIds]);
+  }, [retainedThreadIds, serverThreadIds, visibleThreadIds]);
   const workspacePagesRef = useRef(workspacePages);
   const pathnameRef = useRef(pathname);
   const handledBootstrapThreadIdRef = useRef<string | null>(null);


### PR DESCRIPTION
## Summary
- Fix Cursor provider interruption, session shutdown, and model discovery handling.
- Preserve valid Cursor model choices while exposing supported effort, fast mode, and context controls.
- Use the populated userdata database in dev mode and include the WebSocket auth token in the dev client URL.

## Tests
- `bun run test src/provider/acp/CursorAcpSupport.test.ts`
- `bun run test src/components/chat/composerTraits.test.ts src/components/chat/composerProviderRegistry.test.tsx src/cursorModelVariants.test.ts`
- `bun run test src/git/Layers/CursorTextGeneration.test.ts`
- `bun run test src/main.test.ts`
- `bunx vitest run scripts/dev-runner.test.ts`