### PR TITLE
Optimize capped snapshot hydration

### DIFF
--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -49,6 +49,7 @@ import Migration0033 from "./Migrations/033_ProjectionThreadsSidechatSource.ts";
 import Migration0034 from "./Migrations/034_AuthAccessManagement.ts";
 import Migration0035 from "./Migrations/035_NormalizeLegacyModelSelectionOptions.ts";
 import Migration0036 from "./Migrations/036_ProjectionThreadsPinned.ts";
+import Migration0037 from "./Migrations/037_ProjectionSnapshotCapIndexes.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -97,6 +98,7 @@ export const migrationEntries = [
   [34, "AuthAccessManagement", Migration0034],
   [35, "NormalizeLegacyModelSelectionOptions", Migration0035],
   [36, "ProjectionThreadsPinned", Migration0036],
+  [37, "ProjectionSnapshotCapIndexes", Migration0037],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/037_ProjectionSnapshotCapIndexes.ts
+++ b/apps/server/src/persistence/Migrations/037_ProjectionSnapshotCapIndexes.ts
@@ -1,0 +1,22 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_thread_messages_thread_created_desc
+    ON projection_thread_messages(thread_id, created_at DESC, message_id DESC)
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_thread_activities_thread_rank_desc
+    ON projection_thread_activities(
+      thread_id,
+      (CASE WHEN sequence IS NULL THEN 0 ELSE 1 END) DESC,
+      sequence DESC,
+      created_at DESC,
+      activity_id DESC
+    )
+  `;
+});

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -398,19 +398,12 @@ export const makeWsRpcLayer = () =>
         [ORCHESTRATION_WS_METHODS.subscribeThread]: (input) =>
           Stream.merge(
             Stream.fromEffect(
-              Effect.all([
-                projectionReadModelQuery.getThreadDetailById(input.threadId),
-                orchestrationEngine
-                  .getReadModel()
-                  .pipe(Effect.map((model) => model.snapshotSequence)),
-              ]).pipe(
-                Effect.map(([thread, snapshotSequence]) =>
-                  Option.isSome(thread)
-                    ? Option.some({
-                        kind: "snapshot" as const,
-                        snapshot: { snapshotSequence, thread: thread.value },
-                      })
-                    : Option.none(),
+              projectionReadModelQuery.getThreadDetailSnapshotById(input.threadId).pipe(
+                Effect.map((snapshot) =>
+                  Option.map(snapshot, (value) => ({
+                    kind: "snapshot" as const,
+                    snapshot: value,
+                  })),
                 ),
                 Effect.mapError((cause) => toWsRpcError(cause, "Failed to load thread snapshot")),
               ),


### PR DESCRIPTION
## Summary
- Add projection indexes that match the capped message/activity snapshot reads introduced in PR 126.
- Use `getThreadDetailSnapshotById` for thread subscription bootstrap so subscribing to one thread no longer asks the orchestration engine for the full read model just to get `snapshotSequence`.

## Why
PR 126 bounds hydrated snapshots, but the new capped reads can still pay extra database work without indexes shaped for the latest-N access pattern. Thread subscriptions also had one remaining full read-model dependency in the initial snapshot path.

## Validation
- `bun run test src/orchestration/Layers/ProjectionSnapshotQuery.test.ts` from `apps/server`
- `bun typecheck`
- `bun lint` (0 errors; existing warnings remain)
- `git diff --check`
