### PR TITLE
Cap thread snapshots and runtime payloads to reduce memory pressure

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -447,6 +447,218 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
     }),
   );
 
+  it.effect("limits hydrated thread activities to the latest activity window", () =>
+    Effect.gen(function* () {
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`DELETE FROM projection_projects`;
+      yield* sql`DELETE FROM projection_threads`;
+      yield* sql`DELETE FROM projection_thread_activities`;
+
+      yield* sql`
+        INSERT INTO projection_projects (
+          project_id,
+          title,
+          workspace_root,
+          default_model_selection_json,
+          scripts_json,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES (
+          'project-activity-cap',
+          'Project Activity Cap',
+          '/tmp/project-activity-cap',
+          '{"provider":"codex","model":"gpt-5-codex"}',
+          '[]',
+          '2026-02-24T00:00:00.000Z',
+          '2026-02-24T00:00:00.000Z',
+          NULL
+        )
+      `;
+      yield* sql`
+        INSERT INTO projection_threads (
+          thread_id,
+          project_id,
+          title,
+          model_selection_json,
+          branch,
+          worktree_path,
+          latest_turn_id,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES (
+          'thread-activity-cap',
+          'project-activity-cap',
+          'Thread Activity Cap',
+          '{"provider":"codex","model":"gpt-5-codex"}',
+          NULL,
+          NULL,
+          NULL,
+          '2026-02-24T00:00:00.000Z',
+          '2026-02-24T00:00:00.000Z',
+          NULL
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_thread_activities (
+          activity_id,
+          thread_id,
+          turn_id,
+          tone,
+          kind,
+          summary,
+          payload_json,
+          sequence,
+          created_at
+        )
+        VALUES (
+          'approval-old',
+          'thread-activity-cap',
+          NULL,
+          'approval',
+          'approval.requested',
+          'Command approval requested',
+          '{"requestId":"approval-1","requestKind":"command"}',
+          0,
+          '2026-02-24T00:00:00.000Z'
+        )
+      `;
+
+      for (let index = 0; index < 505; index += 1) {
+        yield* sql`
+          INSERT INTO projection_thread_activities (
+            activity_id,
+            thread_id,
+            turn_id,
+            tone,
+            kind,
+            summary,
+            payload_json,
+            sequence,
+            created_at
+          )
+          VALUES (
+            ${`activity-${index}`},
+            'thread-activity-cap',
+            NULL,
+            'tool',
+            'tool.completed',
+            'Tool completed',
+            '{"stage":"completed"}',
+            ${index + 1},
+            '2026-02-24T00:00:00.000Z'
+          )
+        `;
+      }
+
+      const snapshot = yield* snapshotQuery.getSnapshot();
+      const snapshotActivities = snapshot.threads[0]?.activities ?? [];
+      assert.equal(snapshotActivities.length, 501);
+      assert.equal(snapshotActivities[0]?.id, asEventId("approval-old"));
+      assert.equal(snapshotActivities[1]?.id, asEventId("activity-5"));
+      assert.equal(snapshotActivities.at(-1)?.id, asEventId("activity-504"));
+
+      const detail = yield* snapshotQuery.getThreadDetailById(asThreadId("thread-activity-cap"));
+      assert.isTrue(Option.isSome(detail));
+      const detailActivities = Option.isSome(detail) ? detail.value.activities : [];
+      assert.equal(detailActivities.length, 501);
+      assert.equal(detailActivities[0]?.id, asEventId("approval-old"));
+      assert.equal(detailActivities[1]?.id, asEventId("activity-5"));
+      assert.equal(detailActivities.at(-1)?.id, asEventId("activity-504"));
+
+      yield* sql`
+        DELETE FROM projection_thread_activities
+        WHERE thread_id = 'thread-activity-cap'
+      `;
+      yield* sql`
+        INSERT INTO projection_thread_activities (
+          activity_id,
+          thread_id,
+          turn_id,
+          tone,
+          kind,
+          summary,
+          payload_json,
+          sequence,
+          created_at
+        )
+        VALUES
+          (
+            'approval-old',
+            'thread-activity-cap',
+            NULL,
+            'approval',
+            'approval.requested',
+            'Command approval requested',
+            '{"requestId":"approval-1","requestKind":"command"}',
+            0,
+            '2026-02-24T00:00:00.000Z'
+          ),
+          (
+            'approval-resolved-old',
+            'thread-activity-cap',
+            NULL,
+            'approval',
+            'approval.resolved',
+            'Command approval resolved',
+            '{"requestId":"approval-1","decision":"accept"}',
+            1,
+            '2026-02-24T00:00:00.000Z'
+          )
+      `;
+
+      for (let index = 0; index < 505; index += 1) {
+        yield* sql`
+          INSERT INTO projection_thread_activities (
+            activity_id,
+            thread_id,
+            turn_id,
+            tone,
+            kind,
+            summary,
+            payload_json,
+            sequence,
+            created_at
+          )
+          VALUES (
+            ${`resolved-activity-${index}`},
+            'thread-activity-cap',
+            NULL,
+            'tool',
+            'tool.completed',
+            'Tool completed',
+            '{"stage":"completed"}',
+            ${index + 2},
+            '2026-02-24T00:00:00.000Z'
+          )
+        `;
+      }
+
+      const resolvedSnapshot = yield* snapshotQuery.getSnapshot();
+      const resolvedSnapshotActivities = resolvedSnapshot.threads[0]?.activities ?? [];
+      assert.equal(resolvedSnapshotActivities.length, 500);
+      assert.equal(resolvedSnapshotActivities[0]?.id, asEventId("resolved-activity-5"));
+      assert.equal(resolvedSnapshotActivities.at(-1)?.id, asEventId("resolved-activity-504"));
+
+      const resolvedDetail = yield* snapshotQuery.getThreadDetailById(
+        asThreadId("thread-activity-cap"),
+      );
+      assert.isTrue(Option.isSome(resolvedDetail));
+      const resolvedDetailActivities = Option.isSome(resolvedDetail)
+        ? resolvedDetail.value.activities
+        : [];
+      assert.equal(resolvedDetailActivities.length, 500);
+      assert.equal(resolvedDetailActivities[0]?.id, asEventId("resolved-activity-5"));
+      assert.equal(resolvedDetailActivities.at(-1)?.id, asEventId("resolved-activity-504"));
+    }),
+  );
+
   it.effect("normalizes imported T3 Code model-selection shapes from projection reads", () =>
     Effect.gen(function* () {
       const snapshotQuery = yield* ProjectionSnapshotQuery;

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -64,6 +64,8 @@ const decodeThreadDetail = Schema.decodeUnknownEffect(OrchestrationThread);
 const decodeThreadDetailSnapshot = Schema.decodeUnknownEffect(OrchestrationThreadDetailSnapshot);
 const decodeModelSelection = Schema.decodeUnknownEffect(ModelSelection);
 const ModelSelectionJsonUnknown = Schema.fromJsonString(Schema.Unknown);
+const MAX_THREAD_MESSAGES = 2_000;
+const MAX_THREAD_ACTIVITIES = 500;
 const ProjectionProjectDbRowSchema = ProjectionProject.mapFields(
   Struct.assign({
     defaultModelSelection: Schema.NullOr(ModelSelectionJsonUnknown),
@@ -599,7 +601,16 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           source,
           created_at AS "createdAt",
           updated_at AS "updatedAt"
-        FROM projection_thread_messages
+        FROM (
+          SELECT
+            *,
+            ROW_NUMBER() OVER (
+              PARTITION BY thread_id
+              ORDER BY created_at DESC, message_id DESC
+            ) AS message_rank
+          FROM projection_thread_messages
+        )
+        WHERE message_rank <= ${MAX_THREAD_MESSAGES}
         ORDER BY thread_id ASC, created_at ASC, message_id ASC
       `,
   });
@@ -638,7 +649,79 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           payload_json AS "payload",
           sequence,
           created_at AS "createdAt"
-        FROM projection_thread_activities
+        FROM (
+          SELECT
+            *,
+            ROW_NUMBER() OVER (
+              PARTITION BY thread_id
+              ORDER BY
+                CASE WHEN sequence IS NULL THEN 0 ELSE 1 END DESC,
+                sequence DESC,
+                created_at DESC,
+                activity_id DESC
+            ) AS activity_rank
+          FROM projection_thread_activities
+        ) AS ranked
+        WHERE activity_rank <= ${MAX_THREAD_ACTIVITIES}
+          OR (
+            kind IN ('approval.requested', 'user-input.requested')
+            AND json_extract(payload_json, '$.requestId') IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1
+              FROM projection_thread_activities AS later
+              WHERE later.thread_id = ranked.thread_id
+                AND json_extract(later.payload_json, '$.requestId') =
+                  json_extract(ranked.payload_json, '$.requestId')
+                AND (
+                  (ranked.kind = 'approval.requested' AND later.kind = 'approval.resolved')
+                  OR (
+                    ranked.kind = 'approval.requested'
+                    AND later.kind = 'provider.approval.respond.failed'
+                    AND (
+                      lower(COALESCE(json_extract(later.payload_json, '$.detail'), '')) LIKE
+                        '%stale pending approval request%'
+                      OR lower(COALESCE(json_extract(later.payload_json, '$.detail'), '')) LIKE
+                        '%unknown pending approval request%'
+                      OR lower(COALESCE(json_extract(later.payload_json, '$.detail'), '')) LIKE
+                        '%unknown pending permission request%'
+                    )
+                  )
+                  OR (ranked.kind = 'user-input.requested' AND later.kind = 'user-input.resolved')
+                  OR (
+                    ranked.kind = 'user-input.requested'
+                    AND later.kind = 'provider.user-input.respond.failed'
+                    AND (
+                      lower(COALESCE(json_extract(later.payload_json, '$.detail'), '')) LIKE
+                        '%stale pending user-input request%'
+                      OR lower(COALESCE(json_extract(later.payload_json, '$.detail'), '')) LIKE
+                        '%unknown pending user-input request%'
+                    )
+                  )
+                )
+                AND (
+                  CASE WHEN later.sequence IS NULL THEN 0 ELSE 1 END >
+                    CASE WHEN ranked.sequence IS NULL THEN 0 ELSE 1 END
+                  OR (
+                    CASE WHEN later.sequence IS NULL THEN 0 ELSE 1 END =
+                      CASE WHEN ranked.sequence IS NULL THEN 0 ELSE 1 END
+                    AND COALESCE(later.sequence, -1) > COALESCE(ranked.sequence, -1)
+                  )
+                  OR (
+                    CASE WHEN later.sequence IS NULL THEN 0 ELSE 1 END =
+                      CASE WHEN ranked.sequence IS NULL THEN 0 ELSE 1 END
+                    AND COALESCE(later.sequence, -1) = COALESCE(ranked.sequence, -1)
+                    AND later.created_at > ranked.created_at
+                  )
+                  OR (
+                    CASE WHEN later.sequence IS NULL THEN 0 ELSE 1 END =
+                      CASE WHEN ranked.sequence IS NULL THEN 0 ELSE 1 END
+                    AND COALESCE(later.sequence, -1) = COALESCE(ranked.sequence, -1)
+                    AND later.created_at = ranked.created_at
+                    AND later.activity_id > ranked.activity_id
+                  )
+                )
+            )
+          )
         ORDER BY
           thread_id ASC,
           CASE WHEN sequence IS NULL THEN 0 ELSE 1 END ASC,
@@ -860,8 +943,18 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           source,
           created_at AS "createdAt",
           updated_at AS "updatedAt"
-        FROM projection_thread_messages
+        FROM (
+          SELECT
+            *,
+            ROW_NUMBER() OVER (
+              PARTITION BY thread_id
+              ORDER BY created_at DESC, message_id DESC
+            ) AS message_rank
+          FROM projection_thread_messages
+          WHERE thread_id = ${threadId}
+        )
         WHERE thread_id = ${threadId}
+          AND message_rank <= ${MAX_THREAD_MESSAGES}
         ORDER BY created_at ASC, message_id ASC
       `,
   });
@@ -901,8 +994,83 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           payload_json AS "payload",
           sequence,
           created_at AS "createdAt"
-        FROM projection_thread_activities
+        FROM (
+          SELECT
+            *,
+            ROW_NUMBER() OVER (
+              PARTITION BY thread_id
+              ORDER BY
+                CASE WHEN sequence IS NULL THEN 0 ELSE 1 END DESC,
+                sequence DESC,
+                created_at DESC,
+                activity_id DESC
+            ) AS activity_rank
+          FROM projection_thread_activities
+          WHERE thread_id = ${threadId}
+        ) AS ranked
         WHERE thread_id = ${threadId}
+          AND (
+            activity_rank <= ${MAX_THREAD_ACTIVITIES}
+            OR (
+              kind IN ('approval.requested', 'user-input.requested')
+              AND json_extract(payload_json, '$.requestId') IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1
+                FROM projection_thread_activities AS later
+                WHERE later.thread_id = ranked.thread_id
+                  AND json_extract(later.payload_json, '$.requestId') =
+                    json_extract(ranked.payload_json, '$.requestId')
+                  AND (
+                    (ranked.kind = 'approval.requested' AND later.kind = 'approval.resolved')
+                    OR (
+                      ranked.kind = 'approval.requested'
+                      AND later.kind = 'provider.approval.respond.failed'
+                      AND (
+                        lower(COALESCE(json_extract(later.payload_json, '$.detail'), '')) LIKE
+                          '%stale pending approval request%'
+                        OR lower(COALESCE(json_extract(later.payload_json, '$.detail'), '')) LIKE
+                          '%unknown pending approval request%'
+                        OR lower(COALESCE(json_extract(later.payload_json, '$.detail'), '')) LIKE
+                          '%unknown pending permission request%'
+                      )
+                    )
+                    OR (ranked.kind = 'user-input.requested' AND later.kind = 'user-input.resolved')
+                    OR (
+                      ranked.kind = 'user-input.requested'
+                      AND later.kind = 'provider.user-input.respond.failed'
+                      AND (
+                        lower(COALESCE(json_extract(later.payload_json, '$.detail'), '')) LIKE
+                          '%stale pending user-input request%'
+                        OR lower(COALESCE(json_extract(later.payload_json, '$.detail'), '')) LIKE
+                          '%unknown pending user-input request%'
+                      )
+                    )
+                  )
+                  AND (
+                    CASE WHEN later.sequence IS NULL THEN 0 ELSE 1 END >
+                      CASE WHEN ranked.sequence IS NULL THEN 0 ELSE 1 END
+                    OR (
+                      CASE WHEN later.sequence IS NULL THEN 0 ELSE 1 END =
+                        CASE WHEN ranked.sequence IS NULL THEN 0 ELSE 1 END
+                      AND COALESCE(later.sequence, -1) > COALESCE(ranked.sequence, -1)
+                    )
+                    OR (
+                      CASE WHEN later.sequence IS NULL THEN 0 ELSE 1 END =
+                        CASE WHEN ranked.sequence IS NULL THEN 0 ELSE 1 END
+                      AND COALESCE(later.sequence, -1) = COALESCE(ranked.sequence, -1)
+                      AND later.created_at > ranked.created_at
+                    )
+                    OR (
+                      CASE WHEN later.sequence IS NULL THEN 0 ELSE 1 END =
+                        CASE WHEN ranked.sequence IS NULL THEN 0 ELSE 1 END
+                      AND COALESCE(later.sequence, -1) = COALESCE(ranked.sequence, -1)
+                      AND later.created_at = ranked.created_at
+                      AND later.activity_id > ranked.activity_id
+                    )
+                  )
+              )
+            )
+          )
         ORDER BY
           CASE WHEN sequence IS NULL THEN 0 ELSE 1 END ASC,
           sequence ASC,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2621,6 +2621,103 @@ describe("ProviderRuntimeIngestion", () => {
     expect(resolvedPayload?.requestType).toBe("command_execution_approval");
   });
 
+  it("bounds large tool activity data while keeping command metadata", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    const largeOutput = "line\n".repeat(20_000);
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-large-tool-data"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-large-tool-data"),
+      payload: {
+        itemType: "command_execution",
+        status: "completed",
+        title: "Ran command",
+        detail: "bun run something",
+        data: {
+          rawInput: { command: "bun run something" },
+          rawOutput: {
+            stdout: largeOutput,
+            stderr: largeOutput,
+          },
+          item: {
+            command: "bun run something",
+          },
+        },
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.activities.some((activity) => activity.id === "evt-large-tool-data"),
+    );
+    const activity = thread.activities.find((entry) => entry.id === "evt-large-tool-data");
+    const payload =
+      activity?.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : {};
+    const data =
+      payload.data && typeof payload.data === "object"
+        ? (payload.data as Record<string, unknown>)
+        : {};
+    const rawInput =
+      data.rawInput && typeof data.rawInput === "object"
+        ? (data.rawInput as Record<string, unknown>)
+        : {};
+    const rawOutput =
+      data.rawOutput && typeof data.rawOutput === "object"
+        ? (data.rawOutput as Record<string, unknown>)
+        : {};
+
+    expect(data.__dpcodeTruncated).toBe(true);
+    expect(JSON.stringify(data).length).toBeLessThan(17_000);
+    expect(rawInput.command).toBe("bun run something");
+    expect(String(rawOutput.stdout ?? "").length).toBeLessThan(3_000);
+  });
+
+  it("hard-caps pathological tool activity data", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    const wideData = Object.fromEntries(
+      Array.from({ length: 50 }, (_, index) => [`wideField${index}`, "x".repeat(5_000)]),
+    );
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-pathological-tool-data"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-pathological-tool-data"),
+      payload: {
+        itemType: "command_execution",
+        status: "completed",
+        title: "Ran noisy command",
+        data: wideData,
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.activities.some((activity) => activity.id === "evt-pathological-tool-data"),
+    );
+    const activity = thread.activities.find((entry) => entry.id === "evt-pathological-tool-data");
+    const payload =
+      activity?.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : {};
+    const data =
+      payload.data && typeof payload.data === "object"
+        ? (payload.data as Record<string, unknown>)
+        : {};
+
+    expect(data.__dpcodeTruncated).toBe(true);
+    expect(typeof data.preview).toBe("string");
+    expect(JSON.stringify(data).length).toBeLessThanOrEqual(16_000);
+  });
+
   it("maps runtime.error into errored session state", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -57,6 +57,11 @@ const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL = Duration.minutes(120);
 const BUFFERED_PROPOSED_PLAN_BY_ID_CACHE_CAPACITY = 10_000;
 const BUFFERED_PROPOSED_PLAN_BY_ID_TTL = Duration.minutes(120);
 const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
+const MAX_ACTIVITY_DATA_JSON_CHARS = 16_000;
+const MAX_ACTIVITY_DATA_STRING_CHARS = 2_000;
+const MAX_ACTIVITY_DATA_ARRAY_ITEMS = 24;
+const MAX_ACTIVITY_DATA_OBJECT_KEYS = 64;
+const ACTIVITY_DATA_TRUNCATION_MARKER = "__dpcodeTruncated";
 const STRICT_PROVIDER_LIFECYCLE_GUARD = process.env.T3CODE_STRICT_PROVIDER_LIFECYCLE_GUARD !== "0";
 
 type TurnStartRequestedDomainEvent = Extract<
@@ -125,6 +130,191 @@ function inferRuntimeModeFromUserInputAnswers(
 
 function truncateDetail(value: string, limit = 180): string {
   return value.length > limit ? `${value.slice(0, limit - 3)}...` : value;
+}
+
+function stringifyJsonLike(value: unknown): string {
+  const seen = new WeakSet<object>();
+  return (
+    JSON.stringify(value, (_key, entry) => {
+      if (typeof entry === "bigint") {
+        return entry.toString();
+      }
+      if (typeof entry === "function" || typeof entry === "symbol") {
+        return undefined;
+      }
+      if (entry && typeof entry === "object") {
+        if (seen.has(entry)) {
+          return "[Circular]";
+        }
+        seen.add(entry);
+      }
+      return entry;
+    }) ?? "null"
+  );
+}
+
+function truncateJsonString(value: string, limit: number): string {
+  return value.length > limit ? `${value.slice(0, Math.max(0, limit - 15))}... [truncated]` : value;
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function activityPayloadKeyRank(key: string): number {
+  const ranks: Record<string, number> = {
+    itemType: 0,
+    status: 1,
+    title: 2,
+    detail: 3,
+    toolName: 4,
+    tool: 5,
+    toolCallId: 6,
+    callID: 7,
+    callId: 8,
+    command: 9,
+    cmd: 10,
+    input: 11,
+    rawInput: 12,
+    arguments: 13,
+    args: 14,
+    params: 15,
+    item: 16,
+    result: 17,
+    rawOutput: 18,
+    output: 19,
+    data: 20,
+    commandActions: 21,
+    files: 22,
+    changes: 23,
+    path: 24,
+    file: 25,
+    filePath: 26,
+    stdout: 27,
+    stderr: 28,
+    content: 29,
+    totalFiles: 30,
+    truncated: 31,
+  };
+  return ranks[key] ?? 100;
+}
+
+function truncateJsonValue(
+  value: unknown,
+  options: {
+    readonly stringLimit: number;
+    readonly arrayItems: number;
+    readonly objectKeys: number;
+    readonly depth: number;
+    readonly seen?: WeakSet<object>;
+  },
+): unknown {
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return truncateJsonString(value, options.stringLimit);
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "function" || typeof value === "symbol" || value === undefined) {
+    return null;
+  }
+  const seen = options.seen ?? new WeakSet<object>();
+  if (value && typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+  }
+  if (options.depth <= 0) {
+    return isJsonObject(value) || Array.isArray(value)
+      ? {
+          [ACTIVITY_DATA_TRUNCATION_MARKER]: true,
+        }
+      : String(value);
+  }
+  if (Array.isArray(value)) {
+    const retained = value
+      .slice(0, options.arrayItems)
+      .map((entry) => truncateJsonValue(entry, { ...options, depth: options.depth - 1 }));
+    if (value.length > options.arrayItems) {
+      retained.push({
+        [ACTIVITY_DATA_TRUNCATION_MARKER]: true,
+        omittedItems: value.length - options.arrayItems,
+      });
+    }
+    return retained;
+  }
+  if (!isJsonObject(value)) {
+    return String(value);
+  }
+
+  const entries = Object.entries(value)
+    .filter(([, entry]) => entry !== undefined && typeof entry !== "function" && typeof entry !== "symbol")
+    .toSorted((left, right) => {
+      const byRank = activityPayloadKeyRank(left[0]) - activityPayloadKeyRank(right[0]);
+      return byRank !== 0 ? byRank : left[0].localeCompare(right[0]);
+    });
+  const retainedEntries = entries.slice(0, options.objectKeys);
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of retainedEntries) {
+    result[key] = truncateJsonValue(entry, { ...options, depth: options.depth - 1 });
+  }
+  if (entries.length > options.objectKeys) {
+    result[ACTIVITY_DATA_TRUNCATION_MARKER] = true;
+    result.omittedKeys = entries.length - options.objectKeys;
+  }
+  return result;
+}
+
+function boundActivityData(value: unknown): unknown {
+  const serialized = stringifyJsonLike(value);
+  if (serialized.length <= MAX_ACTIVITY_DATA_JSON_CHARS) {
+    return JSON.parse(serialized);
+  }
+
+  const withTruncationMetadata = (bounded: unknown): Record<string, unknown> => {
+    const metadata = {
+      [ACTIVITY_DATA_TRUNCATION_MARKER]: true,
+      originalJsonChars: serialized.length,
+    };
+    return isJsonObject(bounded) ? { ...bounded, ...metadata } : { ...metadata, value: bounded };
+  };
+  const hardFallback = (): Record<string, unknown> => ({
+    [ACTIVITY_DATA_TRUNCATION_MARKER]: true,
+    originalJsonChars: serialized.length,
+    preview: truncateJsonString(serialized, MAX_ACTIVITY_DATA_STRING_CHARS),
+  });
+
+  const compact = truncateJsonValue(value, {
+    stringLimit: MAX_ACTIVITY_DATA_STRING_CHARS,
+    arrayItems: MAX_ACTIVITY_DATA_ARRAY_ITEMS,
+    objectKeys: MAX_ACTIVITY_DATA_OBJECT_KEYS,
+    depth: 6,
+  });
+  const compactWithMetadata = withTruncationMetadata(compact);
+  if (stringifyJsonLike(compactWithMetadata).length <= MAX_ACTIVITY_DATA_JSON_CHARS) {
+    return compactWithMetadata;
+  }
+
+  const bounded = withTruncationMetadata(
+    truncateJsonValue(value, {
+      stringLimit: 800,
+      arrayItems: 12,
+      objectKeys: 32,
+      depth: 4,
+    }),
+  );
+  return stringifyJsonLike(bounded).length <= MAX_ACTIVITY_DATA_JSON_CHARS
+    ? bounded
+    : hardFallback();
+}
+
+// Tool payloads power the timeline, but they must stay small enough for snapshots.
+function activityDataField(data: unknown): { readonly data?: unknown } {
+  return data === undefined ? {} : { data: boundActivityData(data) };
 }
 
 // Keep MCP progress payloads available to the web timeline so it can render the specific tool call.
@@ -687,7 +877,7 @@ function runtimeEventToActivities(
               itemType: event.payload.itemType,
               status: event.payload.status,
               ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
-              ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
+              ...activityDataField(event.payload.data),
             }),
             turnId: toTurnId(event.turnId) ?? null,
             ...maybeSequence,
@@ -709,7 +899,7 @@ function runtimeEventToActivities(
             ...(event.payload.status ? { status: event.payload.status } : {}),
             ...(event.payload.title ? { title: event.payload.title } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
-            ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
+            ...activityDataField(event.payload.data),
           }),
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
@@ -733,7 +923,7 @@ function runtimeEventToActivities(
             ...(event.payload.status ? { status: event.payload.status } : {}),
             ...(event.payload.title ? { title: event.payload.title } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
-            ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
+            ...activityDataField(event.payload.data),
           }),
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
@@ -757,7 +947,7 @@ function runtimeEventToActivities(
             ...(event.payload.status ? { status: event.payload.status } : {}),
             ...(event.payload.title ? { title: event.payload.title } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
-            ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
+            ...activityDataField(event.payload.data),
           }),
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -31,6 +31,7 @@ import {
 
 type ThreadPatch = Partial<Omit<OrchestrationThread, "id" | "projectId">>;
 const MAX_THREAD_MESSAGES = 2_000;
+const MAX_THREAD_ACTIVITIES = 500;
 const MAX_THREAD_CHECKPOINTS = 500;
 
 function checkpointStatusToLatestTurnState(status: "ready" | "missing" | "error") {
@@ -844,7 +845,7 @@ export function projectEvent(
             payload.activity,
           ]
             .toSorted(compareThreadActivities)
-            .slice(-500);
+            .slice(-MAX_THREAD_ACTIVITIES);
 
           return {
             ...nextBase,

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -49,6 +49,7 @@ import Migration0033 from "./Migrations/033_ProjectionThreadsSidechatSource.ts";
 import Migration0034 from "./Migrations/034_AuthAccessManagement.ts";
 import Migration0035 from "./Migrations/035_NormalizeLegacyModelSelectionOptions.ts";
 import Migration0036 from "./Migrations/036_ProjectionThreadsPinned.ts";
+import Migration0037 from "./Migrations/037_ProjectionSnapshotCapIndexes.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -97,6 +98,7 @@ export const migrationEntries = [
   [34, "AuthAccessManagement", Migration0034],
   [35, "NormalizeLegacyModelSelectionOptions", Migration0035],
   [36, "ProjectionThreadsPinned", Migration0036],
+  [37, "ProjectionSnapshotCapIndexes", Migration0037],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/037_ProjectionSnapshotCapIndexes.ts
+++ b/apps/server/src/persistence/Migrations/037_ProjectionSnapshotCapIndexes.ts
@@ -1,0 +1,22 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_thread_messages_thread_created_desc
+    ON projection_thread_messages(thread_id, created_at DESC, message_id DESC)
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_thread_activities_thread_rank_desc
+    ON projection_thread_activities(
+      thread_id,
+      (CASE WHEN sequence IS NULL THEN 0 ELSE 1 END) DESC,
+      sequence DESC,
+      created_at DESC,
+      activity_id DESC
+    )
+  `;
+});

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -398,19 +398,12 @@ export const makeWsRpcLayer = () =>
         [ORCHESTRATION_WS_METHODS.subscribeThread]: (input) =>
           Stream.merge(
             Stream.fromEffect(
-              Effect.all([
-                projectionReadModelQuery.getThreadDetailById(input.threadId),
-                orchestrationEngine
-                  .getReadModel()
-                  .pipe(Effect.map((model) => model.snapshotSequence)),
-              ]).pipe(
-                Effect.map(([thread, snapshotSequence]) =>
-                  Option.isSome(thread)
-                    ? Option.some({
-                        kind: "snapshot" as const,
-                        snapshot: { snapshotSequence, thread: thread.value },
-                      })
-                    : Option.none(),
+              projectionReadModelQuery.getThreadDetailSnapshotById(input.threadId).pipe(
+                Effect.map((snapshot) =>
+                  Option.map(snapshot, (value) => ({
+                    kind: "snapshot" as const,
+                    snapshot: value,
+                  })),
                 ),
                 Effect.mapError((cause) => toWsRpcError(cause, "Failed to load thread snapshot")),
               ),

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import { realpathSync } from "node:fs";
 
 import {
@@ -12,6 +13,7 @@ import {
   type OrchestrationShellStreamEvent,
   type OrchestrationThreadStreamItem,
   type ServerConfigStreamEvent,
+  type ServerDiagnosticsResult,
   type ServerLifecycleStreamEvent,
 } from "@t3tools/contracts";
 import { clamp } from "effect/Number";
@@ -45,6 +47,91 @@ import { ServerSettingsService } from "./serverSettings";
 import { TerminalManager } from "./terminal/Services/Manager";
 import { WorkspaceEntries } from "./workspace/Services/WorkspaceEntries";
 import { WorkspaceFileSystem } from "./workspace/Services/WorkspaceFileSystem";
+
+const MAX_DIAGNOSTIC_CHILD_PROCESSES = 80;
+const MAX_DIAGNOSTIC_ARGS_CHARS = 500;
+
+interface ProcessTableRow {
+  readonly pid: number;
+  readonly ppid: number;
+  readonly rssBytes: number;
+  readonly virtualSizeBytes: number;
+  readonly command: string;
+  readonly args: string;
+}
+
+function truncateDiagnosticText(value: string, limit: number): string {
+  return value.length > limit ? `${value.slice(0, Math.max(0, limit - 15))}... [truncated]` : value;
+}
+
+function redactProcessArgs(args: string): string {
+  const redacted = args
+    .replace(
+      /(--?(?:api[-_]?key|auth|authorization|key|password|secret|token)(?:=|\s+))(\S+)/gi,
+      "$1[redacted]",
+    )
+    .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "[redacted]");
+  return truncateDiagnosticText(redacted, MAX_DIAGNOSTIC_ARGS_CHARS);
+}
+
+function parseProcessTable(output: string): ProcessTableRow[] {
+  const rows: ProcessTableRow[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const match = line
+      .trim()
+      .match(/^(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\S+)(?:\s+(.*))?$/);
+    if (!match) {
+      continue;
+    }
+    rows.push({
+      pid: Number(match[1]),
+      ppid: Number(match[2]),
+      rssBytes: Number(match[3]) * 1024,
+      virtualSizeBytes: Number(match[4]) * 1024,
+      command: match[5] ?? "",
+      args: redactProcessArgs(match[6] ?? ""),
+    });
+  }
+  return rows;
+}
+
+function collectDescendantProcesses(
+  rows: readonly ProcessTableRow[],
+  rootPid: number,
+): ProcessTableRow[] {
+  const childrenByParent = new Map<number, ProcessTableRow[]>();
+  for (const row of rows) {
+    const children = childrenByParent.get(row.ppid) ?? [];
+    children.push(row);
+    childrenByParent.set(row.ppid, children);
+  }
+
+  const descendants: ProcessTableRow[] = [];
+  const stack = [...(childrenByParent.get(rootPid) ?? [])];
+  while (stack.length > 0) {
+    const row = stack.pop()!;
+    descendants.push(row);
+    stack.push(...(childrenByParent.get(row.pid) ?? []));
+  }
+  return descendants.toSorted((left, right) => right.rssBytes - left.rssBytes);
+}
+
+function readDescendantProcesses(rootPid: number): Promise<ProcessTableRow[]> {
+  if (process.platform === "win32") {
+    return Promise.resolve([]);
+  }
+  return new Promise((resolve) => {
+    execFile(
+      "ps",
+      ["-axo", "pid=,ppid=,rss=,vsz=,comm=,args="],
+      { maxBuffer: 2 * 1024 * 1024 },
+      (_error, stdout) => {
+        resolve(collectDescendantProcesses(parseProcessTable(stdout), rootPid));
+      },
+    );
+  });
+}
 
 function toWsRpcError(cause: unknown, fallbackMessage: string) {
   return Schema.is(WsRpcError)(cause)
@@ -494,6 +581,40 @@ export const makeWsRpcLayer = () =>
         [WS_METHODS.serverListWorktrees]: () => Effect.succeed({ worktrees: [] }),
         [WS_METHODS.serverGetProviderUsageSnapshot]: (input) =>
           rpcEffect(getProviderUsageSnapshot(input), "Failed to load provider usage"),
+        [WS_METHODS.serverGetDiagnostics]: () =>
+          rpcEffect(
+            Effect.gen(function* () {
+              const [projection, fullChildProcesses] = yield* Effect.all([
+                projectionReadModelQuery.getCounts(),
+                Effect.promise(() => readDescendantProcesses(process.pid)),
+              ]);
+              const childProcesses = fullChildProcesses.slice(0, MAX_DIAGNOSTIC_CHILD_PROCESSES);
+              const memory = process.memoryUsage();
+              const diagnostics: ServerDiagnosticsResult = {
+                generatedAt: new Date().toISOString(),
+                process: {
+                  pid: process.pid,
+                  uptimeSeconds: Math.max(0, Math.round(process.uptime())),
+                  memory: {
+                    rssBytes: Math.max(0, Math.round(memory.rss)),
+                    heapTotalBytes: Math.max(0, Math.round(memory.heapTotal)),
+                    heapUsedBytes: Math.max(0, Math.round(memory.heapUsed)),
+                    externalBytes: Math.max(0, Math.round(memory.external)),
+                    arrayBuffersBytes: Math.max(0, Math.round(memory.arrayBuffers)),
+                  },
+                },
+                childProcesses,
+                childProcessTotalCount: fullChildProcesses.length,
+                childProcessTotalRssBytes: fullChildProcesses.reduce(
+                  (total, processRow) => total + processRow.rssBytes,
+                  0,
+                ),
+                projection,
+              };
+              return diagnostics;
+            }),
+            "Failed to load server diagnostics",
+          ),
         [WS_METHODS.serverTranscribeVoice]: (input) =>
           rpcEffect(
             providerAdapterRegistry

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -818,7 +818,7 @@ export default function ChatView({
   onCloseThreadPane,
 }: ChatViewProps) {
   const markThreadVisited = useStore((store) => store.markThreadVisited);
-  const syncServerReadModel = useStore((store) => store.syncServerReadModel);
+  const syncServerShellSnapshot = useStore((store) => store.syncServerShellSnapshot);
   const setStoreThreadError = useStore((store) => store.setError);
   const setStoreThreadWorkspace = useStore((store) => store.setThreadWorkspace);
   const { settings } = useAppSettings();
@@ -3253,8 +3253,8 @@ export default function ChatView({
             commandId: newCommandId(),
             threadId: activeThreadId,
           });
-          const snapshot = await api.orchestration.getSnapshot();
-          syncServerReadModel(snapshot);
+          const snapshot = await api.orchestration.getShellSnapshot();
+          syncServerShellSnapshot(snapshot);
           useComposerDraftStore.getState().clearDraftThread(activeThreadId);
           storeClearTerminalState(activeThreadId);
           removeThreadFromSplitViews(activeThreadId);
@@ -3292,7 +3292,7 @@ export default function ChatView({
       removeThreadFromSplitViews,
       storeClearTerminalState,
       storeCloseTerminal,
-      syncServerReadModel,
+      syncServerShellSnapshot,
       settings.confirmTerminalTabClose,
       terminalState.entryPoint,
       terminalState.terminalIds.length,
@@ -3547,7 +3547,7 @@ export default function ChatView({
     stopActiveThreadSession,
     runProjectScript,
     setStoreThreadWorkspace,
-    syncServerReadModel,
+    syncServerShellSnapshot,
   });
   const persistProjectScripts = useCallback(
     async (input: {
@@ -5362,14 +5362,13 @@ export default function ChatView({
             await waitForRecoverableProjectForDuplicateCreate({
               message: description,
               workspaceRoot: firstSendTarget.creation.workspaceRoot,
-              loadSnapshot: () => api.orchestration.getSnapshot().catch(() => null),
-              repairSnapshot: () => api.orchestration.repairState().catch(() => null),
+              loadSnapshot: () => api.orchestration.getShellSnapshot().catch(() => null),
             });
           if (!snapshot || !recoveredProject) {
             throw error;
           }
 
-          syncServerReadModel(snapshot);
+          syncServerShellSnapshot(snapshot);
           targetProjectIdForSend = recoveredProject.id;
           targetProjectKindForSend = "project";
           targetProjectCwdForSend = recoveredProject.workspaceRoot;
@@ -6265,9 +6264,9 @@ export default function ChatView({
           createdAt,
         });
       })
-      .then(() => api.orchestration.getSnapshot())
+      .then(() => api.orchestration.getShellSnapshot())
       .then((snapshot) => {
-        syncServerReadModel(snapshot);
+        syncServerShellSnapshot(snapshot);
         // Signal that the plan sidebar should open on the new thread.
         planSidebarOpenOnNextThreadRef.current = true;
         return navigate({
@@ -6284,9 +6283,9 @@ export default function ChatView({
           })
           .catch(() => undefined);
         await api.orchestration
-          .getSnapshot()
+          .getShellSnapshot()
           .then((snapshot) => {
-            syncServerReadModel(snapshot);
+            syncServerShellSnapshot(snapshot);
           })
           .catch(() => undefined);
         toastManager.add({
@@ -6315,7 +6314,7 @@ export default function ChatView({
     rememberCustomBinaryPathForDispatch,
     selectedProvider,
     settings.enableAssistantStreaming,
-    syncServerReadModel,
+    syncServerShellSnapshot,
     selectedModel,
   ]);
 
@@ -6804,7 +6803,7 @@ export default function ChatView({
     runtimeMode,
     interactionMode,
     threadId,
-    syncServerReadModel,
+    syncServerShellSnapshot,
     navigateToThread: (nextThreadId, options) =>
       navigate({
         to: "/$threadId",

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -53,7 +53,7 @@ import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-
 import { CSS } from "@dnd-kit/utilities";
 import {
   type DesktopUpdateState,
-  type OrchestrationReadModel,
+  type OrchestrationShellSnapshot,
   PROVIDER_DISPLAY_NAMES,
   ProjectId,
   type ProviderKind,
@@ -1098,7 +1098,6 @@ export default function Sidebar() {
   const threadsHydrated = useStore((store) => store.threadsHydrated);
   const sidebarThreadSummaryById = useStore((store) => store.sidebarThreadSummaryById);
   const syncServerShellSnapshot = useStore((store) => store.syncServerShellSnapshot);
-  const syncServerReadModel = useStore((store) => store.syncServerReadModel);
   const markThreadVisited = useStore((store) => store.markThreadVisited);
   const markThreadUnread = useStore((store) => store.markThreadUnread);
   const toggleProject = useStore((store) => store.toggleProject);
@@ -1509,20 +1508,19 @@ export default function Sidebar() {
   );
 
   const openOrCreateProjectThreadFromSnapshot = useCallback(
-    async (projectId: ProjectId, snapshot: OrchestrationReadModel) => {
+    async (projectId: ProjectId, snapshot: OrchestrationShellSnapshot) => {
       const latestThread = sortThreadsForSidebar(
         snapshot.threads
           .filter(
             (thread) =>
               thread.projectId === projectId &&
-              thread.deletedAt === null &&
               (thread.archivedAt ?? null) === null,
           )
           .map((thread) => ({
             id: thread.id,
             createdAt: thread.createdAt,
             updatedAt: thread.updatedAt,
-            messages: thread.messages,
+            latestUserMessageAt: thread.latestUserMessageAt,
           })),
         appSettings.sidebarThreadSortOrder,
       )[0];
@@ -1547,11 +1545,9 @@ export default function Sidebar() {
   );
 
   const openExistingProjectFromSnapshot = useCallback(
-    async (projectId: ProjectId, snapshot: OrchestrationReadModel): Promise<boolean> => {
+    async (projectId: ProjectId, snapshot: OrchestrationShellSnapshot): Promise<boolean> => {
       const existingProject =
-        snapshot.projects.find(
-          (candidate) => candidate.id === projectId && candidate.deletedAt === null,
-        ) ?? null;
+        snapshot.projects.find((candidate) => candidate.id === projectId) ?? null;
       if (!existingProject) {
         return false;
       }
@@ -1561,14 +1557,13 @@ export default function Sidebar() {
           .filter(
             (thread) =>
               thread.projectId === projectId &&
-              thread.deletedAt === null &&
               (thread.archivedAt ?? null) === null,
           )
           .map((thread) => ({
             id: thread.id,
             createdAt: thread.createdAt,
             updatedAt: thread.updatedAt,
-            messages: thread.messages,
+            latestUserMessageAt: thread.latestUserMessageAt,
           })),
         appSettings.sidebarThreadSortOrder,
       )[0];
@@ -1601,13 +1596,12 @@ export default function Sidebar() {
       api: NonNullable<ReturnType<typeof readNativeApi>>,
       projectId: ProjectId,
     ): Promise<{
-      project: OrchestrationReadModel["projects"][number] | null;
-      snapshot: OrchestrationReadModel | null;
+      project: OrchestrationShellSnapshot["projects"][number] | null;
+      snapshot: OrchestrationShellSnapshot | null;
     }> =>
       waitForRecoverableProjectInReadModel({
         projectId,
-        loadSnapshot: () => api.orchestration.getSnapshot().catch(() => null),
-        repairSnapshot: () => api.orchestration.repairState().catch(() => null),
+        loadSnapshot: () => api.orchestration.getShellSnapshot().catch(() => null),
         maxAttempts: ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS,
         delayMs: ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS,
       }),
@@ -1619,13 +1613,12 @@ export default function Sidebar() {
       api: NonNullable<ReturnType<typeof readNativeApi>>,
       workspaceRoot: string,
     ): Promise<{
-      project: OrchestrationReadModel["projects"][number] | null;
-      snapshot: OrchestrationReadModel | null;
+      project: OrchestrationShellSnapshot["projects"][number] | null;
+      snapshot: OrchestrationShellSnapshot | null;
     }> =>
       waitForRecoverableProjectInReadModel({
         workspaceRoot,
-        loadSnapshot: () => api.orchestration.getSnapshot().catch(() => null),
-        repairSnapshot: () => api.orchestration.repairState().catch(() => null),
+        loadSnapshot: () => api.orchestration.getShellSnapshot().catch(() => null),
         maxAttempts: ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS,
         delayMs: ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS,
       }),
@@ -1640,7 +1633,7 @@ export default function Sidebar() {
     ): Promise<boolean> => {
       const { project, snapshot } = await waitForProjectInSnapshot(api, projectId);
       if (snapshot) {
-        syncServerReadModel(snapshot);
+        syncServerShellSnapshot(snapshot);
       }
       if (!project || !snapshot) {
         return false;
@@ -1649,7 +1642,7 @@ export default function Sidebar() {
       await openOrCreateProjectThreadFromSnapshot(project.id, snapshot);
       return true;
     },
-    [openOrCreateProjectThreadFromSnapshot, syncServerReadModel, waitForProjectInSnapshot],
+    [openOrCreateProjectThreadFromSnapshot, syncServerShellSnapshot, waitForProjectInSnapshot],
   );
 
   const recoverExistingProjectFromServer = useCallback(
@@ -1659,7 +1652,7 @@ export default function Sidebar() {
     ): Promise<boolean> => {
       const { project, snapshot } = await waitForProjectInSnapshot(api, projectId);
       if (snapshot) {
-        syncServerReadModel(snapshot);
+        syncServerShellSnapshot(snapshot);
       }
       if (!project || !snapshot) {
         return false;
@@ -1667,7 +1660,7 @@ export default function Sidebar() {
 
       return openExistingProjectFromSnapshot(project.id, snapshot);
     },
-    [openExistingProjectFromSnapshot, syncServerReadModel, waitForProjectInSnapshot],
+    [openExistingProjectFromSnapshot, syncServerShellSnapshot, waitForProjectInSnapshot],
   );
 
   const recoverExistingProjectByWorkspaceRootFromServer = useCallback(
@@ -1677,7 +1670,7 @@ export default function Sidebar() {
     ): Promise<boolean> => {
       const { project, snapshot } = await waitForProjectWorkspaceRootInSnapshot(api, workspaceRoot);
       if (snapshot) {
-        syncServerReadModel(snapshot);
+        syncServerShellSnapshot(snapshot);
       }
       if (!project || !snapshot) {
         return false;
@@ -1685,7 +1678,7 @@ export default function Sidebar() {
 
       return openExistingProjectFromSnapshot(project.id, snapshot);
     },
-    [openExistingProjectFromSnapshot, syncServerReadModel, waitForProjectWorkspaceRootInSnapshot],
+    [openExistingProjectFromSnapshot, syncServerShellSnapshot, waitForProjectWorkspaceRootInSnapshot],
   );
 
   const handleOpenProjectFromSearch = useCallback(
@@ -1913,13 +1906,12 @@ export default function Sidebar() {
             const { project, snapshot } = await waitForRecoverableProjectForDuplicateCreate({
               message: description,
               workspaceRoot: cwd,
-              loadSnapshot: () => api.orchestration.getSnapshot().catch(() => null),
-              repairSnapshot: () => api.orchestration.repairState().catch(() => null),
+              loadSnapshot: () => api.orchestration.getShellSnapshot().catch(() => null),
               maxAttempts: ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS,
               delayMs: ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS,
             });
             if (snapshot) {
-              syncServerReadModel(snapshot);
+              syncServerShellSnapshot(snapshot);
             }
             if (project && snapshot) {
               const recovered = await openExistingProjectFromSnapshot(project.id, snapshot);
@@ -1960,7 +1952,6 @@ export default function Sidebar() {
       recoverExistingProjectFromServer,
       recoverExistingProjectByWorkspaceRootFromServer,
       recoverProjectThreadFromServer,
-      syncServerReadModel,
       openExistingProjectFromSnapshot,
       setProjectExpanded,
     ],

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -1,6 +1,6 @@
 import {
   type ModelSelection,
-  type OrchestrationReadModel,
+  type OrchestrationShellSnapshot,
   type ProviderInteractionMode,
   type ProviderKind,
   type ProviderNativeCommandDescriptor,
@@ -63,7 +63,7 @@ export function useComposerSlashCommands(input: {
   runtimeMode: RuntimeMode;
   interactionMode: ProviderInteractionMode;
   threadId: ThreadId;
-  syncServerReadModel: (snapshot: OrchestrationReadModel) => void;
+  syncServerShellSnapshot: (snapshot: OrchestrationShellSnapshot) => void;
   navigateToThread: (threadId: ThreadId, options?: { splitViewId?: SplitViewId }) => Promise<void>;
   handleClearConversation: () => Promise<void> | void;
   handleInteractionModeChange: (mode: "default" | "plan") => Promise<void> | void;
@@ -111,7 +111,7 @@ export function useComposerSlashCommands(input: {
     runtimeMode,
     interactionMode,
     threadId,
-    syncServerReadModel,
+    syncServerShellSnapshot,
     navigateToThread,
     handleClearConversation,
     handleInteractionModeChange,
@@ -274,8 +274,8 @@ export function useComposerSlashCommands(input: {
         importedMessages: [...importedMessages],
         createdAt,
       });
-      const snapshot = await api.orchestration.getSnapshot();
-      syncServerReadModel(snapshot);
+      const snapshot = await api.orchestration.getShellSnapshot();
+      syncServerShellSnapshot(snapshot);
       await navigateToThread(nextThreadId);
       return true;
     },
@@ -288,7 +288,7 @@ export function useComposerSlashCommands(input: {
       navigateToThread,
       runtimeMode,
       selectedModelSelection,
-      syncServerReadModel,
+      syncServerShellSnapshot,
     ],
   );
 
@@ -352,8 +352,8 @@ export function useComposerSlashCommands(input: {
         });
       }
 
-      const snapshot = await api.orchestration.getSnapshot();
-      syncServerReadModel(snapshot);
+      const snapshot = await api.orchestration.getShellSnapshot();
+      syncServerShellSnapshot(snapshot);
       const splitViewId = createSplitViewFromDrop({
         sourceThreadId: activeThread.id,
         ownerProjectId: activeProject.id,
@@ -372,7 +372,7 @@ export function useComposerSlashCommands(input: {
       isServerThread,
       navigateToThread,
       selectedModelSelection,
-      syncServerReadModel,
+      syncServerShellSnapshot,
     ],
   );
 
@@ -456,8 +456,8 @@ export function useComposerSlashCommands(input: {
           interactionMode: "default",
           createdAt,
         });
-        const snapshot = await api.orchestration.getSnapshot();
-        syncServerReadModel(snapshot);
+        const snapshot = await api.orchestration.getShellSnapshot();
+        syncServerShellSnapshot(snapshot);
         await navigateToThread(nextThreadId);
         return true;
       } catch (error) {
@@ -477,7 +477,7 @@ export function useComposerSlashCommands(input: {
       navigateToThread,
       runtimeMode,
       selectedModelSelection,
-      syncServerReadModel,
+      syncServerShellSnapshot,
     ],
   );
 

--- a/apps/web/src/hooks/useDisposableThreadLifecycle.ts
+++ b/apps/web/src/hooks/useDisposableThreadLifecycle.ts
@@ -11,7 +11,7 @@ import { useTerminalStateStore } from "../terminalStateStore";
 import { getThreadFromState } from "../threadDerivation";
 
 export function useDisposableThreadLifecycle(activeThreadId: ThreadId | null): void {
-  const syncServerReadModel = useStore((store) => store.syncServerReadModel);
+  const syncServerShellSnapshot = useStore((store) => store.syncServerShellSnapshot);
   const clearDraftThread = useComposerDraftStore((store) => store.clearDraftThread);
   const clearTerminalState = useTerminalStateStore((store) => store.clearTerminalState);
   const removeThreadFromSplitViews = useSplitViewStore((store) => store.removeThreadFromSplitViews);
@@ -84,9 +84,9 @@ export function useDisposableThreadLifecycle(activeThreadId: ThreadId | null): v
                 threadId: disposableThreadId,
               })
               .catch(() => undefined);
-            const snapshot = await api.orchestration.getSnapshot().catch(() => null);
+            const snapshot = await api.orchestration.getShellSnapshot().catch(() => null);
             if (snapshot) {
-              syncServerReadModel(snapshot);
+              syncServerShellSnapshot(snapshot);
             }
           }
         }
@@ -105,7 +105,7 @@ export function useDisposableThreadLifecycle(activeThreadId: ThreadId | null): v
     clearTerminalState,
     clearTemporaryThread,
     removeThreadFromSplitViews,
-    syncServerReadModel,
+    syncServerShellSnapshot,
     temporaryThreadIds,
   ]);
 }

--- a/apps/web/src/hooks/useThreadHandoff.ts
+++ b/apps/web/src/hooks/useThreadHandoff.ts
@@ -25,7 +25,7 @@ export function useThreadHandoff() {
   const navigate = useNavigate();
   const { settings } = useAppSettings();
   const projects = useStore((store) => store.projects);
-  const syncServerReadModel = useStore((store) => store.syncServerReadModel);
+  const syncServerShellSnapshot = useStore((store) => store.syncServerShellSnapshot);
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
 
   const createThreadHandoff = useCallback(
@@ -107,8 +107,8 @@ export function useThreadHandoff() {
 
       copyTransferableComposerState(thread.id, nextThreadId);
 
-      const snapshot = await api.orchestration.getSnapshot();
-      syncServerReadModel(snapshot);
+      const snapshot = await api.orchestration.getShellSnapshot();
+      syncServerShellSnapshot(snapshot);
       await navigate({
         to: "/$threadId",
         params: { threadId: nextThreadId },
@@ -116,7 +116,7 @@ export function useThreadHandoff() {
 
       return nextThreadId;
     },
-    [navigate, projects, serverConfigQuery.data?.providers, settings, syncServerReadModel],
+    [navigate, projects, serverConfigQuery.data?.providers, settings, syncServerShellSnapshot],
   );
 
   return {

--- a/apps/web/src/hooks/useThreadWorkspaceHandoff.ts
+++ b/apps/web/src/hooks/useThreadWorkspaceHandoff.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { OrchestrationReadModel, ThreadId } from "@t3tools/contracts";
+import type { OrchestrationShellSnapshot, ThreadId } from "@t3tools/contracts";
 import { resolveWorktreeHandoffIntent } from "@t3tools/shared/worktreeHandoff";
 import { useCallback, useState } from "react";
 import { gitHandoffThreadMutationOptions } from "~/lib/gitReactQuery";
@@ -31,7 +31,7 @@ export function useThreadWorkspaceHandoff(input: {
     },
   ) => Promise<void>;
   setStoreThreadWorkspace: (threadId: ThreadId, patch: ThreadWorkspacePatch) => void;
-  syncServerReadModel: (snapshot: OrchestrationReadModel) => void;
+  syncServerShellSnapshot: (snapshot: OrchestrationShellSnapshot) => void;
 }) {
   const queryClient = useQueryClient();
   const handoffThreadMutation = useMutation(
@@ -89,8 +89,8 @@ export function useThreadWorkspaceHandoff(input: {
         });
         input.setStoreThreadWorkspace(input.activeThread.id, workspacePatch);
 
-        const snapshot = await api.orchestration.getSnapshot();
-        input.syncServerReadModel(snapshot);
+        const snapshot = await api.orchestration.getShellSnapshot();
+        input.syncServerShellSnapshot(snapshot);
 
         if (targetMode === "worktree" && result.worktreePath) {
           const setupScript = setupProjectScript(input.activeProject.scripts);

--- a/apps/web/src/lib/projectCreateRecovery.test.ts
+++ b/apps/web/src/lib/projectCreateRecovery.test.ts
@@ -112,6 +112,23 @@ describe("projectCreateRecovery", () => {
     expect(recovered?.id).toBe("project-123");
   });
 
+  it("recovers active shell-snapshot projects that do not carry deletedAt", () => {
+    const recovered = findRecoverableProjectForDuplicateCreate({
+      message:
+        "Orchestration command invariant failed (project.create): Project 'project-123' already uses workspace root '/Users/tester/Code/one'.",
+      projects: [
+        {
+          id: "project-123",
+          kind: "project",
+          workspaceRoot: "/Users/tester/Code/one",
+        },
+      ],
+      workspaceRoot: "/Users/tester/Code/one",
+    });
+
+    expect(recovered?.id).toBe("project-123");
+  });
+
   it("ignores deleted and non-project rows during recovery", () => {
     const recovered = findRecoverableProjectForDuplicateCreate({
       message:

--- a/apps/web/src/lib/projectCreateRecovery.ts
+++ b/apps/web/src/lib/projectCreateRecovery.ts
@@ -14,7 +14,7 @@ export interface DuplicateProjectCreateRecoveryCandidate {
   readonly id: string;
   readonly kind?: string | undefined;
   readonly workspaceRoot: string;
-  readonly deletedAt: string | null;
+  readonly deletedAt?: string | null | undefined;
 }
 
 interface SnapshotWithProjects<T extends DuplicateProjectCreateRecoveryCandidate> {
@@ -28,6 +28,10 @@ interface ProjectLookupInput {
 
 function isRecoverableProjectKind(kind: string | undefined): boolean {
   return (kind ?? "project") === "project";
+}
+
+function isRecoverableActiveProject(project: DuplicateProjectCreateRecoveryCandidate): boolean {
+  return (project.deletedAt ?? null) === null && isRecoverableProjectKind(project.kind);
 }
 
 function wait(ms: number): Promise<void> {
@@ -62,10 +66,7 @@ export function findRecoverableProject<T extends DuplicateProjectCreateRecoveryC
 ): T | null {
   if (input.projectId) {
     const projectById = input.projects.find(
-      (project) =>
-        project.deletedAt === null &&
-        isRecoverableProjectKind(project.kind) &&
-        project.id === input.projectId,
+      (project) => isRecoverableActiveProject(project) && project.id === input.projectId,
     );
     if (projectById) {
       return projectById;
@@ -80,8 +81,7 @@ export function findRecoverableProject<T extends DuplicateProjectCreateRecoveryC
   return (
     input.projects.find(
       (project) =>
-        project.deletedAt === null &&
-        isRecoverableProjectKind(project.kind) &&
+        isRecoverableActiveProject(project) &&
         workspaceRootsEqual(project.workspaceRoot, workspaceRoot),
     ) ?? null
   );
@@ -106,18 +106,20 @@ export function findRecoverableProjectForDuplicateCreate<
   });
 }
 
-export async function waitForRecoverableProjectInReadModel(
+export async function waitForRecoverableProjectInReadModel<
+  TSnapshot extends SnapshotWithProjects<DuplicateProjectCreateRecoveryCandidate> = OrchestrationReadModel,
+>(
   input: ProjectLookupInput & {
-    readonly loadSnapshot: () => Promise<OrchestrationReadModel | null>;
-    readonly repairSnapshot?: (() => Promise<OrchestrationReadModel | null>) | undefined;
+    readonly loadSnapshot: () => Promise<TSnapshot | null>;
+    readonly repairSnapshot?: (() => Promise<TSnapshot | null>) | undefined;
     readonly maxAttempts?: number;
     readonly delayMs?: number;
   },
 ): Promise<{
-  project: OrchestrationReadModel["projects"][number] | null;
-  snapshot: OrchestrationReadModel | null;
+  project: TSnapshot["projects"][number] | null;
+  snapshot: TSnapshot | null;
 }> {
-  let latestSnapshot: OrchestrationReadModel | null = null;
+  let latestSnapshot: TSnapshot | null = null;
   const maxAttempts = input.maxAttempts ?? DEFAULT_RECOVERY_MAX_ATTEMPTS;
   const delayMs = input.delayMs ?? DEFAULT_RECOVERY_DELAY_MS;
 
@@ -129,7 +131,7 @@ export async function waitForRecoverableProjectInReadModel(
         projects: snapshot.projects,
         projectId: input.projectId,
         workspaceRoot: input.workspaceRoot,
-      });
+      }) as TSnapshot["projects"][number] | null;
       if (project) {
         return { project, snapshot };
       }
@@ -148,7 +150,7 @@ export async function waitForRecoverableProjectInReadModel(
         projects: repairedSnapshot.projects,
         projectId: input.projectId,
         workspaceRoot: input.workspaceRoot,
-      });
+      }) as TSnapshot["projects"][number] | null;
       if (repairedProject) {
         return {
           project: repairedProject,

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -1137,7 +1137,7 @@ function SettingsRouteView() {
     async (input: { workspaceRoot: string; worktreePath: string }) => {
       const api = readNativeApi() ?? ensureNativeApi();
       const displayName = formatWorktreePathForDisplay(input.worktreePath);
-      const snapshot = await api.orchestration.getSnapshot().catch(() => null);
+      const snapshot = await api.orchestration.getShellSnapshot().catch(() => null);
       if (snapshot === null) {
         toastManager.add({
           type: "error",
@@ -1148,9 +1148,6 @@ function SettingsRouteView() {
       }
 
       const linkedThreadsFromSnapshot = snapshot.threads.filter((thread) => {
-        if (thread.deletedAt !== null) {
-          return false;
-        }
         const candidatePaths = [
           normalizeManagedWorktreePath(thread.worktreePath),
           normalizeManagedWorktreePath(thread.associatedWorktreePath ?? null),

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -2222,6 +2222,91 @@ describe("store read model sync", () => {
     expect(next.activityByThreadId?.[threadId]?.["activity-command"]).toBe(richActivity);
   });
 
+  it("caps stored activity detail to the latest activity window", () => {
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const activities = Array.from({ length: 505 }, (_, index) =>
+      makeActivity({
+        id: `activity-${index}`,
+        sequence: index,
+        createdAt: "2026-02-27T00:00:00.000Z",
+      }),
+    );
+
+    const next = syncServerReadModel(
+      makeState(makeThread()),
+      makeReadModel(makeReadModelThread({ activities })),
+    );
+
+    expect(next.threads[0]?.activities).toHaveLength(500);
+    expect(next.threads[0]?.activities[0]?.id).toBe(EventId.makeUnsafe("activity-5"));
+    expect(next.threads[0]?.activities.at(-1)?.id).toBe(EventId.makeUnsafe("activity-504"));
+    expect(next.activityIdsByThreadId?.[threadId]).toHaveLength(500);
+    expect(next.activityIdsByThreadId?.[threadId]?.[0]).toBe("activity-5");
+  });
+
+  it("keeps pending interaction activities outside the latest activity window", () => {
+    const activities = [
+      makeActivity({
+        id: "approval-old",
+        kind: "approval.requested",
+        tone: "approval",
+        payload: { requestId: "approval-1", requestKind: "command" },
+        sequence: 0,
+      }),
+      ...Array.from({ length: 505 }, (_, index) =>
+        makeActivity({
+          id: `activity-${index}`,
+          sequence: index + 1,
+          createdAt: "2026-02-27T00:00:00.000Z",
+        }),
+      ),
+    ];
+
+    const next = syncServerReadModel(
+      makeState(makeThread()),
+      makeReadModel(makeReadModelThread({ activities })),
+    );
+
+    expect(next.threads[0]?.activities).toHaveLength(501);
+    expect(next.threads[0]?.activities[0]?.id).toBe(EventId.makeUnsafe("approval-old"));
+    expect(next.threads[0]?.activities[1]?.id).toBe(EventId.makeUnsafe("activity-5"));
+  });
+
+  it("does not keep resolved interaction activities outside the latest activity window", () => {
+    const activities = [
+      makeActivity({
+        id: "approval-old",
+        kind: "approval.requested",
+        tone: "approval",
+        payload: { requestId: "approval-1", requestKind: "command" },
+        sequence: 0,
+      }),
+      makeActivity({
+        id: "approval-resolved-old",
+        kind: "approval.resolved",
+        tone: "approval",
+        payload: { requestId: "approval-1", decision: "accept" },
+        sequence: 1,
+      }),
+      ...Array.from({ length: 505 }, (_, index) =>
+        makeActivity({
+          id: `activity-${index}`,
+          sequence: index + 2,
+          createdAt: "2026-02-27T00:00:00.000Z",
+        }),
+      ),
+    ];
+
+    const next = syncServerReadModel(
+      makeState(makeThread()),
+      makeReadModel(makeReadModelThread({ activities })),
+    );
+
+    expect(next.threads[0]?.activities).toHaveLength(500);
+    expect(next.threads[0]?.activities[0]?.id).toBe(EventId.makeUnsafe("activity-5"));
+    expect(next.threads[0]?.activities.at(-1)?.id).toBe(EventId.makeUnsafe("activity-504"));
+  });
+
   it("preserves the existing sidebar pending-user-input state during detail-only response events", () => {
     const initialState = syncServerReadModel(
       makeState(

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -90,6 +90,7 @@ const LEGACY_PERSISTED_STATE_KEYS = [
   "codething:renderer-state:v1",
 ] as const;
 const MAX_THREAD_MESSAGES = 2_000;
+const MAX_THREAD_ACTIVITIES = 500;
 const EMPTY_THREAD_IDS: ThreadId[] = [];
 const EMPTY_THREAD_SHELL_BY_ID: Record<ThreadId, ThreadShell> = {};
 const EMPTY_THREAD_SESSION_BY_ID: Record<ThreadId, ThreadSession | null> = {};
@@ -116,6 +117,7 @@ const THREAD_SUMMARY_ACTIVITY_KINDS = new Set([
   "user-input.resolved",
   "provider.user-input.respond.failed",
 ]);
+const PENDING_INTERACTION_REQUEST_KINDS = new Set(["approval.requested", "user-input.requested"]);
 
 const initialState: AppState = {
   projects: [],
@@ -460,7 +462,7 @@ function buildActivitySlice(thread: Thread): {
   ids: string[];
   byId: Record<string, Thread["activities"][number]>;
 } {
-  const activities = dedupeActivitiesById(thread.activities);
+  const activities = capThreadActivities(dedupeActivitiesById(thread.activities));
   return {
     ids: activities.map((activity) => activity.id),
     byId: Object.fromEntries(
@@ -1265,7 +1267,80 @@ function normalizeActivities(
     }
     return activity;
   });
-  return arraysShallowEqual(previous, nextActivities) ? previous : nextActivities;
+  const cappedActivities = capThreadActivities(nextActivities);
+  return arraysShallowEqual(previous, cappedActivities) ? previous : cappedActivities;
+}
+
+function capThreadActivities<TActivity extends Thread["activities"][number]>(
+  activities: readonly TActivity[],
+): TActivity[] {
+  if (activities.length <= MAX_THREAD_ACTIVITIES) {
+    return activities as TActivity[];
+  }
+  const retainedIds = new Set(
+    activities.slice(-MAX_THREAD_ACTIVITIES).map((activity) => activity.id),
+  );
+  const pendingRequestIds = pendingInteractionRequestIds(activities);
+  for (const activity of activities) {
+    const requestId = activityRequestId(activity);
+    if (
+      requestId !== null &&
+      pendingRequestIds.has(requestId) &&
+      PENDING_INTERACTION_REQUEST_KINDS.has(activity.kind)
+    ) {
+      retainedIds.add(activity.id);
+    }
+  }
+  return activities.filter((activity) => retainedIds.has(activity.id));
+}
+
+function activityRequestId(activity: Thread["activities"][number]): string | null {
+  const payload = asActivityRecord(activity.payload);
+  const requestId = payload?.requestId;
+  return typeof requestId === "string" && requestId.trim().length > 0 ? requestId : null;
+}
+
+function isStalePendingRequestFailureDetail(detail: unknown): boolean {
+  if (typeof detail !== "string") {
+    return false;
+  }
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes("stale pending approval request") ||
+    normalized.includes("stale pending user-input request") ||
+    normalized.includes("unknown pending approval request") ||
+    normalized.includes("unknown pending permission request") ||
+    normalized.includes("unknown pending user-input request")
+  );
+}
+
+// Keep old actionable prompts even when their timeline rows fall outside the cap.
+function pendingInteractionRequestIds(
+  activities: readonly Thread["activities"][number][],
+): Set<string> {
+  const pendingRequestIds = new Set<string>();
+  for (const activity of activities) {
+    const requestId = activityRequestId(activity);
+    if (requestId === null) {
+      continue;
+    }
+    if (activity.kind === "approval.requested" || activity.kind === "user-input.requested") {
+      pendingRequestIds.add(requestId);
+      continue;
+    }
+    if (activity.kind === "approval.resolved" || activity.kind === "user-input.resolved") {
+      pendingRequestIds.delete(requestId);
+      continue;
+    }
+    if (
+      (activity.kind === "provider.approval.respond.failed" ||
+        activity.kind === "provider.user-input.respond.failed") &&
+      isStalePendingRequestFailureDetail(asActivityRecord(activity.payload)?.detail)
+    ) {
+      pendingRequestIds.delete(requestId);
+    }
+  }
+  return pendingRequestIds;
 }
 
 function dedupeActivitiesById<TActivity extends Thread["activities"][number]>(

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -559,6 +559,7 @@ export function createWsNativeApi(): NativeApi {
       listWorktrees: () => transport.request(WS_METHODS.serverListWorktrees),
       getProviderUsageSnapshot: (input) =>
         transport.request(WS_METHODS.serverGetProviderUsageSnapshot, input),
+      getDiagnostics: () => transport.request(WS_METHODS.serverGetDiagnostics),
       transcribeVoice: (input) => {
         if (window.desktopBridge?.server?.transcribeVoice) {
           return window.desktopBridge.server.transcribeVoice(input);

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -58,6 +58,7 @@ import type {
 import type { FilesystemBrowseInput, FilesystemBrowseResult } from "./filesystem";
 import type {
   ServerConfig,
+  ServerDiagnosticsResult,
   ServerGetEnvironmentResult,
   ServerGetProviderUsageSnapshotInput,
   ServerGetProviderUsageSnapshotResult,
@@ -402,6 +403,7 @@ export interface NativeApi {
     getProviderUsageSnapshot: (
       input: ServerGetProviderUsageSnapshotInput,
     ) => Promise<ServerGetProviderUsageSnapshotResult>;
+    getDiagnostics: () => Promise<ServerDiagnosticsResult>;
     transcribeVoice: (
       input: ServerVoiceTranscriptionInput,
     ) => Promise<ServerVoiceTranscriptionResult>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -78,6 +78,7 @@ import {
 import {
   ServerConfig,
   ServerConfigStreamEvent,
+  ServerDiagnosticsResult,
   ServerGetEnvironmentResult,
   ServerGetProviderUsageSnapshotInput,
   ServerGetProviderUsageSnapshotResult,
@@ -458,6 +459,12 @@ export const WsServerGetProviderUsageSnapshotRpc = Rpc.make(
   },
 );
 
+export const WsServerGetDiagnosticsRpc = Rpc.make(WS_METHODS.serverGetDiagnostics, {
+  payload: Schema.Struct({}),
+  success: ServerDiagnosticsResult,
+  error: WsRpcError,
+});
+
 export const WsServerTranscribeVoiceRpc = Rpc.make(WS_METHODS.serverTranscribeVoice, {
   payload: ServerVoiceTranscriptionInput,
   success: ServerVoiceTranscriptionResult,
@@ -606,6 +613,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerUpdateProviderRpc,
   WsServerListWorktreesRpc,
   WsServerGetProviderUsageSnapshotRpc,
+  WsServerGetDiagnosticsRpc,
   WsServerTranscribeVoiceRpc,
   WsServerUpsertKeybindingRpc,
   WsSubscribeServerLifecycleRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -140,6 +140,42 @@ export type ServerGetProviderUsageSnapshotInput = typeof ServerGetProviderUsageS
 export const ServerGetProviderUsageSnapshotResult = Schema.NullOr(ServerProviderUsageSnapshot);
 export type ServerGetProviderUsageSnapshotResult = typeof ServerGetProviderUsageSnapshotResult.Type;
 
+export const ServerDiagnosticsMemory = Schema.Struct({
+  rssBytes: NonNegativeInt,
+  heapTotalBytes: NonNegativeInt,
+  heapUsedBytes: NonNegativeInt,
+  externalBytes: NonNegativeInt,
+  arrayBuffersBytes: NonNegativeInt,
+});
+export type ServerDiagnosticsMemory = typeof ServerDiagnosticsMemory.Type;
+
+export const ServerDiagnosticsChildProcess = Schema.Struct({
+  pid: NonNegativeInt,
+  ppid: NonNegativeInt,
+  rssBytes: NonNegativeInt,
+  virtualSizeBytes: NonNegativeInt,
+  command: Schema.String,
+  args: Schema.String,
+});
+export type ServerDiagnosticsChildProcess = typeof ServerDiagnosticsChildProcess.Type;
+
+export const ServerDiagnosticsResult = Schema.Struct({
+  generatedAt: IsoDateTime,
+  process: Schema.Struct({
+    pid: NonNegativeInt,
+    uptimeSeconds: NonNegativeInt,
+    memory: ServerDiagnosticsMemory,
+  }),
+  childProcesses: Schema.Array(ServerDiagnosticsChildProcess),
+  childProcessTotalCount: NonNegativeInt,
+  childProcessTotalRssBytes: NonNegativeInt,
+  projection: Schema.Struct({
+    projectCount: NonNegativeInt,
+    threadCount: NonNegativeInt,
+  }),
+});
+export type ServerDiagnosticsResult = typeof ServerDiagnosticsResult.Type;
+
 export const ServerVoiceTranscriptionInput = Schema.Struct({
   provider: ProviderKind,
   cwd: TrimmedNonEmptyString,

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -137,6 +137,7 @@ export const WS_METHODS = {
   serverUpdateProvider: "server.updateProvider",
   serverListWorktrees: "server.listWorktrees",
   serverGetProviderUsageSnapshot: "server.getProviderUsageSnapshot",
+  serverGetDiagnostics: "server.getDiagnostics",
   serverTranscribeVoice: "server.transcribeVoice",
   serverUpsertKeybinding: "server.upsertKeybinding",
   subscribeServerLifecycle: "server.subscribeLifecycle",
@@ -252,6 +253,7 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.serverUpdateProvider, ServerProviderUpdateInput),
   tagRequestBody(WS_METHODS.serverListWorktrees, Schema.Struct({})),
   tagRequestBody(WS_METHODS.serverGetProviderUsageSnapshot, ServerGetProviderUsageSnapshotInput),
+  tagRequestBody(WS_METHODS.serverGetDiagnostics, Schema.Struct({})),
   tagRequestBody(WS_METHODS.serverTranscribeVoice, ServerVoiceTranscriptionInput),
   tagRequestBody(WS_METHODS.serverUpsertKeybinding, KeybindingRule),
 


### PR DESCRIPTION
## Summary
- Caps hydrated thread messages and activities in projection queries so snapshots stay bounded even for very large threads.
- Truncates oversized provider runtime activity payloads before they are persisted, while preserving important command metadata and adding truncation markers.
- Simplifies Pi adapter turn completion/error handling and removes now-unused helper logic and tests.
- Updates web state and RPC plumbing to match the new bounded snapshot and runtime payload behavior.

## Testing
- Not run (not requested).
- Added/updated unit coverage for projection snapshot capping and provider runtime activity truncation.
- Added/updated store and recovery tests around the new bounded data flow.