### PR TITLE
[codex] Add desktop Remote SSH support

### DIFF
--- a/apps/desktop/src/browserManager.ts
+++ b/apps/desktop/src/browserManager.ts
@@ -9,6 +9,7 @@ import {
   BrowserWindow,
   clipboard,
   nativeImage,
+  session as electronSession,
   shell,
   webContents as electronWebContents,
   WebContentsView,
@@ -40,6 +41,15 @@ const BROWSER_ERROR_ABORTED = -3;
 const SEARCH_URL_PREFIX = "https://www.google.com/search?q=";
 
 type BrowserStateListener = (state: ThreadBrowserState) => void;
+
+export interface BrowserResolvedUrl {
+  url: string;
+}
+
+export interface BrowserUrlResolver {
+  resolveUrl(url: string): Promise<BrowserResolvedUrl>;
+  normalizeDisplayUrl(url: string): string;
+}
 
 interface LiveTabRuntime {
   key: string;
@@ -279,9 +289,11 @@ export class DesktopBrowserManager {
   private readonly runtimeLastActiveAtByKey = new Map<string, number>();
   private readonly pendingRuntimeSyncs = new Map<string, PendingRuntimeSync>();
   private readonly listeners = new Set<BrowserStateListener>();
+  private urlResolver: BrowserUrlResolver | null = null;
   private readonly tabSuspendTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly suspendTimers = new Map<ThreadId, ReturnType<typeof setTimeout>>();
   private runtimeSyncFlushScheduled = false;
+  private loopbackRequestResolverInstalled = false;
   private readonly perfCounters = {
     setPanelBoundsCalls: 0,
     setPanelBoundsNoopSkips: 0,
@@ -300,6 +312,7 @@ export class DesktopBrowserManager {
   setWindow(window: BrowserWindow | null): void {
     this.window = window;
     if (window) {
+      this.installLoopbackRequestResolver();
       const bounds = this.activeThreadId
         ? this.getVisibleBoundsForThread(this.activeThreadId)
         : null;
@@ -320,6 +333,41 @@ export class DesktopBrowserManager {
     };
   }
 
+  setUrlResolver(resolver: BrowserUrlResolver | null): void {
+    this.urlResolver = resolver;
+  }
+
+  private normalizeDisplayUrl(url: string): string {
+    return this.urlResolver?.normalizeDisplayUrl(url) ?? url;
+  }
+
+  private installLoopbackRequestResolver(): void {
+    if (this.loopbackRequestResolverInstalled) {
+      return;
+    }
+    this.loopbackRequestResolverInstalled = true;
+    const browserSession = electronSession.fromPartition(BROWSER_SESSION_PARTITION);
+    browserSession.webRequest.onBeforeRequest(
+      { urls: ["http://*/*", "https://*/*", "ws://*/*", "wss://*/*"] },
+      (details, callback) => {
+        const resolver = this.urlResolver;
+        if (!resolver) {
+          callback({});
+          return;
+        }
+
+        void resolver
+          .resolveUrl(details.url)
+          .then((resolved) => {
+            callback(resolved.url !== details.url ? { redirectURL: resolved.url } : {});
+          })
+          .catch(() => {
+            callback({ cancel: true });
+          });
+      },
+    );
+  }
+
   dispose(): void {
     for (const timer of this.suspendTimers.values()) {
       clearTimeout(timer);
@@ -334,6 +382,7 @@ export class DesktopBrowserManager {
     this.pendingRuntimeSyncs.clear();
     this.runtimeLastActiveAtByKey.clear();
     this.listeners.clear();
+    this.urlResolver = null;
     this.states.clear();
     this.threadVersionById.clear();
     this.snapshotCacheByThreadId.clear();
@@ -517,6 +566,7 @@ export class DesktopBrowserManager {
     }
 
     const existing = this.runtimes.get(key);
+    let adoptedWebContents = false;
     if (existing?.webContents.id !== webContents.id) {
       if (existing) {
         this.destroyRuntime(input.threadId, tab.id);
@@ -532,12 +582,16 @@ export class DesktopBrowserManager {
       };
       this.configureRuntimeWebContents(runtime);
       this.runtimes.set(key, runtime);
+      adoptedWebContents = true;
     }
 
     const bounds = this.getVisibleBoundsForThread(input.threadId);
     const runtime = this.runtimes.get(key);
     if (runtime && bounds) {
       this.attachRuntime(runtime, bounds);
+    }
+    if (runtime && adoptedWebContents) {
+      void this.loadTab(input.threadId, tab.id, { force: true, runtime });
     }
 
     const didChange = tab.status !== LIVE_TAB_STATUS || tab.lastError !== null;
@@ -547,7 +601,9 @@ export class DesktopBrowserManager {
     if (didChange) {
       this.markThreadStateChanged(input.threadId);
     }
-    this.queueRuntimeStateSync(input.threadId, tab.id);
+    if (!adoptedWebContents) {
+      this.queueRuntimeStateSync(input.threadId, tab.id);
+    }
     this.emitState(input.threadId);
     return this.snapshotThreadState(input.threadId, state);
   }
@@ -740,7 +796,7 @@ export class DesktopBrowserManager {
     const runtime = this.ensureLiveRuntime(input.threadId, tab.id);
     const webContents = runtime.webContents;
     const expectedUrl = normalizeUrlInput(tab.lastCommittedUrl ?? tab.url);
-    const currentUrl = webContents.getURL();
+    const currentUrl = this.normalizeDisplayUrl(webContents.getURL());
     const bounds = this.getVisibleBoundsForThread(input.threadId);
     if (bounds) {
       this.attachActiveTab(input.threadId, bounds);
@@ -932,7 +988,14 @@ export class DesktopBrowserManager {
       if (wasSuspended) {
         void this.loadTab(threadId, tab.id, { force: true, runtime });
       } else {
-        didChange = syncTabStateFromRuntime(state, tab, runtime.webContents) || didChange;
+        didChange =
+          syncTabStateFromRuntime(
+            state,
+            tab,
+            runtime.webContents,
+            undefined,
+            (url) => this.normalizeDisplayUrl(url),
+          ) || didChange;
       }
     }
 
@@ -1229,10 +1292,15 @@ export class DesktopBrowserManager {
     const { threadId, tabId, webContents } = runtime;
 
     webContents.setWindowOpenHandler(({ url }) => {
-      if (url.startsWith("http://") || url.startsWith("https://") || url === ABOUT_BLANK_URL) {
+      const displayUrl = this.normalizeDisplayUrl(url);
+      if (
+        displayUrl.startsWith("http://") ||
+        displayUrl.startsWith("https://") ||
+        displayUrl === ABOUT_BLANK_URL
+      ) {
         this.newTab({
           threadId,
-          url,
+          url: displayUrl,
           activate: true,
         });
         const bounds = this.getVisibleBoundsForThread(threadId);
@@ -1242,7 +1310,7 @@ export class DesktopBrowserManager {
         return { action: "deny" };
       }
 
-      void shell.openExternal(url);
+      void shell.openExternal(displayUrl);
       return { action: "deny" };
     });
 
@@ -1312,7 +1380,7 @@ export class DesktopBrowserManager {
         return;
       }
 
-      tab.url = validatedURL || tab.url;
+      tab.url = validatedURL ? this.normalizeDisplayUrl(validatedURL) : tab.url;
       tab.title = defaultTitleForUrl(tab.url);
       tab.isLoading = false;
       tab.lastError = mapBrowserLoadError(errorCode);
@@ -1361,9 +1429,22 @@ export class DesktopBrowserManager {
 
     const runtime = options.runtime ?? this.ensureLiveRuntime(threadId, tabId);
     const webContents = runtime.webContents;
-    const nextUrl = normalizeUrlInput(
+    const displayUrl = normalizeUrlInput(
       options.force === true ? tab.url : (tab.lastCommittedUrl ?? tab.url),
     );
+    let nextUrl = displayUrl;
+    try {
+      nextUrl = this.urlResolver ? (await this.urlResolver.resolveUrl(displayUrl)).url : displayUrl;
+    } catch {
+      tab.url = displayUrl;
+      tab.status = "live";
+      tab.isLoading = false;
+      tab.lastError = "Couldn't open this page.";
+      syncThreadLastError(state);
+      this.markThreadStateChanged(threadId);
+      this.emitState(threadId);
+      return;
+    }
     const currentUrl = webContents.getURL();
     const shouldLoad = options.force === true || currentUrl !== nextUrl || currentUrl.length === 0;
 
@@ -1372,7 +1453,7 @@ export class DesktopBrowserManager {
       return;
     }
 
-    tab.url = nextUrl;
+    tab.url = displayUrl;
     tab.status = "live";
     tab.isLoading = true;
     tab.lastError = null;
@@ -1406,7 +1487,13 @@ export class DesktopBrowserManager {
       return;
     }
 
-    const didChange = syncTabStateFromRuntime(state, tab, runtime.webContents, faviconUrls);
+    const didChange = syncTabStateFromRuntime(
+      state,
+      tab,
+      runtime.webContents,
+      faviconUrls,
+      (url) => this.normalizeDisplayUrl(url),
+    );
     const nextDidChange = syncThreadLastError(state) || didChange;
     if (nextDidChange) {
       this.markThreadStateChanged(threadId);
@@ -1673,8 +1760,9 @@ function syncTabStateFromRuntime(
   tab: BrowserTabState,
   webContents: WebContents,
   faviconUrls?: string[],
+  normalizeDisplayUrl: (url: string) => string = (url) => url,
 ): boolean {
-  const currentUrl = webContents.getURL();
+  const currentUrl = normalizeDisplayUrl(webContents.getURL());
   const nextUrl = currentUrl || tab.url;
   const nextTitle = webContents.getTitle();
   let didChange = false;

--- a/apps/desktop/src/loopbackPort.ts
+++ b/apps/desktop/src/loopbackPort.ts
@@ -1,0 +1,23 @@
+import * as Net from "node:net";
+
+export async function reserveLoopbackPort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = Net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        if (port <= 0) {
+          reject(new Error("Failed to reserve a local loopback port."));
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -12,6 +12,7 @@ import * as Path from "node:path";
 import {
   app,
   BrowserWindow,
+  clipboard,
   dialog,
   ipcMain,
   Menu,
@@ -29,6 +30,7 @@ import type {
   DesktopTheme,
   DesktopUpdateActionResult,
   DesktopUpdateState,
+  RemoteSshConnectInput,
 } from "@t3tools/contracts";
 import { autoUpdater } from "electron-updater";
 
@@ -86,6 +88,8 @@ import {
   resolveLegacyDesktopUserDataPaths,
   seedDesktopUserDataProfileFromLegacy,
 } from "./desktopUserDataProfile";
+import { RemotePortForwarder } from "./remotePortForwarder";
+import { RemoteSshBackendManager } from "./remoteSshBackend";
 
 syncShellEnvironment();
 
@@ -104,6 +108,10 @@ const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
 const NOTIFICATIONS_IS_SUPPORTED_CHANNEL = "desktop:notifications-is-supported";
 const NOTIFICATIONS_SHOW_CHANNEL = "desktop:notifications-show";
+const CLIPBOARD_READ_IMAGE_CHANNEL = "desktop:clipboard-read-image";
+const REMOTE_SSH_CONNECT_CHANNEL = "desktop:remote-ssh-connect";
+const REMOTE_SSH_DISCONNECT_CHANNEL = "desktop:remote-ssh-disconnect";
+const REMOTE_SSH_GET_STATUS_CHANNEL = "desktop:remote-ssh-get-status";
 const BASE_DIR =
   process.env.DPCODE_HOME?.trim() ||
   process.env.T3CODE_HOME?.trim() ||
@@ -141,6 +149,9 @@ let backendPort = 0;
 let backendAuthToken = "";
 let backendHttpUrl = "";
 let backendWsUrl = "";
+let localBackendHttpUrl = "";
+let localBackendWsUrl = "";
+let activeBackendEndpointKind: "local" | "remote" = "local";
 let backendReadinessAbortController: AbortController | null = null;
 let backendInitialWindowOpenInFlight: Promise<void> | null = null;
 let backendListeningDetector: ServerListeningDetector | null = null;
@@ -155,12 +166,18 @@ let restoreStdIoCapture: (() => void) | null = null;
 let unreadBackgroundNotificationCount = 0;
 let browserPerfInterval: ReturnType<typeof setInterval> | null = null;
 const browserManager = new DesktopBrowserManager();
+const remoteSshBackendManager = new RemoteSshBackendManager();
+const remotePortForwarder = new RemotePortForwarder();
 let browserUsePipeServer: BrowserUsePipeServer | null = null;
 let configuredGitHubUpdateSource: ReturnType<typeof resolveGitHubUpdateSource> = null;
 let configuredGitHubUpdateToken = "";
 
 browserManager.subscribe((state) => {
   sendBrowserState(mainWindow?.webContents, state);
+});
+browserManager.setUrlResolver(remotePortForwarder);
+remoteSshBackendManager.subscribeLifecycle((event) => {
+  handleRemoteSshBackendLifecycle(event.status.message ?? "Remote SSH backend stopped.");
 });
 
 function startBrowserPerformanceLogging(): void {
@@ -335,11 +352,60 @@ async function reserveBackendEndpoint(reason: string): Promise<void> {
     Effect.provide(NetService.layer),
     Effect.runPromise,
   );
-  backendHttpUrl = `http://127.0.0.1:${backendPort}`;
-  backendWsUrl = `ws://127.0.0.1:${backendPort}/?token=${encodeURIComponent(backendAuthToken)}`;
-  process.env.DPCODE_DESKTOP_WS_URL = backendWsUrl;
-  process.env.T3CODE_DESKTOP_WS_URL = backendWsUrl;
+  localBackendHttpUrl = `http://127.0.0.1:${backendPort}`;
+  localBackendWsUrl = `ws://127.0.0.1:${backendPort}/?token=${encodeURIComponent(backendAuthToken)}`;
+  if (activeBackendEndpointKind === "local") {
+    restoreLocalBackendEndpoint();
+  }
   writeDesktopLogHeader(`${reason} resolved backend endpoint port=${backendPort}`);
+}
+
+function setActiveBackendEndpoint(input: {
+  readonly kind: "local" | "remote";
+  readonly httpUrl: string;
+  readonly wsUrl: string;
+}): void {
+  activeBackendEndpointKind = input.kind;
+  backendHttpUrl = input.httpUrl;
+  backendWsUrl = input.wsUrl;
+  process.env.DPCODE_DESKTOP_WS_URL = input.wsUrl;
+  process.env.T3CODE_DESKTOP_WS_URL = input.wsUrl;
+}
+
+function restoreLocalBackendEndpoint(): void {
+  if (localBackendHttpUrl.length === 0 || localBackendWsUrl.length === 0) {
+    return;
+  }
+  setActiveBackendEndpoint({
+    kind: "local",
+    httpUrl: localBackendHttpUrl,
+    wsUrl: localBackendWsUrl,
+  });
+}
+
+function handleRemoteSshBackendLifecycle(message: string): void {
+  if (isQuitting) {
+    return;
+  }
+  remotePortForwarder.setTarget(null);
+  restoreLocalBackendEndpoint();
+  console.warn(`[desktop] remote SSH backend stopped; restored local backend: ${message}`);
+
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.reload();
+  }
+
+  if (Notification.isSupported()) {
+    try {
+      new Notification({
+        title: "Remote SSH disconnected",
+        body: "DP Code switched back to the local backend.",
+        silent: false,
+      }).show();
+    } catch {
+      // The endpoint switch and reload above are the reliable recovery path.
+    }
+  }
 }
 
 async function waitForBackendWindowReady(baseUrl: string): Promise<"listening" | "http"> {
@@ -1748,6 +1814,33 @@ function registerIpcHandlers(): void {
     shell.showItemInFolder(resolvedPath);
   });
 
+  ipcMain.removeHandler(REMOTE_SSH_CONNECT_CHANNEL);
+  ipcMain.handle(REMOTE_SSH_CONNECT_CHANNEL, async (_event, input: RemoteSshConnectInput) => {
+    remotePortForwarder.setTarget(null);
+    restoreLocalBackendEndpoint();
+    try {
+      const result = await remoteSshBackendManager.connect(input);
+      setActiveBackendEndpoint({ kind: "remote", httpUrl: result.httpUrl, wsUrl: result.wsUrl });
+      remotePortForwarder.setTarget(result.target);
+      return result;
+    } catch (error) {
+      remotePortForwarder.setTarget(null);
+      restoreLocalBackendEndpoint();
+      throw error;
+    }
+  });
+
+  ipcMain.removeHandler(REMOTE_SSH_DISCONNECT_CHANNEL);
+  ipcMain.handle(REMOTE_SSH_DISCONNECT_CHANNEL, async () => {
+    remotePortForwarder.setTarget(null);
+    const status = await remoteSshBackendManager.disconnect();
+    restoreLocalBackendEndpoint();
+    return status;
+  });
+
+  ipcMain.removeHandler(REMOTE_SSH_GET_STATUS_CHANNEL);
+  ipcMain.handle(REMOTE_SSH_GET_STATUS_CHANNEL, async () => remoteSshBackendManager.getStatus());
+
   ipcMain.removeHandler(UPDATE_GET_STATE_CHANNEL);
   ipcMain.handle(UPDATE_GET_STATE_CHANNEL, async () => updateState);
 
@@ -1809,6 +1902,24 @@ function registerIpcHandlers(): void {
         ...(typeof input?.threadId === "string" ? { threadId: input.threadId } : {}),
       }),
   );
+
+  ipcMain.removeHandler(CLIPBOARD_READ_IMAGE_CHANNEL);
+  ipcMain.handle(CLIPBOARD_READ_IMAGE_CHANNEL, async () => {
+    const image = clipboard.readImage();
+    if (image.isEmpty()) {
+      return null;
+    }
+    const png = image.toPNG();
+    if (png.byteLength === 0) {
+      return null;
+    }
+    return {
+      dataUrl: `data:image/png;base64,${png.toString("base64")}`,
+      mimeType: "image/png" as const,
+      sizeBytes: png.byteLength,
+    };
+  });
+
   registerDesktopVoiceTranscriptionHandler();
   startBrowserPerformanceLogging();
   void ensureBrowserUsePipeServer().catch((error) => {
@@ -2028,6 +2139,8 @@ app.on("before-quit", () => {
   void browserUsePipeServer?.dispose().finally(() => {
     browserUsePipeServer = null;
   });
+  remotePortForwarder.dispose();
+  void remoteSshBackendManager.disconnect();
   cancelBackendReadinessWait();
   stopBackend();
   browserManager.dispose();

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -23,6 +23,10 @@ const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
 const NOTIFICATIONS_IS_SUPPORTED_CHANNEL = "desktop:notifications-is-supported";
 const NOTIFICATIONS_SHOW_CHANNEL = "desktop:notifications-show";
+const CLIPBOARD_READ_IMAGE_CHANNEL = "desktop:clipboard-read-image";
+const REMOTE_SSH_CONNECT_CHANNEL = "desktop:remote-ssh-connect";
+const REMOTE_SSH_DISCONNECT_CHANNEL = "desktop:remote-ssh-disconnect";
+const REMOTE_SSH_GET_STATUS_CHANNEL = "desktop:remote-ssh-get-status";
 
 function getDesktopWsUrl(): string | null {
   try {
@@ -75,8 +79,16 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     isSupported: () => ipcRenderer.invoke(NOTIFICATIONS_IS_SUPPORTED_CHANNEL),
     show: (input) => ipcRenderer.invoke(NOTIFICATIONS_SHOW_CHANNEL, input),
   },
+  clipboard: {
+    readImage: () => ipcRenderer.invoke(CLIPBOARD_READ_IMAGE_CHANNEL),
+  },
   server: {
     transcribeVoice: (input) => ipcRenderer.invoke(SERVER_TRANSCRIBE_VOICE_CHANNEL, input),
+  },
+  remoteSsh: {
+    connect: (input) => ipcRenderer.invoke(REMOTE_SSH_CONNECT_CHANNEL, input),
+    disconnect: () => ipcRenderer.invoke(REMOTE_SSH_DISCONNECT_CHANNEL),
+    getStatus: () => ipcRenderer.invoke(REMOTE_SSH_GET_STATUS_CHANNEL),
   },
   browser: {
     open: (input) => ipcRenderer.invoke(BROWSER_IPC_CHANNELS.open, input),

--- a/apps/desktop/src/remotePortForwarder.ts
+++ b/apps/desktop/src/remotePortForwarder.ts
@@ -1,0 +1,328 @@
+import * as ChildProcess from "node:child_process";
+import * as Net from "node:net";
+
+import { reserveLoopbackPort } from "./loopbackPort";
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "[::1]", "::1"]);
+const SSH_ERROR_BUFFER_MAX_BYTES = 16 * 1024;
+const SSH_CONNECT_TIMEOUT_SECONDS = 10;
+const SSH_OPTIONS = [
+  "-o",
+  "BatchMode=yes",
+  "-o",
+  "StrictHostKeyChecking=accept-new",
+  "-o",
+  `ConnectTimeout=${SSH_CONNECT_TIMEOUT_SECONDS}`,
+] as const;
+
+interface ForwardedPort {
+  remotePort: number;
+  localPort: number;
+  process: ChildProcess.ChildProcess;
+}
+
+interface SshProcessDiagnostics {
+  stderr: string;
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return LOOPBACK_HOSTS.has(hostname.toLowerCase());
+}
+
+function defaultPortForProtocol(protocol: string): number | null {
+  if (protocol === "http:" || protocol === "ws:") return 80;
+  if (protocol === "https:" || protocol === "wss:") return 443;
+  return null;
+}
+
+function createSshTunnelProcess(input: {
+  readonly target: string;
+  readonly localPort: number;
+  readonly remotePort: number;
+}): ChildProcess.ChildProcess {
+  return ChildProcess.spawn(
+    "ssh",
+    [
+      "-N",
+      "-T",
+      ...SSH_OPTIONS,
+      "-o",
+      "ExitOnForwardFailure=yes",
+      "-o",
+      "ServerAliveInterval=30",
+      "-o",
+      "ServerAliveCountMax=3",
+      "-L",
+      `127.0.0.1:${input.localPort}:127.0.0.1:${input.remotePort}`,
+      input.target,
+    ],
+    {
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+}
+
+function appendBounded(buffer: string, chunk: Buffer | string): string {
+  const next = `${buffer}${chunk.toString()}`;
+  if (Buffer.byteLength(next) <= SSH_ERROR_BUFFER_MAX_BYTES) {
+    return next;
+  }
+  return next.slice(-SSH_ERROR_BUFFER_MAX_BYTES);
+}
+
+function captureSshDiagnostics(child: ChildProcess.ChildProcess): SshProcessDiagnostics {
+  const diagnostics: SshProcessDiagnostics = { stderr: "" };
+  child.stderr?.on("data", (chunk: Buffer | string) => {
+    diagnostics.stderr = appendBounded(diagnostics.stderr, chunk);
+  });
+  return diagnostics;
+}
+
+function cleanSshStderr(stderr: string): string {
+  return stderr.replace(/\s+/g, " ").trim();
+}
+
+async function waitForLocalPort(port: number, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const connected = await new Promise<boolean>((resolve) => {
+      const socket = Net.createConnection({ host: "127.0.0.1", port });
+      const timer = setTimeout(() => {
+        socket.destroy();
+        resolve(false);
+      }, 250);
+      socket.once("connect", () => {
+        clearTimeout(timer);
+        socket.end();
+        resolve(true);
+      });
+      socket.once("error", () => {
+        clearTimeout(timer);
+        resolve(false);
+      });
+    });
+    if (connected) {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for SSH port forward on 127.0.0.1:${port}.`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+function waitForTunnelExit(input: {
+  readonly process: ChildProcess.ChildProcess;
+  readonly remotePort: number;
+  readonly diagnostics: SshProcessDiagnostics;
+}): { promise: Promise<never>; dispose: () => void } {
+  let settled = false;
+  let rejectPromise: (error: Error) => void = () => {};
+
+  const cleanup = () => {
+    input.process.off("error", onError);
+    input.process.off("exit", onExit);
+  };
+  const fail = (error: Error) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanup();
+    rejectPromise(error);
+  };
+  const onError = (error: Error) => {
+    fail(new Error(`SSH port forward for remote port ${input.remotePort} failed: ${error.message}`));
+  };
+  const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+    const exitReason =
+      code !== null ? `exit code ${code}` : signal !== null ? `signal ${signal}` : "unknown exit";
+    const stderr = cleanSshStderr(input.diagnostics.stderr);
+    const suffix =
+      stderr.length > 0 ? `: ${stderr}` : ". Check SSH target, key auth, and remote port.";
+    fail(
+      new Error(
+        `SSH port forward for remote port ${input.remotePort} failed (${exitReason})${suffix}`,
+      ),
+    );
+  };
+
+  const promise = new Promise<never>((_resolve, reject) => {
+    rejectPromise = reject;
+    input.process.once("error", onError);
+    input.process.once("exit", onExit);
+  });
+
+  return {
+    promise,
+    dispose: cleanup,
+  };
+}
+
+export class RemotePortForwarder {
+  private target: string | null = null;
+  private readonly forwardsByRemotePort = new Map<number, ForwardedPort>();
+  private readonly pendingForwardsByRemotePort = new Map<number, Promise<ForwardedPort>>();
+  private readonly logicalOriginsByLocalOrigin = new Map<string, string>();
+
+  setTarget(target: string | null): void {
+    if (this.target === target) {
+      return;
+    }
+    this.dispose();
+    this.target = target;
+  }
+
+  isActive(): boolean {
+    return this.target !== null;
+  }
+
+  async resolveUrl(rawUrl: string): Promise<{ url: string }> {
+    if (!this.target) {
+      return { url: rawUrl };
+    }
+
+    let url: URL;
+    try {
+      url = new URL(rawUrl);
+    } catch {
+      return { url: rawUrl };
+    }
+
+    if (
+      !["http:", "https:", "ws:", "wss:"].includes(url.protocol) ||
+      !isLoopbackHost(url.hostname)
+    ) {
+      return { url: rawUrl };
+    }
+
+    const remotePort = url.port
+      ? Number.parseInt(url.port, 10)
+      : defaultPortForProtocol(url.protocol);
+    if (!remotePort || !Number.isFinite(remotePort) || remotePort <= 0) {
+      return { url: rawUrl };
+    }
+    for (const forward of this.forwardsByRemotePort.values()) {
+      if (forward.localPort === remotePort) {
+        return { url: rawUrl };
+      }
+    }
+
+    const logicalOrigin = url.origin;
+    const forwarded = await this.ensureForward(remotePort);
+    url.hostname = "127.0.0.1";
+    url.port = String(forwarded.localPort);
+    this.logicalOriginsByLocalOrigin.set(url.origin, logicalOrigin);
+    return { url: url.toString() };
+  }
+
+  normalizeDisplayUrl(rawUrl: string): string {
+    if (!this.target) {
+      return rawUrl;
+    }
+
+    let url: URL;
+    try {
+      url = new URL(rawUrl);
+    } catch {
+      return rawUrl;
+    }
+
+    const logicalOrigin = this.logicalOriginsByLocalOrigin.get(url.origin);
+    if (!logicalOrigin) {
+      return rawUrl;
+    }
+
+    const logicalUrl = new URL(logicalOrigin);
+    url.protocol = logicalUrl.protocol;
+    url.hostname = logicalUrl.hostname;
+    url.port = logicalUrl.port;
+    url.username = "";
+    url.password = "";
+    return url.toString();
+  }
+
+  dispose(): void {
+    for (const forward of this.forwardsByRemotePort.values()) {
+      forward.process.kill("SIGTERM");
+    }
+    this.target = null;
+    this.forwardsByRemotePort.clear();
+    this.pendingForwardsByRemotePort.clear();
+    this.logicalOriginsByLocalOrigin.clear();
+  }
+
+  private async ensureForward(remotePort: number): Promise<ForwardedPort> {
+    const existing = this.forwardsByRemotePort.get(remotePort);
+    if (existing && existing.process.exitCode === null && existing.process.signalCode === null) {
+      return existing;
+    }
+    const pending = this.pendingForwardsByRemotePort.get(remotePort);
+    if (pending) {
+      return pending;
+    }
+
+    if (!this.target) {
+      throw new Error("Remote SSH forwarding is not active.");
+    }
+
+    const pendingForward = this.createForward(remotePort);
+    this.pendingForwardsByRemotePort.set(remotePort, pendingForward);
+    try {
+      return await pendingForward;
+    } finally {
+      if (this.pendingForwardsByRemotePort.get(remotePort) === pendingForward) {
+        this.pendingForwardsByRemotePort.delete(remotePort);
+      }
+    }
+  }
+
+  private async createForward(remotePort: number): Promise<ForwardedPort> {
+    const target = this.target;
+    if (!target) {
+      throw new Error("Remote SSH forwarding is not active.");
+    }
+    const localPort = await reserveLoopbackPort();
+    if (this.target !== target) {
+      throw new Error("Remote SSH forwarding was cancelled.");
+    }
+    const process = createSshTunnelProcess({
+      target,
+      localPort,
+      remotePort,
+    });
+    const diagnostics = captureSshDiagnostics(process);
+    const forward: ForwardedPort = { remotePort, localPort, process };
+    this.forwardsByRemotePort.set(remotePort, forward);
+    process.once("error", () => {
+      if (this.forwardsByRemotePort.get(remotePort) === forward) {
+        this.forwardsByRemotePort.delete(remotePort);
+      }
+    });
+    process.once("exit", () => {
+      if (this.forwardsByRemotePort.get(remotePort) === forward) {
+        this.forwardsByRemotePort.delete(remotePort);
+      }
+    });
+    const tunnelExit = waitForTunnelExit({ process, remotePort, diagnostics });
+    try {
+      await Promise.race([waitForLocalPort(localPort), tunnelExit.promise]);
+    } catch (error) {
+      tunnelExit.dispose();
+      process.kill("SIGTERM");
+      if (this.forwardsByRemotePort.get(remotePort) === forward) {
+        this.forwardsByRemotePort.delete(remotePort);
+      }
+      throw error;
+    }
+    tunnelExit.dispose();
+    if (this.target !== target) {
+      process.kill("SIGTERM");
+      if (this.forwardsByRemotePort.get(remotePort) === forward) {
+        this.forwardsByRemotePort.delete(remotePort);
+      }
+      throw new Error("Remote SSH forwarding was cancelled.");
+    }
+    return forward;
+  }
+}

--- a/apps/desktop/src/remoteSshBackend.test.ts
+++ b/apps/desktop/src/remoteSshBackend.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { buildStartupCommand, isRemoteHealthReady, quotePosix } from "./remoteSshBackend";
+
+describe("remoteSshBackend", () => {
+  it("quotes shell values for remote startup commands", () => {
+    expect(quotePosix("plain")).toBe("'plain'");
+    expect(quotePosix("path with spaces")).toBe("'path with spaces'");
+    expect(quotePosix("it's-here")).toBe("'it'\\''s-here'");
+  });
+
+  it("builds the default remote DP Code server command", () => {
+    expect(
+      buildStartupCommand({
+        template: undefined,
+        remotePort: 53123,
+        authToken: "secret-token",
+        remoteProjectPath: "/srv/app",
+      }),
+    ).toBe(
+      "cd '/srv/app' && t3 --mode desktop --host 127.0.0.1 --port 53123 --auth-token 'secret-token' --no-browser",
+    );
+  });
+
+  it("fills startup command placeholders", () => {
+    expect(
+      buildStartupCommand({
+        template:
+          "cd {remoteProjectPath} && t3 --port {port} --auth-token {token} --no-browser",
+        remotePort: 53123,
+        authToken: "secret-token",
+        remoteProjectPath: "/srv/my app",
+      }),
+    ).toBe("cd '/srv/my app' && t3 --port 53123 --auth-token 'secret-token' --no-browser");
+  });
+
+  it("requires remote /health to be ok and startupReady", async () => {
+    await expect(
+      isRemoteHealthReady(
+        new Response(JSON.stringify({ startupReady: true }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ).resolves.toBe(false);
+
+    await expect(
+      isRemoteHealthReady(
+        new Response(JSON.stringify({ startupReady: false }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ).resolves.toBe(false);
+
+    await expect(
+      isRemoteHealthReady(
+        new Response(JSON.stringify({ startupReady: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
+});

--- a/apps/desktop/src/remoteSshBackend.ts
+++ b/apps/desktop/src/remoteSshBackend.ts
@@ -1,0 +1,471 @@
+import * as ChildProcess from "node:child_process";
+import * as Crypto from "node:crypto";
+
+import type {
+  RemoteSshConnectInput,
+  RemoteSshConnectionResult,
+  RemoteSshStatus,
+} from "@t3tools/contracts";
+
+import { waitForHttpReady } from "./backendReadiness";
+import { reserveLoopbackPort } from "./loopbackPort";
+
+const DEFAULT_REMOTE_PORT_MIN = 43000;
+const DEFAULT_REMOTE_PORT_SPAN = 12000;
+const SSH_ERROR_BUFFER_MAX_BYTES = 16 * 1024;
+const SSH_CONNECT_TIMEOUT_SECONDS = 10;
+const SSH_OPTIONS = [
+  "-o",
+  "BatchMode=yes",
+  "-o",
+  "StrictHostKeyChecking=accept-new",
+  "-o",
+  `ConnectTimeout=${SSH_CONNECT_TIMEOUT_SECONDS}`,
+] as const;
+
+export interface RemoteSshBackendLifecycleEvent {
+  status: RemoteSshStatus;
+  previousSession: {
+    target: string;
+    remoteProjectPath: string;
+    httpUrl: string;
+    wsUrl: string;
+  };
+}
+
+type RemoteSshBackendLifecycleListener = (event: RemoteSshBackendLifecycleEvent) => void;
+
+interface ActiveRemoteSession {
+  target: string;
+  remoteProjectPath: string;
+  remotePort: number;
+  localPort: number;
+  authToken: string;
+  httpUrl: string;
+  wsUrl: string;
+  serverProcess: ChildProcess.ChildProcess;
+  tunnelProcess: ChildProcess.ChildProcess;
+}
+
+interface SshProcessDiagnostics {
+  label: string;
+  stderr: string;
+}
+
+function trimRequired(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`${label} is required.`);
+  }
+  if (/[\r\n]/.test(trimmed)) {
+    throw new Error(`${label} cannot contain newlines.`);
+  }
+  return trimmed;
+}
+
+export function quotePosix(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function chooseRemotePort(input: number | undefined): number {
+  if (input !== undefined) {
+    if (!Number.isInteger(input) || input <= 0 || input > 65535) {
+      throw new Error("Remote port must be a valid TCP port.");
+    }
+    return input;
+  }
+  return DEFAULT_REMOTE_PORT_MIN + Crypto.randomInt(DEFAULT_REMOTE_PORT_SPAN);
+}
+
+function buildDefaultStartupCommand(input: {
+  readonly remotePort: number;
+  readonly authToken: string;
+  readonly remoteProjectPath: string;
+}): string {
+  const command = [
+    "t3",
+    "--mode",
+    "desktop",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(input.remotePort),
+    "--auth-token",
+    quotePosix(input.authToken),
+    "--no-browser",
+  ].join(" ");
+  return `cd ${quotePosix(input.remoteProjectPath)} && ${command}`;
+}
+
+export function buildStartupCommand(input: {
+  readonly template: string | undefined;
+  readonly remotePort: number;
+  readonly authToken: string;
+  readonly remoteProjectPath: string;
+}): string {
+  const template = input.template?.trim();
+  const command =
+    template && template.length > 0
+      ? template
+      : buildDefaultStartupCommand({
+          remotePort: input.remotePort,
+          authToken: input.authToken,
+          remoteProjectPath: input.remoteProjectPath,
+        });
+  return command
+    .replaceAll("{port}", String(input.remotePort))
+    .replaceAll("{token}", quotePosix(input.authToken))
+    .replaceAll("{remoteProjectPath}", quotePosix(input.remoteProjectPath));
+}
+
+export async function isRemoteHealthReady(response: Response): Promise<boolean> {
+  if (!response.ok) {
+    return false;
+  }
+  try {
+    const payload = (await response.json()) as {
+      startupReady?: unknown;
+    };
+    return payload.startupReady === true;
+  } catch {
+    return false;
+  }
+}
+
+function createRemoteServerProcess(input: {
+  readonly target: string;
+  readonly command: string;
+}): ChildProcess.ChildProcess {
+  return ChildProcess.spawn("ssh", [...SSH_OPTIONS, "-T", input.target, input.command], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+}
+
+function createTunnelProcess(input: {
+  readonly target: string;
+  readonly localPort: number;
+  readonly remotePort: number;
+}): ChildProcess.ChildProcess {
+  return ChildProcess.spawn(
+    "ssh",
+    [
+      "-N",
+      "-T",
+      ...SSH_OPTIONS,
+      "-o",
+      "ExitOnForwardFailure=yes",
+      "-o",
+      "ServerAliveInterval=30",
+      "-o",
+      "ServerAliveCountMax=3",
+      "-L",
+      `127.0.0.1:${input.localPort}:127.0.0.1:${input.remotePort}`,
+      input.target,
+    ],
+    {
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+}
+
+function stopProcess(child: ChildProcess.ChildProcess | null | undefined): void {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.kill("SIGTERM");
+}
+
+function sessionSummary(session: ActiveRemoteSession): RemoteSshBackendLifecycleEvent["previousSession"] {
+  return {
+    target: session.target,
+    remoteProjectPath: session.remoteProjectPath,
+    httpUrl: session.httpUrl,
+    wsUrl: session.wsUrl,
+  };
+}
+
+function appendBounded(buffer: string, chunk: Buffer | string): string {
+  const next = `${buffer}${chunk.toString()}`;
+  if (Buffer.byteLength(next) <= SSH_ERROR_BUFFER_MAX_BYTES) {
+    return next;
+  }
+  return next.slice(-SSH_ERROR_BUFFER_MAX_BYTES);
+}
+
+function captureSshDiagnostics(
+  child: ChildProcess.ChildProcess,
+  label: string,
+): SshProcessDiagnostics {
+  const diagnostics: SshProcessDiagnostics = { label, stderr: "" };
+  child.stderr?.on("data", (chunk: Buffer | string) => {
+    diagnostics.stderr = appendBounded(diagnostics.stderr, chunk);
+  });
+  return diagnostics;
+}
+
+function cleanSshStderr(stderr: string): string {
+  return stderr.replace(/\s+/g, " ").trim();
+}
+
+function sshFailureMessage(input: {
+  readonly diagnostics: SshProcessDiagnostics;
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}): string {
+  const exitReason =
+    input.code !== null
+      ? `exit code ${input.code}`
+      : input.signal !== null
+        ? `signal ${input.signal}`
+        : "unknown exit";
+  const stderr = cleanSshStderr(input.diagnostics.stderr);
+  return stderr.length > 0
+    ? `${input.diagnostics.label} failed (${exitReason}): ${stderr}`
+    : `${input.diagnostics.label} failed (${exitReason}). Check SSH target, key auth, and remote command.`;
+}
+
+function waitForProcessFailure(
+  child: ChildProcess.ChildProcess,
+  diagnostics: SshProcessDiagnostics,
+): { promise: Promise<never>; dispose: () => void } {
+  let settled = false;
+  let rejectPromise: (error: Error) => void = () => {};
+
+  const cleanup = () => {
+    child.off("error", onError);
+    child.off("exit", onExit);
+  };
+  const fail = (error: Error) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cleanup();
+    rejectPromise(error);
+  };
+  const onError = (error: Error) => {
+    fail(new Error(`${diagnostics.label} failed: ${error.message}`));
+  };
+  const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+    fail(new Error(sshFailureMessage({ diagnostics, code, signal })));
+  };
+
+  const promise = new Promise<never>((_resolve, reject) => {
+    rejectPromise = reject;
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
+
+  return {
+    promise,
+    dispose: cleanup,
+  };
+}
+
+function statusFromSession(session: ActiveRemoteSession | null): RemoteSshStatus {
+  if (!session) {
+    return {
+      mode: "local",
+      target: null,
+      remoteProjectPath: null,
+      httpUrl: null,
+      wsUrl: null,
+      message: null,
+    };
+  }
+  return {
+    mode: "remote",
+    target: session.target,
+    remoteProjectPath: session.remoteProjectPath,
+    httpUrl: session.httpUrl,
+    wsUrl: session.wsUrl,
+    message: null,
+  };
+}
+
+export class RemoteSshBackendManager {
+  private session: ActiveRemoteSession | null = null;
+  private status: RemoteSshStatus = statusFromSession(null);
+  private connectInFlight = false;
+  private sessionGeneration = 0;
+  private readonly lifecycleListeners = new Set<RemoteSshBackendLifecycleListener>();
+
+  getStatus(): RemoteSshStatus {
+    return this.status;
+  }
+
+  getActiveTarget(): string | null {
+    return this.session?.target ?? null;
+  }
+
+  subscribeLifecycle(listener: RemoteSshBackendLifecycleListener): () => void {
+    this.lifecycleListeners.add(listener);
+    return () => {
+      this.lifecycleListeners.delete(listener);
+    };
+  }
+
+  async connect(input: RemoteSshConnectInput): Promise<RemoteSshConnectionResult> {
+    if (this.connectInFlight) {
+      throw new Error("Remote SSH connection is already in progress.");
+    }
+    this.connectInFlight = true;
+    try {
+      return await this.connectInternal(input);
+    } finally {
+      this.connectInFlight = false;
+    }
+  }
+
+  private async connectInternal(input: RemoteSshConnectInput): Promise<RemoteSshConnectionResult> {
+    const target = trimRequired(input.target, "SSH target");
+    const remoteProjectPath = trimRequired(input.remoteProjectPath, "Remote project path");
+    await this.disconnect();
+    const generation = ++this.sessionGeneration;
+
+    const remotePort = chooseRemotePort(input.remotePort);
+    const localPort = await reserveLoopbackPort();
+    const authToken = Crypto.randomBytes(24).toString("hex");
+    const httpUrl = `http://127.0.0.1:${localPort}`;
+    const wsUrl = `ws://127.0.0.1:${localPort}/?token=${encodeURIComponent(authToken)}`;
+    const command = buildStartupCommand({
+      template: input.startupCommand,
+      remotePort,
+      authToken,
+      remoteProjectPath,
+    });
+
+    this.status = {
+      mode: "connecting",
+      target,
+      remoteProjectPath,
+      httpUrl,
+      wsUrl,
+      message: "Starting remote DP Code server...",
+    };
+
+    const serverProcess = createRemoteServerProcess({ target, command });
+    const tunnelProcess = createTunnelProcess({ target, localPort, remotePort });
+    const serverDiagnostics = captureSshDiagnostics(serverProcess, "Remote DP Code server SSH");
+    const tunnelDiagnostics = captureSshDiagnostics(tunnelProcess, "Remote SSH tunnel");
+    const nextSession: ActiveRemoteSession = {
+      target,
+      remoteProjectPath,
+      remotePort,
+      localPort,
+      authToken,
+      httpUrl,
+      wsUrl,
+      serverProcess,
+      tunnelProcess,
+    };
+
+    let ready = false;
+    const failActiveSession = (message: string, notifyLifecycle: boolean) => {
+      if (this.session !== nextSession || this.sessionGeneration !== generation) {
+        return;
+      }
+      const previousSession = sessionSummary(nextSession);
+      this.session = null;
+      stopProcess(serverProcess);
+      stopProcess(tunnelProcess);
+      this.status = {
+        mode: "error",
+        target,
+        remoteProjectPath,
+        httpUrl,
+        wsUrl,
+        message,
+      };
+      if (notifyLifecycle) {
+        this.emitLifecycle({ status: this.status, previousSession });
+      }
+    };
+    const onServerExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      failActiveSession(sshFailureMessage({ diagnostics: serverDiagnostics, code, signal }), ready);
+    };
+    const onTunnelExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      failActiveSession(sshFailureMessage({ diagnostics: tunnelDiagnostics, code, signal }), ready);
+    };
+    const onError = (error: Error) => {
+      failActiveSession(error.message, ready);
+    };
+    serverProcess.once("error", onError);
+    tunnelProcess.once("error", onError);
+    serverProcess.once("exit", onServerExit);
+    tunnelProcess.once("exit", onTunnelExit);
+    this.session = nextSession;
+    const serverFailure = waitForProcessFailure(serverProcess, serverDiagnostics);
+    const tunnelFailure = waitForProcessFailure(tunnelProcess, tunnelDiagnostics);
+
+    try {
+      await Promise.race([
+        waitForHttpReady(httpUrl, {
+          path: "/health",
+          timeoutMs: 45_000,
+          isReady: isRemoteHealthReady,
+        }),
+        serverFailure.promise,
+        tunnelFailure.promise,
+      ]);
+    } catch (error) {
+      serverFailure.dispose();
+      tunnelFailure.dispose();
+      stopProcess(serverProcess);
+      stopProcess(tunnelProcess);
+      if (this.session === nextSession && this.sessionGeneration === generation) {
+        this.session = null;
+      }
+      const message = error instanceof Error ? error.message : "Remote SSH connection failed.";
+      if (this.sessionGeneration === generation) {
+        this.status = {
+          mode: "error",
+          target,
+          remoteProjectPath,
+          httpUrl,
+          wsUrl,
+          message,
+        };
+      }
+      throw new Error(message);
+    }
+    serverFailure.dispose();
+    tunnelFailure.dispose();
+
+    if (this.session !== nextSession || this.sessionGeneration !== generation) {
+      stopProcess(serverProcess);
+      stopProcess(tunnelProcess);
+      throw new Error("Remote SSH connection was cancelled.");
+    }
+
+    ready = true;
+    this.status = statusFromSession(nextSession);
+    return {
+      mode: "remote",
+      target,
+      remoteProjectPath,
+      httpUrl,
+      wsUrl,
+    };
+  }
+
+  async disconnect(): Promise<RemoteSshStatus> {
+    this.sessionGeneration += 1;
+    const current = this.session;
+    this.session = null;
+    stopProcess(current?.serverProcess);
+    stopProcess(current?.tunnelProcess);
+    this.status = statusFromSession(null);
+    return this.status;
+  }
+
+  private emitLifecycle(event: RemoteSshBackendLifecycleEvent): void {
+    for (const listener of this.lifecycleListeners) {
+      try {
+        listener(event);
+      } catch {
+        // Lifecycle listeners must not prevent process cleanup after an SSH failure.
+      }
+    }
+  }
+}

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -467,7 +467,13 @@ export function BrowserPanel({ mode, threadId, onClosePanel }: BrowserPanelProps
     if (browserWebviewTabIdRef.current !== activeTab.id) {
       browserWebviewTabIdRef.current = activeTab.id;
       browserWebviewAttachKeyRef.current = null;
-      webview.setAttribute("src", initialUrl.length > 0 ? initialUrl : BROWSER_BLANK_URL);
+      const initialWebviewUrl =
+        window.desktopBridge !== undefined
+          ? BROWSER_BLANK_URL
+          : initialUrl.length > 0
+            ? initialUrl
+            : BROWSER_BLANK_URL;
+      webview.setAttribute("src", initialWebviewUrl);
     }
 
     const attachVisibleWebview = () => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2,6 +2,7 @@ import {
   type ApprovalRequestId,
   DEFAULT_MODEL_BY_PROVIDER,
   type ClaudeCodeEffort,
+  type DesktopClipboardImageResult,
   MessageId,
   type ModelSelection,
   type ProjectScript,
@@ -388,6 +389,26 @@ function revokeBlobPreviewUrlsAfterPaint(previewUrls: readonly string[]): void {
         revokeBlobPreviewUrl(previewUrl);
       }
     }, 0);
+  });
+}
+
+function fileFromDesktopClipboardImage(result: DesktopClipboardImageResult): File | null {
+  const commaIndex = result.dataUrl.indexOf(",");
+  if (commaIndex < 0 || !result.dataUrl.slice(0, commaIndex).includes(";base64")) {
+    return null;
+  }
+
+  const binary = window.atob(result.dataUrl.slice(commaIndex + 1));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  if (bytes.byteLength === 0) {
+    return null;
+  }
+
+  return new File([bytes], `clipboard-${Date.now()}.png`, {
+    type: result.mimeType,
   });
 }
 
@@ -4780,15 +4801,41 @@ export default function ChatView({
 
   const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
     const files = Array.from(event.clipboardData.files);
-    if (files.length === 0) {
+    const itemFiles = Array.from(event.clipboardData.items)
+      .filter((item) => item.kind === "file" && item.type.startsWith("image/"))
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => file !== null);
+    const pastedFiles = files.length > 0 ? files : itemFiles;
+    if (pastedFiles.length > 0) {
+      const imageFiles = pastedFiles.filter((file) => file.type.startsWith("image/"));
+      if (imageFiles.length === 0) {
+        return;
+      }
+      event.preventDefault();
+      addComposerImages(imageFiles);
       return;
     }
-    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) {
+
+    if (!isElectron || event.clipboardData.getData("text").trim().length > 0) {
+      return;
+    }
+    const clipboardBridge = window.desktopBridge?.clipboard;
+    if (!clipboardBridge) {
       return;
     }
     event.preventDefault();
-    addComposerImages(imageFiles);
+    void clipboardBridge
+      .readImage()
+      .then((result) => {
+        if (!result) {
+          return;
+        }
+        const file = fileFromDesktopClipboardImage(result);
+        if (file) {
+          addComposerImages([file]);
+        }
+      })
+      .catch(() => {});
   };
 
   const onComposerDragEnter = (event: React.DragEvent<HTMLDivElement>) => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -58,6 +58,7 @@ import {
   PROVIDER_DISPLAY_NAMES,
   ProjectId,
   type ProviderKind,
+  type RemoteSshStatus,
   ThreadId,
   type GitStatusResult,
   type ResolvedKeybindingsConfig,
@@ -268,6 +269,7 @@ const ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS = 50;
 const THREAD_INTENT_PREWARM_RELEASE_MS = 10_000;
 const ADD_PROJECT_EXISTING_SYNC_ERROR =
   "This folder is already linked, but the existing project has not synced into the sidebar yet. Try again in a moment.";
+const REMOTE_SSH_PENDING_PROJECT_PATH_KEY = "dpcode.remoteSsh.pendingProjectPath";
 const DebugFeatureFlagsMenu = import.meta.env.DEV
   ? lazy(() =>
       import("./DebugFeatureFlagsMenu").then((module) => ({
@@ -1232,8 +1234,14 @@ export default function Sidebar() {
   const [searchPaletteInitialQuery, setSearchPaletteInitialQuery] = useState<string | null>(null);
   const [isPickingFolder, setIsPickingFolder] = useState(false);
   const [showManualPathInput, setShowManualPathInput] = useState(false);
+  const [showRemoteSshInput, setShowRemoteSshInput] = useState(false);
   const [isAddingProject, setIsAddingProject] = useState(false);
+  const [isConnectingRemoteSsh, setIsConnectingRemoteSsh] = useState(false);
   const [addProjectError, setAddProjectError] = useState<string | null>(null);
+  const [remoteSshTarget, setRemoteSshTarget] = useState("");
+  const [remoteSshProjectPath, setRemoteSshProjectPath] = useState("");
+  const [remoteSshStartupCommand, setRemoteSshStartupCommand] = useState("");
+  const [remoteSshStatus, setRemoteSshStatus] = useState<RemoteSshStatus | null>(null);
   const addProjectErrorMeaning = useMemo(
     () => (addProjectError ? describeAddProjectError(addProjectError) : null),
     [addProjectError],
@@ -1969,6 +1977,126 @@ export default function Sidebar() {
   };
 
   const canAddProject = newCwd.trim().length > 0 && !isAddingProject;
+  const canConnectRemoteSsh =
+    remoteSshTarget.trim().length > 0 &&
+    remoteSshProjectPath.trim().length > 0 &&
+    !isConnectingRemoteSsh;
+
+  const handleConnectRemoteSsh = useCallback(() => {
+    const bridge = window.desktopBridge?.remoteSsh;
+    if (!bridge) {
+      setAddProjectError("Remote SSH is only available in the desktop app.");
+      return;
+    }
+    if (!canConnectRemoteSsh) {
+      return;
+    }
+
+    const remoteProjectPath = remoteSshProjectPath.trim();
+    setIsConnectingRemoteSsh(true);
+    setAddProjectError(null);
+    void bridge
+      .connect({
+        target: remoteSshTarget.trim(),
+        remoteProjectPath,
+        ...(remoteSshStartupCommand.trim()
+          ? { startupCommand: remoteSshStartupCommand.trim() }
+          : {}),
+      })
+      .then(() => {
+        setRemoteSshStatus({
+          mode: "remote",
+          target: remoteSshTarget.trim(),
+          remoteProjectPath,
+          httpUrl: null,
+          wsUrl: null,
+          message: null,
+        });
+        window.localStorage.setItem(REMOTE_SSH_PENDING_PROJECT_PATH_KEY, remoteProjectPath);
+        window.location.reload();
+      })
+      .catch((error) => {
+        const description =
+          error instanceof Error ? error.message : "Unable to connect to the SSH host.";
+        setAddProjectError(description);
+        toastManager.add({
+          type: "error",
+          title: "Unable to connect over SSH",
+          description,
+        });
+      })
+      .finally(() => {
+        setIsConnectingRemoteSsh(false);
+      });
+  }, [
+    canConnectRemoteSsh,
+    remoteSshProjectPath,
+    remoteSshStartupCommand,
+    remoteSshTarget,
+  ]);
+
+  useEffect(() => {
+    if (!isElectron) {
+      return;
+    }
+    const api = readNativeApi();
+    if (!api) return;
+    const pendingProjectPath = window.localStorage.getItem(REMOTE_SSH_PENDING_PROJECT_PATH_KEY);
+    if (!pendingProjectPath) {
+      return;
+    }
+    window.localStorage.removeItem(REMOTE_SSH_PENDING_PROJECT_PATH_KEY);
+    void addProjectFromPath(pendingProjectPath, { createIfMissing: true }).catch((error) => {
+      const description =
+        error instanceof Error ? error.message : "Unable to add the remote project.";
+      setAddProjectError(description);
+      setAddingProject(true);
+      setShowRemoteSshInput(true);
+      setRemoteSshProjectPath(pendingProjectPath);
+      toastManager.add({
+        type: "error",
+        title: "Unable to add remote project",
+        description,
+      });
+    });
+  }, [addProjectFromPath]);
+
+  useEffect(() => {
+    const bridge = window.desktopBridge?.remoteSsh;
+    if (!isElectron || !bridge) {
+      return;
+    }
+    let cancelled = false;
+    void bridge
+      .getStatus()
+      .then((status) => {
+        if (!cancelled) {
+          setRemoteSshStatus(status);
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleDisconnectRemoteSsh = useCallback(() => {
+    const bridge = window.desktopBridge?.remoteSsh;
+    if (!bridge) return;
+    void bridge
+      .disconnect()
+      .then((status) => {
+        setRemoteSshStatus(status);
+        window.location.reload();
+      })
+      .catch((error) => {
+        toastManager.add({
+          type: "error",
+          title: "Unable to disconnect SSH",
+          description: error instanceof Error ? error.message : "An unexpected error occurred.",
+        });
+      });
+  }, []);
 
   // Keep the native folder picker and project creation in one awaited flow so
   // the UI can show whether we're still opening the dialog or creating the project.
@@ -2008,6 +2136,7 @@ export default function Sidebar() {
   const handleStartAddProject = useCallback(() => {
     setAddProjectError(null);
     setShowManualPathInput(false);
+    setShowRemoteSshInput(false);
     setAddingProject((prev) => !prev);
   }, []);
 
@@ -5479,6 +5608,17 @@ export default function Sidebar() {
                 )}
               </SidebarMenu>
             </SidebarGroup>
+            {isElectron && remoteSshStatus?.mode === "remote" ? (
+              <SidebarGroup className="px-1.5 pb-1.5">
+                <SidebarMenu className="gap-0.5">
+                  <SidebarPrimaryAction
+                    icon={TerminalIcon}
+                    label="Disconnect SSH"
+                    onClick={handleDisconnectRemoteSsh}
+                  />
+                </SidebarMenu>
+              </SidebarGroup>
+            ) : null}
 
             {isOnWorkspace ? (
               <SidebarGroup className="px-1.5 pt-1 pb-1.5">
@@ -5690,8 +5830,13 @@ export default function Sidebar() {
 
                 {shouldShowProjectPathEntry && (
                   <div className="mb-2.5 px-1">
-                    {!showManualPathInput ? (
-                      <div className="flex gap-1.5">
+                    {!showManualPathInput && !showRemoteSshInput ? (
+                      <div
+                        className={cn(
+                          "grid gap-1.5",
+                          isElectron ? "grid-cols-2" : "grid-cols-1",
+                        )}
+                      >
                         {isElectron && (
                           <button
                             type="button"
@@ -5715,6 +5860,75 @@ export default function Sidebar() {
                           <TbCursorText className="size-3.5" />
                           Type path
                         </button>
+                        {isElectron && (
+                          <button
+                            type="button"
+                            className="col-span-2 flex h-8 items-center justify-center gap-2 rounded-lg bg-[var(--color-background-elevated-secondary)] px-2 text-[length:var(--app-font-size-ui,12px)] font-normal text-[var(--color-text-foreground-secondary)] transition-colors hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)] disabled:opacity-50"
+                            onClick={() => {
+                              setShowRemoteSshInput(true);
+                              setAddProjectError(null);
+                            }}
+                            disabled={isConnectingRemoteSsh}
+                          >
+                            <TerminalIcon className="size-3.5" />
+                            Remote SSH
+                          </button>
+                        )}
+                      </div>
+                    ) : showRemoteSshInput ? (
+                      <div className="space-y-1.5">
+                        <input
+                          className="h-8 w-full rounded-lg border border-[color:var(--color-border)] bg-[var(--color-background-control-opaque)] px-2.5 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-[color:var(--color-border-focus)] focus:outline-none"
+                          placeholder="user@host"
+                          value={remoteSshTarget}
+                          onChange={(event) => {
+                            setRemoteSshTarget(event.target.value);
+                            setAddProjectError(null);
+                          }}
+                          autoFocus
+                        />
+                        <input
+                          className="h-8 w-full rounded-lg border border-[color:var(--color-border)] bg-[var(--color-background-control-opaque)] px-2.5 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-[color:var(--color-border-focus)] focus:outline-none"
+                          placeholder="/path/on/remote/server"
+                          value={remoteSshProjectPath}
+                          onChange={(event) => {
+                            setRemoteSshProjectPath(event.target.value);
+                            setAddProjectError(null);
+                          }}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter") handleConnectRemoteSsh();
+                            if (event.key === "Escape") {
+                              setShowRemoteSshInput(false);
+                              setAddProjectError(null);
+                            }
+                          }}
+                        />
+                        <input
+                          className="h-8 w-full rounded-lg border border-[color:var(--color-border)] bg-[var(--color-background-control-opaque)] px-2.5 text-sm text-foreground placeholder:text-muted-foreground/40 focus:border-[color:var(--color-border-focus)] focus:outline-none"
+                          placeholder="Start command, optional"
+                          value={remoteSshStartupCommand}
+                          onChange={(event) => setRemoteSshStartupCommand(event.target.value)}
+                        />
+                        <div className="flex gap-1.5">
+                          <button
+                            type="button"
+                            className="flex h-8 flex-1 items-center justify-center rounded-lg bg-[var(--color-background-elevated-secondary)] px-2 text-[length:var(--app-font-size-ui,12px)] text-muted-foreground/80 transition-colors hover:bg-[var(--color-background-button-secondary-hover)] hover:text-foreground"
+                            onClick={() => {
+                              setShowRemoteSshInput(false);
+                              setAddProjectError(null);
+                            }}
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            className="flex h-8 flex-1 items-center justify-center rounded-lg bg-[var(--color-background-button-primary)] px-2 text-[length:var(--app-font-size-ui,12px)] text-white transition-colors disabled:opacity-50"
+                            onClick={handleConnectRemoteSsh}
+                            disabled={!canConnectRemoteSsh}
+                          >
+                            {isConnectingRemoteSsh ? "Connecting..." : "Connect"}
+                          </button>
+                        </div>
                       </div>
                     ) : (
                       <div

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -165,6 +165,30 @@ export interface DesktopUpdateActionResult {
   state: DesktopUpdateState;
 }
 
+export interface RemoteSshConnectInput {
+  target: string;
+  remoteProjectPath: string;
+  remotePort?: number;
+  startupCommand?: string;
+}
+
+export interface RemoteSshConnectionResult {
+  mode: "remote";
+  target: string;
+  remoteProjectPath: string;
+  httpUrl: string;
+  wsUrl: string;
+}
+
+export interface RemoteSshStatus {
+  mode: "local" | "remote" | "connecting" | "error";
+  target: string | null;
+  remoteProjectPath: string | null;
+  httpUrl: string | null;
+  wsUrl: string | null;
+  message: string | null;
+}
+
 export interface BrowserTabState {
   id: string;
   url: string;
@@ -249,6 +273,12 @@ export interface DesktopNotificationInput {
   threadId?: ThreadId;
 }
 
+export interface DesktopClipboardImageResult {
+  dataUrl: string;
+  mimeType: "image/png";
+  sizeBytes: number;
+}
+
 export interface DesktopBridge {
   getWsUrl: () => string | null;
   pickFolder: () => Promise<string | null>;
@@ -278,10 +308,18 @@ export interface DesktopBridge {
     isSupported: () => Promise<boolean>;
     show: (input: DesktopNotificationInput) => Promise<boolean>;
   };
+  clipboard?: {
+    readImage: () => Promise<DesktopClipboardImageResult | null>;
+  };
   server?: {
     transcribeVoice: (
       input: ServerVoiceTranscriptionInput,
     ) => Promise<ServerVoiceTranscriptionResult>;
+  };
+  remoteSsh?: {
+    connect: (input: RemoteSshConnectInput) => Promise<RemoteSshConnectionResult>;
+    disconnect: () => Promise<RemoteSshStatus>;
+    getStatus: () => Promise<RemoteSshStatus>;
   };
   browser: {
     open: (input: BrowserOpenInput) => Promise<ThreadBrowserState>;


### PR DESCRIPTION
## Summary

Adds desktop Remote SSH support so the local Electron app can connect to a DP Code server started on an SSH host, tunnel the backend WebSocket/HTTP connection, and open remote projects from the local UI.

## Details

- Adds desktop IPC/contracts/preload APIs for Remote SSH connection status and local clipboard image reads.
- Starts the remote DP Code backend over SSH with key-based, non-interactive options, remote project cwd, health readiness, stderr diagnostics, and lifecycle cleanup.
- Adds localhost forwarding for the built-in browser, including HTTP/HTTPS/WS/WSS loopback URLs, fail-closed behavior on forwarding errors, and logical URL preservation in the address/history state.
- Adds local clipboard image paste fallback for Electron so pasted screenshots/images still attach while connected to a remote backend.
- Adds focused tests for remote startup command construction and readiness handling.

## Validation

- `git diff --cached --check`
- `npx -y -p node@24.13.1 -p bun@1.3.9 -c 'cd apps/desktop && bun run test'`
- `npx -y -p node@24.13.1 -p bun@1.3.9 -c 'cd apps/web && bun run test'`
- `npx -y -p node@24.13.1 -p bun@1.3.9 -c 'bun run build:desktop'`
- Local SSH smoke for the remote backend manager and browser port forwarder during implementation
