### PR TITLE
fix thread activity trace payloads

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
   buildTurnDiffSummaryByAssistantMessageId,
   computeMessageDurationStart,
+  computeStableMessagesTimelineRows,
   deriveTerminalAssistantMessageIds,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
+  type MessagesTimelineRow,
+  type StableMessagesTimelineRowsState,
 } from "./MessagesTimeline.logic";
 import type { TurnDiffSummary } from "../../types";
 
@@ -165,6 +168,118 @@ describe("normalizeCompactToolLabel", () => {
 
   it("removes trailing completion wording from other labels", () => {
     expect(normalizeCompactToolLabel("Read file completed")).toBe("Read file");
+  });
+});
+
+describe("computeStableMessagesTimelineRows", () => {
+  const emptyStableRows = (): StableMessagesTimelineRowsState => ({
+    byId: new Map(),
+    result: [],
+  });
+
+  it("replaces work rows when later tool metadata adds visible details", () => {
+    const firstRows: MessagesTimelineRow[] = [
+      {
+        kind: "work",
+        id: "work-group-1",
+        createdAt: "2026-05-09T10:00:00.000Z",
+        groupedEntries: [
+          {
+            id: "activity-read",
+            createdAt: "2026-05-09T10:00:00.000Z",
+            label: "Read",
+            tone: "tool",
+            itemType: "dynamic_tool_call",
+            toolTitle: "Read",
+          },
+        ],
+      },
+    ];
+    const first = computeStableMessagesTimelineRows(firstRows, emptyStableRows());
+
+    const enrichedRows: MessagesTimelineRow[] = [
+      {
+        kind: "work",
+        id: "work-group-1",
+        createdAt: "2026-05-09T10:00:00.000Z",
+        groupedEntries: [
+          {
+            id: "activity-read",
+            createdAt: "2026-05-09T10:00:00.000Z",
+            label: "Read",
+            tone: "tool",
+            itemType: "dynamic_tool_call",
+            toolTitle: "Read",
+            detail: "apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts:12",
+            changedFiles: [
+              "apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts",
+            ],
+          },
+        ],
+      },
+    ];
+
+    const second = computeStableMessagesTimelineRows(enrichedRows, first);
+
+    expect(second).not.toBe(first);
+    expect(second.result[0]).toBe(enrichedRows[0]);
+  });
+
+  it("replaces assistant rows when inline tool metadata becomes richer", () => {
+    const assistantMessage = {
+      id: MessageId.makeUnsafe("assistant-1"),
+      role: "assistant" as const,
+      text: "Working on it.",
+      createdAt: "2026-05-09T10:00:01.000Z",
+      streaming: true,
+    };
+    const firstRows: MessagesTimelineRow[] = [
+      {
+        kind: "message",
+        id: "assistant-1",
+        createdAt: "2026-05-09T10:00:01.000Z",
+        message: assistantMessage,
+        inlineWorkEntries: [
+          {
+            id: "activity-command",
+            createdAt: "2026-05-09T10:00:00.000Z",
+            label: "Ran command",
+            tone: "tool",
+            itemType: "command_execution",
+            toolTitle: "Ran",
+          },
+        ],
+        inlineWorkGroupId: "activity-command",
+        durationStart: "2026-05-09T10:00:01.000Z",
+        showCompletionDivider: false,
+        showAssistantCopyButton: false,
+      },
+    ];
+    const first = computeStableMessagesTimelineRows(firstRows, emptyStableRows());
+
+    const enrichedRows: MessagesTimelineRow[] = [
+      {
+        ...firstRows[0]!,
+        inlineWorkEntries: [
+          {
+            id: "activity-command",
+            createdAt: "2026-05-09T10:00:00.000Z",
+            label: "Ran command",
+            tone: "tool",
+            itemType: "command_execution",
+            toolTitle: "Ran",
+            command: "git grep -n \"model.rerouted\"",
+            rawCommand: "/bin/zsh -lc 'git grep -n \"model.rerouted\"'",
+            requestKind: "command",
+          },
+        ],
+      },
+    ];
+
+    const second = computeStableMessagesTimelineRows(enrichedRows, first);
+
+    expect(second).not.toBe(first);
+    expect(second.result[0]).toBe(enrichedRows[0]);
   });
 });
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -312,17 +312,76 @@ export function computeStableMessagesTimelineRows(
   return anyChanged ? { byId: next, result } : previous;
 }
 
+function stringArraysEqual(
+  left: ReadonlyArray<string> | undefined,
+  right: ReadonlyArray<string> | undefined,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return left.length === right.length && left.every((entry, index) => entry === right[index]);
+}
+
+function workLogSubagentActionsEqual(
+  a: WorkLogEntry["subagentAction"],
+  b: WorkLogEntry["subagentAction"],
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.tool === b.tool &&
+    a.status === b.status &&
+    a.summaryText === b.summaryText &&
+    a.model === b.model &&
+    a.prompt === b.prompt
+  );
+}
+
+function workLogSubagentsEqual(
+  left: WorkLogEntry["subagents"],
+  right: WorkLogEntry["subagents"],
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  if (left.length !== right.length) return false;
+  return left.every((a, index) => {
+    const b = right[index];
+    return (
+      b !== undefined &&
+      a.threadId === b.threadId &&
+      a.providerThreadId === b.providerThreadId &&
+      a.resolvedThreadId === b.resolvedThreadId &&
+      a.agentId === b.agentId &&
+      a.nickname === b.nickname &&
+      a.role === b.role &&
+      a.model === b.model &&
+      a.prompt === b.prompt &&
+      a.rawStatus === b.rawStatus &&
+      a.latestUpdate === b.latestUpdate &&
+      a.title === b.title &&
+      a.statusLabel === b.statusLabel &&
+      a.isActive === b.isActive
+    );
+  });
+}
+
 function workLogEntryContentEqual(a: WorkLogEntry, b: WorkLogEntry): boolean {
   return (
     a.id === b.id &&
+    a.createdAt === b.createdAt &&
     a.label === b.label &&
+    a.detail === b.detail &&
     a.toolTitle === b.toolTitle &&
     a.command === b.command &&
     a.rawCommand === b.rawCommand &&
     a.preview === b.preview &&
     a.tone === b.tone &&
     a.itemType === b.itemType &&
-    a.toolCallId === b.toolCallId
+    a.requestKind === b.requestKind &&
+    a.toolName === b.toolName &&
+    a.toolCallId === b.toolCallId &&
+    stringArraysEqual(a.changedFiles, b.changedFiles) &&
+    workLogSubagentActionsEqual(a.subagentAction, b.subagentAction) &&
+    workLogSubagentsEqual(a.subagents, b.subagents)
   );
 }
 

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1502,6 +1502,55 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain("&gt;/bin/zsh -lc");
   });
 
+  it("renders command text even when commandActions provide a short preview", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        hasMessages
+        isWorking={false}
+        activeTurnInProgress={false}
+        activeTurnStartedAt={null}
+        timelineEntries={[
+          {
+            id: "entry-inline-command-actions",
+            kind: "work",
+            createdAt: "2026-05-09T10:06:54.443Z",
+            entry: {
+              id: "work-inline-command-actions",
+              createdAt: "2026-05-09T10:06:54.443Z",
+              label: "Ran command",
+              tone: "tool",
+              itemType: "command_execution",
+              toolTitle: "Listed",
+              preview: "web",
+              command: "find apps/web/src -maxdepth 2 -type d",
+              rawCommand: `/bin/zsh -lc "find apps/web/src -maxdepth 2 -type d | sort | sed -n '1,120p'"`,
+            },
+          },
+        ]}
+        completionDividerBeforeEntryId={null}
+        completionSummary={null}
+        turnDiffSummaryByAssistantMessageId={new Map()}
+        nowIso="2026-05-09T10:07:00.000Z"
+        expandedWorkGroups={{}}
+        onToggleWorkGroup={() => {}}
+        onOpenTurnDiff={() => {}}
+        revertTurnCountByUserMessageId={new Map()}
+        onRevertUserMessage={() => {}}
+        isRevertingCheckpoint={false}
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        resolvedTheme="dark"
+        timestampFormat="locale"
+        workspaceRoot={undefined}
+      />,
+    );
+
+    expect(markup).toContain("Listed");
+    expect(markup).toContain("find apps/web/src -maxdepth 2 -type d");
+    expect(markup).not.toContain(">Listed web<");
+  });
+
   it("renders plain location details as file basenames", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1603,6 +1603,11 @@ function workEntryPreview(
     workEntry.requestKind === "file-change" ||
     workEntry.itemType === "file_change";
 
+  if (workEntry.itemType === "command_execution" || workEntry.command || workEntry.rawCommand) {
+    const command = workEntry.command ?? workEntry.rawCommand;
+    if (command) return deriveInlineCommandCall(command);
+  }
+
   if (workEntry.preview) return workEntry.preview;
 
   // Prefer clean basenames from changedFiles
@@ -1611,8 +1616,6 @@ function workEntryPreview(
     if (names.length === 1) return names[0]!;
     return `${names.length} files`;
   }
-
-  if (workEntry.command) return deriveInlineCommandCall(workEntry.command);
 
   if (workEntry.itemType === "collab_agent_tool_call" && (workEntry.subagents?.length ?? 0) > 0) {
     if (workEntry.subagentAction?.summaryText) {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -62,7 +62,7 @@ export interface WorkLogEntry {
   subagentAction?: WorkLogSubagentAction;
 }
 
-export const WORK_LOG_PRESENTATION_VERSION = 4;
+export const WORK_LOG_PRESENTATION_VERSION = 5;
 
 export interface WorkLogSubagent {
   threadId: string;

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -10,6 +10,7 @@ import {
   OrchestrationEvent,
   OrchestrationGetTurnDiffInput,
   OrchestrationLatestTurn,
+  OrchestrationReadModel,
   ProjectCreatedPayload,
   ProjectMetaUpdatedPayload,
   OrchestrationProposedPlan,
@@ -39,6 +40,87 @@ const decodeThreadMetaUpdatedPayload = Schema.decodeUnknownEffect(ThreadMetaUpda
 const decodeClientOrchestrationCommand = Schema.decodeUnknownEffect(ClientOrchestrationCommand);
 const decodeOrchestrationCommand = Schema.decodeUnknownEffect(OrchestrationCommand);
 const decodeOrchestrationEvent = Schema.decodeUnknownEffect(OrchestrationEvent);
+
+it.effect("preserves thread activity payloads through the RPC JSON codec", () =>
+  Effect.gen(function* () {
+    const codec = Schema.toCodecJson(OrchestrationReadModel);
+    const readModel = {
+      snapshotSequence: 1,
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      projects: [],
+      threads: [
+        {
+          id: "thread-1",
+          codexThreadId: null,
+          projectId: "project-1",
+          title: "Thread 1",
+          modelSelection: {
+            provider: "codex",
+            model: "gpt-5.5",
+          },
+          interactionMode: "default",
+          runtimeMode: "full-access",
+          envMode: "local",
+          branch: null,
+          worktreePath: null,
+          associatedWorktreePath: null,
+          associatedWorktreeBranch: null,
+          associatedWorktreeRef: null,
+          createBranchFlowCompleted: false,
+          parentThreadId: null,
+          subagentAgentId: null,
+          subagentNickname: null,
+          subagentRole: null,
+          forkSourceThreadId: null,
+          sidechatSourceThreadId: null,
+          lastKnownPr: null,
+          handoff: null,
+          latestTurn: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          archivedAt: null,
+          deletedAt: null,
+          messages: [],
+          proposedPlans: [],
+          activities: [
+            {
+              id: "activity-1",
+              tone: "tool",
+              kind: "tool.completed",
+              summary: "Ran command",
+              payload: {
+                itemType: "command_execution",
+                data: {
+                  item: {
+                    command: "git status --short",
+                  },
+                },
+              },
+              turnId: null,
+              sequence: 1,
+              createdAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+          checkpoints: [],
+          session: null,
+        },
+      ],
+    };
+
+    const encoded = yield* Schema.encodeUnknownEffect(codec)(readModel);
+    const decoded = yield* Schema.decodeUnknownEffect(codec)(encoded);
+    const activity = decoded.threads[0]?.activities[0];
+
+    assert.deepStrictEqual(activity?.payload, {
+      itemType: "command_execution",
+      data: {
+        item: {
+          command: "git status --short",
+        },
+      },
+    });
+  }),
+);
 
 it.effect("parses turn diff input when fromTurnCount <= toTurnCount", () =>
   Effect.gen(function* () {

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -402,7 +402,7 @@ export const OrchestrationThreadActivity = Schema.Struct({
   tone: OrchestrationThreadActivityTone,
   kind: TrimmedNonEmptyString,
   summary: TrimmedNonEmptyString,
-  payload: Schema.Unknown,
+  payload: Schema.Json,
   turnId: Schema.NullOr(TurnId),
   sequence: Schema.optional(NonNegativeInt),
   createdAt: IsoDateTime,


### PR DESCRIPTION
## Summary
- Preserve orchestration thread activity payloads across the Effect RPC JSON codec by using `Schema.Json` instead of `Schema.Unknown`.
- Refresh stale transcript work rows when richer tool metadata arrives.
- Prefer concrete command text over generic command previews in trace rows.

## Root Cause
The projection database already stored full command metadata, but `OrchestrationThreadActivity.payload` was typed as `Schema.Unknown`. Effect RPC encodes `Schema.Unknown` as `null` through `Schema.toCodecJson(...)`, so the browser received only generic `Ran command` activities.

## Validation
- `bun run --cwd packages/contracts test src/orchestration.test.ts`
- `bun run --cwd apps/web test src/session-logic.test.ts src/components/chat/MessagesTimeline.logic.test.ts src/components/chat/MessagesTimeline.test.tsx src/store.test.ts`

Note: `bun fmt`, `bun lint`, and `bun typecheck` were not run per repo instructions unless explicitly requested.