### PR TITLE
[codex] Fix OpenCode model discovery and live event replay

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1301,7 +1301,7 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
-  it("passes OpenCode model selection and provider options into thread-title generation", async () => {
+  it("uses deterministic first-turn titles for OpenCode threads without launching title generation", async () => {
     const harness = await createHarness({
       threadModelSelection: {
         provider: "opencode",
@@ -1360,24 +1360,14 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await waitFor(() => harness.generateThreadTitle.mock.calls.length === 1);
-    expect(harness.generateThreadTitle.mock.calls[0]?.[0]).toMatchObject({
-      modelSelection: {
-        provider: "opencode",
-        model: "openai/gpt-5",
-        options: {
-          agent: "plan",
-          variant: "balanced",
-        },
-      },
-      providerOptions: {
-        opencode: {
-          binaryPath: "/custom/bin/opencode",
-          serverUrl: "http://127.0.0.1:4096",
-          serverPassword: "secret",
-        },
-      },
+    await waitFor(async () => {
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      return (
+        readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"))?.title ===
+        "Plan the release workflow"
+      );
     });
+    expect(harness.generateThreadTitle.mock.calls.length).toBe(0);
   });
 
   it("queues a follow-up turn while the current turn is still running", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1059,6 +1059,20 @@ const make = Effect.gen(function* () {
     if (!isGenericChatThreadTitle(currentTitle) && currentTitle !== fallbackTitle) {
       return;
     }
+    const titleModelSelection =
+      input.modelSelection ?? threadModelSelections.get(input.threadId) ?? thread.modelSelection;
+    if (titleModelSelection.provider === "opencode") {
+      if (currentTitle === fallbackTitle) {
+        return;
+      }
+      yield* orchestrationEngine.dispatch({
+        type: "thread.meta.update",
+        commandId: serverCommandId("thread-title-fallback"),
+        threadId: input.threadId,
+        title: fallbackTitle,
+      });
+      return;
+    }
 
     const cwd = resolveThreadWorkspaceCwd({
       thread,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2021,6 +2021,7 @@ describe("ProviderRuntimeIngestion", () => {
       );
     });
     expect(completionEvents).toHaveLength(1);
+    expect(completionEvents[0]?.payload.text).toBe("done");
   });
 
   it("reuses the live assistant message when item.completed omits the item id", async () => {

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1125,11 +1125,12 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.message.assistant.complete": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
       });
+      const existingMessage = thread.messages.find((message) => message.id === command.messageId);
       return {
         ...withEventBase({
           aggregateKind: "thread",
@@ -1142,7 +1143,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           messageId: command.messageId,
           role: "assistant",
-          text: "",
+          text: existingMessage?.text ?? "",
           turnId: command.turnId ?? null,
           streaming: false,
           createdAt: command.createdAt,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../opencodeRuntime.ts";
 import { OpenCodeAdapter } from "../Services/OpenCodeAdapter.ts";
 import {
+  flattenOpenCodeCliModels,
   flattenOpenCodeModels,
   makeOpenCodeAdapterLive,
   normalizeOpenCodeTokenUsage,
@@ -563,6 +564,181 @@ describe("resolvePreferredOpenCodeModelProviders", () => {
 });
 
 describe("flattenOpenCodeModels", () => {
+  it("converts OpenCode CLI model output into grouped model descriptors", () => {
+    const models = flattenOpenCodeCliModels({
+      models: [
+        {
+          slug: "openai/gpt-5.4",
+          providerID: "openai",
+          modelID: "gpt-5.4",
+          name: "GPT-5.4",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+        {
+          slug: "opencode/minimax-m2.5-free",
+          providerID: "opencode",
+          modelID: "minimax-m2.5-free",
+          name: "MiniMax M2.5 Free",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+        {
+          slug: "opencode-go/kimi-k2.6",
+          providerID: "opencode-go",
+          modelID: "kimi-k2.6",
+          name: "Kimi K2.6",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+        {
+          slug: "kimi-for-coding/k2p6",
+          providerID: "kimi-for-coding",
+          modelID: "k2p6",
+          name: "K2P6",
+          variants: [],
+          supportedReasoningEfforts: [
+            {
+              value: "high",
+            },
+          ],
+          defaultReasoningEffort: "high",
+        },
+        {
+          slug: "github-copilot/claude-sonnet-4.6",
+          providerID: "github-copilot",
+          modelID: "claude-sonnet-4.6",
+          name: "Claude Sonnet 4.6",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+        {
+          slug: "anthropic/claude-sonnet-4-5",
+          providerID: "anthropic",
+          modelID: "claude-sonnet-4-5",
+          name: "Claude Sonnet 4.5",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+        {
+          slug: "google-vertex/gemini-3-pro",
+          providerID: "google-vertex",
+          modelID: "gemini-3-pro",
+          name: "Gemini 3 Pro",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+        {
+          slug: "openrouter/qwen/qwen3-coder",
+          providerID: "openrouter",
+          modelID: "qwen/qwen3-coder",
+          name: "Qwen3 Coder",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+        {
+          slug: "ollama/qwen3-coder:30b",
+          providerID: "ollama",
+          modelID: "qwen3-coder:30b",
+          name: "Qwen3 Coder 30B",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+        {
+          slug: "amazon-bedrock/anthropic-claude-sonnet-4.5",
+          providerID: "amazon-bedrock",
+          modelID: "anthropic-claude-sonnet-4.5",
+          name: "Claude Sonnet 4.5",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+        {
+          slug: "vercel-ai-gateway/xai/grok-code-fast",
+          providerID: "vercel-ai-gateway",
+          modelID: "xai/grok-code-fast",
+          name: "Grok Code Fast",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+      ],
+    });
+
+    expect(models).toEqual([
+      {
+        slug: "amazon-bedrock/anthropic-claude-sonnet-4.5",
+        name: "Claude Sonnet 4.5",
+        upstreamProviderId: "amazon-bedrock",
+        upstreamProviderName: "Amazon Bedrock",
+      },
+      {
+        slug: "anthropic/claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        upstreamProviderId: "anthropic",
+        upstreamProviderName: "Anthropic",
+      },
+      {
+        slug: "github-copilot/claude-sonnet-4.6",
+        name: "Claude Sonnet 4.6",
+        upstreamProviderId: "github-copilot",
+        upstreamProviderName: "GitHub Copilot",
+      },
+      {
+        slug: "google-vertex/gemini-3-pro",
+        name: "Gemini 3 Pro",
+        upstreamProviderId: "google-vertex",
+        upstreamProviderName: "Google Vertex AI",
+      },
+      {
+        slug: "kimi-for-coding/k2p6",
+        name: "K2P6",
+        upstreamProviderId: "kimi-for-coding",
+        upstreamProviderName: "Kimi For Coding",
+        supportedReasoningEfforts: [
+          {
+            value: "high",
+          },
+        ],
+        defaultReasoningEffort: "high",
+      },
+      {
+        slug: "ollama/qwen3-coder:30b",
+        name: "Qwen3 Coder 30B",
+        upstreamProviderId: "ollama",
+        upstreamProviderName: "Ollama",
+      },
+      {
+        slug: "openai/gpt-5.4",
+        name: "GPT-5.4",
+        upstreamProviderId: "openai",
+        upstreamProviderName: "OpenAI",
+      },
+      {
+        slug: "opencode/minimax-m2.5-free",
+        name: "MiniMax M2.5 Free",
+        upstreamProviderId: "opencode",
+        upstreamProviderName: "OpenCode",
+      },
+      {
+        slug: "opencode-go/kimi-k2.6",
+        name: "Kimi K2.6",
+        upstreamProviderId: "opencode-go",
+        upstreamProviderName: "OpenCode Go",
+      },
+      {
+        slug: "openrouter/qwen/qwen3-coder",
+        name: "Qwen3 Coder",
+        upstreamProviderId: "openrouter",
+        upstreamProviderName: "OpenRouter",
+      },
+      {
+        slug: "vercel-ai-gateway/xai/grok-code-fast",
+        name: "Grok Code Fast",
+        upstreamProviderId: "vercel-ai-gateway",
+        upstreamProviderName: "Vercel AI Gateway",
+      },
+    ]);
+  });
+
   it("includes upstream provider metadata for grouped OpenCode model menus", () => {
     const models = flattenOpenCodeModels({
       inventory: {
@@ -777,8 +953,26 @@ describe("flattenOpenCodeModels", () => {
 });
 
 describe("OpenCodeAdapter runtime lifecycle", () => {
-  it("augments OpenCode server discovery with CLI models", async () => {
+  it("lists OpenCode models from the CLI before falling back to server inventory", async () => {
     const runtime = createMockOpenCodeRuntime({
+      cliModels: [
+        {
+          slug: "opencode/minimax-m2.5-free",
+          providerID: "opencode",
+          modelID: "minimax-m2.5-free",
+          name: "MiniMax M2.5 Free",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+        {
+          slug: "opencode-go/kimi-k2.6",
+          providerID: "opencode-go",
+          modelID: "kimi-k2.6",
+          name: "Kimi K2.6",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+      ],
       inventory: {
         providerList: {
           connected: ["openai"],
@@ -799,30 +993,15 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
         agents: [],
         consoleState: null,
       },
-      cliModels: [
-        {
-          slug: "opencode/big-pickle",
-          providerID: "opencode",
-          modelID: "big-pickle",
-          name: "Big Pickle",
-          variants: [],
-          supportedReasoningEfforts: [],
-        },
-        {
-          slug: "kimi-for-coding/k2p6",
-          providerID: "kimi-for-coding",
-          modelID: "k2p6",
-          name: "Kimi K2P6",
-          variants: [],
-          supportedReasoningEfforts: [],
-        },
-      ],
     });
 
-    const models = await Effect.runPromise(
+    const result = await Effect.runPromise(
       Effect.gen(function* () {
         const adapter = yield* OpenCodeAdapter;
-        return yield* adapter.listModels!({});
+        return yield* adapter.listModels?.({
+          provider: "opencode",
+          binaryPath: "opencode",
+        });
       }).pipe(
         Effect.provide(
           makeOpenCodeAdapterLive({ runtime: runtime.runtime }).pipe(
@@ -835,8 +1014,14 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
       ),
     );
 
-    expect(models.models.map((model) => model.slug)).toContain("opencode/big-pickle");
-    expect(models.models.map((model) => model.slug)).toContain("kimi-for-coding/k2p6");
+    expect(result).toMatchObject({
+      source: "opencode-cli",
+      cached: false,
+    });
+    expect(result?.models.map((model) => model.slug)).toEqual([
+      "opencode/minimax-m2.5-free",
+      "opencode-go/kimi-k2.6",
+    ]);
   });
 
   it("pins the initial model on new OpenCode sessions", async () => {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -960,6 +960,89 @@ function toOpenCodeModelDescriptor(input: {
   };
 }
 
+function formatOpenCodeCliProviderName(providerId: string): string {
+  const normalizedProviderId = providerId.trim();
+  const knownNames: Record<string, string> = {
+    "302-ai": "302.AI",
+    "amazon-bedrock": "Amazon Bedrock",
+    anthropic: "Anthropic",
+    "atomic-chat": "Atomic Chat",
+    "azure-openai": "Azure OpenAI",
+    "azure-cognitive-services": "Azure Cognitive Services",
+    baseten: "Baseten",
+    cerebras: "Cerebras",
+    "cloudflare-ai-gateway": "Cloudflare AI Gateway",
+    "cloudflare-workers-ai": "Cloudflare Workers AI",
+    cortecs: "Cortecs",
+    deepinfra: "Deep Infra",
+    deepseek: "DeepSeek",
+    fireworks: "Fireworks AI",
+    "fireworks-ai": "Fireworks AI",
+    frogbot: "FrogBot",
+    "github-copilot": "GitHub Copilot",
+    "gitlab-duo": "GitLab Duo",
+    "google-vertex": "Google Vertex AI",
+    "google-vertex-ai": "Google Vertex AI",
+    groq: "Groq",
+    "hugging-face": "Hugging Face",
+    huggingface: "Hugging Face",
+    "io-net": "IO.NET",
+    "kimi-for-coding": "Kimi For Coding",
+    "llama.cpp": "llama.cpp",
+    lmstudio: "LM Studio",
+    minimax: "MiniMax",
+    "moonshot-ai": "Moonshot AI",
+    "nebius-token-factory": "Nebius Token Factory",
+    nvidia: "NVIDIA",
+    ollama: "Ollama",
+    "ollama-cloud": "Ollama Cloud",
+    openai: "OpenAI",
+    opencode: "OpenCode",
+    "opencode-go": "OpenCode Go",
+    "opencode-zen": "OpenCode Zen",
+    openrouter: "OpenRouter",
+    "ovhcloud-ai-endpoints": "OVHcloud AI Endpoints",
+    "sap-ai-core": "SAP AI Core",
+    scaleway: "Scaleway",
+    stackit: "STACKIT",
+    "together-ai": "Together AI",
+    "venice-ai": "Venice AI",
+    "vercel-ai-gateway": "Vercel AI Gateway",
+    xai: "xAI",
+    "z-ai": "Z.AI",
+    zenmux: "ZenMux",
+  };
+  const knownName = knownNames[normalizedProviderId.toLowerCase()];
+  if (knownName) {
+    return knownName;
+  }
+
+  return normalizedProviderId
+    .split(/[-_/]+/u)
+    .filter((segment) => segment.length > 0)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export function flattenOpenCodeCliModels(input: {
+  readonly models: ReadonlyArray<OpenCodeCliModelDescriptor>;
+}): ProviderListModelsResult["models"] {
+  return input.models
+    .flatMap((model) => {
+      const descriptor = toOpenCodeModelDescriptor({
+        slug: model.slug,
+        name: model.name,
+        provider: {
+          id: model.providerID,
+          name: formatOpenCodeCliProviderName(model.providerID),
+        },
+        cliModel: model,
+      });
+      return descriptor ? [descriptor] : [];
+    })
+    .toSorted(compareOpenCodeModelDescriptors);
+}
+
 export function flattenOpenCodeModels(input: {
   readonly inventory: OpenCodeModelInventory;
 }): ProviderListModelsResult["models"] {
@@ -980,51 +1063,6 @@ export function flattenOpenCodeModels(input: {
       }),
     )
     .toSorted(compareOpenCodeModelDescriptors);
-}
-
-function fallbackOpenCodeProviderName(providerId: string): string {
-  return providerId
-    .split(/[-_/]+/u)
-    .filter((segment) => segment.length > 0)
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-    .join(" ");
-}
-
-function mergeOpenCodeCliModelDescriptors(input: {
-  readonly inventory: OpenCodeModelInventory;
-  readonly models: ReadonlyArray<OpenCodeModelDescriptor>;
-  readonly cliModels: ReadonlyArray<OpenCodeCliModelDescriptor>;
-}): ProviderListModelsResult["models"] {
-  const providerById = new Map(
-    input.inventory.providerList.all.map((provider) => [provider.id, provider] as const),
-  );
-  const mergedBySlug = new Map(input.models.map((model) => [model.slug, model] as const));
-
-  for (const cliModel of input.cliModels) {
-    if (mergedBySlug.has(cliModel.slug)) {
-      continue;
-    }
-    const provider =
-      providerById.get(cliModel.providerID) ??
-      ({
-        id: cliModel.providerID,
-        name: fallbackOpenCodeProviderName(cliModel.providerID) || cliModel.providerID,
-      } satisfies Pick<OpenCodeInventoryProvider, "id" | "name">);
-    const descriptor = toOpenCodeModelDescriptor({
-      slug: cliModel.slug,
-      name: cliModel.name,
-      provider,
-      ...(providerById.get(cliModel.providerID)?.models[cliModel.modelID]
-        ? { model: providerById.get(cliModel.providerID)!.models[cliModel.modelID] }
-        : {}),
-      cliModel,
-    });
-    if (descriptor) {
-      mergedBySlug.set(descriptor.slug, descriptor);
-    }
-  }
-
-  return [...mergedBySlug.values()].toSorted(compareOpenCodeModelDescriptors);
 }
 
 function flattenOpenCodeAgents(agents: ReadonlyArray<Agent>): ProviderListAgentsResult["agents"] {
@@ -2375,36 +2413,28 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           );
         });
 
-      const listModels: NonNullable<OpenCodeAdapterShape["listModels"]> = (input) =>
-        withDiscoveryInventory(
-          { binaryPath: input.binaryPath?.trim() || "opencode" },
-          ({ inventory }) =>
-            Effect.gen(function* () {
-              const binaryPath = input.binaryPath?.trim() || "opencode";
-              const inventoryModels = flattenOpenCodeModels({ inventory });
-              const cliModels = yield* openCodeRuntime
-                .listOpenCodeCliModels({ binaryPath })
-                .pipe(Effect.catch(() => Effect.succeed([])));
-              const models = mergeOpenCodeCliModelDescriptors({
-                inventory,
-                models: inventoryModels,
-                cliModels,
-              });
-              yield* Effect.logDebug("OpenCode model discovery resolved", {
-                binaryPath,
-                connectedProviders: inventory.providerList.connected,
-                inventoryModelCount: inventoryModels.length,
-                cliModelCount: cliModels.length,
-                modelCount: models.length,
-                sampleModels: models.slice(0, 12).map((model) => model.slug),
-              });
-              return {
-                models,
-                source: cliModels.length > 0 ? "opencode-cli" : "opencode",
-                cached: false,
-              };
-            }),
+      const listModels: NonNullable<OpenCodeAdapterShape["listModels"]> = (input) => {
+        const binaryPath = input.binaryPath?.trim() || "opencode";
+        const inventoryModels = withDiscoveryInventory({ binaryPath }, ({ inventory }) =>
+          Effect.succeed({
+            models: flattenOpenCodeModels({ inventory }),
+            source: "opencode",
+            cached: false,
+          }),
         );
+
+        return openCodeRuntime.listOpenCodeCliModels({ binaryPath }).pipe(
+          Effect.map((models) => ({
+            models: flattenOpenCodeCliModels({ models }),
+            source: "opencode-cli",
+            cached: false,
+          })),
+          Effect.flatMap((result) =>
+            result.models.length > 0 ? Effect.succeed(result) : inventoryModels,
+          ),
+          Effect.catch(() => inventoryModels),
+        );
+      };
 
       const listAgents: NonNullable<OpenCodeAdapterShape["listAgents"]> = () =>
         withDiscoveryInventory({}, ({ inventory }) =>

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -336,6 +336,84 @@ it.effect("ProviderServiceLive keeps persisted resumable sessions on startup", (
 );
 
 it.effect(
+  "ProviderServiceLive persists active sessions as stopped before adapter cleanup runs",
+  () =>
+    Effect.gen(function* () {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-provider-service-stopall-"));
+      const dbPath = path.join(tempDir, "orchestration.sqlite");
+      const persistenceLayer = makeSqlitePersistenceLive(dbPath);
+      const runtimeRepositoryLayer = ProviderSessionRuntimeRepositoryLive.pipe(
+        Layer.provide(persistenceLayer),
+      );
+
+      const codex = makeFakeCodexAdapter();
+      const threadId = asThreadId("thread-stopall");
+      const resumeCursor = {
+        threadId,
+        resume: "resume-session-stopall",
+        resumeSessionAt: "assistant-message-stopall",
+        turnCount: 1,
+      };
+      codex.stopAll.mockImplementation(() =>
+        Effect.fail(
+          new ProviderAdapterSessionNotFoundError({
+            provider: "codex",
+            threadId,
+          }),
+        ),
+      );
+
+      const registry: typeof ProviderAdapterRegistry.Service = {
+        getByProvider: (provider) =>
+          provider === "codex"
+            ? Effect.succeed(codex.adapter)
+            : Effect.fail(new ProviderUnsupportedError({ provider })),
+        listProviders: () => Effect.succeed(["codex"]),
+      };
+
+      const providerLayer = makeProviderServiceLive().pipe(
+        Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
+        Layer.provide(
+          ProviderSessionDirectoryLive.pipe(Layer.provide(runtimeRepositoryLayer)),
+        ),
+        Layer.provide(AnalyticsService.layerTest),
+      );
+
+      yield* Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        yield* provider.startSession(threadId, {
+          provider: "codex",
+          cwd: "/tmp/project",
+          runtimeMode: "full-access",
+          threadId,
+        });
+        codex.updateSession(threadId, (existing) => ({
+          ...existing,
+          status: "running",
+          activeTurnId: asTurnId("turn-stopall"),
+          resumeCursor,
+        }));
+      }).pipe(Effect.provide(providerLayer));
+
+      const persisted = yield* Effect.gen(function* () {
+        const repository = yield* ProviderSessionRuntimeRepository;
+        return yield* repository.getByThreadId({ threadId });
+      }).pipe(Effect.provide(runtimeRepositoryLayer));
+
+      assert.equal(Option.isSome(persisted), true);
+      if (Option.isSome(persisted)) {
+        const runtimePayload = persisted.value.runtimePayload as Record<string, unknown>;
+        assert.equal(persisted.value.status, "stopped");
+        assert.deepEqual(persisted.value.resumeCursor, resumeCursor);
+        assert.equal(runtimePayload.activeTurnId, null);
+        assert.equal(runtimePayload.lastRuntimeEvent, "provider.stopAll");
+      }
+
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }).pipe(Effect.provide(NodeServices.layer)),
+);
+
+it.effect(
   "ProviderServiceLive restores rollback routing after restart using persisted thread mapping",
   () =>
     Effect.gen(function* () {
@@ -746,6 +824,61 @@ routing.layer("ProviderServiceLive routing", (it) => {
           assert.equal(runtimePayload.activeTurnId, `turn-${String(session.threadId)}`);
           assert.equal(runtimePayload.lastError, null);
           assert.equal(runtimePayload.lastRuntimeEvent, "provider.sendTurn");
+        }
+      }
+    }),
+  );
+
+  it.effect("clears persisted active turn metadata when a runtime turn completes", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+
+      const session = yield* provider.startSession(asThreadId("thread-runtime-complete"), {
+        provider: "codex",
+        threadId: asThreadId("thread-runtime-complete"),
+        runtimeMode: "full-access",
+      });
+      const turn = yield* provider.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+        modelSelection: {
+          provider: "opencode",
+          model: "opencode/minimax-m2.5-free",
+        },
+      });
+      yield* sleep(50);
+
+      routing.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-complete-event"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId: session.threadId,
+        turnId: turn.turnId,
+        payload: { state: "completed" },
+      });
+      yield* sleep(50);
+
+      const runtime = yield* runtimeRepository.getByThreadId({
+        threadId: session.threadId,
+      });
+      assert.equal(Option.isSome(runtime), true);
+      if (Option.isSome(runtime)) {
+        const payload = runtime.value.runtimePayload;
+        assert.equal(payload !== null && typeof payload === "object", true);
+        if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
+          const runtimePayload = payload as {
+            activeTurnId: string | null;
+            lastRuntimeEvent: string | null;
+          };
+          assert.equal(runtimePayload.activeTurnId, null);
+          assert.equal(runtimePayload.lastRuntimeEvent, "turn.completed");
+          assert.deepEqual(runtimePayload.modelSelection, {
+            provider: "opencode",
+            model: "opencode/minimax-m2.5-free",
+          });
         }
       }
     }),

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -27,7 +27,7 @@ import {
   type ProviderRuntimeEvent,
   type ProviderSession,
 } from "@t3tools/contracts";
-import { Effect, Layer, Option, PubSub, Schema, SchemaIssue, Stream } from "effect";
+import { Cause, Effect, Layer, Option, PubSub, Schema, SchemaIssue, Stream } from "effect";
 
 import { ProviderValidationError } from "../Errors.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
@@ -154,6 +154,12 @@ function readPersistedCwd(
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function runtimePayloadRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
 const makeProviderService = (options?: ProviderServiceLiveOptions) =>
   Effect.gen(function* () {
     const analytics = yield* Effect.service(AnalyticsService);
@@ -239,12 +245,105 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         runtimePayload: toRuntimePayloadFromSession(session, extra),
       });
 
+    const upsertStoppedSessionBinding = (
+      session: ProviderSession,
+      stoppedAt: string,
+    ): Effect.Effect<void> =>
+      directory.upsert({
+        threadId: session.threadId,
+        provider: session.provider,
+        runtimeMode: session.runtimeMode,
+        status: "stopped",
+        ...(session.resumeCursor !== undefined ? { resumeCursor: session.resumeCursor } : {}),
+        runtimePayload: {
+          ...toRuntimePayloadFromSession(session, {
+            lastRuntimeEvent: "provider.stopAll",
+            lastRuntimeEventAt: stoppedAt,
+          }),
+          activeTurnId: null,
+        },
+      });
+
+    const markPersistedThreadStopped = (
+      threadId: ThreadId,
+      stoppedAt: string,
+    ): Effect.Effect<void> =>
+      directory.getProvider(threadId).pipe(
+        Effect.flatMap((provider) =>
+          directory.upsert({
+            threadId,
+            provider,
+            status: "stopped",
+            runtimePayload: {
+              activeTurnId: null,
+              lastRuntimeEvent: "provider.stopAll",
+              lastRuntimeEventAt: stoppedAt,
+            },
+          }),
+        ),
+      );
+
+    const updateSessionBindingFromRuntimeEvent = (
+      event: ProviderRuntimeEvent,
+    ): Effect.Effect<void> => {
+      switch (event.type) {
+        case "session.started":
+        case "thread.started":
+        case "turn.started":
+        case "turn.completed":
+        case "turn.aborted":
+        case "session.exited":
+          break;
+        default:
+          return Effect.void;
+      }
+
+      return Effect.gen(function* () {
+        const binding = Option.getOrUndefined(yield* directory.getBinding(event.threadId));
+        if (!binding) {
+          return;
+        }
+
+        const activeTurnId =
+          event.type === "turn.started"
+            ? (event.turnId ?? null)
+            : event.type === "turn.completed" ||
+                event.type === "turn.aborted" ||
+                event.type === "session.exited"
+              ? null
+              : (runtimePayloadRecord(binding.runtimePayload).activeTurnId ?? null);
+
+        yield* directory.upsert({
+          threadId: event.threadId,
+          provider: binding.provider,
+          ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
+          ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
+          status: event.type === "session.exited" ? "stopped" : "running",
+          ...(binding.resumeCursor !== undefined ? { resumeCursor: binding.resumeCursor } : {}),
+          runtimePayload: {
+            activeTurnId,
+            lastRuntimeEvent: event.type,
+            lastRuntimeEventAt: event.createdAt,
+          },
+        });
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("provider.session.runtime_binding_update_failed", {
+            threadId: event.threadId,
+            eventType: event.type,
+            cause: Cause.pretty(cause),
+          }),
+        ),
+      );
+    };
+
     const providers = yield* registry.listProviders();
     const adapters = yield* Effect.forEach(providers, (provider) =>
       registry.getByProvider(provider),
     );
     const processRuntimeEvent = (event: ProviderRuntimeEvent): Effect.Effect<void> =>
       Effect.sync(() => reconcileRuntimeIdleTimer(event)).pipe(
+        Effect.andThen(updateSessionBindingFromRuntimeEvent(event)),
         Effect.andThen(publishRuntimeEvent(event)),
       );
 
@@ -925,6 +1024,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const runStopAll = () =>
       Effect.gen(function* () {
+        const stoppedAt = new Date().toISOString();
         const threadIds = yield* directory.listThreadIds();
         const activeSessions = yield* Effect.forEach(adapters, (adapter) =>
           adapter.listSessions(),
@@ -932,28 +1032,12 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           Effect.map((sessionsByAdapter) => sessionsByAdapter.flatMap((sessions) => sessions)),
         );
         yield* Effect.forEach(activeSessions, (session) =>
-          upsertSessionBinding(session, session.threadId, {
-            lastRuntimeEvent: "provider.stopAll",
-            lastRuntimeEventAt: new Date().toISOString(),
-          }),
+          upsertStoppedSessionBinding(session, stoppedAt),
+        ).pipe(Effect.asVoid);
+        yield* Effect.forEach(threadIds, (threadId) =>
+          markPersistedThreadStopped(threadId, stoppedAt),
         ).pipe(Effect.asVoid);
         yield* Effect.forEach(adapters, (adapter) => adapter.stopAll()).pipe(Effect.asVoid);
-        yield* Effect.forEach(threadIds, (threadId) =>
-          directory.getProvider(threadId).pipe(
-            Effect.flatMap((provider) =>
-              directory.upsert({
-                threadId,
-                provider,
-                status: "stopped",
-                runtimePayload: {
-                  activeTurnId: null,
-                  lastRuntimeEvent: "provider.stopAll",
-                  lastRuntimeEventAt: new Date().toISOString(),
-                },
-              }),
-            ),
-          ),
-        ).pipe(Effect.asVoid);
         yield* analytics.record("provider.sessions.stopped_all", {
           sessionCount: threadIds.length,
         });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -617,6 +617,9 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
               ...process.env,
               OPENCODE_CONFIG_CONTENT: JSON.stringify({}),
             },
+            detached: false,
+            killSignal: "SIGKILL",
+            forceKillAfter: "1500 millis",
           }),
         )
         .pipe(
@@ -629,7 +632,11 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
                 cause,
               }),
           ),
-        );
+      );
+      yield* Scope.addFinalizer(
+        runtimeScope,
+        child.kill({ killSignal: "SIGKILL", forceKillAfter: "1500 millis" }).pipe(Effect.ignore),
+      );
 
       const stdoutRef = yield* Ref.make("");
       const stderrRef = yield* Ref.make("");

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -15,7 +15,7 @@ import {
   type ServerLifecycleStreamEvent,
 } from "@t3tools/contracts";
 import { clamp } from "effect/Number";
-import { Cause, Effect, FileSystem, Layer, Option, Path, Schema, Stream } from "effect";
+import { Effect, FileSystem, Layer, Option, Path, Queue, Schema, Stream } from "effect";
 import { HttpRouter, HttpServerRequest } from "effect/unstable/http";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 
@@ -317,27 +317,20 @@ export const makeWsRpcLayer = () =>
                   .getReadModel()
                   .pipe(Effect.map((model) => model.snapshotSequence)),
               ]).pipe(
-                Effect.flatMap(([thread, snapshotSequence]) =>
+                Effect.map(([thread, snapshotSequence]) =>
                   Option.isSome(thread)
-                    ? Effect.succeed({
+                    ? Option.some({
                         kind: "snapshot" as const,
                         snapshot: { snapshotSequence, thread: thread.value },
                       })
-                    : Effect.fail(new Error(`Thread ${input.threadId} was not found yet`)),
+                    : Option.none(),
                 ),
                 Effect.mapError((cause) => toWsRpcError(cause, "Failed to load thread snapshot")),
               ),
             ).pipe(
-              Stream.catchCause((cause) => {
-                const error = Cause.squash(cause);
-                if (
-                  error instanceof WsRpcError &&
-                  error.message.includes("was not found yet")
-                ) {
-                  return Stream.empty;
-                }
-                return Stream.failCause(cause);
-              }),
+              Stream.flatMap((snapshot) =>
+                Option.isSome(snapshot) ? Stream.succeed(snapshot.value) : Stream.empty,
+              ),
             ),
             orchestrationEngine.streamDomainEvents.pipe(
               Stream.filter((event) => isThreadDetailEventFor(input.threadId, event)),

--- a/apps/web/src/components/EventRouter.browser.tsx
+++ b/apps/web/src/components/EventRouter.browser.tsx
@@ -31,6 +31,7 @@ import { getThreadFromState } from "../threadDerivation";
 import { useWorkspaceStore } from "../workspaceStore";
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-root-browser-test");
+const OTHER_THREAD_ID = ThreadId.makeUnsafe("thread-other-browser-test");
 const PROJECT_ID = ProjectId.makeUnsafe("project-root-browser-test");
 const NOW_ISO = "2026-03-04T12:00:00.000Z";
 
@@ -46,6 +47,9 @@ let pushSequence = 1;
 let delayNextThreadSnapshot = false;
 let subscribeShellRequestCount = 0;
 const subscribeThreadRequestCountById = new Map<ThreadId, number>();
+let subscribeThreadRequests: ThreadId[] = [];
+let replayEvents: OrchestrationEvent[] = [];
+let replayRequestCursors: number[] = [];
 
 const wsLink = ws.link(/ws(s)?:\/\/.*/);
 
@@ -212,9 +216,16 @@ function getThreadDetailFromFixtureSnapshot(threadId: ThreadId): OrchestrationTh
   return thread;
 }
 
-function resolveWsRpc(tag: string): unknown {
+function resolveWsRpc(tag: string, body?: unknown): unknown {
   if (tag === ORCHESTRATION_WS_METHODS.getSnapshot) {
     return fixture.snapshot;
+  }
+  if (tag === ORCHESTRATION_WS_METHODS.replayEvents) {
+    const request = body as { readonly fromSequenceExclusive?: unknown } | null;
+    const fromSequenceExclusive =
+      typeof request?.fromSequenceExclusive === "number" ? request.fromSequenceExclusive : 0;
+    replayRequestCursors.push(fromSequenceExclusive);
+    return replayEvents.filter((event) => event.sequence > fromSequenceExclusive);
   }
   if (tag === WS_METHODS.serverGetConfig) {
     return fixture.serverConfig;
@@ -275,7 +286,7 @@ const worker = setupWorker(
       client.send(
         JSON.stringify({
           id: request.id,
-          result: resolveWsRpc(method),
+          result: resolveWsRpc(method, request.body),
         }),
       );
       if (method === ORCHESTRATION_WS_METHODS.subscribeShell) {
@@ -297,6 +308,7 @@ const worker = setupWorker(
           threadId,
           (subscribeThreadRequestCountById.get(threadId) ?? 0) + 1,
         );
+        subscribeThreadRequests.push(threadId);
         if (delayNextThreadSnapshot) {
           delayNextThreadSnapshot = false;
           return;
@@ -469,6 +481,9 @@ describe("EventRouter scoped orchestration sync", () => {
     });
     subscribeShellRequestCount = 0;
     subscribeThreadRequestCountById.clear();
+    subscribeThreadRequests = [];
+    replayEvents = [];
+    replayRequestCursors = [];
   });
 
   afterEach(() => {
@@ -554,6 +569,232 @@ describe("EventRouter scoped orchestration sync", () => {
         { timeout: 4_000, interval: 16 },
       );
     } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("replays missed thread detail events when a subscribed shell row advances", async () => {
+    const mounted = await mountApp();
+
+    try {
+      const assistantMessage = {
+        sequence: 2,
+        eventId: EventId.makeUnsafe("event-replay-assistant"),
+        aggregateKind: "thread",
+        aggregateId: THREAD_ID,
+        occurredAt: "2026-03-04T12:00:05.000Z",
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.message-sent",
+        payload: {
+          threadId: THREAD_ID,
+          messageId: MessageId.makeUnsafe("msg-replayed-assistant"),
+          role: "assistant",
+          text: "Recovered from replay",
+          turnId: TurnId.makeUnsafe("turn-replayed"),
+          source: "native",
+          streaming: false,
+          createdAt: "2026-03-04T12:00:05.000Z",
+          updatedAt: "2026-03-04T12:00:05.000Z",
+        },
+      } satisfies Extract<OrchestrationEvent, { type: "thread.message-sent" }>;
+      const sessionReady = {
+        sequence: 3,
+        eventId: EventId.makeUnsafe("event-replay-session-ready"),
+        aggregateKind: "thread",
+        aggregateId: THREAD_ID,
+        occurredAt: "2026-03-04T12:00:06.000Z",
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.session-set",
+        payload: {
+          threadId: THREAD_ID,
+          session: {
+            threadId: THREAD_ID,
+            status: "ready",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: "2026-03-04T12:00:06.000Z",
+          },
+        },
+      } satisfies Extract<OrchestrationEvent, { type: "thread.session-set" }>;
+      const otherThreadMessage = {
+        sequence: 4,
+        eventId: EventId.makeUnsafe("event-replay-other-thread"),
+        aggregateKind: "thread",
+        aggregateId: OTHER_THREAD_ID,
+        occurredAt: "2026-03-04T12:00:07.000Z",
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.message-sent",
+        payload: {
+          threadId: OTHER_THREAD_ID,
+          messageId: MessageId.makeUnsafe("msg-replayed-other-thread"),
+          role: "assistant",
+          text: "Wrong thread",
+          turnId: TurnId.makeUnsafe("turn-replayed-other-thread"),
+          source: "native",
+          streaming: false,
+          createdAt: "2026-03-04T12:00:07.000Z",
+          updatedAt: "2026-03-04T12:00:07.000Z",
+        },
+      } satisfies Extract<OrchestrationEvent, { type: "thread.message-sent" }>;
+      const futureSameThreadMessage = {
+        ...assistantMessage,
+        sequence: 5,
+        eventId: EventId.makeUnsafe("event-replay-future-assistant"),
+        occurredAt: "2026-03-04T12:00:08.000Z",
+        payload: {
+          ...assistantMessage.payload,
+          messageId: MessageId.makeUnsafe("msg-replayed-future-assistant"),
+          text: "Future event",
+          createdAt: "2026-03-04T12:00:08.000Z",
+          updatedAt: "2026-03-04T12:00:08.000Z",
+        },
+      } satisfies Extract<OrchestrationEvent, { type: "thread.message-sent" }>;
+      replayEvents = [assistantMessage, sessionReady, otherThreadMessage, futureSameThreadMessage];
+
+      sendShellEventPush({
+        kind: "thread-upserted",
+        sequence: 3,
+        thread: {
+          ...createShellSnapshotFromFixtureSnapshot(fixture.snapshot).threads[0]!,
+          updatedAt: "2026-03-04T12:00:06.000Z",
+          session: sessionReady.payload.session,
+        },
+      });
+
+      await vi.waitFor(
+        () => {
+          const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+          expect(
+            thread?.messages.some(
+              (message) =>
+                message.id === MessageId.makeUnsafe("msg-replayed-assistant") &&
+                message.text === "Recovered from replay" &&
+                message.streaming === false,
+            ),
+          ).toBe(true);
+          expect(thread?.session?.orchestrationStatus).toBe("ready");
+          expect(
+            thread?.messages.some(
+              (message) => message.id === MessageId.makeUnsafe("msg-replayed-future-assistant"),
+            ),
+          ).toBe(false);
+          expect(thread?.messages.some((message) => message.text === "Wrong thread")).toBe(false);
+        },
+        { timeout: 4_000, interval: 16 },
+      );
+      expect(replayRequestCursors).toContain(1);
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("polls a subscribed running thread to recover missed detail events", async () => {
+    const runningTurnId = TurnId.makeUnsafe("turn-catchup-running");
+    fixture = {
+      ...fixture,
+      snapshot: createSnapshot({
+        latestTurn: {
+          turnId: runningTurnId,
+          state: "running",
+          requestedAt: "2026-03-04T12:00:04.000Z",
+          startedAt: "2026-03-04T12:00:04.500Z",
+          completedAt: null,
+          assistantMessageId: null,
+        },
+        session: {
+          threadId: THREAD_ID,
+          status: "running",
+          providerName: "opencode",
+          runtimeMode: "full-access",
+          activeTurnId: runningTurnId,
+          lastError: null,
+          updatedAt: "2026-03-04T12:00:04.500Z",
+        },
+        updatedAt: "2026-03-04T12:00:04.500Z",
+      }),
+    };
+
+    const assistantMessage = {
+      sequence: 2,
+      eventId: EventId.makeUnsafe("event-catchup-assistant"),
+      aggregateKind: "thread",
+      aggregateId: THREAD_ID,
+      occurredAt: "2026-03-04T12:00:05.000Z",
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      type: "thread.message-sent",
+      payload: {
+        threadId: THREAD_ID,
+        messageId: MessageId.makeUnsafe("msg-catchup-assistant"),
+        role: "assistant",
+        text: "Recovered by periodic catch-up",
+        turnId: runningTurnId,
+        source: "native",
+        streaming: false,
+        createdAt: "2026-03-04T12:00:05.000Z",
+        updatedAt: "2026-03-04T12:00:05.000Z",
+      },
+    } satisfies Extract<OrchestrationEvent, { type: "thread.message-sent" }>;
+    const sessionReady = {
+      sequence: 3,
+      eventId: EventId.makeUnsafe("event-catchup-session-ready"),
+      aggregateKind: "thread",
+      aggregateId: THREAD_ID,
+      occurredAt: "2026-03-04T12:00:06.000Z",
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      type: "thread.session-set",
+      payload: {
+        threadId: THREAD_ID,
+        session: {
+          threadId: THREAD_ID,
+          status: "ready",
+          providerName: "opencode",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: "2026-03-04T12:00:06.000Z",
+        },
+      },
+    } satisfies Extract<OrchestrationEvent, { type: "thread.session-set" }>;
+    replayEvents = [assistantMessage, sessionReady];
+
+    const mounted = await mountApp();
+
+    try {
+      await vi.waitFor(
+        () => {
+          const thread = getThreadFromState(useStore.getState(), THREAD_ID);
+          expect(
+            thread?.messages.some(
+              (message) =>
+                message.id === MessageId.makeUnsafe("msg-catchup-assistant") &&
+                message.text === "Recovered by periodic catch-up" &&
+                message.streaming === false,
+            ),
+          ).toBe(true);
+          expect(thread?.session?.orchestrationStatus).toBe("ready");
+        },
+        { timeout: 5_000, interval: 16 },
+      );
+      expect(replayRequestCursors).toContain(1);
+    } finally {
+      fixture = buildFixture();
       await mounted.cleanup();
     }
   });
@@ -724,6 +965,14 @@ describe("EventRouter scoped orchestration sync", () => {
     });
 
     try {
+      await vi.waitFor(
+        () => {
+          expect(subscribeThreadRequests.filter((threadId) => threadId === draftThreadId).length)
+            .toBeGreaterThanOrEqual(1);
+        },
+        { timeout: 4_000, interval: 16 },
+      );
+
       const baseThread = fixture.snapshot.threads[0]!;
       fixture.snapshot = {
         ...fixture.snapshot,
@@ -744,6 +993,30 @@ describe("EventRouter scoped orchestration sync", () => {
         ],
       };
 
+      sendThreadEventPush({
+        sequence: 3,
+        eventId: EventId.makeUnsafe("event-draft-promoted-assistant"),
+        aggregateKind: "thread",
+        aggregateId: draftThreadId,
+        occurredAt: "2026-03-04T12:00:09.000Z",
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.message-sent",
+        payload: {
+          threadId: draftThreadId,
+          messageId: MessageId.makeUnsafe("msg-draft-promoted-assistant"),
+          role: "assistant",
+          text: "draft promotion rendered",
+          turnId: TurnId.makeUnsafe("turn-draft-promoted"),
+          source: "native",
+          streaming: false,
+          createdAt: "2026-03-04T12:00:09.000Z",
+          updatedAt: "2026-03-04T12:00:09.000Z",
+        },
+      } satisfies Extract<OrchestrationEvent, { type: "thread.message-sent" }>);
+
       sendShellEventPush({
         kind: "thread-upserted",
         sequence: 2,
@@ -758,6 +1031,10 @@ describe("EventRouter scoped orchestration sync", () => {
             true,
           );
           expect(subscribeThreadRequestCountById.get(draftThreadId)).toBeGreaterThanOrEqual(2);
+          expect(subscribeThreadRequests.filter((threadId) => threadId === draftThreadId).length)
+            .toBeGreaterThanOrEqual(2);
+          const thread = getThreadFromState(useStore.getState(), draftThreadId);
+          expect(thread?.messages.at(-1)?.text).toBe("draft promotion rendered");
         },
         { timeout: 4_000, interval: 16 },
       );

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -61,6 +61,7 @@ import {
   subscribeRetainedThreadDetailIdChanges,
   useRetainedThreadDetailIds,
 } from "../threadDetailSubscriptionRetention";
+import { getThreadFromState } from "../threadDerivation";
 import { useAppTypography } from "../hooks/useAppTypography";
 import { useChatCodeFont } from "../hooks/useChatCodeFont";
 import { useTheme } from "../hooks/useTheme";
@@ -73,6 +74,7 @@ import { resolveSplitViewThreadIds, selectSplitView, useSplitViewStore } from ".
 import { providerDiscoveryQueryKeys } from "../lib/providerDiscoveryReactQuery";
 
 const SHELL_SNAPSHOT_BOOTSTRAP_FALLBACK_DELAY_MS = 1_500;
+const THREAD_DETAIL_CATCHUP_INTERVAL_MS = 1_500;
 
 function shellThreadHasStarted(thread: OrchestrationShellSnapshot["threads"][number]): boolean {
   return thread.latestTurn !== null || thread.session !== null;
@@ -363,6 +365,28 @@ function shouldFlushDomainEventImmediately(
   return true;
 }
 
+function isThreadDetailEventForThread(event: OrchestrationEvent, threadId: ThreadId): boolean {
+  if (event.aggregateKind !== "thread" || event.aggregateId !== threadId) {
+    return false;
+  }
+  return (
+    event.type === "thread.message-sent" ||
+    event.type === "thread.proposed-plan-upserted" ||
+    event.type === "thread.activity-appended" ||
+    event.type === "thread.turn-diff-completed" ||
+    event.type === "thread.reverted" ||
+    event.type === "thread.conversation-rolled-back" ||
+    event.type === "thread.session-set"
+  );
+}
+
+function shouldPollThreadDetailCatchup(threadId: ThreadId): boolean {
+  const thread = getThreadFromState(useStore.getState(), threadId);
+  return (
+    thread?.session?.orchestrationStatus === "running" || thread?.latestTurn?.state === "running"
+  );
+}
+
 function EventRouter() {
   const syncServerShellSnapshot = useStore((store) => store.syncServerShellSnapshot);
   const syncServerThreadDetailHotPath = useStore((store) => store.syncServerThreadDetailHotPath);
@@ -403,6 +427,9 @@ function EventRouter() {
   const subscribedThreadIds = useMemo(() => {
     const nextThreadIds = new Set<ThreadId>();
     for (const threadId of visibleThreadIds) {
+      // Visible draft routes need a detail subscription before their shell row exists.
+      // Otherwise fast provider responses can complete before the promoted thread is
+      // known to the shell list, leaving the chat detail stuck on its optimistic state.
       nextThreadIds.add(threadId);
     }
     for (const threadId of retainedThreadIds) {
@@ -440,6 +467,7 @@ function EventRouter() {
     const threadSnapshotSequenceById = new Map<ThreadId, number>();
     const pendingThreadEventsById = new Map<ThreadId, OrchestrationEvent[]>();
     const threadSnapshotRequestInFlight = new Set<ThreadId>();
+    const threadReplayRequestInFlight = new Set<ThreadId>();
     let reconcileThreadSubscriptionsChain = Promise.resolve();
 
     const beginThreadSubscription = (threadId: ThreadId) => {
@@ -509,6 +537,7 @@ function EventRouter() {
         threadSnapshotSequenceById.delete(threadId);
         pendingThreadEventsById.delete(threadId);
         threadSnapshotRequestInFlight.delete(threadId);
+        threadReplayRequestInFlight.delete(threadId);
         subscribedThreadIds.delete(threadId);
       }
       await Promise.all(
@@ -570,6 +599,7 @@ function EventRouter() {
       subscribedThreadIds.clear();
       threadSnapshotSequenceById.clear();
       pendingThreadEventsById.clear();
+      threadReplayRequestInFlight.clear();
       await api.orchestration.subscribeShell().catch(() => loadShellSnapshotOnce());
       await enqueueThreadSubscriptionReconcile(visibleThreadIdsRef.current);
     };
@@ -638,6 +668,41 @@ function EventRouter() {
       domainEventFlushThrottler.maybeExecute();
     };
 
+    const replayThreadEvents = async (
+      threadId: ThreadId,
+      targetSequence?: number,
+    ): Promise<void> => {
+      if (disposed || threadReplayRequestInFlight.has(threadId)) {
+        return;
+      }
+      const fromSequence = threadSnapshotSequenceById.get(threadId);
+      if (
+        fromSequence === undefined ||
+        (targetSequence !== undefined && fromSequence >= targetSequence)
+      ) {
+        return;
+      }
+      threadReplayRequestInFlight.add(threadId);
+      try {
+        const replayedEvents = await api.orchestration.replayEvents(fromSequence);
+        for (const event of replayedEvents
+          .filter((candidate) => isThreadDetailEventForThread(candidate, threadId))
+          .filter(
+            (candidate) => targetSequence === undefined || candidate.sequence <= targetSequence,
+          )
+          .toSorted((left, right) => left.sequence - right.sequence)) {
+          const latestThreadSequence = threadSnapshotSequenceById.get(threadId) ?? fromSequence;
+          if (event.sequence <= latestThreadSequence) {
+            continue;
+          }
+          threadSnapshotSequenceById.set(threadId, event.sequence);
+          queueDomainEvent(event);
+        }
+      } finally {
+        threadReplayRequestInFlight.delete(threadId);
+      }
+    };
+
     const domainEventFlushThrottler = new Throttler(
       () => {
         flushPendingDomainEvents();
@@ -680,6 +745,9 @@ function EventRouter() {
         !threadSnapshotSequenceById.has(item.thread.id)
       ) {
         void requestThreadSnapshot(item.thread.id);
+      }
+      if (item.kind === "thread-upserted" && subscribedThreadIds.has(item.thread.id)) {
+        void replayThreadEvents(item.thread.id, item.sequence).catch(() => undefined);
       }
     });
     const unsubThreadEvent = api.orchestration.onThreadEvent((item) => {
@@ -836,11 +904,23 @@ function EventRouter() {
     const shellBootstrapFallbackTimer = window.setTimeout(() => {
       void loadShellSnapshotOnce().catch(() => undefined);
     }, SHELL_SNAPSHOT_BOOTSTRAP_FALLBACK_DELAY_MS);
+    const threadDetailCatchupInterval = window.setInterval(() => {
+      for (const threadId of subscribedThreadIds) {
+        if (shouldPollThreadDetailCatchup(threadId)) {
+          if (!threadSnapshotSequenceById.has(threadId)) {
+            void requestThreadSnapshot(threadId);
+          } else {
+            void replayThreadEvents(threadId).catch(() => undefined);
+          }
+        }
+      }
+    }, THREAD_DETAIL_CATCHUP_INTERVAL_MS);
 
     return () => {
       flushPendingDomainEvents();
       disposed = true;
       window.clearTimeout(shellBootstrapFallbackTimer);
+      window.clearInterval(threadDetailCatchupInterval);
       needsProviderInvalidation = false;
       domainEventFlushThrottler.cancel();
       reconcileThreadSubscriptionsRef.current = null;

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -380,14 +380,16 @@ export class WsTransport {
   }
 
   private startThreadStream(client: RpcClientInstance, threadId: string, input: unknown): void {
-    this.stopStream(`orchestration.thread:${threadId}`);
+    const key = `orchestration.thread:${threadId}`;
+    this.stopStream(key);
+    this.stoppingStreams.delete(key);
     const restartThread = () => {
       void this.getClient()
         .then((nextClient) => this.startThreadStream(nextClient, threadId, input))
         .catch((error) => console.warn("WebSocket RPC thread stream failed to restart", error));
     };
     this.startStream(
-      `orchestration.thread:${threadId}`,
+      key,
       client[ORCHESTRATION_WS_METHODS.subscribeThread](input as never),
       (event: OrchestrationThreadStreamItem) =>
         this.emit(ORCHESTRATION_WS_CHANNELS.threadEvent, event),
@@ -407,7 +409,9 @@ export class WsTransport {
       Stream.runForEach(runnableStream, (event) => Effect.sync(() => listener(event))),
       {
         onExit: (exit) => {
-          this.streamCleanups.delete(key);
+          if (this.streamCleanups.get(key) === cancel) {
+            this.streamCleanups.delete(key);
+          }
           const wasStoppedIntentionally = this.stoppingStreams.delete(key);
           if (wasStoppedIntentionally || this.disposed) {
             return;


### PR DESCRIPTION
## Summary
- list OpenCode models through the OpenCode CLI first, so DP Code mirrors the same connected provider/model set shown by `opencode models`
- preserve provider grouping metadata for OpenCode, OpenCode Go, Kimi-for-coding, OpenAI, and common OpenCode providers such as Anthropic, GitHub Copilot, OpenRouter, Ollama, Bedrock, Vertex, and Vercel AI Gateway
- keep OpenCode runtime cleanup deterministic so temporary `opencode serve` processes do not linger after discovery or app stop
- avoid launching a second OpenCode request just to generate a first-turn title
- fix fresh draft-thread live replay so completed assistant messages render in the GUI instead of remaining stuck behind `Working...`

## Root Cause
DP Code was using temporary OpenCode server inventory discovery for the OpenCode model picker. In local testing, that path could hang during scoped discovery cleanup, so React Query never resolved and the picker fell back to a static OpenAI GPT-5 entry.

There were also two live rendering issues:
- assistant completion events could carry an empty final text payload after a streamed assistant message, which made the live UI path fragile even though the projection database kept the answer
- a draft chat could subscribe to thread details before the server thread existed; the server closed that stream without a snapshot, and later assistant/session events stayed buffered forever, leaving the visible chat stuck on `Working...` until reload

## Validation
- `opencode models` on a configured local OpenCode install returned 29 models across `opencode`, `opencode-go`, `kimi-for-coding`, and `openai`
- `bunx vitest run apps/server/src/provider/opencodeRuntime.test.ts apps/server/src/provider/Layers/OpenCodeAdapter.test.ts apps/server/src/provider/Layers/ProviderService.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts` passed
- `bunx vitest run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts apps/server/src/provider/Layers/ProviderService.test.ts` passed: 111 tests
- `bunx vitest run apps/web/src/store.test.ts apps/web/src/wsTransport.test.ts` passed: 63 tests
- `bun run --cwd apps/web build` passed
- `bun run --cwd apps/server build` passed
- `git diff --check` passed
- packaged and installed a patched local desktop build
- manual GUI validation passed for authenticated local providers: OpenAI GPT-5.4 Mini, Kimi K2.6 via Kimi For Coding, MiniMax M2.5 Free via OpenCode Zen Free, and DeepSeek V4 Flash via OpenCode Go

## Notes
The local browser test harness is currently not a clean signal: after installing the matching Playwright Chromium shell, existing browser specs fail before assertions because the mocked WebSocket never opens (`SocketOpenError: timeout waiting for \"open\"`). I added focused EventRouter browser coverage for the replay behavior, but did not mix that unrelated harness repair into this fix.