### PR TITLE
Fix Kilo and OpenCode transcript handling

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -44,6 +44,7 @@ import { TextGeneration } from "../../git/Services/TextGeneration.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { clearWorkspaceIndexCache } from "../../workspaceEntries.ts";
 import {
+  buildPriorTranscriptBootstrapText,
   buildForkBootstrapText,
   buildHandoffBootstrapText,
   hasNativeAssistantMessagesBefore,
@@ -793,6 +794,11 @@ const make = Effect.gen(function* () {
     if (!thread) {
       return;
     }
+    const activeSessionBeforeEnsure = yield* providerService
+      .listSessions()
+      .pipe(
+        Effect.map((sessions) => sessions.find((session) => session.threadId === input.threadId)),
+      );
     yield* ensureSessionForThread(input.threadId, input.createdAt, {
       ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
       ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
@@ -825,6 +831,20 @@ const make = Effect.gen(function* () {
       shouldBootstrapSidechatContext && availableBootstrapChars > 0
         ? buildForkBootstrapText(thread, availableBootstrapChars)
         : null;
+    const selectedProvider =
+      input.modelSelection?.provider ??
+      threadModelSelections.get(input.threadId)?.provider ??
+      thread.session?.providerName ??
+      thread.modelSelection.provider;
+    const shouldBootstrapPriorTranscriptContext =
+      (selectedProvider === "kilo" || selectedProvider === "opencode") &&
+      activeSessionBeforeEnsure === undefined &&
+      !handoffBootstrapText &&
+      !sidechatBootstrapText;
+    const priorTranscriptBootstrapText =
+      shouldBootstrapPriorTranscriptContext && availableBootstrapChars > 0
+        ? buildPriorTranscriptBootstrapText(thread, input.messageId, availableBootstrapChars)
+        : null;
     const boundaryMessageText = thread.sidechatSourceThreadId
       ? wrapSidechatInput(input.messageText)
       : input.messageText;
@@ -832,6 +852,8 @@ const make = Effect.gen(function* () {
       ? `<handoff_context>\n${handoffBootstrapText}\n</handoff_context>\n\n<latest_user_message>\n${boundaryMessageText}\n</latest_user_message>`
       : sidechatBootstrapText
         ? `<sidechat_context>\n${sidechatBootstrapText}\n</sidechat_context>\n\n${boundaryMessageText}`
+        : priorTranscriptBootstrapText
+          ? `<thread_context>\n${priorTranscriptBootstrapText}\n</thread_context>\n\n<latest_user_message>\n${boundaryMessageText}\n</latest_user_message>`
         : boundaryMessageText;
     const normalizedInput = toNonEmptyProviderInput(providerInput);
     const normalizedAttachments = input.attachments ?? [];

--- a/apps/server/src/orchestration/handoff.ts
+++ b/apps/server/src/orchestration/handoff.ts
@@ -73,6 +73,24 @@ export function hasNativeAssistantMessagesBefore(
   });
 }
 
+export function listPriorTranscriptMessages(
+  thread: Pick<OrchestrationThread, "messages">,
+  currentMessageId: string,
+): ReadonlyArray<OrchestrationMessage> {
+  const currentIndex = thread.messages.findIndex((message) => message.id === currentMessageId);
+  if (currentIndex <= 0) {
+    return [];
+  }
+
+  return thread.messages.slice(0, currentIndex).filter((message) => {
+    return (
+      (message.role === "user" || message.role === "assistant") &&
+      message.streaming === false &&
+      normalizeMessageText(message.text).length > 0
+    );
+  });
+}
+
 function buildImportedMessagesBootstrapText(input: {
   thread: Pick<OrchestrationThread, "title" | "branch" | "worktreePath">;
   importedMessages: ReadonlyArray<OrchestrationMessage>;
@@ -139,6 +157,25 @@ export function buildHandoffBootstrapText(
     thread,
     importedMessages,
     intro: `This conversation was handed off from ${thread.handoff.sourceProvider}.`,
+    maxChars,
+  });
+}
+
+export function buildPriorTranscriptBootstrapText(
+  thread: Pick<OrchestrationThread, "title" | "branch" | "worktreePath" | "messages">,
+  currentMessageId: string,
+  maxChars = HANDOFF_BOOTSTRAP_CHAR_BUDGET,
+): string | null {
+  const priorMessages = listPriorTranscriptMessages(thread, currentMessageId);
+  if (priorMessages.length === 0) {
+    return null;
+  }
+
+  return buildImportedMessagesBootstrapText({
+    thread,
+    importedMessages: priorMessages,
+    intro:
+      "This provider session may have been restarted without native conversation state. Use this prior DP Code transcript as context for the latest user message.",
     maxChars,
   });
 }

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1593,7 +1593,6 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
 
     expect(runtime.promptCalls[0]).toMatchObject({
       agent: "build",
-      noReply: false,
     });
   });
 
@@ -1793,7 +1792,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 5)).pipe(
+        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
           Effect.forkChild,
         );
 
@@ -1814,7 +1813,6 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
         });
 
         eventQueue.push(assistantMessageUpdated());
-        eventQueue.push(idleStatusEvent());
 
         const events = Array.from(yield* Fiber.join(eventsFiber));
         eventQueue.close();
@@ -1855,13 +1853,6 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
         source: "opencode.sdk.event",
       },
     });
-    expect(result.events.at(-1)).toMatchObject({
-      type: "turn.completed",
-      payload: {
-        state: "completed",
-        totalCostUsd: 0.1234,
-      },
-    });
   });
 
   it("does not emit duplicate usage for identical assistant message updates", async () => {
@@ -1882,7 +1873,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     const events = await Effect.runPromise(
       Effect.gen(function* () {
         const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 5)).pipe(
+        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
           Effect.forkChild,
         );
 
@@ -1904,7 +1895,6 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
 
         eventQueue.push(assistantMessageUpdated());
         eventQueue.push(assistantMessageUpdated());
-        eventQueue.push(idleStatusEvent());
 
         const runtimeEvents = Array.from(yield* Fiber.join(eventsFiber));
         eventQueue.close();
@@ -1940,7 +1930,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     const events = await Effect.runPromise(
       Effect.gen(function* () {
         const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 5)).pipe(
+        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
           Effect.forkChild,
         );
 
@@ -1961,7 +1951,6 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
         });
 
         eventQueue.push(assistantMessageUpdated());
-        eventQueue.push(idleStatusEvent());
 
         const runtimeEvents = Array.from(yield* Fiber.join(eventsFiber));
         eventQueue.close();
@@ -2009,7 +1998,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     const events = await Effect.runPromise(
       Effect.gen(function* () {
         const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
+        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 3)).pipe(
           Effect.forkChild,
         );
 
@@ -2056,8 +2045,6 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
             },
           }),
         );
-        eventQueue.push(idleStatusEvent());
-
         const runtimeEvents = Array.from(yield* Fiber.join(eventsFiber));
         eventQueue.close();
         return runtimeEvents;
@@ -2077,7 +2064,6 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
       "session.started",
       "thread.started",
       "turn.started",
-      "turn.completed",
     ]);
   });
 
@@ -2371,452 +2357,15 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     });
   });
 
-  it("recovers completed OpenCode replies from session messages when live events are missed", async () => {
-    let messagesCallCount = 0;
-    const runtime = createMockOpenCodeRuntime({
-      messages: async () => {
-        messagesCallCount += 1;
-        return {
-          data:
-            messagesCallCount === 1
-              ? []
-              : [
-                  {
-                    info: {
-                      id: "msg-user-1",
-                      sessionID: "opencode-session-1",
-                      role: "user",
-                      time: { created: 1 },
-                    },
-                    parts: [
-                      {
-                        id: "part-user-1",
-                        sessionID: "opencode-session-1",
-                        messageID: "msg-user-1",
-                        type: "text",
-                        text: "yo",
-                      } as Part,
-                    ],
-                  },
-                  {
-                    info: {
-                      id: "msg-assistant-1",
-                      sessionID: "opencode-session-1",
-                      role: "assistant",
-                      time: { created: 2, completed: 3 },
-                      cost: 0.012,
-                      tokens: {
-                        input: 0,
-                        output: 0,
-                        reasoning: 0,
-                        cache: { read: 0, write: 0 },
-                      },
-                      finish: "stop",
-                    },
-                    parts: [
-                      {
-                        id: "part-assistant-1",
-                        sessionID: "opencode-session-1",
-                        messageID: "msg-assistant-1",
-                        type: "text",
-                        text: "yo, what's up?",
-                        time: { start: 2, end: 3 },
-                      } as Part,
-                    ],
-                  },
-                ],
-        };
-      },
-    });
-
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 6)).pipe(
-          Effect.forkChild,
-        );
-
-        yield* adapter.startSession({
-          provider: "opencode",
-          threadId: asThreadId("thread-recovered-messages"),
-          runtimeMode: "full-access",
-        });
-
-        yield* adapter.sendTurn({
-          threadId: asThreadId("thread-recovered-messages"),
-          input: "yo",
-          attachments: [],
-          modelSelection: {
-            provider: "opencode",
-            model: "opencode/claude-opus-4-7",
-          },
-        });
-
-        const events = Array.from(yield* Fiber.join(eventsFiber));
-        return events;
-      }).pipe(
-        Effect.provide(
-          makeOpenCodeAdapterLive({
-            runtime: runtime.runtime,
-            promptAcceptedRecoveryDelaysMs: [1],
-            promptAcceptedActivityTimeoutMs: 10,
-          }).pipe(
-            Layer.provideMerge(
-              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
-            ),
-            Layer.provideMerge(NodeServices.layer),
-          ),
-        ),
-      ),
-    );
-
-    expect(result.map((event) => event.type)).toEqual([
-      "session.started",
-      "thread.started",
-      "turn.started",
-      "content.delta",
-      "item.completed",
-      "turn.completed",
-    ]);
-    expect(result[3]).toMatchObject({
-      type: "content.delta",
-      payload: {
-        streamKind: "assistant_text",
-        delta: "yo, what's up?",
-      },
-    });
-    expect(result[5]).toMatchObject({
-      type: "turn.completed",
-      payload: {
-        state: "completed",
-        totalCostUsd: 0.012,
-      },
-    });
-  });
-
-  it("does not recover a new OpenCode turn from an older completed assistant message", async () => {
-    let messagesCallCount = 0;
-    const previousMessages = [
-      {
-        info: {
-          id: "msg-user-old",
-          sessionID: "opencode-session-1",
-          role: "user",
-          time: { created: 1 },
-        },
-        parts: [
-          {
-            id: "part-user-old",
-            sessionID: "opencode-session-1",
-            messageID: "msg-user-old",
-            type: "text",
-            text: "old question",
-          } as Part,
-        ],
-      },
-      {
-        info: {
-          id: "msg-assistant-old",
-          sessionID: "opencode-session-1",
-          role: "assistant",
-          time: { created: 2, completed: 3 },
-          cost: 0.01,
-          tokens: {
-            input: 0,
-            output: 0,
-            reasoning: 0,
-            cache: { read: 0, write: 0 },
-          },
-          finish: "stop",
-        },
-        parts: [
-          {
-            id: "part-assistant-old",
-            sessionID: "opencode-session-1",
-            messageID: "msg-assistant-old",
-            type: "text",
-            text: "old answer",
-            time: { start: 2, end: 3 },
-          } as Part,
-        ],
-      },
-    ];
-    const runtime = createMockOpenCodeRuntime({
-      messages: async () => {
-        messagesCallCount += 1;
-        return {
-          data:
-            messagesCallCount < 3
-              ? previousMessages
-              : [
-                  ...previousMessages,
-                  {
-                    info: {
-                      id: "msg-user-new",
-                      sessionID: "opencode-session-1",
-                      role: "user",
-                      time: { created: 4 },
-                    },
-                    parts: [
-                      {
-                        id: "part-user-new",
-                        sessionID: "opencode-session-1",
-                        messageID: "msg-user-new",
-                        type: "text",
-                        text: "new question",
-                      } as Part,
-                    ],
-                  },
-                  {
-                    info: {
-                      id: "msg-assistant-new",
-                      sessionID: "opencode-session-1",
-                      role: "assistant",
-                      time: { created: 5, completed: 6 },
-                      cost: 0.02,
-                      tokens: {
-                        input: 0,
-                        output: 0,
-                        reasoning: 0,
-                        cache: { read: 0, write: 0 },
-                      },
-                      finish: "stop",
-                    },
-                    parts: [
-                      {
-                        id: "part-assistant-new",
-                        sessionID: "opencode-session-1",
-                        messageID: "msg-assistant-new",
-                        type: "text",
-                        text: "new answer",
-                        time: { start: 5, end: 6 },
-                      } as Part,
-                    ],
-                  },
-                ],
-        };
-      },
-    });
-
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 6)).pipe(
-          Effect.forkChild,
-        );
-
-        yield* adapter.startSession({
-          provider: "opencode",
-          threadId: asThreadId("thread-recovered-second-turn"),
-          runtimeMode: "full-access",
-        });
-
-        yield* adapter.sendTurn({
-          threadId: asThreadId("thread-recovered-second-turn"),
-          input: "new question",
-          attachments: [],
-          modelSelection: {
-            provider: "opencode",
-            model: "opencode/claude-opus-4-7",
-          },
-        });
-
-        const events = Array.from(yield* Fiber.join(eventsFiber));
-        return events;
-      }).pipe(
-        Effect.provide(
-          makeOpenCodeAdapterLive({
-            runtime: runtime.runtime,
-            promptAcceptedRecoveryDelaysMs: [1, 1],
-            promptAcceptedActivityTimeoutMs: 10,
-          }).pipe(
-            Layer.provideMerge(
-              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
-            ),
-            Layer.provideMerge(NodeServices.layer),
-          ),
-        ),
-      ),
-    );
-
-    expect(messagesCallCount).toBeGreaterThanOrEqual(3);
-    expect(result.map((event) => event.type)).toEqual([
-      "session.started",
-      "thread.started",
-      "turn.started",
-      "content.delta",
-      "item.completed",
-      "turn.completed",
-    ]);
-    expect(result[3]).toMatchObject({
-      type: "content.delta",
-      payload: {
-        streamKind: "assistant_text",
-        delta: "new answer",
-      },
-    });
-    expect(result[5]).toMatchObject({
-      type: "turn.completed",
-      payload: {
-        state: "completed",
-        totalCostUsd: 0.02,
-      },
-    });
-    expect(result).not.toContainEqual(
-      expect.objectContaining({
-        payload: expect.objectContaining({
-          delta: "old answer",
-        }),
-      }),
-    );
-  });
-
-  it("completes recovered OpenCode turns without replaying already streamed next text", async () => {
-    const eventQueue = createSubscribedEventQueue();
-    let messagesCallCount = 0;
-    const runtime = createMockOpenCodeRuntime({
-      messages: async () => {
-        messagesCallCount += 1;
-        return {
-          data:
-            messagesCallCount === 1
-              ? []
-              : [
-                  {
-                    info: {
-                      id: "msg-assistant-1",
-                      sessionID: "opencode-session-1",
-                      role: "assistant",
-                      time: { created: 2, completed: 3 },
-                      cost: 0.012,
-                      tokens: {
-                        input: 0,
-                        output: 0,
-                        reasoning: 0,
-                        cache: { read: 0, write: 0 },
-                      },
-                      finish: "stop",
-                    },
-                    parts: [
-                      {
-                        id: "part-assistant-1",
-                        sessionID: "opencode-session-1",
-                        messageID: "msg-assistant-1",
-                        type: "text",
-                        text: "hello from opencode",
-                        time: { start: 2, end: 3 },
-                      } as Part,
-                    ],
-                  },
-                ],
-        };
-      },
-    });
-    const client = runtime.runtime.createOpenCodeSdkClient({
-      baseUrl: "http://127.0.0.1:4099",
-      directory: process.cwd(),
-    }) as unknown as {
-      event: {
-        subscribe: () => Promise<{ stream: AsyncIterable<unknown> }>;
-      };
-    };
-    client.event.subscribe = async () => ({ stream: eventQueue.stream });
-
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 6)).pipe(
-          Effect.forkChild,
-        );
-
-        yield* adapter.startSession({
-          provider: "opencode",
-          threadId: asThreadId("thread-recovered-next-text"),
-          runtimeMode: "full-access",
-        });
-
-        yield* adapter.sendTurn({
-          threadId: asThreadId("thread-recovered-next-text"),
-          input: "hello",
-          attachments: [],
-          modelSelection: {
-            provider: "opencode",
-            model: "opencode/claude-opus-4-7",
-          },
-        });
-
-        eventQueue.push({
-          id: "evt-next-text-delta",
-          type: "session.next.text.delta",
-          properties: {
-            timestamp: 1,
-            sessionID: "opencode-session-1",
-            delta: "hello from opencode",
-          },
-        });
-        eventQueue.push({
-          id: "evt-next-text-ended",
-          type: "session.next.text.ended",
-          properties: {
-            timestamp: 2,
-            sessionID: "opencode-session-1",
-            text: "hello from opencode",
-          },
-        });
-
-        const events = Array.from(yield* Fiber.join(eventsFiber));
-        eventQueue.close();
-        return events;
-      }).pipe(
-        Effect.provide(
-          makeOpenCodeAdapterLive({
-            runtime: runtime.runtime,
-            promptAcceptedRecoveryDelaysMs: [25],
-            promptAcceptedActivityTimeoutMs: 10,
-          }).pipe(
-            Layer.provideMerge(
-              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
-            ),
-            Layer.provideMerge(NodeServices.layer),
-          ),
-        ),
-      ),
-    );
-
-    expect(result.map((event) => event.type)).toEqual([
-      "session.started",
-      "thread.started",
-      "turn.started",
-      "content.delta",
-      "item.completed",
-      "turn.completed",
-    ]);
-    expect(
-      result.filter(
-        (event) =>
-          event.type === "content.delta" &&
-          event.payload.streamKind === "assistant_text" &&
-          event.payload.delta === "hello from opencode",
-      ),
-    ).toHaveLength(1);
-    expect(result[5]).toMatchObject({
-      type: "turn.completed",
-      payload: {
-        state: "completed",
-        totalCostUsd: 0.012,
-      },
-    });
-  });
-
   it("does not block sendTurn when the OpenCode prompt request stalls during startup", async () => {
     const runtime = createMockOpenCodeRuntime({
-      prompt: async () => await new Promise(() => {}),
+      promptAsync: async () => await new Promise(() => {}),
     });
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 5)).pipe(
+        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 3)).pipe(
           Effect.forkChild,
         );
 
@@ -2847,8 +2396,6 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
         Effect.provide(
           makeOpenCodeAdapterLive({
             runtime: runtime.runtime,
-            promptAcceptedRecoveryDelaysMs: [1],
-            promptAcceptedActivityTimeoutMs: 10,
             promptSubmissionInlineWaitMs: 1,
           }).pipe(
             Layer.provideMerge(
@@ -2866,251 +2413,12 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
       "session.started",
       "thread.started",
       "turn.started",
-      "turn.completed",
-      "runtime.error",
     ]);
-    expect(result.events[3]).toMatchObject({
-      type: "turn.completed",
-      payload: {
-        state: "failed",
-        errorMessage: expect.stringContaining("did not produce any activity"),
-      },
-    });
-  });
-
-  it("recovers completed OpenCode replies from the prompt response when live events are missed", async () => {
-    const runtime = createMockOpenCodeRuntime({
-      prompt: async () => ({
-        data: {
-          info: {
-            id: "msg-assistant-response",
-            sessionID: "opencode-session-1",
-            role: "assistant",
-            time: { created: 2, completed: 3 },
-            cost: 0.02,
-            tokens: {
-              input: 0,
-              output: 0,
-              reasoning: 0,
-              cache: { read: 0, write: 0 },
-            },
-            finish: "stop",
-          },
-          parts: [
-            {
-              id: "part-assistant-response",
-              sessionID: "opencode-session-1",
-              messageID: "msg-assistant-response",
-              type: "text",
-              text: "response from prompt",
-              time: { start: 2, end: 3 },
-            } as Part,
-          ],
-        },
-      }),
-    });
-
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 6)).pipe(
-          Effect.forkChild,
-        );
-
-        yield* adapter.startSession({
-          provider: "opencode",
-          threadId: asThreadId("thread-prompt-response-recovery"),
-          runtimeMode: "full-access",
-        });
-
-        yield* adapter.sendTurn({
-          threadId: asThreadId("thread-prompt-response-recovery"),
-          input: "hello",
-          attachments: [],
-          modelSelection: {
-            provider: "opencode",
-            model: "opencode/claude-opus-4-7",
-          },
-        });
-
-        return Array.from(yield* Fiber.join(eventsFiber));
-      }).pipe(
-        Effect.provide(
-          makeOpenCodeAdapterLive({
-            runtime: runtime.runtime,
-          }).pipe(
-            Layer.provideMerge(
-              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
-            ),
-            Layer.provideMerge(NodeServices.layer),
-          ),
-        ),
-      ),
-    );
-
-    expect(result.map((event) => event.type)).toEqual([
-      "session.started",
-      "thread.started",
-      "turn.started",
-      "content.delta",
-      "item.completed",
-      "turn.completed",
-    ]);
-    expect(result[3]).toMatchObject({
-      type: "content.delta",
-      payload: {
-        streamKind: "assistant_text",
-        delta: "response from prompt",
-      },
-    });
-    expect(result[5]).toMatchObject({
-      type: "turn.completed",
-      payload: {
-        state: "completed",
-        totalCostUsd: 0.02,
-      },
-    });
-  });
-
-  it("recovers prompt responses after user-message SSE activity", async () => {
-    let markUserEventHandled: () => void = () => {};
-    const userEventHandled = new Promise<void>((resolve) => {
-      markUserEventHandled = resolve;
-    });
-    const eventQueue = createSubscribedEventQueue();
-    const userMessageEvent = {
-      type: "message.updated",
-      properties: {
-        sessionID: "opencode-session-1",
-        info: {
-          id: "msg-user-echo",
-          sessionID: "opencode-session-1",
-          role: "user",
-          time: { created: 1 },
-        },
-      },
-    };
-    const runtime = createMockOpenCodeRuntime({
-      events: eventQueue.stream,
-      prompt: async () => {
-        eventQueue.push(userMessageEvent);
-        await userEventHandled;
-        return {
-          data: {
-            info: {
-              id: "msg-assistant-after-user-event",
-              sessionID: "opencode-session-1",
-              role: "assistant",
-              time: { created: 2, completed: 3 },
-              cost: 0.03,
-              tokens: {
-                input: 0,
-                output: 0,
-                reasoning: 0,
-                cache: { read: 0, write: 0 },
-              },
-              finish: "stop",
-            },
-            parts: [
-              {
-                id: "part-assistant-after-user-event",
-                sessionID: "opencode-session-1",
-                messageID: "msg-assistant-after-user-event",
-                type: "text",
-                text: "response after user event",
-                time: { start: 2, end: 3 },
-              } as Part,
-            ],
-          },
-        };
-      },
-    });
-
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
-        const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 6)).pipe(
-          Effect.forkChild,
-        );
-
-        yield* adapter.startSession({
-          provider: "opencode",
-          threadId: asThreadId("thread-prompt-response-after-user-event"),
-          runtimeMode: "full-access",
-        });
-
-        yield* adapter.sendTurn({
-          threadId: asThreadId("thread-prompt-response-after-user-event"),
-          input: "hello",
-          attachments: [],
-          modelSelection: {
-            provider: "opencode",
-            model: "opencode/claude-opus-4-7",
-          },
-        });
-
-        const eventsOption = yield* Fiber.join(eventsFiber).pipe(Effect.timeoutOption(500));
-        if (eventsOption._tag === "None") {
-          yield* Fiber.interrupt(eventsFiber);
-          return null;
-        }
-        return Array.from(eventsOption.value);
-      }).pipe(
-        Effect.provide(
-          makeOpenCodeAdapterLive({
-            runtime: runtime.runtime,
-            nativeEventLogger: {
-              filePath: "native-event-test",
-              write: (event) =>
-                Effect.sync(() => {
-                  const eventType =
-                    event && typeof event === "object" && "event" in event
-                      ? (event.event as { readonly type?: unknown }).type
-                      : undefined;
-                  if (eventType === "message.updated") {
-                    markUserEventHandled();
-                  }
-                }),
-              close: () => Effect.void,
-            },
-            promptSubmissionInlineWaitMs: 50,
-          }).pipe(
-            Layer.provideMerge(
-              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
-            ),
-            Layer.provideMerge(NodeServices.layer),
-          ),
-        ),
-      ),
-    );
-
-    expect(result?.map((event) => event.type)).toEqual([
-      "session.started",
-      "thread.started",
-      "turn.started",
-      "content.delta",
-      "item.completed",
-      "turn.completed",
-    ]);
-    expect(result?.[3]).toMatchObject({
-      type: "content.delta",
-      payload: {
-        streamKind: "assistant_text",
-        delta: "response after user event",
-      },
-    });
-    expect(result?.[5]).toMatchObject({
-      type: "turn.completed",
-      payload: {
-        state: "completed",
-        totalCostUsd: 0.03,
-      },
-    });
   });
 
   it("keeps immediate OpenCode prompt failures on the sendTurn failure path", async () => {
     const runtime = createMockOpenCodeRuntime({
-      prompt: async () => {
+      promptAsync: async () => {
         throw new Error("prompt rejected");
       },
     });
@@ -3188,7 +2496,7 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const adapter = yield* OpenCodeAdapter;
-        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 4)).pipe(
+        const eventsFiber = yield* Stream.runCollect(Stream.take(adapter.streamEvents, 6)).pipe(
           Effect.forkChild,
         );
 
@@ -3208,6 +2516,32 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
           },
         });
 
+        eventQueue.push({
+          type: "message.updated",
+          properties: {
+            sessionID: "opencode-session-1",
+            info: {
+              id: "msg-session-idle",
+              role: "assistant",
+            },
+          },
+        });
+        eventQueue.push({
+          type: "message.part.updated",
+          properties: {
+            sessionID: "opencode-session-1",
+            part: {
+              id: "part-session-idle",
+              messageID: "msg-session-idle",
+              type: "text",
+              text: "done",
+              time: {
+                start: 1,
+                end: 2,
+              },
+            },
+          },
+        });
         eventQueue.push({
           id: "evt-session-idle",
           type: "session.idle",
@@ -3235,6 +2569,8 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
       "session.started",
       "thread.started",
       "turn.started",
+      "content.delta",
+      "item.completed",
       "turn.completed",
     ]);
   });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -145,6 +145,10 @@ interface OpenCodeSessionContext {
   activeTurnId: TurnId | undefined;
   activeTurnEventSerial: number;
   activeTurnProviderActivitySerial: number;
+  activeTurnCompletionActivitySerial: number;
+  activeTurnSawToolCallFinish: boolean;
+  activeTurnSawFinalAssistant: boolean;
+  activeTurnToolCallIdleWatchdogStarted: boolean;
   activeInteractionMode: "default" | "plan" | undefined;
   activeAgent: string | undefined;
   activeVariant: string | undefined;
@@ -674,6 +678,10 @@ function clearActiveTurnState(context: OpenCodeSessionContext): void {
   context.activeTurnId = undefined;
   context.activeTurnEventSerial = 0;
   context.activeTurnProviderActivitySerial = 0;
+  context.activeTurnCompletionActivitySerial = 0;
+  context.activeTurnSawToolCallFinish = false;
+  context.activeTurnSawFinalAssistant = false;
+  context.activeTurnToolCallIdleWatchdogStarted = false;
   context.activeInteractionMode = undefined;
   context.activeAgent = undefined;
   context.activeVariant = undefined;
@@ -688,6 +696,16 @@ function markOpenCodeTurnProviderActivity(
     return;
   }
   context.activeTurnProviderActivitySerial += 1;
+}
+
+function markOpenCodeTurnCompletionActivity(
+  context: OpenCodeSessionContext,
+  turnId: TurnId | undefined,
+): void {
+  if (!turnId || context.activeTurnId !== turnId) {
+    return;
+  }
+  context.activeTurnCompletionActivitySerial += 1;
 }
 
 function openCodeNextTextItemId(turnId: TurnId): string {
@@ -723,10 +741,19 @@ function isOpenCodeTerminalStepFinish(value: unknown): boolean {
   return !["tool-call", "tool-calls", "function-call", "continue", "unknown"].includes(finish);
 }
 
+function isOpenCodeToolCallFinish(value: unknown): boolean {
+  const finish = trimNonEmptyString(value)?.toLowerCase().replace(/_/gu, "-");
+  return finish === "tool-call" || finish === "tool-calls" || finish === "function-call";
+}
+
 function isOpenCodeCompletedAssistantMessage(
   entry: OpenCodeMessageSnapshot & { readonly info: Record<string, unknown> },
 ): boolean {
   if (entry.info.role !== "assistant") {
+    return false;
+  }
+  const finish = trimNonEmptyString(entry.info.finish);
+  if (finish !== undefined && !isOpenCodeTerminalStepFinish(finish)) {
     return false;
   }
   const time = entry.info.time;
@@ -738,7 +765,24 @@ function isOpenCodeCompletedAssistantMessage(
   ) {
     return true;
   }
-  return trimNonEmptyString(entry.info.finish) !== undefined;
+  return finish !== undefined;
+}
+
+function trackActiveTurnAssistantFinish(
+  context: OpenCodeSessionContext,
+  turnId: TurnId | undefined,
+  entry: OpenCodeMessageSnapshot & { readonly info: Record<string, unknown> },
+): void {
+  if (!turnId || context.activeTurnId !== turnId || entry.info.role !== "assistant") {
+    return;
+  }
+  if (isOpenCodeToolCallFinish(entry.info.finish)) {
+    context.activeTurnSawToolCallFinish = true;
+  }
+  if (isOpenCodeCompletedAssistantMessage(entry)) {
+    context.activeTurnSawFinalAssistant = true;
+    markOpenCodeTurnCompletionActivity(context, turnId);
+  }
 }
 
 function extractResumeSessionId(resumeCursor: unknown): string | undefined {
@@ -1755,9 +1799,18 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         if (text === undefined) {
           return;
         }
-        const previousText = context.emittedTextByPartId.get(part.id);
+        const nextTextItemId =
+          turnId && part.type === "text" ? openCodeNextTextItemId(turnId) : undefined;
+        const itemId =
+          nextTextItemId && context.emittedTextByPartId.has(nextTextItemId)
+            ? nextTextItemId
+            : part.id;
+        const previousText = context.emittedTextByPartId.get(itemId);
         const { latestText, deltaToEmit } = mergeOpenCodeAssistantText(previousText, text);
-        context.emittedTextByPartId.set(part.id, latestText);
+        context.emittedTextByPartId.set(itemId, latestText);
+        if (itemId !== part.id) {
+          context.emittedTextByPartId.set(part.id, latestText);
+        }
         if (latestText !== text) {
           context.partById.set(
             part.id,
@@ -1767,11 +1820,12 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           );
         }
         if (deltaToEmit.length > 0) {
+          markOpenCodeTurnCompletionActivity(context, turnId);
           yield* emit({
             ...buildEventBase({
               threadId: context.session.threadId,
               turnId,
-              itemId: part.id,
+              itemId,
               createdAt:
                 part.type === "text" || part.type === "reasoning"
                   ? isoFromEpochMs(part.time?.start)
@@ -1789,9 +1843,12 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         if (
           part.type === "text" &&
           part.time?.end !== undefined &&
-          !context.completedAssistantPartIds.has(part.id)
+          !context.completedAssistantPartIds.has(itemId)
         ) {
-          context.completedAssistantPartIds.add(part.id);
+          context.completedAssistantPartIds.add(itemId);
+          if (itemId !== part.id) {
+            context.completedAssistantPartIds.add(part.id);
+          }
           const proposedPlanMarkdown =
             context.activeInteractionMode === "plan"
               ? extractProposedPlanMarkdown(latestText)
@@ -1801,7 +1858,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
               ...buildEventBase({
                 threadId: context.session.threadId,
                 turnId,
-                itemId: part.id,
+                itemId,
                 createdAt: isoFromEpochMs(part.time.end),
                 raw,
               }),
@@ -1815,7 +1872,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             ...buildEventBase({
               threadId: context.session.threadId,
               turnId,
-              itemId: part.id,
+              itemId,
               createdAt: isoFromEpochMs(part.time.end),
               raw,
             }),
@@ -1849,6 +1906,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           context.emittedTextByPartId.set(part.id, latestText);
           context.partById.set(part.id, { ...part, text: latestText });
           if (deltaToEmit.length > 0) {
+            markOpenCodeTurnCompletionActivity(context, turnId);
             yield* emit({
               ...buildEventBase({
                 threadId: context.session.threadId,
@@ -1941,6 +1999,66 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         });
       });
 
+      const deferPrematureIdleCompletion = Effect.fn("deferPrematureIdleCompletion")(
+        function* (context: OpenCodeSessionContext, turnId: TurnId, raw: unknown) {
+          const idleBeforeAssistantActivity = context.activeTurnCompletionActivitySerial === 0;
+          const idleAfterToolCalls =
+            context.activeTurnSawToolCallFinish && !context.activeTurnSawFinalAssistant;
+          if (!idleBeforeAssistantActivity && !idleAfterToolCalls) {
+            return false;
+          }
+          if (!context.activeTurnToolCallIdleWatchdogStarted) {
+            context.activeTurnToolCallIdleWatchdogStarted = true;
+            yield* Effect.gen(function* () {
+              yield* Effect.sleep(10_000);
+              if (
+                (yield* Ref.get(context.stopped)) ||
+                context.activeTurnId !== turnId ||
+                context.activeTurnSawFinalAssistant
+              ) {
+                return;
+              }
+
+              const message = idleAfterToolCalls
+                ? `${adapterConfig.displayName} became idle after tool calls without producing a final assistant response.`
+                : `${adapterConfig.displayName} became idle before producing an assistant response.`;
+              yield* completeOpenCodeTurn(context, {
+                turnId,
+                raw: {
+                  source: "dpcode.opencode.idle-after-tool-calls",
+                  event: raw,
+                },
+                errorMessage: message,
+              });
+              updateProviderSession(
+                context,
+                {
+                  status: "error",
+                  lastError: message,
+                },
+                { clearActiveTurnId: true },
+              );
+              yield* emit({
+                ...buildEventBase({
+                  threadId: context.session.threadId,
+                  turnId,
+                  raw: {
+                    source: "dpcode.opencode.idle-after-tool-calls",
+                    event: raw,
+                  },
+                }),
+                type: "runtime.error",
+                payload: {
+                  message,
+                  class: "provider_error",
+                },
+              });
+            }).pipe(Effect.forkIn(context.sessionScope), Effect.asVoid);
+          }
+          return true;
+        },
+      );
+
       const recoverOpenCodeTurnFromAssistantMessage = Effect.fn(
         "recoverOpenCodeTurnFromAssistantMessage",
       )(function* (
@@ -1954,6 +2072,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         },
       ) {
         context.messageRoleById.set(input.assistantEntry.info.id, "assistant");
+        trackActiveTurnAssistantFinish(context, input.turnId, input.assistantEntry);
         for (const part of input.assistantEntry.parts) {
           context.partById.set(part.id, part);
           yield* emitRecoveredAssistantTextDelta(context, part, input.turnId, input.raw);
@@ -2230,6 +2349,59 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         }
       });
 
+      const submitOpenCodePromptAsync = Effect.fn("submitOpenCodePromptAsync")(function* (
+        context: OpenCodeSessionContext,
+        input: {
+          readonly turnId: TurnId;
+          readonly promptInput: Parameters<OpencodeClient["session"]["promptAsync"]>[0];
+        },
+      ) {
+        const settled = yield* Deferred.make<AdapterRequestError | null>();
+        yield* runOpenCodeSdk("session.promptAsync", () =>
+          context.client.session.promptAsync(input.promptInput),
+        ).pipe(
+          Effect.mapError(toAdapterRequestError),
+          Effect.as(null),
+          Effect.catch((requestError) =>
+            Effect.gen(function* () {
+              if (yield* Ref.get(context.stopped)) {
+                return requestError;
+              }
+              if (context.activeTurnId !== input.turnId) {
+                return requestError;
+              }
+              clearActiveTurnState(context);
+              updateProviderSession(
+                context,
+                {
+                  status: "ready",
+                  model: context.session.model,
+                  lastError: requestError.detail,
+                },
+                { clearActiveTurnId: true },
+              );
+              yield* emit({
+                ...buildEventBase({ threadId: context.session.threadId, turnId: input.turnId }),
+                type: "turn.aborted",
+                payload: {
+                  reason: requestError.detail,
+                },
+              });
+              return requestError;
+            }),
+          ),
+          Effect.flatMap((result) => Deferred.succeed(settled, result)),
+          Effect.forkIn(context.sessionScope),
+        );
+
+        const quickResult = yield* Deferred.await(settled).pipe(
+          Effect.timeoutOption(promptSubmissionInlineWaitMs),
+        );
+        if (quickResult._tag === "Some" && quickResult.value) {
+          return yield* quickResult.value;
+        }
+      });
+
       const handleSubscribedEvent = Effect.fn("handleSubscribedEvent")(function* (
         context: OpenCodeSessionContext,
         event: OpenCodeSubscribedEvent,
@@ -2268,6 +2440,13 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             );
             if (event.properties.info.role === "assistant") {
               const assistantMessage = event.properties.info;
+              trackActiveTurnAssistantFinish(context, turnId, {
+                info: {
+                  ...assistantMessage,
+                  role: "assistant",
+                },
+                parts: [],
+              });
               const selectedModel = context.session.model;
               const maxTokens =
                 selectedModel !== undefined
@@ -2360,6 +2539,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             if (deltaToEmit.length === 0) {
               break;
             }
+            markOpenCodeTurnCompletionActivity(context, turnId);
             context.emittedTextByPartId.set(event.properties.partID, nextText);
             if (resolvedPart.type === "text" || resolvedPart.type === "reasoning") {
               const nextPart = {
@@ -2594,6 +2774,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             }
 
             if (event.properties.status.type === "idle" && turnId) {
+              if (yield* deferPrematureIdleCompletion(context, turnId, event)) {
+                break;
+              }
               yield* completeOpenCodeTurn(context, {
                 turnId,
                 raw: event,
@@ -2605,6 +2788,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
 
           case "session.idle": {
             if (turnId) {
+              if (yield* deferPrematureIdleCompletion(context, turnId, event)) {
+                break;
+              }
               yield* completeOpenCodeTurn(context, {
                 turnId,
                 raw: event,
@@ -2630,6 +2816,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
               break;
             }
             context.emittedTextByPartId.set(itemId, nextText);
+            markOpenCodeTurnCompletionActivity(context, turnId);
             yield* emit({
               ...buildEventBase({
                 threadId: context.session.threadId,
@@ -2657,6 +2844,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             const { latestText, deltaToEmit } = mergeOpenCodeAssistantText(previousText, text);
             context.emittedTextByPartId.set(itemId, latestText);
             if (deltaToEmit.length > 0) {
+              markOpenCodeTurnCompletionActivity(context, turnId);
               yield* emit({
                 ...buildEventBase({
                   threadId: context.session.threadId,
@@ -2855,6 +3043,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
               });
             }
             context.latestTurnCostUsd = asFiniteNonNegativeNumber(event.properties.cost);
+            if (isOpenCodeToolCallFinish(event.properties.finish)) {
+              context.activeTurnSawToolCallFinish = true;
+            }
             if (isOpenCodeTerminalStepFinish(event.properties.finish)) {
               yield* completeOpenCodeTurn(context, {
                 turnId,
@@ -2916,6 +3107,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
 
           case "session.idle": {
             if (turnId) {
+              if (yield* deferPrematureIdleCompletion(context, turnId, event)) {
+                break;
+              }
               const totalCostUsd = context.latestTurnCostUsd;
               clearActiveTurnState(context);
               updateProviderSession(context, { status: "ready" }, { clearActiveTurnId: true });
@@ -3337,6 +3531,10 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             activeTurnId: undefined,
             activeTurnEventSerial: 0,
             activeTurnProviderActivitySerial: 0,
+            activeTurnCompletionActivitySerial: 0,
+            activeTurnSawToolCallFinish: false,
+            activeTurnSawFinalAssistant: false,
+            activeTurnToolCallIdleWatchdogStarted: false,
             activeInteractionMode: undefined,
             activeAgent: undefined,
             activeVariant: undefined,
@@ -3415,6 +3613,10 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         context.activeTurnId = turnId;
         context.activeTurnEventSerial = 0;
         context.activeTurnProviderActivitySerial = 0;
+        context.activeTurnCompletionActivitySerial = 0;
+        context.activeTurnSawToolCallFinish = false;
+        context.activeTurnSawFinalAssistant = false;
+        context.activeTurnToolCallIdleWatchdogStarted = false;
         context.activeInteractionMode = input.interactionMode === "plan" ? "plan" : "default";
         // Always pin DP Code's interaction mode to OpenCode's primary agent.
         // Otherwise a user config with default agent=plan can trap default turns in plan mode.
@@ -3441,35 +3643,41 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           },
         });
 
-        const baselineMessageIds =
-          provider === "kilo"
-            ? yield* rememberCurrentMessageSnapshots(context).pipe(
-                Effect.catchCause(() => Effect.succeed(new Set<string>())),
-              )
-            : new Set<string>();
-        const recoveryBaselineMessageIds = yield* captureOpenCodeRecoveryBaseline(context);
-
-        const providerActivitySerial = context.activeTurnProviderActivitySerial;
-        yield* schedulePromptAcceptedWatchdog(context, {
-          turnId,
-          providerActivitySerial,
-          excludedMessageIds: recoveryBaselineMessageIds,
-        });
-        yield* submitOpenCodePrompt(context, {
-          turnId,
-          promptInput: {
-            sessionID: context.openCodeSessionId,
-            messageID: `msg_${randomUUID()}`,
-            model: parsedModel,
-            ...(context.activeAgent ? { agent: context.activeAgent } : {}),
-            ...(context.activeVariant ? { variant: context.activeVariant } : {}),
-            noReply: false,
-            parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
-          },
-        });
-
         if (provider === "kilo") {
+          const baselineMessageIds = yield* rememberCurrentMessageSnapshots(context).pipe(
+            Effect.catchCause(() => Effect.succeed(new Set<string>())),
+          );
+          const recoveryBaselineMessageIds = yield* captureOpenCodeRecoveryBaseline(context);
+          const providerActivitySerial = context.activeTurnProviderActivitySerial;
+          yield* schedulePromptAcceptedWatchdog(context, {
+            turnId,
+            providerActivitySerial,
+            excludedMessageIds: recoveryBaselineMessageIds,
+          });
+          yield* submitOpenCodePrompt(context, {
+            turnId,
+            promptInput: {
+              sessionID: context.openCodeSessionId,
+              messageID: `msg_${randomUUID()}`,
+              model: parsedModel,
+              ...(context.activeAgent ? { agent: context.activeAgent } : {}),
+              ...(context.activeVariant ? { variant: context.activeVariant } : {}),
+              noReply: false,
+              parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
+            },
+          });
           yield* startKiloTurnSnapshotWatchdog(context, turnId, baselineMessageIds);
+        } else {
+          yield* submitOpenCodePromptAsync(context, {
+            turnId,
+            promptInput: {
+              sessionID: context.openCodeSessionId,
+              model: parsedModel,
+              ...(context.activeAgent ? { agent: context.activeAgent } : {}),
+              ...(context.activeVariant ? { variant: context.activeVariant } : {}),
+              parts: [...(text ? [{ type: "text" as const, text }] : []), ...fileParts],
+            },
+          });
         }
 
         return {


### PR DESCRIPTION
## Summary

Fixes Kilo/OpenCode transcript handling issues in the shared OpenCode-compatible provider path.

- Adds a prior-transcript fallback for Kilo/OpenCode turns when no live runtime session exists before dispatch, so a restarted or recovered provider session still receives the relevant DP Code conversation context.
- Submits OpenCode turns through `session.promptAsync`, matching the event-stream-first path used upstream in T3 Code, while keeping the compatibility `session.prompt` recovery path for Kilo.
- Coalesces replayed OpenCode final message parts with the already-streamed `session.next` assistant item, avoiding duplicate assistant responses when both event shapes arrive for the same answer.
- Stops treating `finish: "tool-calls"` as a completed assistant answer, and reports a provider error if the provider goes idle after tool calls without producing a final assistant response.
- Defers idle completion until the active turn has produced assistant completion activity, preventing a fresh follow-up turn from being completed immediately by usage-only or stale idle events.

## Impact

Users should see fewer cases where Kilo/OpenCode replies as if it only received the latest short follow-up, fewer duplicate final assistant messages, and no misleading completed turn when the provider only emitted an interim status update or a stale idle event.

## Validation

- `bun run --cwd apps/server test src/provider/Layers/OpenCodeAdapter.test.ts`
- `bun run --cwd apps/server test src/provider/Layers/OpenCodeAdapter.test.ts src/orchestration/Layers/ProviderCommandReactor.test.ts`

Note: temporary regression tests used during debugging were removed before this PR, as requested.
