### PR TITLE
Fix OpenCode default agent selection

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -58,6 +58,8 @@ import {
 import { extractProposedPlanMarkdown, withProviderPlanModePrompt } from "../planMode.ts";
 
 const PROVIDER = "opencode" as const;
+const OPENCODE_BUILD_AGENT = "build";
+const OPENCODE_PLAN_AGENT = "plan";
 
 type OpenCodeSubscribedEvent =
   Awaited<ReturnType<OpencodeClient["event"]["subscribe"]>> extends {
@@ -1907,7 +1909,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           });
         }
 
-        const agent =
+        const selectedAgent =
           input.modelSelection?.provider === PROVIDER
             ? input.modelSelection.options?.agent
             : undefined;
@@ -1915,10 +1917,13 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           input.modelSelection?.provider === PROVIDER
             ? input.modelSelection.options?.variant
             : undefined;
+        const agent =
+          selectedAgent ??
+          (input.interactionMode === "plan" ? OPENCODE_PLAN_AGENT : OPENCODE_BUILD_AGENT);
 
         context.activeTurnId = turnId;
         context.activeInteractionMode = input.interactionMode === "plan" ? "plan" : "default";
-        context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
+        context.activeAgent = agent;
         context.activeVariant = variant;
         updateProviderSession(
           context,


### PR DESCRIPTION
## Summary

- Explicitly sends OpenCode `build` agent for DP Code default-mode turns when no custom OpenCode agent is selected
- Keeps DP Code plan-mode turns pinned to OpenCode `plan` agent
- Preserves explicitly selected OpenCode agents

## Why

OpenCode can be configured with `default_agent` set to `plan`. DP Code `/default` only changed the app interaction mode, and the OpenCode adapter omitted `agent` for default-mode turns. OpenCode then fell back to its configured `default_agent`, leaving users stuck in plan mode.

Closes #94.

## Validation

Not run. User requested no test changes for this PR.