### PR TITLE
Guard unavailable create PR actions

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -6,6 +6,7 @@ import {
   requiresFeatureBranchForDefaultBranchAction,
   requiresDefaultBranchConfirmation,
   resolveAutoFeatureBranchName,
+  resolveCreatePrActionAvailability,
   resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
   resolveLiveThreadBranchUpdate,
@@ -319,6 +320,42 @@ describe("when: branch is clean, up to date, and has no open PR", () => {
       label: "Create PR",
       hint: "No branch changes to include in a PR.",
       disabled: true,
+    });
+  });
+
+  it("resolveCreatePrActionAvailability blocks stale create-pr calls for default upstream", () => {
+    const availability = resolveCreatePrActionAvailability({
+      gitStatus: status({
+        branch: "dpcode/pi-cleanup",
+        upstreamBranch: "main",
+        aheadCount: 0,
+        behindCount: 0,
+        pr: null,
+      }),
+      defaultBranchName: "main",
+    });
+
+    assert.deepEqual(availability, {
+      canRun: false,
+      hint: "No branch changes to include in a PR.",
+    });
+  });
+
+  it("resolveCreatePrActionAvailability allows clean published feature branches", () => {
+    const availability = resolveCreatePrActionAvailability({
+      gitStatus: status({
+        branch: "feature/test",
+        upstreamBranch: "feature/test",
+        aheadCount: 0,
+        behindCount: 0,
+        pr: null,
+      }),
+      defaultBranchName: "main",
+    });
+
+    assert.deepEqual(availability, {
+      canRun: true,
+      hint: null,
     });
   });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -27,6 +27,7 @@ export interface GitQuickAction {
 }
 
 const FALLBACK_DEFAULT_BRANCH_NAMES = new Set(["main", "master"]);
+const CREATE_PR_UNAVAILABLE_HINT = "No branch changes to include in a PR.";
 
 export interface DefaultBranchActionDialogCopy {
   title: string;
@@ -395,7 +396,7 @@ export function resolveQuickAction(
       label: "Create PR",
       disabled: true,
       kind: "show_hint",
-      hint: "No branch changes to include in a PR.",
+      hint: CREATE_PR_UNAVAILABLE_HINT,
     };
   }
 
@@ -404,7 +405,7 @@ export function resolveQuickAction(
       label: "Create PR",
       disabled: true,
       kind: "show_hint",
-      hint: "No branch changes to include in a PR.",
+      hint: CREATE_PR_UNAVAILABLE_HINT,
     };
   }
 
@@ -422,6 +423,32 @@ export function resolveQuickAction(
     disabled: true,
     kind: "show_hint",
     hint: "Branch is up to date. No action needed.",
+  };
+}
+
+export function resolveCreatePrActionAvailability(input: {
+  gitStatus: GitStatusResult | null;
+  isDefaultBranch?: boolean;
+  hasOriginRemote?: boolean;
+  defaultBranchName?: string | null;
+}): { canRun: boolean; hint: string | null } {
+  const quickAction = resolveQuickAction(
+    input.gitStatus,
+    false,
+    input.isDefaultBranch ?? false,
+    input.hasOriginRemote ?? true,
+    false,
+    input.defaultBranchName,
+  );
+
+  const canRun =
+    quickAction.kind === "run_action" &&
+    quickAction.action === "create_pr" &&
+    !quickAction.disabled;
+
+  return {
+    canRun,
+    hint: canRun ? null : (quickAction.hint ?? CREATE_PR_UNAVAILABLE_HINT),
   };
 }
 

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -30,6 +30,7 @@ import {
   resolveLiveThreadBranchUpdate,
   resolveDefaultCreateBranchName,
   resolveDefaultBranchActionDialogCopy,
+  resolveCreatePrActionAvailability,
   resolveQuickAction,
   shouldOfferCreateBranchPrompt,
   summarizeGitResult,
@@ -653,6 +654,23 @@ export default function GitActionsControl({
         });
         return;
       }
+      if (action === "create_pr" && !featureBranch) {
+        const createPrAvailability = resolveCreatePrActionAvailability({
+          gitStatus: actionStatus,
+          isDefaultBranch: actionIsDefaultBranch,
+          hasOriginRemote,
+          defaultBranchName,
+        });
+        if (!createPrAvailability.canRun) {
+          toastManager.add({
+            type: "info",
+            title: "Create PR unavailable",
+            description: createPrAvailability.hint ?? "No branch changes to include in a PR.",
+            data: threadToastData,
+          });
+          return;
+        }
+      }
       onConfirmed?.();
 
       const progressStages = buildGitActionProgressStages({
@@ -743,18 +761,27 @@ export default function GitActionsControl({
           (!actionIsDefaultBranch ||
             result.pr.status === "created" ||
             result.pr.status === "opened_existing");
-        const shouldOfferCreatePrCta =
-          (action === "push" || action === "commit_push") &&
-          !prUrl &&
-          result.push.status === "pushed" &&
-          !actionIsDefaultBranch;
         const postPushStatus = actionStatus
           ? {
               ...actionStatus,
               hasUpstream: true,
+              upstreamBranch:
+                actionStatus.upstreamBranch ??
+                (!actionStatus.hasUpstream ? (result.push.branch ?? actionStatus.branch) : null),
               aheadCount: 0,
             }
           : null;
+        const shouldOfferCreatePrCta =
+          (action === "push" || action === "commit_push") &&
+          !prUrl &&
+          result.push.status === "pushed" &&
+          !actionIsDefaultBranch &&
+          resolveCreatePrActionAvailability({
+            gitStatus: postPushStatus,
+            isDefaultBranch: actionIsDefaultBranch,
+            hasOriginRemote,
+            defaultBranchName,
+          }).canRun;
         const closeResultToast = () => {
           toastManager.close(resolvedProgressToastId);
         };


### PR DESCRIPTION
## Summary
- route direct create-pr attempts through the same availability check as the header action
- prevent stale post-push toasts from offering Create PR when there is no branch diff
- cover default-upstream and published feature-branch cases in git action logic tests

## Verification
- bun run vitest run src/components/GitActionsControl.logic.test.ts
- bun run build
- git diff --check