### PR TITLE
Show the packaged desktop window before backend readiness

### DIFF
--- a/apps/desktop/src/initialBackendWindowOpen.test.ts
+++ b/apps/desktop/src/initialBackendWindowOpen.test.ts
@@ -1,0 +1,94 @@
+// FILE: initialBackendWindowOpen.test.ts
+// Purpose: Locks desktop startup behavior so packaged windows appear before backend readiness.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  openInitialBackendWindow,
+  type InitialBackendWindowOpenOptions,
+} from "./initialBackendWindowOpen";
+
+function createOptions(
+  overrides: Partial<InitialBackendWindowOpenOptions> = {},
+): InitialBackendWindowOpenOptions {
+  let readinessInFlight: Promise<void> | null = null;
+
+  return {
+    isDevelopment: false,
+    baseUrl: "http://127.0.0.1:49152",
+    hasExistingWindow: vi.fn(() => false),
+    createWindow: vi.fn(),
+    getReadinessInFlight: vi.fn(() => readinessInFlight),
+    setReadinessInFlight: vi.fn((promise) => {
+      readinessInFlight = promise;
+    }),
+    waitForBackendWindowReady: vi.fn<
+      InitialBackendWindowOpenOptions["waitForBackendWindowReady"]
+    >(async () => "listening"),
+    writeLog: vi.fn(),
+    isReadinessAborted: vi.fn(() => false),
+    formatErrorMessage: vi.fn((error) => (error instanceof Error ? error.message : String(error))),
+    warn: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("openInitialBackendWindow", () => {
+  it("creates the packaged window before backend readiness resolves", async () => {
+    const order: string[] = [];
+    let resolveBackendReady!: () => void;
+    const backendReady = new Promise<"listening">((resolve) => {
+      resolveBackendReady = () => resolve("listening");
+    });
+    const options = createOptions({
+      createWindow: vi.fn<InitialBackendWindowOpenOptions["createWindow"]>(() => {
+        order.push("create-window");
+      }),
+      waitForBackendWindowReady: vi.fn<
+        InitialBackendWindowOpenOptions["waitForBackendWindowReady"]
+      >(() => {
+        order.push("wait-backend");
+        return backendReady;
+      }),
+    });
+
+    openInitialBackendWindow(options);
+
+    const setReadinessInFlight = vi.mocked(options.setReadinessInFlight);
+    const watchedPromise = setReadinessInFlight.mock.calls[0]?.[0];
+
+    expect(order).toEqual(["create-window", "wait-backend"]);
+    expect(watchedPromise).toBeInstanceOf(Promise);
+    expect(options.writeLog).toHaveBeenCalledWith("bootstrap main window created");
+    if (!watchedPromise) {
+      throw new Error("Expected startup readiness watcher to be registered.");
+    }
+
+    resolveBackendReady();
+    await expect(watchedPromise).resolves.toBeUndefined();
+  });
+
+  it("still opens a missing window without duplicating an active readiness watch", () => {
+    const activeWatch = Promise.resolve();
+    const options = createOptions({
+      getReadinessInFlight: vi.fn(() => activeWatch),
+    });
+
+    openInitialBackendWindow(options);
+
+    expect(options.createWindow).toHaveBeenCalledTimes(1);
+    expect(options.waitForBackendWindowReady).not.toHaveBeenCalled();
+    expect(options.setReadinessInFlight).not.toHaveBeenCalled();
+  });
+
+  it("skips startup work when a window already exists", () => {
+    const options = createOptions({
+      hasExistingWindow: vi.fn(() => true),
+    });
+
+    openInitialBackendWindow(options);
+
+    expect(options.createWindow).not.toHaveBeenCalled();
+    expect(options.waitForBackendWindowReady).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/initialBackendWindowOpen.ts
+++ b/apps/desktop/src/initialBackendWindowOpen.ts
@@ -1,0 +1,57 @@
+// FILE: initialBackendWindowOpen.ts
+// Purpose: Coordinates first packaged-window reveal without waiting on backend readiness.
+// Layer: Desktop startup utility
+// Exports: openInitialBackendWindow
+
+export type BackendWindowReadySource = "listening" | "http";
+
+export interface InitialBackendWindowOpenOptions {
+  readonly isDevelopment: boolean;
+  readonly baseUrl: string;
+  readonly hasExistingWindow: () => boolean;
+  readonly createWindow: () => void;
+  readonly getReadinessInFlight: () => Promise<void> | null;
+  readonly setReadinessInFlight: (promise: Promise<void> | null) => void;
+  readonly waitForBackendWindowReady: (baseUrl: string) => Promise<BackendWindowReadySource>;
+  readonly writeLog: (message: string) => void;
+  readonly isReadinessAborted: (error: unknown) => boolean;
+  readonly formatErrorMessage: (error: unknown) => string;
+  readonly warn: (message: string, error: unknown) => void;
+}
+
+export function openInitialBackendWindow(options: InitialBackendWindowOpenOptions): void {
+  if (options.isDevelopment || options.baseUrl.length === 0 || options.hasExistingWindow()) {
+    return;
+  }
+
+  // The packaged renderer is served from local files, so surface the window
+  // while the backend finishes startup instead of leaving macOS menu-bar-only.
+  options.createWindow();
+  options.writeLog("bootstrap main window created");
+
+  if (options.getReadinessInFlight() !== null) {
+    return;
+  }
+
+  const nextOpen = options
+    .waitForBackendWindowReady(options.baseUrl)
+    .then((source) => {
+      options.writeLog(`bootstrap backend ready source=${source}`);
+    })
+    .catch((error) => {
+      if (options.isReadinessAborted(error)) {
+        return;
+      }
+      options.writeLog(
+        `bootstrap backend readiness warning message=${options.formatErrorMessage(error)}`,
+      );
+      options.warn("[desktop] backend readiness check timed out during packaged bootstrap", error);
+    })
+    .finally(() => {
+      if (options.getReadinessInFlight() === nextOpen) {
+        options.setReadinessInFlight(null);
+      }
+    });
+
+  options.setReadinessInFlight(nextOpen);
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -33,6 +33,7 @@ import { RotatingFileSink } from "@t3tools/shared/logging";
 import { isBackendReadinessAborted, waitForHttpReady } from "./backendReadiness";
 import { waitForBackendStartupReady } from "./backendStartupReadiness";
 import { showDesktopConfirmDialog } from "./confirmDialog";
+import { openInitialBackendWindow } from "./initialBackendWindowOpen";
 import { shouldAllowMediaPermissionRequest } from "./mediaPermissions";
 import { ServerListeningDetector } from "./serverListeningDetector";
 import { syncShellEnvironment } from "./syncShellEnvironment";
@@ -356,41 +357,25 @@ async function waitForBackendWindowReady(baseUrl: string): Promise<"listening" |
 }
 
 function ensureInitialBackendWindowOpen(baseUrl: string): void {
-  const existingWindow = mainWindow ?? BrowserWindow.getAllWindows()[0] ?? null;
-  if (
-    isDevelopment ||
-    baseUrl.length === 0 ||
-    existingWindow !== null ||
-    backendInitialWindowOpenInFlight !== null
-  ) {
-    return;
-  }
-
-  const nextOpen = waitForBackendWindowReady(baseUrl)
-    .then((source) => {
-      writeDesktopLogHeader(`bootstrap backend ready source=${source}`);
-      if (mainWindow ?? BrowserWindow.getAllWindows()[0]) {
-        return;
-      }
+  openInitialBackendWindow({
+    isDevelopment,
+    baseUrl,
+    hasExistingWindow: () => (mainWindow ?? BrowserWindow.getAllWindows()[0] ?? null) !== null,
+    createWindow: () => {
       mainWindow = createWindow();
-      writeDesktopLogHeader("bootstrap main window created");
-    })
-    .catch((error) => {
-      if (isBackendReadinessAborted(error)) {
-        return;
-      }
-      writeDesktopLogHeader(
-        `bootstrap backend readiness warning message=${formatErrorMessage(error)}`,
-      );
-      console.warn("[desktop] backend readiness check timed out during packaged bootstrap", error);
-    })
-    .finally(() => {
-      if (backendInitialWindowOpenInFlight === nextOpen) {
-        backendInitialWindowOpenInFlight = null;
-      }
-    });
-
-  backendInitialWindowOpenInFlight = nextOpen;
+    },
+    getReadinessInFlight: () => backendInitialWindowOpenInFlight,
+    setReadinessInFlight: (promise) => {
+      backendInitialWindowOpenInFlight = promise;
+    },
+    waitForBackendWindowReady,
+    writeLog: writeDesktopLogHeader,
+    isReadinessAborted: isBackendReadinessAborted,
+    formatErrorMessage,
+    warn: (message, error) => {
+      console.warn(message, error);
+    },
+  });
 }
 
 function writeDesktopStreamChunk(


### PR DESCRIPTION
## Summary
- Open the initial packaged desktop window immediately instead of waiting for backend readiness, so the app no longer appears to hang at launch.
- Add startup coordination logic and tests to ensure the first window is created once, even while backend readiness is still in flight.
- Simplify the desktop browser-use pipe flow by removing the panel-open wait path and related IPC wiring.
- Refactor browser runtime handling to rely on a single visible `WebContentsView` path, with updated tab state syncing and cleanup.
- Remove now-unused browser-use and startup plumbing across desktop, server, web, and shared contract packages.

## Testing
- Not run (not requested).
- Added focused unit coverage for initial packaged window launch timing in `apps/desktop/src/initialBackendWindowOpen.test.ts`.
- Existing browser manager and browser-use behavior should be rechecked in CI after the refactor.