### PR TITLE
Fix task banner layout

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -3105,6 +3105,17 @@ describe("ChatView timeline estimator parity (full app)", () => {
         { timeout: 8_000, interval: 16 },
       );
 
+      const transcriptPane = document.querySelector<HTMLElement>("[data-chat-transcript-pane]");
+      const taskListCard = document.querySelector<HTMLElement>(
+        '[data-testid="active-task-list-card"]',
+      );
+      expect(transcriptPane).not.toBeNull();
+      expect(taskListCard).not.toBeNull();
+      expect(transcriptPane!.getBoundingClientRect().bottom).toBeGreaterThan(
+        taskListCard!.getBoundingClientRect().top + 1,
+      );
+      expect(taskListCard!.getBoundingClientRect().width).toBeLessThan(window.innerWidth);
+
       const openPlanButton = await waitForElement(
         () => document.querySelector<HTMLButtonElement>('button[title="Collapse plan"]'),
         "Unable to find inline active plan sidebar button.",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -147,6 +147,7 @@ import {
   hasToolActivityForTurn,
   isLatestTurnSettled,
   formatElapsed,
+  type ActiveTaskListState,
 } from "../session-logic";
 import {
   buildPendingUserInputAnswers,
@@ -1395,6 +1396,8 @@ export default function ChatView({
   const customModelsByProvider = useMemo(() => getCustomModelsByProvider(settings), [settings]);
   const featureFlags = useFeatureFlags();
   const showExpandedCursorModelVariants = featureFlags["show-expanded-cursor-model-variants"];
+  const showDebugTaskBanner =
+    import.meta.env.DEV && featureFlags["show-debug-task-banner"];
   const composerModelHintByProvider = useMemo<Record<ProviderKind, string | null>>(() => {
     const threadModelSelection = activeThread?.modelSelection ?? null;
     const projectModelSelection = activeProject?.defaultModelSelection ?? null;
@@ -1785,20 +1788,68 @@ export default function ChatView({
     ],
   );
   const planSidebarLabel = sidebarProposedPlan || interactionMode === "plan" ? "Plan" : "Tasks";
+  const [activeTaskListCardHeight, setActiveTaskListCardHeight] = useState(0);
+  const activeTaskListCardRef = useRef<HTMLDivElement | null>(null);
+  const previousActiveTaskListCardHeightRef = useRef(0);
   const activeTaskList = useMemo(
-    () =>
-      latestTurnSettled
+    (): ActiveTaskListState | null => {
+      if (showDebugTaskBanner) {
+        return {
+          createdAt: new Date().toISOString(),
+          turnId: activeLatestTurn?.turnId ?? null,
+          tasks: [
+            {
+              task: "Inspect banner layout without overlapping transcript text",
+              status: "inProgress",
+            },
+            {
+              task: "Confirm compact task banner width",
+              status: "pending",
+            },
+            {
+              task: "Verify sidebar task controls",
+              status: "completed",
+            },
+          ],
+        };
+      }
+
+      return latestTurnSettled
         ? null
-        : deriveActiveTaskListState(threadActivities, activeLatestTurn?.turnId ?? undefined),
-    [activeLatestTurn?.turnId, latestTurnSettled, threadActivities],
+        : deriveActiveTaskListState(threadActivities, activeLatestTurn?.turnId ?? undefined);
+    },
+    [activeLatestTurn?.turnId, latestTurnSettled, showDebugTaskBanner, threadActivities],
   );
   const activeBackgroundTasks = useMemo(
     () =>
       latestTurnSettled
         ? null
-        : deriveActiveBackgroundTasksState(threadActivities, activeLatestTurn?.turnId ?? undefined),
+      : deriveActiveBackgroundTasksState(threadActivities, activeLatestTurn?.turnId ?? undefined),
     [activeLatestTurn?.turnId, latestTurnSettled, threadActivities],
   );
+  useLayoutEffect(() => {
+    if (!activeTaskList || planSidebarOpen) {
+      setActiveTaskListCardHeight(0);
+      return;
+    }
+
+    const element = activeTaskListCardRef.current;
+    if (!element) {
+      setActiveTaskListCardHeight(0);
+      return;
+    }
+
+    const updateHeight = () => {
+      setActiveTaskListCardHeight(Math.ceil(element.getBoundingClientRect().height));
+    };
+
+    updateHeight();
+    const resizeObserver = new ResizeObserver(updateHeight);
+    resizeObserver.observe(element);
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [activeTaskList, activeTaskListCompact, planSidebarOpen]);
   const showPlanFollowUpPrompt =
     pendingUserInputs.length === 0 &&
     interactionMode === "plan" &&
@@ -3671,6 +3722,30 @@ export default function ChatView({
     programmaticScrollUntilRef.current = performance.now() + 200;
     legendListRef.current?.scrollToEnd?.({ animated });
   }, []);
+  useLayoutEffect(() => {
+    const previousHeight = previousActiveTaskListCardHeightRef.current;
+    previousActiveTaskListCardHeightRef.current = activeTaskListCardHeight;
+
+    if (previousHeight <= 0 || activeTaskListCardHeight <= 0 || planSidebarOpen) {
+      return;
+    }
+
+    const delta = activeTaskListCardHeight - previousHeight;
+    if (delta <= 0.5) {
+      return;
+    }
+    if (!isAtEndRef.current) {
+      return;
+    }
+
+    const scrollContainer = legendListRef.current?.getScrollableNode?.();
+    if (!(scrollContainer instanceof HTMLElement)) {
+      return;
+    }
+
+    programmaticScrollUntilRef.current = performance.now() + 200;
+    scrollContainer.scrollTop += delta;
+  }, [activeTaskListCardHeight, planSidebarOpen]);
   const transcriptMessageCount = useMemo(
     () => timelineEntries.filter((entry) => entry.kind === "message").length,
     [timelineEntries],
@@ -7123,22 +7198,24 @@ export default function ChatView({
   // Composer layout keeps the task list and footer actions in one render path so
   // follow-up prompts and normal chat mode stay visually in sync.
   const taskListAboveComposer = Boolean(activeTaskList && !planSidebarOpen);
+  const renderActiveTaskListCard = () =>
+    activeTaskList && !planSidebarOpen ? (
+      <div className="pointer-events-none mx-auto w-full max-w-3xl">
+        <div ref={activeTaskListCardRef} className="pointer-events-auto mx-auto w-11/12">
+          <ActiveTaskListCard
+            activeTaskList={activeTaskList}
+            backgroundTaskCount={activeBackgroundTasks?.activeCount ?? 0}
+            compact={activeTaskListCompact}
+            onCompactChange={setActiveTaskListCompact}
+            onOpenSidebar={() => setPlanSidebarOpen(true)}
+          />
+        </div>
+      </div>
+    ) : null;
 
   const composerSection = secondaryChromeReady ? (
     <>
-      {activeTaskList && !planSidebarOpen ? (
-        <div className="pointer-events-none mx-auto w-full max-w-3xl">
-          <div className="pointer-events-auto mx-auto w-11/12">
-            <ActiveTaskListCard
-              activeTaskList={activeTaskList}
-              backgroundTaskCount={activeBackgroundTasks?.activeCount ?? 0}
-              compact={activeTaskListCompact}
-              onCompactChange={setActiveTaskListCompact}
-              onOpenSidebar={() => setPlanSidebarOpen(true)}
-            />
-          </div>
-        </div>
-      ) : null}
+      {renderActiveTaskListCard()}
       <form
         ref={composerFormRef}
         onSubmit={onSend}
@@ -7850,6 +7927,11 @@ export default function ChatView({
                 onMessagesTouchEnd={onMessagesTouchEnd}
                 scrollButtonVisible={showScrollToBottom}
                 onScrollToBottom={onScrollToBottom}
+                bottomContentInsetPx={
+                  activeTaskList && !planSidebarOpen && activeTaskListCardHeight > 0
+                    ? activeTaskListCardHeight + 8
+                    : undefined
+                }
               />
             )}
 
@@ -7871,15 +7953,7 @@ export default function ChatView({
                   >
                     {activeTaskList && !planSidebarOpen ? (
                       <div className="pointer-events-none absolute inset-x-0 bottom-full z-20">
-                        <div className="pointer-events-auto mx-auto w-11/12">
-                          <ActiveTaskListCard
-                            activeTaskList={activeTaskList}
-                            backgroundTaskCount={activeBackgroundTasks?.activeCount ?? 0}
-                            compact={activeTaskListCompact}
-                            onCompactChange={setActiveTaskListCompact}
-                            onOpenSidebar={() => setPlanSidebarOpen(true)}
-                          />
-                        </div>
+                        {renderActiveTaskListCard()}
                       </div>
                     ) : null}
                     {queuedComposerTurns.length > 0 ? (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1844,6 +1844,10 @@ export default function ChatView({
     };
 
     updateHeight();
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
     const resizeObserver = new ResizeObserver(updateHeight);
     resizeObserver.observe(element);
     return () => {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -19,12 +19,14 @@ import {
   getVisibleThreadsForProject,
   getProjectSortTimestamp,
   hasUnseenCompletion,
+  isLoopbackHostname,
   isDuplicateProjectCreateError,
   pruneExpandedProjectThreadListsForCollapsedProjects,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
+  shouldShowDebugFeatureFlagsMenu,
   shouldPrunePinnedThreads,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
@@ -92,6 +94,47 @@ describe("shouldClearThreadSelectionOnMouseDown", () => {
     } as unknown as HTMLElement;
 
     expect(shouldClearThreadSelectionOnMouseDown(unrelated)).toBe(true);
+  });
+});
+
+describe("debug feature flags menu visibility", () => {
+  it("allows loopback hostnames", () => {
+    expect(isLoopbackHostname("localhost")).toBe(true);
+    expect(isLoopbackHostname("127.0.0.1")).toBe(true);
+    expect(isLoopbackHostname("::1")).toBe(true);
+    expect(isLoopbackHostname("[::1]")).toBe(true);
+  });
+
+  it("requires dev mode, localhost, and explicit storage opt-in", () => {
+    expect(
+      shouldShowDebugFeatureFlagsMenu({
+        isDev: true,
+        hostname: "localhost",
+        storageValue: "true",
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldShowDebugFeatureFlagsMenu({
+        isDev: false,
+        hostname: "localhost",
+        storageValue: "true",
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowDebugFeatureFlagsMenu({
+        isDev: true,
+        hostname: "app.example.com",
+        storageValue: "true",
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowDebugFeatureFlagsMenu({
+        isDev: true,
+        hostname: "localhost",
+        storageValue: null,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -22,6 +22,7 @@ export {
 
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 10;
+export const DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY = "dpcode:show-debug-feature-flags-menu";
 export type SidebarNewThreadEnvMode = "local" | "worktree";
 type SidebarProject = {
   id: string;
@@ -35,6 +36,29 @@ type SidebarThreadSortInput = {
   latestUserMessageAt?: string | null | undefined;
   messages?: ReadonlyArray<Pick<ChatMessage, "role" | "createdAt">> | undefined;
 };
+
+export function isLoopbackHostname(hostname: string): boolean {
+  const normalizedHostname = hostname.trim().toLowerCase().replace(/\.$/, "");
+
+  return (
+    normalizedHostname === "localhost" ||
+    normalizedHostname === "127.0.0.1" ||
+    normalizedHostname === "::1" ||
+    normalizedHostname === "[::1]"
+  );
+}
+
+export function shouldShowDebugFeatureFlagsMenu(input: {
+  readonly isDev: boolean;
+  readonly hostname: string;
+  readonly storageValue: string | null;
+}): boolean {
+  return (
+    input.isDev &&
+    isLoopbackHostname(input.hostname) &&
+    input.storageValue === "true"
+  );
+}
 
 export type SidebarProjectEntry = {
   kind: "thread";

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -189,11 +189,13 @@ import {
   getVisibleSidebarEntriesForPreview,
   groupSidebarThreadsByProjectId,
   pruneExpandedProjectThreadListsForCollapsedProjects,
+  DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY,
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   isDuplicateProjectCreateError,
   type SidebarDerivedProjectData,
+  shouldShowDebugFeatureFlagsMenu,
   shouldPrunePinnedThreads,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
@@ -258,7 +260,6 @@ const SIDEBAR_LIST_ANIMATION_OPTIONS = {
 } as const;
 const EMPTY_THREAD_JUMP_LABELS = new Map<ThreadId, string>();
 const EMPTY_SHORTCUT_PARTS: readonly string[] = [];
-const DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY = "dpcode:show-debug-feature-flags-menu";
 const ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS = 6;
 const ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS = 50;
 const THREAD_INTENT_PREWARM_RELEASE_MS = 10_000;
@@ -282,27 +283,22 @@ const PROJECT_CONTEXT_MENU_COPY_PATH_ICON =
 const PROJECT_CONTEXT_MENU_ARCHIVE_ICON = renderToStaticMarkup(<HiOutlineArchiveBox />);
 const PROJECT_CONTEXT_MENU_DELETE_THREADS_ICON = renderToStaticMarkup(<Trash2 />);
 
-function isLoopbackHostname(hostname: string): boolean {
-  const normalizedHostname = hostname.trim().toLowerCase().replace(/\.$/, "");
+type DebugFeatureFlagsWindow = Window & {
+  dpcodeShowFeatureFlags?: () => void;
+  dpcodeHideFeatureFlags?: () => void;
+};
 
-  return (
-    normalizedHostname === "localhost" ||
-    normalizedHostname === "127.0.0.1" ||
-    normalizedHostname === "::1" ||
-    normalizedHostname === "[::1]"
-  );
-}
-
-function shouldShowDebugFeatureFlagsMenu(): boolean {
-  if (!import.meta.env.DEV || typeof window === "undefined") {
+function readDebugFeatureFlagsMenuVisibility(): boolean {
+  if (typeof window === "undefined") {
     return false;
   }
 
   try {
-    return (
-      isLoopbackHostname(window.location.hostname) &&
-      window.localStorage.getItem(DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY) === "true"
-    );
+    return shouldShowDebugFeatureFlagsMenu({
+      isDev: import.meta.env.DEV,
+      hostname: window.location.hostname,
+      storageValue: window.localStorage.getItem(DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY),
+    });
   } catch {
     return false;
   }
@@ -1089,6 +1085,9 @@ function SortableWorkspaceItem({
 }
 
 export default function Sidebar() {
+  const [showDebugFeatureFlagsMenu, setShowDebugFeatureFlagsMenu] = useState(
+    readDebugFeatureFlagsMenuVisibility,
+  );
   const projects = useStore((store) => store.projects);
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const sidebarThreadSummaryById = useStore((store) => store.sidebarThreadSummaryById);
@@ -1148,6 +1147,49 @@ export default function Sidebar() {
   const activeSettingsSection = normalizeSettingsSection(settingsSectionSearch.section);
   const activeSplitView = useSplitViewStore(selectSplitView(routeSearch.splitViewId ?? null));
   const splitViewsById = useSplitViewStore((store) => store.splitViewsById);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const canInstallConsoleCommand = shouldShowDebugFeatureFlagsMenu({
+      isDev: import.meta.env.DEV,
+      hostname: window.location.hostname,
+      storageValue: "true",
+    });
+    if (!canInstallConsoleCommand) {
+      return;
+    }
+
+    const debugWindow = window as DebugFeatureFlagsWindow;
+    const updateVisibility = () => {
+      setShowDebugFeatureFlagsMenu(readDebugFeatureFlagsMenuVisibility());
+    };
+    const showFeatureFlags = () => {
+      window.localStorage.setItem(DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY, "true");
+      updateVisibility();
+    };
+    const hideFeatureFlags = () => {
+      window.localStorage.removeItem(DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY);
+      updateVisibility();
+    };
+
+    debugWindow.dpcodeShowFeatureFlags = showFeatureFlags;
+    debugWindow.dpcodeHideFeatureFlags = hideFeatureFlags;
+    window.addEventListener("storage", updateVisibility);
+    updateVisibility();
+
+    return () => {
+      window.removeEventListener("storage", updateVisibility);
+      if (debugWindow.dpcodeShowFeatureFlags === showFeatureFlags) {
+        delete debugWindow.dpcodeShowFeatureFlags;
+      }
+      if (debugWindow.dpcodeHideFeatureFlags === hideFeatureFlags) {
+        delete debugWindow.dpcodeHideFeatureFlags;
+      }
+    };
+  }, []);
   const createSplitViewFromDrop = useSplitViewStore((store) => store.createFromDrop);
   const setSplitFocusedPane = useSplitViewStore((store) => store.setFocusedPane);
   const removeThreadFromSplitViews = useSplitViewStore((store) => store.removeThreadFromSplitViews);
@@ -5744,7 +5786,7 @@ export default function Sidebar() {
         <SidebarMenu>
           <SidebarMenuItem>
             <div className="flex flex-col gap-1">
-              {DebugFeatureFlagsMenu && shouldShowDebugFeatureFlagsMenu() && !isOnSettings ? (
+              {DebugFeatureFlagsMenu && showDebugFeatureFlagsMenu && !isOnSettings ? (
                 <Suspense fallback={null}>
                   <DebugFeatureFlagsMenu />
                 </Suspense>

--- a/apps/web/src/components/chat/ActiveTaskListCard.tsx
+++ b/apps/web/src/components/chat/ActiveTaskListCard.tsx
@@ -42,7 +42,10 @@ export const ActiveTaskListCard = memo(function ActiveTaskListCard({
   const taskOccurrenceCount = new Map<string, number>();
 
   return (
-    <div className="overflow-hidden rounded-t-2xl border border-b-0 border-[color:var(--color-border)] bg-[var(--color-background-surface-under)]">
+    <div
+      data-testid="active-task-list-card"
+      className="overflow-hidden rounded-t-2xl border border-b-0 border-[color:var(--color-border)] bg-[var(--color-background-surface-under)]"
+    >
       <div className="flex items-center justify-between gap-2 px-2.5 py-2">
         <div className="flex min-w-0 items-center gap-1.5 text-[12px] text-muted-foreground/80">
           {compact && hasInProgressTask ? (

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -27,6 +27,7 @@ interface ChatTranscriptPaneProps {
   activeTurnId?: TurnId | null;
   activeTurnInProgress: boolean;
   activeTurnStartedAt: string | null;
+  bottomContentInsetPx?: ComponentProps<typeof MessagesTimeline>["bottomContentInsetPx"];
   chatFontSizePx: number;
   completionDividerBeforeEntryId: string | null;
   completionSummary: string | null;
@@ -71,6 +72,7 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
   activeTurnId,
   activeTurnInProgress,
   activeTurnStartedAt,
+  bottomContentInsetPx,
   chatFontSizePx,
   completionDividerBeforeEntryId,
   completionSummary,
@@ -111,6 +113,7 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
 }: ChatTranscriptPaneProps) {
   return (
     <div
+      data-chat-transcript-pane="true"
       aria-hidden={terminalWorkspaceTerminalTabActive}
       className={cn(
         "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
@@ -154,6 +157,7 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
           chatFontSizePx={chatFontSizePx}
           timestampFormat={timestampFormat}
           workspaceRoot={workspaceRoot}
+          bottomContentInsetPx={bottomContentInsetPx}
           emptyStateContent={<ChatEmptyStateHero projectName={emptyStateProjectName} />}
           {...(expandedWorkGroups ? { expandedWorkGroups } : {})}
           {...(onToggleWorkGroup ? { onToggleWorkGroup } : {})}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -210,6 +210,7 @@ interface MessagesTimelineProps {
   chatFontSizePx?: number;
   timestampFormat: TimestampFormat;
   workspaceRoot: string | undefined;
+  bottomContentInsetPx?: number | undefined;
 }
 
 export const MessagesTimeline = memo(function MessagesTimeline({
@@ -251,6 +252,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   timestampFormat,
   workspaceRoot,
   emptyStateContent,
+  bottomContentInsetPx,
 }: MessagesTimelineProps) {
   const normalizedChatFontSizePx = normalizeChatFontSizePx(chatFontSizePx);
   const appTypographyScale = useMemo(
@@ -1030,6 +1032,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onWheel={onMessagesWheel}
       data-chat-scroll-container="true"
       className="h-full overflow-x-hidden overscroll-y-contain px-3 py-3 sm:px-5 sm:py-4"
+      style={bottomContentInsetPx ? { paddingBottom: bottomContentInsetPx } : undefined}
     />
   );
 });

--- a/apps/web/src/featureFlags.ts
+++ b/apps/web/src/featureFlags.ts
@@ -17,6 +17,7 @@ export type FeatureFlag =
 
 export type ToggleFeatureFlagId =
   | "persist-action-failed-debug-toasts"
+  | "show-debug-task-banner"
   | "show-expanded-cursor-model-variants";
 
 type FeatureFlagState = Record<ToggleFeatureFlagId, boolean>;
@@ -25,6 +26,7 @@ const FEATURE_FLAG_STORAGE_KEY = "dpcode:feature-flags";
 
 const DEFAULT_FEATURE_FLAG_STATE: FeatureFlagState = {
   "persist-action-failed-debug-toasts": false,
+  "show-debug-task-banner": false,
   "show-expanded-cursor-model-variants": false,
 };
 
@@ -41,6 +43,13 @@ export const FEATURE_FLAGS: readonly FeatureFlag[] = [
     label: "Keep debug error toasts open",
     description: "Disable auto-dismiss for locally triggered error toasts.",
     defaultEnabled: DEFAULT_FEATURE_FLAG_STATE["persist-action-failed-debug-toasts"],
+  },
+  {
+    id: "show-debug-task-banner",
+    kind: "toggle",
+    label: "Show debug task banner",
+    description: "Render a local sample active task banner for UI testing.",
+    defaultEnabled: DEFAULT_FEATURE_FLAG_STATE["show-debug-task-banner"],
   },
   {
     id: "show-expanded-cursor-model-variants",
@@ -71,6 +80,10 @@ function normalizeFeatureFlagState(value: unknown): FeatureFlagState {
       typeof record["persist-action-failed-debug-toasts"] === "boolean"
         ? record["persist-action-failed-debug-toasts"]
         : DEFAULT_FEATURE_FLAG_STATE["persist-action-failed-debug-toasts"],
+    "show-debug-task-banner":
+      typeof record["show-debug-task-banner"] === "boolean"
+        ? record["show-debug-task-banner"]
+        : DEFAULT_FEATURE_FLAG_STATE["show-debug-task-banner"],
     "show-expanded-cursor-model-variants":
       typeof record["show-expanded-cursor-model-variants"] === "boolean"
         ? record["show-expanded-cursor-model-variants"]


### PR DESCRIPTION
## Summary
- Keep the task banner narrow and floating above the composer without creating a full-width clipping row.
- Measure the banner height and use it as transcript bottom clearance so expanded and compact states stay visible.
- Add a localhost-only debug feature flag menu command and a sample task banner flag for local verification.

## Validation
- bun run test -- Sidebar.logic.test.ts -t "debug feature flags"
- git diff --check

Note: full workspace fmt/lint/typecheck were not run because the repo instructions require an explicit request for those heavyweight checks.