### PR TITLE
Improve diff loading and startup hot paths

### DIFF
--- a/apps/server/integration/orchestrationEngine.integration.test.ts
+++ b/apps/server/integration/orchestrationEngine.integration.test.ts
@@ -501,6 +501,7 @@ it.live("runs multi-turn file edits and persists checkpoint diffs", () =>
         fromCheckpointRef: checkpointRefForThreadTurn(THREAD_ID, 1),
         toCheckpointRef: checkpointRefForThreadTurn(THREAD_ID, 2),
         fallbackFromToHead: false,
+        ignoreWhitespace: false,
       });
       assert.equal(incrementalDiff.includes("README.md"), true);
 
@@ -509,6 +510,7 @@ it.live("runs multi-turn file edits and persists checkpoint diffs", () =>
         fromCheckpointRef: checkpointRefForThreadTurn(THREAD_ID, 0),
         toCheckpointRef: checkpointRefForThreadTurn(THREAD_ID, 2),
         fallbackFromToHead: false,
+        ignoreWhitespace: false,
       });
       assert.equal(fullDiff.includes("README.md"), true);
 

--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
@@ -72,6 +72,7 @@ describe("CheckpointDiffQueryLive", () => {
       readonly fromCheckpointRef: CheckpointRef;
       readonly toCheckpointRef: CheckpointRef;
       readonly cwd: string;
+      readonly ignoreWhitespace: boolean;
     }> = [];
 
     const threadCheckpointContext = makeThreadCheckpointContext({
@@ -94,9 +95,9 @@ describe("CheckpointDiffQueryLive", () => {
           return true;
         }),
       restoreCheckpoint: () => Effect.succeed(true),
-      diffCheckpoints: ({ fromCheckpointRef, toCheckpointRef, cwd }) =>
+      diffCheckpoints: ({ fromCheckpointRef, toCheckpointRef, cwd, ignoreWhitespace }) =>
         Effect.sync(() => {
-          diffCheckpointsCalls.push({ fromCheckpointRef, toCheckpointRef, cwd });
+          diffCheckpointsCalls.push({ fromCheckpointRef, toCheckpointRef, cwd, ignoreWhitespace });
           return "diff patch";
         }),
       deleteCheckpointRefs: () => Effect.void,
@@ -107,7 +108,9 @@ describe("CheckpointDiffQueryLive", () => {
       Layer.provideMerge(
         Layer.succeed(ProjectionSnapshotQuery, {
           getSnapshot: () => Effect.die("unused"),
+          getCommandReadModel: () => Effect.die("unused"),
           getCounts: () => Effect.die("unused"),
+          getSnapshotSequence: () => Effect.die("unused"),
           getShellSnapshot: () => Effect.die("unused"),
           getActiveProjectByWorkspaceRoot: () => Effect.die("unused"),
           getProjectShellById: () => Effect.die("unused"),
@@ -115,6 +118,7 @@ describe("CheckpointDiffQueryLive", () => {
           getThreadCheckpointContext: () => Effect.succeed(Option.some(threadCheckpointContext)),
           getFullThreadDiffContext: () => Effect.die("unused"),
           getThreadShellById: () => Effect.die("unused"),
+          findSyntheticSubagentParentThread: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),
         }),
@@ -139,6 +143,7 @@ describe("CheckpointDiffQueryLive", () => {
         cwd: "/tmp/workspace",
         fromCheckpointRef: expectedFromRef,
         toCheckpointRef,
+        ignoreWhitespace: true,
       },
     ]);
     expect(result).toEqual({
@@ -157,6 +162,7 @@ describe("CheckpointDiffQueryLive", () => {
       readonly fromCheckpointRef: CheckpointRef;
       readonly toCheckpointRef: CheckpointRef;
       readonly cwd: string;
+      readonly ignoreWhitespace: boolean;
     }> = [];
 
     const fullThreadDiffContext = makeFullThreadDiffContext({
@@ -174,9 +180,9 @@ describe("CheckpointDiffQueryLive", () => {
       copyCheckpointRef: () => Effect.succeed(true),
       hasCheckpointRef: () => Effect.die("unused"),
       restoreCheckpoint: () => Effect.succeed(true),
-      diffCheckpoints: ({ fromCheckpointRef, toCheckpointRef, cwd }) =>
+      diffCheckpoints: ({ fromCheckpointRef, toCheckpointRef, cwd, ignoreWhitespace }) =>
         Effect.sync(() => {
-          diffCheckpointsCalls.push({ fromCheckpointRef, toCheckpointRef, cwd });
+          diffCheckpointsCalls.push({ fromCheckpointRef, toCheckpointRef, cwd, ignoreWhitespace });
           return "full diff patch";
         }),
       deleteCheckpointRefs: () => Effect.void,
@@ -187,7 +193,9 @@ describe("CheckpointDiffQueryLive", () => {
       Layer.provideMerge(
         Layer.succeed(ProjectionSnapshotQuery, {
           getSnapshot: () => Effect.die("unused"),
+          getCommandReadModel: () => Effect.die("unused"),
           getCounts: () => Effect.die("unused"),
+          getSnapshotSequence: () => Effect.die("unused"),
           getShellSnapshot: () => Effect.die("unused"),
           getActiveProjectByWorkspaceRoot: () => Effect.die("unused"),
           getProjectShellById: () => Effect.die("unused"),
@@ -195,6 +203,7 @@ describe("CheckpointDiffQueryLive", () => {
           getThreadCheckpointContext: () => Effect.die("unused"),
           getFullThreadDiffContext: () => Effect.succeed(Option.some(fullThreadDiffContext)),
           getThreadShellById: () => Effect.die("unused"),
+          findSyntheticSubagentParentThread: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),
         }),
@@ -216,6 +225,7 @@ describe("CheckpointDiffQueryLive", () => {
         cwd: "/tmp/workspace",
         fromCheckpointRef: checkpointRefForThreadTurn(threadId, 0),
         toCheckpointRef,
+        ignoreWhitespace: true,
       },
     ]);
     expect(result).toEqual({
@@ -244,7 +254,9 @@ describe("CheckpointDiffQueryLive", () => {
       Layer.provideMerge(
         Layer.succeed(ProjectionSnapshotQuery, {
           getSnapshot: () => Effect.die("unused"),
+          getCommandReadModel: () => Effect.die("unused"),
           getCounts: () => Effect.die("unused"),
+          getSnapshotSequence: () => Effect.die("unused"),
           getShellSnapshot: () => Effect.die("unused"),
           getActiveProjectByWorkspaceRoot: () => Effect.die("unused"),
           getProjectShellById: () => Effect.die("unused"),
@@ -252,6 +264,7 @@ describe("CheckpointDiffQueryLive", () => {
           getThreadCheckpointContext: () => Effect.succeed(Option.none()),
           getFullThreadDiffContext: () => Effect.die("unused"),
           getThreadShellById: () => Effect.die("unused"),
+          findSyntheticSubagentParentThread: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),
         }),
@@ -302,7 +315,9 @@ describe("CheckpointDiffQueryLive", () => {
       Layer.provideMerge(
         Layer.succeed(ProjectionSnapshotQuery, {
           getSnapshot: () => Effect.die("unused"),
+          getCommandReadModel: () => Effect.die("unused"),
           getCounts: () => Effect.die("unused"),
+          getSnapshotSequence: () => Effect.die("unused"),
           getShellSnapshot: () => Effect.die("unused"),
           getActiveProjectByWorkspaceRoot: () => Effect.die("unused"),
           getProjectShellById: () => Effect.die("unused"),
@@ -310,6 +325,7 @@ describe("CheckpointDiffQueryLive", () => {
           getThreadCheckpointContext: () => Effect.succeed(Option.some(threadCheckpointContext)),
           getFullThreadDiffContext: () => Effect.die("unused"),
           getThreadShellById: () => Effect.die("unused"),
+          findSyntheticSubagentParentThread: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),
         }),
@@ -361,7 +377,9 @@ describe("CheckpointDiffQueryLive", () => {
       Layer.provideMerge(
         Layer.succeed(ProjectionSnapshotQuery, {
           getSnapshot: () => Effect.die("unused"),
+          getCommandReadModel: () => Effect.die("unused"),
           getCounts: () => Effect.die("unused"),
+          getSnapshotSequence: () => Effect.die("unused"),
           getShellSnapshot: () => Effect.die("unused"),
           getActiveProjectByWorkspaceRoot: () => Effect.die("unused"),
           getProjectShellById: () => Effect.die("unused"),
@@ -369,6 +387,7 @@ describe("CheckpointDiffQueryLive", () => {
           getThreadCheckpointContext: () => Effect.succeed(Option.some(threadCheckpointContext)),
           getFullThreadDiffContext: () => Effect.die("unused"),
           getThreadShellById: () => Effect.die("unused"),
+          findSyntheticSubagentParentThread: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),
         }),

--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   ProjectionSnapshotQuery,
+  type ProjectionFullThreadDiffContext,
   type ProjectionThreadCheckpointContext,
 } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { checkpointRefForThreadTurn, checkpointRefForThreadTurnStart } from "../Utils.ts";
@@ -38,6 +39,26 @@ function makeThreadCheckpointContext(input: {
         completedAt: "2026-01-01T00:00:00.000Z",
       },
     ],
+  };
+}
+
+function makeFullThreadDiffContext(input: {
+  readonly projectId: ProjectId;
+  readonly threadId: ThreadId;
+  readonly workspaceRoot: string;
+  readonly envMode?: "local" | "worktree";
+  readonly worktreePath: string | null;
+  readonly latestCheckpointTurnCount: number;
+  readonly toCheckpointRef: CheckpointRef | null;
+}): ProjectionFullThreadDiffContext {
+  return {
+    threadId: input.threadId,
+    projectId: input.projectId,
+    workspaceRoot: input.workspaceRoot,
+    envMode: input.envMode ?? "local",
+    worktreePath: input.worktreePath,
+    latestCheckpointTurnCount: input.latestCheckpointTurnCount,
+    toCheckpointRef: input.toCheckpointRef,
   };
 }
 
@@ -92,6 +113,7 @@ describe("CheckpointDiffQueryLive", () => {
           getProjectShellById: () => Effect.die("unused"),
           getFirstActiveThreadIdByProjectId: () => Effect.die("unused"),
           getThreadCheckpointContext: () => Effect.succeed(Option.some(threadCheckpointContext)),
+          getFullThreadDiffContext: () => Effect.die("unused"),
           getThreadShellById: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),
@@ -111,7 +133,7 @@ describe("CheckpointDiffQueryLive", () => {
     );
 
     const expectedFromRef = checkpointRefForThreadTurnStart(threadId, TurnId.makeUnsafe("turn-1"));
-    expect(hasCheckpointRefCalls).toEqual([expectedFromRef, expectedFromRef, toCheckpointRef]);
+    expect(hasCheckpointRefCalls).toEqual([expectedFromRef]);
     expect(diffCheckpointsCalls).toEqual([
       {
         cwd: "/tmp/workspace",
@@ -124,6 +146,83 @@ describe("CheckpointDiffQueryLive", () => {
       fromTurnCount: 0,
       toTurnCount: 1,
       diff: "diff patch",
+    });
+  });
+
+  it("uses the narrow full-thread diff context without loading checkpoint summaries", async () => {
+    const projectId = ProjectId.makeUnsafe("project-full-diff");
+    const threadId = ThreadId.makeUnsafe("thread-full-diff");
+    const toCheckpointRef = checkpointRefForThreadTurn(threadId, 2);
+    const diffCheckpointsCalls: Array<{
+      readonly fromCheckpointRef: CheckpointRef;
+      readonly toCheckpointRef: CheckpointRef;
+      readonly cwd: string;
+    }> = [];
+
+    const fullThreadDiffContext = makeFullThreadDiffContext({
+      projectId,
+      threadId,
+      workspaceRoot: "/tmp/workspace",
+      worktreePath: null,
+      latestCheckpointTurnCount: 2,
+      toCheckpointRef,
+    });
+
+    const checkpointStore: CheckpointStoreShape = {
+      isGitRepository: () => Effect.succeed(true),
+      captureCheckpoint: () => Effect.void,
+      copyCheckpointRef: () => Effect.succeed(true),
+      hasCheckpointRef: () => Effect.die("unused"),
+      restoreCheckpoint: () => Effect.succeed(true),
+      diffCheckpoints: ({ fromCheckpointRef, toCheckpointRef, cwd }) =>
+        Effect.sync(() => {
+          diffCheckpointsCalls.push({ fromCheckpointRef, toCheckpointRef, cwd });
+          return "full diff patch";
+        }),
+      deleteCheckpointRefs: () => Effect.void,
+    };
+
+    const layer = CheckpointDiffQueryLive.pipe(
+      Layer.provideMerge(Layer.succeed(CheckpointStore, checkpointStore)),
+      Layer.provideMerge(
+        Layer.succeed(ProjectionSnapshotQuery, {
+          getSnapshot: () => Effect.die("unused"),
+          getCounts: () => Effect.die("unused"),
+          getShellSnapshot: () => Effect.die("unused"),
+          getActiveProjectByWorkspaceRoot: () => Effect.die("unused"),
+          getProjectShellById: () => Effect.die("unused"),
+          getFirstActiveThreadIdByProjectId: () => Effect.die("unused"),
+          getThreadCheckpointContext: () => Effect.die("unused"),
+          getFullThreadDiffContext: () => Effect.succeed(Option.some(fullThreadDiffContext)),
+          getThreadShellById: () => Effect.die("unused"),
+          getThreadDetailById: () => Effect.die("unused"),
+          getThreadDetailSnapshotById: () => Effect.die("unused"),
+        }),
+      ),
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const query = yield* CheckpointDiffQuery;
+        return yield* query.getFullThreadDiff({
+          threadId,
+          toTurnCount: 2,
+        });
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(diffCheckpointsCalls).toEqual([
+      {
+        cwd: "/tmp/workspace",
+        fromCheckpointRef: checkpointRefForThreadTurn(threadId, 0),
+        toCheckpointRef,
+      },
+    ]);
+    expect(result).toEqual({
+      threadId,
+      fromTurnCount: 0,
+      toTurnCount: 2,
+      diff: "full diff patch",
     });
   });
 
@@ -151,6 +250,7 @@ describe("CheckpointDiffQueryLive", () => {
           getProjectShellById: () => Effect.die("unused"),
           getFirstActiveThreadIdByProjectId: () => Effect.die("unused"),
           getThreadCheckpointContext: () => Effect.succeed(Option.none()),
+          getFullThreadDiffContext: () => Effect.die("unused"),
           getThreadShellById: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),
@@ -208,6 +308,7 @@ describe("CheckpointDiffQueryLive", () => {
           getProjectShellById: () => Effect.die("unused"),
           getFirstActiveThreadIdByProjectId: () => Effect.die("unused"),
           getThreadCheckpointContext: () => Effect.succeed(Option.some(threadCheckpointContext)),
+          getFullThreadDiffContext: () => Effect.die("unused"),
           getThreadShellById: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),
@@ -266,6 +367,7 @@ describe("CheckpointDiffQueryLive", () => {
           getProjectShellById: () => Effect.die("unused"),
           getFirstActiveThreadIdByProjectId: () => Effect.die("unused"),
           getThreadCheckpointContext: () => Effect.succeed(Option.some(threadCheckpointContext)),
+          getFullThreadDiffContext: () => Effect.die("unused"),
           getThreadShellById: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),

--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
@@ -21,6 +21,20 @@ import {
 
 const isTurnDiffResult = Schema.is(OrchestrationGetTurnDiffResult);
 
+function buildTurnDiffResult(input: {
+  readonly threadId: OrchestrationGetTurnDiffResultType["threadId"];
+  readonly fromTurnCount: number;
+  readonly toTurnCount: number;
+  readonly diff: string;
+}): OrchestrationGetTurnDiffResultType {
+  return {
+    threadId: input.threadId,
+    fromTurnCount: input.fromTurnCount,
+    toTurnCount: input.toTurnCount,
+    diff: input.diff,
+  };
+}
+
 const make = Effect.gen(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const checkpointStore = yield* CheckpointStore;
@@ -146,36 +160,6 @@ const make = Effect.gen(function* () {
         }
       }
 
-      const [fromExists, toExists] = yield* Effect.all(
-        [
-          checkpointStore.hasCheckpointRef({
-            cwd: workspaceCwd,
-            checkpointRef: fromCheckpointRef,
-          }),
-          checkpointStore.hasCheckpointRef({
-            cwd: workspaceCwd,
-            checkpointRef: toCheckpointRef,
-          }),
-        ],
-        { concurrency: "unbounded" },
-      );
-
-      if (!fromExists) {
-        return yield* new CheckpointUnavailableError({
-          threadId: input.threadId,
-          turnCount: input.fromTurnCount,
-          detail: `Filesystem checkpoint is unavailable for turn ${input.fromTurnCount}.`,
-        });
-      }
-
-      if (!toExists) {
-        return yield* new CheckpointUnavailableError({
-          threadId: input.threadId,
-          turnCount: input.toTurnCount,
-          detail: `Filesystem checkpoint is unavailable for turn ${input.toTurnCount}.`,
-        });
-      }
-
       const diff = yield* checkpointStore.diffCheckpoints({
         cwd: workspaceCwd,
         fromCheckpointRef,
@@ -183,12 +167,12 @@ const make = Effect.gen(function* () {
         fallbackFromToHead: false,
       });
 
-      const turnDiff: OrchestrationGetTurnDiffResultType = {
+      const turnDiff = buildTurnDiffResult({
         threadId: input.threadId,
         fromTurnCount: input.fromTurnCount,
         toTurnCount: input.toTurnCount,
         diff,
-      };
+      });
       if (!isTurnDiffResult(turnDiff)) {
         return yield* new CheckpointInvariantError({
           operation,
@@ -202,11 +186,94 @@ const make = Effect.gen(function* () {
   const getFullThreadDiff: CheckpointDiffQueryShape["getFullThreadDiff"] = (
     input: OrchestrationGetFullThreadDiffInput,
   ) =>
-    getTurnDiff({
-      threadId: input.threadId,
-      fromTurnCount: 0,
-      toTurnCount: input.toTurnCount,
-    }).pipe(Effect.map((result): OrchestrationGetFullThreadDiffResult => result));
+    Effect.gen(function* () {
+      const operation = "CheckpointDiffQuery.getFullThreadDiff";
+
+      if (input.toTurnCount === 0) {
+        const emptyDiff = buildTurnDiffResult({
+          threadId: input.threadId,
+          fromTurnCount: 0,
+          toTurnCount: 0,
+          diff: "",
+        });
+        if (!isTurnDiffResult(emptyDiff)) {
+          return yield* new CheckpointInvariantError({
+            operation,
+            detail: "Computed full thread diff result does not satisfy contract schema.",
+          });
+        }
+        return emptyDiff satisfies OrchestrationGetFullThreadDiffResult;
+      }
+
+      const threadContext = yield* projectionSnapshotQuery.getFullThreadDiffContext(
+        input.threadId,
+        input.toTurnCount,
+      );
+      if (Option.isNone(threadContext)) {
+        return yield* new CheckpointInvariantError({
+          operation,
+          detail: `Thread '${input.threadId}' not found.`,
+        });
+      }
+
+      if (input.toTurnCount > threadContext.value.latestCheckpointTurnCount) {
+        return yield* new CheckpointUnavailableError({
+          threadId: input.threadId,
+          turnCount: input.toTurnCount,
+          detail: `Turn diff range exceeds current turn count: requested ${input.toTurnCount}, current ${threadContext.value.latestCheckpointTurnCount}.`,
+        });
+      }
+
+      const workspaceCwd = resolveThreadWorkspaceCwd({
+        thread: {
+          projectId: threadContext.value.projectId,
+          envMode: threadContext.value.envMode,
+          worktreePath: threadContext.value.worktreePath,
+        },
+        projects: [
+          {
+            id: threadContext.value.projectId,
+            workspaceRoot: threadContext.value.workspaceRoot,
+          },
+        ],
+      });
+      if (!workspaceCwd) {
+        return yield* new CheckpointInvariantError({
+          operation,
+          detail: `Workspace path missing for thread '${input.threadId}' when computing full thread diff.`,
+        });
+      }
+
+      if (!threadContext.value.toCheckpointRef) {
+        return yield* new CheckpointUnavailableError({
+          threadId: input.threadId,
+          turnCount: input.toTurnCount,
+          detail: `Checkpoint ref is unavailable for turn ${input.toTurnCount}.`,
+        });
+      }
+
+      const diff = yield* checkpointStore.diffCheckpoints({
+        cwd: workspaceCwd,
+        fromCheckpointRef: checkpointRefForThreadTurn(input.threadId, 0),
+        toCheckpointRef: threadContext.value.toCheckpointRef,
+        fallbackFromToHead: false,
+      });
+
+      const fullThreadDiff = buildTurnDiffResult({
+        threadId: input.threadId,
+        fromTurnCount: 0,
+        toTurnCount: input.toTurnCount,
+        diff,
+      });
+      if (!isTurnDiffResult(fullThreadDiff)) {
+        return yield* new CheckpointInvariantError({
+          operation,
+          detail: "Computed full thread diff result does not satisfy contract schema.",
+        });
+      }
+
+      return fullThreadDiff satisfies OrchestrationGetFullThreadDiffResult;
+    });
 
   return {
     getTurnDiff,

--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
@@ -42,6 +42,7 @@ const make = Effect.gen(function* () {
   const getTurnDiff: CheckpointDiffQueryShape["getTurnDiff"] = (input) =>
     Effect.gen(function* () {
       const operation = "CheckpointDiffQuery.getTurnDiff";
+      const ignoreWhitespace = input.ignoreWhitespace ?? true;
 
       if (input.fromTurnCount === input.toTurnCount) {
         const emptyDiff: OrchestrationGetTurnDiffResultType = {
@@ -165,6 +166,7 @@ const make = Effect.gen(function* () {
         fromCheckpointRef,
         toCheckpointRef,
         fallbackFromToHead: false,
+        ignoreWhitespace,
       });
 
       const turnDiff = buildTurnDiffResult({
@@ -188,6 +190,7 @@ const make = Effect.gen(function* () {
   ) =>
     Effect.gen(function* () {
       const operation = "CheckpointDiffQuery.getFullThreadDiff";
+      const ignoreWhitespace = input.ignoreWhitespace ?? true;
 
       if (input.toTurnCount === 0) {
         const emptyDiff = buildTurnDiffResult({
@@ -257,6 +260,7 @@ const make = Effect.gen(function* () {
         fromCheckpointRef: checkpointRefForThreadTurn(input.threadId, 0),
         toCheckpointRef: threadContext.value.toCheckpointRef,
         fallbackFromToHead: false,
+        ignoreWhitespace,
       });
 
       const fullThreadDiff = buildTurnDiffResult({

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -19,6 +19,8 @@ import { GitCore } from "../../git/Services/GitCore.ts";
 import { CheckpointStore, type CheckpointStoreShape } from "../Services/CheckpointStore.ts";
 import { CheckpointRef } from "@t3tools/contracts";
 
+const CHECKPOINT_DIFF_MAX_OUTPUT_BYTES = 10_000_000;
+
 const makeCheckpointStore = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -259,7 +261,18 @@ const makeCheckpointStore = Effect.gen(function* () {
       const result = yield* git.execute({
         operation,
         cwd: input.cwd,
-        args: ["diff", "--patch", "--minimal", "--no-color", fromCommitOid, toCommitOid],
+        args: [
+          "diff",
+          "--patch",
+          "--minimal",
+          "--no-color",
+          "--no-ext-diff",
+          "--no-textconv",
+          ...(input.ignoreWhitespace ? ["--ignore-all-space"] : []),
+          fromCommitOid,
+          toCommitOid,
+        ],
+        maxOutputBytes: input.maxOutputBytes ?? CHECKPOINT_DIFF_MAX_OUTPUT_BYTES,
       });
 
       return result.stdout;

--- a/apps/server/src/checkpointing/Services/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Services/CheckpointStore.ts
@@ -38,6 +38,8 @@ export interface DiffCheckpointsInput {
   readonly fromCheckpointRef: CheckpointRef;
   readonly toCheckpointRef: CheckpointRef;
   readonly fallbackFromToHead?: boolean;
+  readonly ignoreWhitespace: boolean;
+  readonly maxOutputBytes?: number;
 }
 
 export interface DeleteCheckpointRefsInput {

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -278,6 +278,7 @@ it.layer(testLayer)("server CLI command", (it) => {
           getProjectShellById: () => Effect.die("unused"),
           getFirstActiveThreadIdByProjectId: () => Effect.die("unused"),
           getThreadCheckpointContext: () => Effect.die("unused"),
+          getFullThreadDiffContext: () => Effect.die("unused"),
           getThreadShellById: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -280,6 +280,7 @@ it.layer(testLayer)("server CLI command", (it) => {
           getThreadCheckpointContext: () => Effect.die("unused"),
           getFullThreadDiffContext: () => Effect.die("unused"),
           getThreadShellById: () => Effect.die("unused"),
+          findSyntheticSubagentParentThread: () => Effect.die("unused"),
           getThreadDetailById: () => Effect.die("unused"),
           getThreadDetailSnapshotById: () => Effect.die("unused"),
         }),

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -292,9 +292,10 @@ const makeServerProgram = (input: CliInput) =>
 
     yield* start;
     const orchestrationEngine = yield* OrchestrationEngineService;
+    const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
     // Start the retention loop after the server is live so startup can serve
     // existing history first, then prune inactive threads in the background.
-    yield* startThreadRetentionJob(orchestrationEngine);
+    yield* startThreadRetentionJob(orchestrationEngine, projectionSnapshotQuery);
     yield* Effect.forkChild(recordStartupHeartbeat);
 
     const localUrl = `http://localhost:${config.port}`;

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -23,6 +23,7 @@ import { GitCoreLive } from "../../git/Layers/GitCore.ts";
 import { CheckpointReactorLive } from "./CheckpointReactor.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import { RuntimeReceiptBusLive } from "./RuntimeReceiptBus.ts";
 import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
 import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
@@ -266,9 +267,9 @@ describe("CheckpointReactor", () => {
     );
     const orchestrationLayer = OrchestrationEngineLive.pipe(
       Layer.provide(OrchestrationProjectionPipelineLive),
+      Layer.provide(OrchestrationProjectionSnapshotQueryLive),
       Layer.provide(OrchestrationEventStoreLive),
       Layer.provide(OrchestrationCommandReceiptRepositoryLive),
-      Layer.provide(SqlitePersistenceMemory),
     );
 
     const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
@@ -277,6 +278,7 @@ describe("CheckpointReactor", () => {
 
     const layer = CheckpointReactorLive.pipe(
       Layer.provideMerge(orchestrationLayer),
+      Layer.provideMerge(OrchestrationProjectionSnapshotQueryLive),
       Layer.provideMerge(RuntimeReceiptBusLive),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
       Layer.provideMerge(CheckpointStoreLive.pipe(Layer.provide(GitCoreLive))),

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -6,6 +6,8 @@ import {
   ThreadId,
   TurnId,
   type OrchestrationEvent,
+  type OrchestrationProjectShell,
+  type OrchestrationThread,
   type ProviderRuntimeEvent,
 } from "@t3tools/contracts";
 import { Cause, Effect, Layer, Option, Stream } from "effect";
@@ -25,6 +27,7 @@ import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/Projectio
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { CheckpointReactor, type CheckpointReactorShape } from "../Services/CheckpointReactor.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import { RuntimeReceiptBus } from "../Services/RuntimeReceiptBus.ts";
 import { CheckpointStoreError } from "../../checkpointing/Errors.ts";
 import { OrchestrationDispatchError } from "../Errors.ts";
@@ -98,6 +101,7 @@ const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const providerService = yield* ProviderService;
   const checkpointStore = yield* CheckpointStore;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const projectionTurnRepository = yield* ProjectionTurnRepository;
   const receiptBus = yield* RuntimeReceiptBus;
   const pendingMessageStartByThread = new Map<ThreadId, MessageId>();
@@ -109,8 +113,8 @@ const make = Effect.gen(function* () {
     readonly turnId: TurnId;
     readonly assistantMessageId: MessageId | undefined;
   }) {
-    const currentReadModel = yield* orchestrationEngine.getReadModel();
-    const currentThread = currentReadModel.threads.find((entry) => entry.id === input.threadId);
+    const currentThreadOption = yield* projectionSnapshotQuery.getThreadDetailById(input.threadId);
+    const currentThread = Option.getOrUndefined(currentThreadOption);
     const knownInputAssistantMessageId = resolveExistingAssistantMessageIdForTurn(
       currentThread,
       input.turnId,
@@ -121,8 +125,8 @@ const make = Effect.gen(function* () {
     }
 
     for (let attempt = 0; attempt < ASSISTANT_MESSAGE_ID_RETRY_ATTEMPTS; attempt += 1) {
-      const readModel = yield* orchestrationEngine.getReadModel();
-      const thread = readModel.threads.find((entry) => entry.id === input.threadId);
+      const threadOption = yield* projectionSnapshotQuery.getThreadDetailById(input.threadId);
+      const thread = Option.getOrUndefined(threadOption);
       const candidateAssistantMessageId =
         resolveExistingAssistantMessageIdForTurn(
           thread,
@@ -203,8 +207,10 @@ const make = Effect.gen(function* () {
   const resolveSessionRuntimeForThread = Effect.fnUntraced(function* (
     threadId: ThreadId,
   ): Effect.fn.Return<Option.Option<{ readonly threadId: ThreadId; readonly cwd: string }>> {
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === threadId);
+    const thread = yield* projectionSnapshotQuery.getThreadShellById(threadId);
+    if (Option.isNone(thread)) {
+      return Option.none();
+    }
 
     const sessions = yield* providerService.listSessions();
 
@@ -217,12 +223,10 @@ const make = Effect.gen(function* () {
       return Option.some({ threadId: session.threadId, cwd: session.cwd });
     };
 
-    if (thread) {
-      const projectedSession = sessions.find((session) => session.threadId === thread.id);
-      const fromProjected = findSessionWithCwd(projectedSession);
-      if (Option.isSome(fromProjected)) {
-        return fromProjected;
-      }
+    const projectedSession = sessions.find((session) => session.threadId === thread.value.id);
+    const fromProjected = findSessionWithCwd(projectedSession);
+    if (Option.isSome(fromProjected)) {
+      return fromProjected;
     }
 
     return Option.none();
@@ -230,20 +234,32 @@ const make = Effect.gen(function* () {
 
   const isGitWorkspace = (cwd: string) => isGitRepository(cwd);
 
+  const getThreadDetail = Effect.fnUntraced(function* (
+    threadId: ThreadId,
+  ): Effect.fn.Return<OrchestrationThread | undefined> {
+    return Option.getOrUndefined(yield* projectionSnapshotQuery.getThreadDetailById(threadId));
+  });
+
+  const getProjectShell = Effect.fnUntraced(function* (
+    projectId: ProjectId,
+  ): Effect.fn.Return<OrchestrationProjectShell | undefined> {
+    return Option.getOrUndefined(yield* projectionSnapshotQuery.getProjectShellById(projectId));
+  });
+
   // Resolves the workspace CWD for checkpoint operations, preferring the
   // active provider session CWD and falling back to the thread/project config.
   // Returns undefined when no CWD can be determined or the workspace is not
   // a git repository.
   const resolveCheckpointCwd = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
-    readonly thread: { readonly projectId: ProjectId; readonly worktreePath: string | null };
-    readonly projects: ReadonlyArray<{ readonly id: ProjectId; readonly workspaceRoot: string }>;
+    readonly thread: Pick<OrchestrationThread, "projectId" | "envMode" | "worktreePath">;
+    readonly project: OrchestrationProjectShell;
     readonly preferSessionRuntime: boolean;
   }): Effect.fn.Return<string | undefined> {
     const fromSession = yield* resolveSessionRuntimeForThread(input.threadId);
     const fromThread = resolveThreadWorkspaceCwd({
       thread: input.thread,
-      projects: input.projects,
+      projects: [input.project],
     });
 
     const cwd = input.preferSessionRuntime
@@ -318,6 +334,7 @@ const make = Effect.gen(function* () {
             fromCheckpointRef,
             toCheckpointRef: targetCheckpointRef,
             fallbackFromToHead: false,
+            ignoreWhitespace: false,
           })
           .pipe(
             Effect.map((diff) =>
@@ -449,9 +466,12 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === event.threadId);
+    const thread = yield* getThreadDetail(event.threadId);
     if (!thread) {
+      return;
+    }
+    const project = yield* getProjectShell(thread.projectId);
+    if (!project) {
       return;
     }
 
@@ -474,7 +494,7 @@ const make = Effect.gen(function* () {
     const checkpointCwd = yield* resolveCheckpointCwd({
       threadId: thread.id,
       thread,
-      projects: readModel.projects,
+      project,
       preferSessionRuntime: true,
     });
     if (!checkpointCwd) {
@@ -533,16 +553,19 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === event.threadId);
+    const thread = yield* getThreadDetail(event.threadId);
     if (!thread) {
+      return;
+    }
+    const project = yield* getProjectShell(thread.projectId);
+    if (!project) {
       return;
     }
 
     const checkpointCwd = yield* resolveCheckpointCwd({
       threadId: thread.id,
       thread,
-      projects: readModel.projects,
+      project,
       preferSessionRuntime: false,
     });
     if (!checkpointCwd) {
@@ -618,16 +641,19 @@ const make = Effect.gen(function* () {
     }
 
     const threadId = event.payload.threadId;
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === threadId);
+    const thread = yield* getThreadDetail(threadId);
     if (!thread) {
+      return;
+    }
+    const project = yield* getProjectShell(thread.projectId);
+    if (!project) {
       return;
     }
 
     const checkpointCwd = yield* resolveCheckpointCwd({
       threadId,
       thread,
-      projects: readModel.projects,
+      project,
       preferSessionRuntime: false,
     });
     if (!checkpointCwd) {
@@ -671,13 +697,12 @@ const make = Effect.gen(function* () {
   ) {
     const now = new Date().toISOString();
 
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === event.payload.threadId);
+    const thread = yield* getThreadDetail(event.payload.threadId);
     if (!thread) {
       yield* appendRevertFailureActivity({
         threadId: event.payload.threadId,
         turnCount: event.payload.turnCount,
-        detail: "Thread was not found in read model.",
+        detail: "Thread was not found in projection state.",
         createdAt: now,
       }).pipe(Effect.catch(() => Effect.void));
       return;

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../../persistence/Services/OrchestrationEventStore.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import {
   OrchestrationProjectionPipeline,
@@ -40,6 +41,7 @@ async function createOrchestrationSystem() {
   });
   const orchestrationLayer = OrchestrationEngineLive.pipe(
     Layer.provide(OrchestrationProjectionPipelineLive),
+    Layer.provide(OrchestrationProjectionSnapshotQueryLive),
     Layer.provide(OrchestrationEventStoreLive),
     Layer.provide(OrchestrationCommandReceiptRepositoryLive),
     Layer.provide(SqlitePersistenceMemory),
@@ -351,6 +353,7 @@ describe("OrchestrationEngine", () => {
     const runtime = ManagedRuntime.make(
       OrchestrationEngineLive.pipe(
         Layer.provide(OrchestrationProjectionPipelineLive),
+        Layer.provide(OrchestrationProjectionSnapshotQueryLive),
         Layer.provide(Layer.succeed(OrchestrationEventStore, flakyStore)),
         Layer.provide(OrchestrationCommandReceiptRepositoryLive),
         Layer.provide(SqlitePersistenceMemory),
@@ -449,6 +452,7 @@ describe("OrchestrationEngine", () => {
     const runtime = ManagedRuntime.make(
       OrchestrationEngineLive.pipe(
         Layer.provide(Layer.succeed(OrchestrationProjectionPipeline, flakyProjectionPipeline)),
+        Layer.provide(OrchestrationProjectionSnapshotQueryLive),
         Layer.provide(OrchestrationEventStoreLive),
         Layer.provide(OrchestrationCommandReceiptRepositoryLive),
         Layer.provide(SqlitePersistenceMemory),
@@ -588,6 +592,7 @@ describe("OrchestrationEngine", () => {
     const runtime = ManagedRuntime.make(
       OrchestrationEngineLive.pipe(
         Layer.provide(Layer.succeed(OrchestrationProjectionPipeline, defectiveProjectionPipeline)),
+        Layer.provide(OrchestrationProjectionSnapshotQueryLive),
         Layer.provide(Layer.succeed(OrchestrationEventStore, nonTransactionalStore)),
         Layer.provide(OrchestrationCommandReceiptRepositoryLive),
         Layer.provide(SqlitePersistenceMemory),
@@ -700,6 +705,7 @@ describe("OrchestrationEngine", () => {
     const runtime = ManagedRuntime.make(
       OrchestrationEngineLive.pipe(
         Layer.provide(Layer.succeed(OrchestrationProjectionPipeline, flakyProjectionPipeline)),
+        Layer.provide(OrchestrationProjectionSnapshotQueryLive),
         Layer.provide(Layer.succeed(OrchestrationEventStore, nonTransactionalStore)),
         Layer.provide(OrchestrationCommandReceiptRepositoryLive),
         Layer.provide(SqlitePersistenceMemory),
@@ -823,6 +829,7 @@ describe("OrchestrationEngine", () => {
     const runtime = ManagedRuntime.make(
       OrchestrationEngineLive.pipe(
         Layer.provide(Layer.succeed(OrchestrationProjectionPipeline, flakyProjectionPipeline)),
+        Layer.provide(OrchestrationProjectionSnapshotQueryLive),
         Layer.provide(OrchestrationEventStoreLive),
         Layer.provide(OrchestrationCommandReceiptRepositoryLive),
         Layer.provide(SqlitePersistenceMemory),

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -22,7 +22,6 @@ import {
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { toPersistenceSqlError } from "../../persistence/Errors.ts";
-import { normalizePersistedModelSelection } from "../../persistence/modelSelectionCompatibility.ts";
 import { OrchestrationEventStore } from "../../persistence/Services/OrchestrationEventStore.ts";
 import { OrchestrationCommandReceiptRepository } from "../../persistence/Services/OrchestrationCommandReceipts.ts";
 import {
@@ -37,6 +36,7 @@ import type { ProjectMetadataOrchestrationEvent } from "../projectMetadataProjec
 import { PROJECT_METADATA_SNAPSHOT_PROJECTORS } from "../projectMetadataProjection.ts";
 import { createEmptyReadModel, projectEvent } from "../projector.ts";
 import { OrchestrationProjectionPipeline } from "../Services/ProjectionPipeline.ts";
+import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import {
   OrchestrationEngineService,
   type OrchestrationEngineShape,
@@ -57,7 +57,7 @@ interface CommandEnvelope {
 type CommittedCommandResult = {
   readonly committedEvents: OrchestrationEvent[];
   readonly lastSequence: number;
-  readonly nextReadModel: OrchestrationReadModel;
+  readonly nextCommandReadModel: OrchestrationReadModel;
 };
 
 function commandToAggregateRef(command: OrchestrationCommand): {
@@ -95,8 +95,9 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   const eventStore = yield* OrchestrationEventStore;
   const commandReceiptRepository = yield* OrchestrationCommandReceiptRepository;
   const projectionPipeline = yield* OrchestrationProjectionPipeline;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
 
-  let readModel = createEmptyReadModel(new Date().toISOString());
+  let commandReadModel = createEmptyReadModel(new Date().toISOString());
 
   const commandQueue = yield* Queue.unbounded<CommandEnvelope>();
   const eventPubSub = yield* PubSub.unbounded<OrchestrationEvent>();
@@ -193,93 +194,15 @@ const makeOrchestrationEngine = Effect.gen(function* () {
       .pipe(Effect.forkIn(deferredProjectionScope), Effect.asVoid);
   });
 
-  const refreshReadModelFromProjectionState = Effect.gen(function* () {
-    const projectRows = yield* sql<{
-      readonly projectId: string;
-      readonly kind: "project" | "chat";
-      readonly title: string;
-      readonly workspaceRoot: string;
-      readonly defaultModelSelectionJson: string | null;
-      readonly scriptsJson: string;
-      readonly createdAt: string;
-      readonly updatedAt: string;
-      readonly deletedAt: string | null;
-    }>`
-        SELECT
-          project_id AS "projectId",
-          kind,
-          title,
-          workspace_root AS "workspaceRoot",
-          default_model_selection_json AS "defaultModelSelectionJson",
-          scripts_json AS "scriptsJson",
-          created_at AS "createdAt",
-          updated_at AS "updatedAt",
-          deleted_at AS "deletedAt"
-        FROM projection_projects
-        ORDER BY created_at ASC, project_id ASC
-      `;
-
-    const stateRows = yield* sql<{
-      readonly projector: string;
-      readonly lastAppliedSequence: number;
-    }>`
-        SELECT
-          projector,
-          last_applied_sequence AS "lastAppliedSequence"
-        FROM projection_state
-      `;
-
-    const sequenceByProjector = new Map(
-      stateRows.map((row) => [row.projector, row.lastAppliedSequence] as const),
-    );
-
-    let snapshotSequence = 0;
-    let minSequence = Number.POSITIVE_INFINITY;
-    for (const projector of PROJECT_METADATA_SNAPSHOT_PROJECTORS) {
-      const sequence = sequenceByProjector.get(projector);
-      if (sequence === undefined) {
-        minSequence = Number.POSITIVE_INFINITY;
-        break;
-      }
-      if (sequence < minSequence) {
-        minSequence = sequence;
-      }
-    }
-    if (Number.isFinite(minSequence)) {
-      snapshotSequence = minSequence;
-    }
-
-    const nextReadModel: OrchestrationReadModel = {
-      ...readModel,
-      snapshotSequence,
-      projects: projectRows.map((row) => ({
-        id: row.projectId as ProjectId,
-        kind: row.kind,
-        title: row.title,
-        workspaceRoot: row.workspaceRoot,
-        defaultModelSelection:
-          row.defaultModelSelectionJson === null
-            ? null
-            : (normalizePersistedModelSelection(JSON.parse(row.defaultModelSelectionJson)) as
-                | OrchestrationReadModel["projects"][number]["defaultModelSelection"]
-                | null),
-        scripts: JSON.parse(
-          row.scriptsJson,
-        ) as OrchestrationReadModel["projects"][number]["scripts"],
-        createdAt: row.createdAt,
-        updatedAt: row.updatedAt,
-        deletedAt: row.deletedAt,
-      })),
-      updatedAt: new Date().toISOString(),
-    };
-
-    readModel = nextReadModel;
-    return nextReadModel;
+  const refreshCommandReadModelFromProjectionState = Effect.gen(function* () {
+    const nextCommandReadModel = yield* projectionSnapshotQuery.getCommandReadModel();
+    commandReadModel = nextCommandReadModel;
+    return nextCommandReadModel;
   }).pipe(
-    Effect.catchTag("SqlError", (sqlError) =>
+    Effect.catchCause((cause) =>
       Effect.logError("failed to refresh orchestration read model after project repair").pipe(
         Effect.annotateLogs({
-          cause: Cause.pretty(Cause.fail(sqlError)),
+          cause: Cause.pretty(cause),
         }),
         Effect.flatMap(() =>
           Effect.fail(
@@ -294,6 +217,69 @@ const makeOrchestrationEngine = Effect.gen(function* () {
       ),
     ),
   );
+
+  const overlayThread = (
+    model: OrchestrationReadModel,
+    thread: OrchestrationReadModel["threads"][number],
+  ): OrchestrationReadModel => {
+    const existingThread = model.threads.find((entry) => entry.id === thread.id);
+    const mergedThread =
+      existingThread && existingThread.messages.length > 0
+        ? {
+            ...thread,
+            messages: existingThread.messages,
+          }
+        : thread;
+    const hasThread = existingThread !== undefined;
+    return {
+      ...model,
+      threads: hasThread
+        ? model.threads.map((entry) => (entry.id === thread.id ? mergedThread : entry))
+        : [...model.threads, mergedThread],
+    };
+  };
+
+  const loadThreadDetailForDecider = (
+    command: OrchestrationCommand,
+    model: OrchestrationReadModel,
+    threadId: ThreadId,
+  ): Effect.Effect<OrchestrationReadModel, OrchestrationDispatchError> =>
+    projectionSnapshotQuery.getThreadDetailById(threadId).pipe(
+      Effect.map((threadOption) =>
+        Option.match(threadOption, {
+          onNone: () => model,
+          onSome: (thread) => overlayThread(model, thread),
+        }),
+      ),
+      Effect.mapError(
+        (error) =>
+          new OrchestrationCommandInternalError({
+            commandId: command.commandId,
+            commandType: command.type,
+            detail: `Failed to load thread detail for command validation: ${error.message}`,
+          }),
+      ),
+    );
+
+  const buildDeciderReadModel = (
+    command: OrchestrationCommand,
+  ): Effect.Effect<OrchestrationReadModel, OrchestrationDispatchError> => {
+    switch (command.type) {
+      case "thread.handoff.create":
+      case "thread.fork.create":
+        return loadThreadDetailForDecider(command, commandReadModel, command.sourceThreadId);
+      case "thread.turn.start":
+        return command.sourceProposedPlan
+          ? loadThreadDetailForDecider(command, commandReadModel, command.sourceProposedPlan.threadId)
+          : Effect.succeed(commandReadModel);
+      case "thread.conversation.rollback":
+      case "thread.message.edit-and-resend":
+      case "thread.message.assistant.complete":
+        return loadThreadDetailForDecider(command, commandReadModel, command.threadId);
+      default:
+        return Effect.succeed(commandReadModel);
+    }
+  };
 
   // Rebuild only the project projection rows and snapshot cursors.
   // Existing thread/chat projection rows stay in place so older installs do not
@@ -334,9 +320,9 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   );
 
   const processEnvelope = (envelope: CommandEnvelope): Effect.Effect<void, never> => {
-    const dispatchStartSequence = readModel.snapshotSequence;
+    const dispatchStartSequence = commandReadModel.snapshotSequence;
     const remainingBudgetMs = Math.max(0, envelope.deadlineAtMs - Date.now());
-    const reconcileReadModelAfterDispatchFailure = Effect.gen(function* () {
+    const reconcileCommandReadModelAfterDispatchFailure = Effect.gen(function* () {
       const persistedEvents = yield* Stream.runCollect(
         eventStore.readFromSequence(dispatchStartSequence),
       ).pipe(Effect.map((chunk): OrchestrationEvent[] => Array.from(chunk)));
@@ -344,11 +330,11 @@ const makeOrchestrationEngine = Effect.gen(function* () {
         return;
       }
 
-      let nextReadModel = readModel;
+      let nextCommandReadModel = commandReadModel;
       for (const persistedEvent of persistedEvents) {
-        nextReadModel = yield* projectEvent(nextReadModel, persistedEvent);
+        nextCommandReadModel = yield* projectEvent(nextCommandReadModel, persistedEvent);
       }
-      readModel = nextReadModel;
+      commandReadModel = nextCommandReadModel;
 
       for (const persistedEvent of persistedEvents) {
         yield* PubSub.publish(eventPubSub, persistedEvent);
@@ -390,9 +376,10 @@ const makeOrchestrationEngine = Effect.gen(function* () {
         return;
       }
 
+      const deciderReadModel = yield* buildDeciderReadModel(envelope.command);
       const eventBase = yield* decideOrchestrationCommand({
         command: envelope.command,
-        readModel,
+        readModel: deciderReadModel,
       });
       const eventBases = Array.isArray(eventBase) ? eventBase : [eventBase];
       const transactionalCommitEffect: Effect.Effect<
@@ -401,11 +388,11 @@ const makeOrchestrationEngine = Effect.gen(function* () {
         never
       > = Effect.gen(function* () {
         const committedEvents: OrchestrationEvent[] = [];
-        let nextReadModel = readModel;
+        let nextCommandReadModel = commandReadModel;
 
         for (const nextEvent of eventBases) {
           const savedEvent = yield* eventStore.append(nextEvent);
-          nextReadModel = yield* projectEvent(nextReadModel, savedEvent);
+          nextCommandReadModel = yield* projectEvent(nextCommandReadModel, savedEvent);
           if (isProjectMetadataEvent(savedEvent)) {
             yield* projectionPipeline.projectMetadataEvent(savedEvent);
           } else {
@@ -435,7 +422,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
         return {
           committedEvents,
           lastSequence: lastSavedEvent.sequence,
-          nextReadModel,
+          nextCommandReadModel,
         } as const;
       }).pipe(
         Effect.catchCause((cause): Effect.Effect<never, OrchestrationDispatchError, never> => {
@@ -472,7 +459,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
           ),
         );
 
-      readModel = committedCommand.nextReadModel;
+      commandReadModel = committedCommand.nextCommandReadModel;
       yield* Effect.forEach(
         committedCommand.committedEvents,
         (event) =>
@@ -528,14 +515,14 @@ const makeOrchestrationEngine = Effect.gen(function* () {
       ),
       Effect.catch((error: OrchestrationDispatchError) =>
         Effect.gen(function* () {
-          yield* reconcileReadModelAfterDispatchFailure.pipe(
+          yield* reconcileCommandReadModelAfterDispatchFailure.pipe(
             Effect.catch(() =>
               Effect.logWarning(
                 "failed to reconcile orchestration read model after dispatch failure",
               ).pipe(
                 Effect.annotateLogs({
                   commandId: envelope.command.commandId,
-                  snapshotSequence: readModel.snapshotSequence,
+                  snapshotSequence: commandReadModel.snapshotSequence,
                 }),
               ),
             ),
@@ -565,7 +552,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
                 aggregateKind: aggregateRef.aggregateKind,
                 aggregateId: aggregateRef.aggregateId,
                 acceptedAt: new Date().toISOString(),
-                resultSequence: readModel.snapshotSequence,
+                resultSequence: commandReadModel.snapshotSequence,
                 status: "rejected",
                 error: error.message,
               })
@@ -579,14 +566,14 @@ const makeOrchestrationEngine = Effect.gen(function* () {
           return Effect.interrupt;
         }
         return Effect.gen(function* () {
-          yield* reconcileReadModelAfterDispatchFailure.pipe(
+          yield* reconcileCommandReadModelAfterDispatchFailure.pipe(
             Effect.catch(() =>
               Effect.logWarning(
                 "failed to reconcile orchestration read model after unexpected worker failure",
               ).pipe(
                 Effect.annotateLogs({
                   commandId: envelope.command.commandId,
-                  snapshotSequence: readModel.snapshotSequence,
+                  snapshotSequence: commandReadModel.snapshotSequence,
                 }),
               ),
             ),
@@ -628,24 +615,21 @@ const makeOrchestrationEngine = Effect.gen(function* () {
 
   yield* projectionPipeline.bootstrap;
 
-  // bootstrap in-memory read model from event store
-  yield* Stream.runForEach(eventStore.readAll(), (event) =>
-    Effect.gen(function* () {
-      readModel = yield* projectEvent(readModel, event);
-    }),
-  );
+  commandReadModel = yield* projectionSnapshotQuery.getCommandReadModel();
 
   const worker = Effect.forever(Queue.take(commandQueue).pipe(Effect.flatMap(processEnvelope)));
   yield* Effect.forkScoped(worker);
   yield* Effect.log("orchestration engine started").pipe(
-    Effect.annotateLogs({ sequence: readModel.snapshotSequence }),
+    Effect.annotateLogs({ sequence: commandReadModel.snapshotSequence }),
   );
-
-  const getReadModel: OrchestrationEngineShape["getReadModel"] = () =>
-    Effect.sync((): OrchestrationReadModel => readModel);
 
   const readEvents: OrchestrationEngineShape["readEvents"] = (fromSequenceExclusive) =>
     eventStore.readFromSequence(fromSequenceExclusive);
+
+  // Compatibility bridge for older tests and out-of-tree callers. Production
+  // code should use ProjectionSnapshotQuery directly instead of depending on
+  // the command engine to own a hydrated read model.
+  const getReadModel = () => Effect.sync(() => commandReadModel);
 
   const dispatch: OrchestrationEngineShape["dispatch"] = (command) =>
     Effect.gen(function* () {
@@ -704,7 +688,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
     maintenanceLock.withPermits(1)(
       Effect.gen(function* () {
         yield* Effect.log("repairing orchestration projection state");
-        const previousReadModel = readModel;
+        const previousCommandReadModel = commandReadModel;
 
         yield* backupDerivedProjectionState.pipe(
           Effect.catchTag("SqlError", (sqlError) =>
@@ -762,7 +746,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
               ),
             ),
           );
-          readModel = previousReadModel;
+          commandReadModel = previousCommandReadModel;
           yield* dropProjectionRepairBackup.pipe(Effect.catchCause(() => Effect.void));
 
           return yield* Effect.logError(
@@ -783,7 +767,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
           );
         }
 
-        const snapshot = yield* refreshReadModelFromProjectionState;
+        const snapshot = yield* refreshCommandReadModelFromProjectionState;
         yield* dropProjectionRepairBackup.pipe(Effect.catchCause(() => Effect.void));
         return snapshot;
       }),
@@ -800,7 +784,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
     get streamDomainEvents(): OrchestrationEngineShape["streamDomainEvents"] {
       return Stream.fromPubSub(eventPubSub);
     },
-  } satisfies OrchestrationEngineShape;
+  } as OrchestrationEngineShape & { readonly getReadModel: typeof getReadModel };
 });
 
 export const OrchestrationEngineLive = Layer.effect(

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -26,6 +26,7 @@ import {
   ORCHESTRATION_PROJECTOR_NAMES,
   OrchestrationProjectionPipelineLive,
 } from "./ProjectionPipeline.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { OrchestrationProjectionPipeline } from "../Services/ProjectionPipeline.ts";
 import { ServerConfig } from "../../config.ts";
@@ -2375,6 +2376,7 @@ it.effect("restores pending turn-start metadata across projection pipeline resta
 const engineLayer = it.layer(
   OrchestrationEngineLive.pipe(
     Layer.provide(OrchestrationProjectionPipelineLive),
+    Layer.provide(OrchestrationProjectionSnapshotQueryLive),
     Layer.provide(OrchestrationEventStoreLive),
     Layer.provide(OrchestrationCommandReceiptRepositoryLive),
     Layer.provideMerge(SqlitePersistenceMemory),

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -725,9 +725,22 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
           if (Option.isNone(existingRow)) {
             return;
           }
+          const [messages, session] = yield* Effect.all([
+            projectionThreadMessageRepository.listByThreadId({
+              threadId: event.payload.threadId,
+            }),
+            projectionThreadSessionRepository.getByThreadId({
+              threadId: event.payload.threadId,
+            }),
+          ]);
+          const canAdoptFirstTurnProvider =
+            existingRow.value.latestTurnId === null &&
+            Option.isNone(session) &&
+            messages.length <= 1;
           const modelSelectionPatch =
             event.payload.modelSelection !== undefined &&
-            event.payload.modelSelection.provider === existingRow.value.modelSelection.provider
+            (event.payload.modelSelection.provider === existingRow.value.modelSelection.provider ||
+              canAdoptFirstTurnProvider)
               ? { modelSelection: event.payload.modelSelection }
               : {};
           yield* projectionThreadRepository.upsert({

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -1476,6 +1476,23 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           ],
         });
       }
+
+      const fullThreadDiffContext = yield* snapshotQuery.getFullThreadDiffContext(
+        ThreadId.makeUnsafe("thread-context"),
+        2,
+      );
+      assert.equal(fullThreadDiffContext._tag, "Some");
+      if (fullThreadDiffContext._tag === "Some") {
+        assert.deepEqual(fullThreadDiffContext.value, {
+          threadId: ThreadId.makeUnsafe("thread-context"),
+          projectId: asProjectId("project-context"),
+          workspaceRoot: "/tmp/context-workspace",
+          envMode: "local",
+          worktreePath: "/tmp/context-worktree",
+          latestCheckpointTurnCount: 2,
+          toCheckpointRef: asCheckpointRef("checkpoint-b"),
+        });
+      }
     }),
   );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -56,6 +56,7 @@ import {
   ProjectionSnapshotQuery,
   type ProjectionFullThreadDiffContext,
   type ProjectionSnapshotCounts,
+  type ProjectionSnapshotSequence,
   type ProjectionThreadCheckpointContext,
   type ProjectionSnapshotQueryShape,
 } from "../Services/ProjectionSnapshotQuery.ts";
@@ -128,6 +129,9 @@ const ProjectIdLookupInput = Schema.Struct({
   projectId: ProjectId,
 });
 const ThreadIdLookupInput = Schema.Struct({
+  threadId: ThreadId,
+});
+const SyntheticSubagentParentLookupInput = Schema.Struct({
   threadId: ThreadId,
 });
 const FullThreadDiffContextLookupInput = Schema.Struct({
@@ -939,6 +943,51 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       `,
   });
 
+  const getSyntheticSubagentParentThreadRow = SqlSchema.findOneOption({
+    Request: SyntheticSubagentParentLookupInput,
+    Result: ProjectionThreadDbRowSchema,
+    execute: ({ threadId }) =>
+      sql`
+        SELECT
+          thread_id AS "threadId",
+          project_id AS "projectId",
+          title,
+          model_selection_json AS "modelSelection",
+          runtime_mode AS "runtimeMode",
+          interaction_mode AS "interactionMode",
+          env_mode AS "envMode",
+          branch,
+          worktree_path AS "worktreePath",
+          associated_worktree_path AS "associatedWorktreePath",
+          associated_worktree_branch AS "associatedWorktreeBranch",
+          associated_worktree_ref AS "associatedWorktreeRef",
+          create_branch_flow_completed AS "createBranchFlowCompleted",
+          is_pinned AS "isPinned",
+          parent_thread_id AS "parentThreadId",
+          subagent_agent_id AS "subagentAgentId",
+          subagent_nickname AS "subagentNickname",
+          subagent_role AS "subagentRole",
+          fork_source_thread_id AS "forkSourceThreadId",
+          sidechat_source_thread_id AS "sidechatSourceThreadId",
+          last_known_pr_json AS "lastKnownPr",
+          latest_turn_id AS "latestTurnId",
+          handoff_json AS "handoff",
+          latest_user_message_at AS "latestUserMessageAt",
+          pending_approval_count AS "pendingApprovalCount",
+          pending_user_input_count AS "pendingUserInputCount",
+          has_actionable_proposed_plan AS "hasActionableProposedPlan",
+          created_at AS "createdAt",
+          updated_at AS "updatedAt",
+          archived_at AS "archivedAt",
+          deleted_at AS "deletedAt"
+        FROM projection_threads
+        WHERE ${threadId} LIKE ('subagent:' || thread_id || ':%')
+          AND deleted_at IS NULL
+        ORDER BY length(thread_id) DESC, created_at ASC, thread_id ASC
+        LIMIT 1
+      `,
+  });
+
   const listThreadMessageRowsByThread = SqlSchema.findAll({
     Request: ThreadIdLookupInput,
     Result: ProjectionThreadMessageDbRowSchema,
@@ -1431,6 +1480,160 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         }),
       );
 
+  const getCommandReadModel: ProjectionSnapshotQueryShape["getCommandReadModel"] = () =>
+    sql
+      .withTransaction(
+        Effect.gen(function* () {
+          const [projectRows, threadRows, proposedPlanRows, sessionRows, latestTurnRows, stateRows] =
+            yield* Effect.all([
+              listProjectRows(undefined).pipe(
+                Effect.mapError(
+                  toPersistenceSqlOrDecodeError(
+                    "ProjectionSnapshotQuery.getCommandReadModel:listProjects:query",
+                    "ProjectionSnapshotQuery.getCommandReadModel:listProjects:decodeRows",
+                  ),
+                ),
+                Effect.flatMap((rows) =>
+                  decodeProjectionProjectRows(
+                    rows,
+                    "ProjectionSnapshotQuery.getCommandReadModel:listProjects:decodeModelSelections",
+                  ),
+                ),
+              ),
+              listThreadRows(undefined).pipe(
+                Effect.mapError(
+                  toPersistenceSqlOrDecodeError(
+                    "ProjectionSnapshotQuery.getCommandReadModel:listThreads:query",
+                    "ProjectionSnapshotQuery.getCommandReadModel:listThreads:decodeRows",
+                  ),
+                ),
+                Effect.flatMap((rows) =>
+                  decodeProjectionThreadRows(
+                    rows,
+                    "ProjectionSnapshotQuery.getCommandReadModel:listThreads:decodeModelSelections",
+                  ),
+                ),
+              ),
+              listThreadProposedPlanRows(undefined).pipe(
+                Effect.mapError(
+                  toPersistenceSqlOrDecodeError(
+                    "ProjectionSnapshotQuery.getCommandReadModel:listThreadProposedPlans:query",
+                    "ProjectionSnapshotQuery.getCommandReadModel:listThreadProposedPlans:decodeRows",
+                  ),
+                ),
+              ),
+              listThreadSessionRows(undefined).pipe(
+                Effect.mapError(
+                  toPersistenceSqlOrDecodeError(
+                    "ProjectionSnapshotQuery.getCommandReadModel:listThreadSessions:query",
+                    "ProjectionSnapshotQuery.getCommandReadModel:listThreadSessions:decodeRows",
+                  ),
+                ),
+              ),
+              listLatestTurnRows(undefined).pipe(
+                Effect.mapError(
+                  toPersistenceSqlOrDecodeError(
+                    "ProjectionSnapshotQuery.getCommandReadModel:listLatestTurns:query",
+                    "ProjectionSnapshotQuery.getCommandReadModel:listLatestTurns:decodeRows",
+                  ),
+                ),
+              ),
+              listProjectionStateRows(undefined).pipe(
+                Effect.mapError(
+                  toPersistenceSqlOrDecodeError(
+                    "ProjectionSnapshotQuery.getCommandReadModel:listProjectionState:query",
+                    "ProjectionSnapshotQuery.getCommandReadModel:listProjectionState:decodeRows",
+                  ),
+                ),
+              ),
+            ]);
+
+          const proposedPlansByThread = new Map<string, Array<OrchestrationProposedPlan>>();
+          const sessionsByThread = new Map<string, OrchestrationSession>();
+          const latestTurnByThread = new Map<string, OrchestrationLatestTurn>();
+
+          let updatedAt: string | null = null;
+
+          for (const row of projectRows) {
+            updatedAt = maxIso(updatedAt, row.updatedAt);
+          }
+          for (const row of threadRows) {
+            updatedAt = maxIso(updatedAt, row.updatedAt);
+          }
+          for (const row of proposedPlanRows) {
+            updatedAt = maxIso(updatedAt, row.updatedAt);
+            const threadProposedPlans = proposedPlansByThread.get(row.threadId) ?? [];
+            threadProposedPlans.push(toProjectedProposedPlan(row));
+            proposedPlansByThread.set(row.threadId, threadProposedPlans);
+          }
+          for (const row of sessionRows) {
+            updatedAt = maxIso(updatedAt, row.updatedAt);
+            sessionsByThread.set(row.threadId, toProjectedSession(row));
+          }
+          for (const row of latestTurnRows) {
+            updatedAt = maxIso(updatedAt, row.requestedAt);
+            if (row.startedAt !== null) {
+              updatedAt = maxIso(updatedAt, row.startedAt);
+            }
+            if (row.completedAt !== null) {
+              updatedAt = maxIso(updatedAt, row.completedAt);
+            }
+            if (latestTurnByThread.has(row.threadId)) {
+              continue;
+            }
+            latestTurnByThread.set(row.threadId, toProjectedLatestTurn(row));
+          }
+          for (const row of stateRows) {
+            updatedAt = maxIso(updatedAt, row.updatedAt);
+          }
+
+          const projects: ReadonlyArray<OrchestrationProject> = projectRows.map((row) => ({
+            id: row.projectId,
+            kind: row.kind,
+            title: row.title,
+            workspaceRoot: row.workspaceRoot,
+            defaultModelSelection: row.defaultModelSelection,
+            scripts: row.scripts,
+            createdAt: row.createdAt,
+            updatedAt: row.updatedAt,
+            deletedAt: row.deletedAt,
+          }));
+
+          const threads: ReadonlyArray<OrchestrationThread> = threadRows.map((row) =>
+            toProjectedThread({
+              threadRow: row,
+              latestTurn: latestTurnByThread.get(row.threadId) ?? null,
+              messages: [],
+              proposedPlans: proposedPlansByThread.get(row.threadId) ?? [],
+              activities: [],
+              checkpoints: [],
+              session: sessionsByThread.get(row.threadId) ?? null,
+            }),
+          );
+
+          return yield* decodeReadModel({
+            snapshotSequence: computeSnapshotSequence(stateRows),
+            projects,
+            threads,
+            updatedAt: updatedAt ?? new Date(0).toISOString(),
+          }).pipe(
+            Effect.mapError(
+              toPersistenceDecodeError(
+                "ProjectionSnapshotQuery.getCommandReadModel:decodeReadModel",
+              ),
+            ),
+          );
+        }),
+      )
+      .pipe(
+        Effect.mapError((error) => {
+          if (isPersistenceError(error)) {
+            return error;
+          }
+          return toPersistenceSqlError("ProjectionSnapshotQuery.getCommandReadModel:query")(error);
+        }),
+      );
+
   const getShellSnapshot: ProjectionSnapshotQueryShape["getShellSnapshot"] = () =>
     sql
       .withTransaction(
@@ -1570,6 +1773,21 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         (row): ProjectionSnapshotCounts => ({
           projectCount: row.projectCount,
           threadCount: row.threadCount,
+        }),
+      ),
+    );
+
+  const getSnapshotSequence: ProjectionSnapshotQueryShape["getSnapshotSequence"] = () =>
+    listProjectionStateRows(undefined).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "ProjectionSnapshotQuery.getSnapshotSequence:query",
+          "ProjectionSnapshotQuery.getSnapshotSequence:decodeRows",
+        ),
+      ),
+      Effect.map(
+        (stateRows): ProjectionSnapshotSequence => ({
+          snapshotSequence: computeSnapshotSequence(stateRows),
         }),
       ),
     );
@@ -1777,6 +1995,42 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         }),
       );
 
+  const findSyntheticSubagentParentThread: ProjectionSnapshotQueryShape["findSyntheticSubagentParentThread"] =
+    (threadId) =>
+      sql
+        .withTransaction(
+          Effect.gen(function* () {
+            const parentRow = yield* getSyntheticSubagentParentThreadRow({ threadId }).pipe(
+              Effect.mapError(
+                toPersistenceSqlOrDecodeError(
+                  "ProjectionSnapshotQuery.findSyntheticSubagentParentThread:getThread:query",
+                  "ProjectionSnapshotQuery.findSyntheticSubagentParentThread:getThread:decodeRow",
+                ),
+              ),
+              Effect.flatMap((option) =>
+                decodeProjectionThreadOption(
+                  option,
+                  "ProjectionSnapshotQuery.findSyntheticSubagentParentThread:getThread:decodeModelSelection",
+                ),
+              ),
+            );
+            if (Option.isNone(parentRow)) {
+              return Option.none<OrchestrationThread>();
+            }
+            return yield* loadThreadDetail(parentRow.value.threadId);
+          }),
+        )
+        .pipe(
+          Effect.mapError((error) => {
+            if (isPersistenceError(error)) {
+              return error;
+            }
+            return toPersistenceSqlError(
+              "ProjectionSnapshotQuery.findSyntheticSubagentParentThread:query",
+            )(error);
+          }),
+        );
+
   // Hydrate a full thread detail projection without opening its own transaction.
   const loadThreadDetail = (threadId: ThreadId) =>
     Effect.gen(function* () {
@@ -1938,15 +2192,18 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       );
 
   return {
+    getCommandReadModel,
     getSnapshot,
     getShellSnapshot,
     getCounts,
+    getSnapshotSequence,
     getActiveProjectByWorkspaceRoot,
     getProjectShellById,
     getFirstActiveThreadIdByProjectId,
     getThreadCheckpointContext,
     getFullThreadDiffContext,
     getThreadShellById,
+    findSyntheticSubagentParentThread,
     getThreadDetailById,
     getThreadDetailSnapshotById,
   } satisfies ProjectionSnapshotQueryShape;

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -1,5 +1,6 @@
 import {
   ChatAttachment,
+  CheckpointRef,
   IsoDateTime,
   MessageId,
   NonNegativeInt,
@@ -53,6 +54,7 @@ import { ProjectionThread } from "../../persistence/Services/ProjectionThreads.t
 import { ORCHESTRATION_PROJECTOR_NAMES } from "./ProjectionPipeline.ts";
 import {
   ProjectionSnapshotQuery,
+  type ProjectionFullThreadDiffContext,
   type ProjectionSnapshotCounts,
   type ProjectionThreadCheckpointContext,
   type ProjectionSnapshotQueryShape,
@@ -128,6 +130,10 @@ const ProjectIdLookupInput = Schema.Struct({
 const ThreadIdLookupInput = Schema.Struct({
   threadId: ThreadId,
 });
+const FullThreadDiffContextLookupInput = Schema.Struct({
+  threadId: ThreadId,
+  checkpointTurnCount: NonNegativeInt,
+});
 const ProjectionProjectLookupRowSchema = ProjectionProjectDbRowSchema;
 const ProjectionThreadIdLookupRowSchema = Schema.Struct({
   threadId: ThreadId,
@@ -138,6 +144,15 @@ const ProjectionThreadCheckpointContextThreadRowSchema = Schema.Struct({
   workspaceRoot: Schema.String,
   envMode: ThreadEnvironmentMode,
   worktreePath: Schema.NullOr(Schema.String),
+});
+const ProjectionFullThreadDiffContextRowSchema = Schema.Struct({
+  threadId: ThreadId,
+  projectId: ProjectId,
+  workspaceRoot: Schema.String,
+  envMode: ThreadEnvironmentMode,
+  worktreePath: Schema.NullOr(Schema.String),
+  latestCheckpointTurnCount: Schema.NullOr(NonNegativeInt),
+  toCheckpointRef: Schema.NullOr(CheckpointRef),
 });
 
 type ProjectionThreadDbRowRaw = Schema.Schema.Type<typeof ProjectionThreadDbRowSchema>;
@@ -1167,6 +1182,41 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       `,
   });
 
+  const getFullThreadDiffContextRow = SqlSchema.findOneOption({
+    Request: FullThreadDiffContextLookupInput,
+    Result: ProjectionFullThreadDiffContextRowSchema,
+    execute: ({ threadId, checkpointTurnCount }) =>
+      sql`
+        SELECT
+          threads.thread_id AS "threadId",
+          threads.project_id AS "projectId",
+          projects.workspace_root AS "workspaceRoot",
+          threads.env_mode AS "envMode",
+          threads.worktree_path AS "worktreePath",
+          (
+            SELECT MAX(turns.checkpoint_turn_count)
+            FROM projection_turns AS turns
+            WHERE turns.thread_id = threads.thread_id
+              AND turns.checkpoint_turn_count IS NOT NULL
+              AND turns.completed_at IS NOT NULL
+          ) AS "latestCheckpointTurnCount",
+          (
+            SELECT turns.checkpoint_ref
+            FROM projection_turns AS turns
+            WHERE turns.thread_id = threads.thread_id
+              AND turns.checkpoint_turn_count = ${checkpointTurnCount}
+              AND turns.completed_at IS NOT NULL
+            LIMIT 1
+          ) AS "toCheckpointRef"
+        FROM projection_threads AS threads
+        INNER JOIN projection_projects AS projects
+          ON projects.project_id = threads.project_id
+        WHERE threads.thread_id = ${threadId}
+          AND threads.deleted_at IS NULL
+        LIMIT 1
+      `,
+  });
+
   const getSnapshot: ProjectionSnapshotQueryShape["getSnapshot"] = () =>
     sql
       .withTransaction(
@@ -1631,6 +1681,37 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
       });
     });
 
+  const getFullThreadDiffContext: ProjectionSnapshotQueryShape["getFullThreadDiffContext"] = (
+    threadId,
+    toTurnCount,
+  ) =>
+    Effect.gen(function* () {
+      const row = yield* getFullThreadDiffContextRow({
+        threadId,
+        checkpointTurnCount: toTurnCount,
+      }).pipe(
+        Effect.mapError(
+          toPersistenceSqlOrDecodeError(
+            "ProjectionSnapshotQuery.getFullThreadDiffContext:query",
+            "ProjectionSnapshotQuery.getFullThreadDiffContext:decodeRow",
+          ),
+        ),
+      );
+      if (Option.isNone(row)) {
+        return Option.none<ProjectionFullThreadDiffContext>();
+      }
+
+      return Option.some({
+        threadId: row.value.threadId,
+        projectId: row.value.projectId,
+        workspaceRoot: row.value.workspaceRoot,
+        envMode: row.value.envMode,
+        worktreePath: row.value.worktreePath,
+        latestCheckpointTurnCount: row.value.latestCheckpointTurnCount ?? 0,
+        toCheckpointRef: row.value.toCheckpointRef,
+      });
+    });
+
   const getThreadShellById: ProjectionSnapshotQueryShape["getThreadShellById"] = (threadId) =>
     sql
       .withTransaction(
@@ -1864,6 +1945,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
     getProjectShellById,
     getFirstActiveThreadIdByProjectId,
     getThreadCheckpointContext,
+    getFullThreadDiffContext,
     getThreadShellById,
     getThreadDetailById,
     getThreadDetailSnapshotById,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -30,6 +30,7 @@ import { GitCore, type GitCoreShape } from "../../git/Services/GitCore.ts";
 import { TextGeneration, type TextGenerationShape } from "../../git/Services/TextGeneration.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import { ProviderCommandReactorLive } from "./ProviderCommandReactor.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ProviderCommandReactor } from "../Services/ProviderCommandReactor.ts";
@@ -292,12 +293,13 @@ describe("ProviderCommandReactor", () => {
 
     const orchestrationLayer = OrchestrationEngineLive.pipe(
       Layer.provide(OrchestrationProjectionPipelineLive),
+      Layer.provide(OrchestrationProjectionSnapshotQueryLive),
       Layer.provide(OrchestrationEventStoreLive),
       Layer.provide(OrchestrationCommandReceiptRepositoryLive),
-      Layer.provide(SqlitePersistenceMemory),
     );
     const layer = ProviderCommandReactorLive.pipe(
       Layer.provideMerge(orchestrationLayer),
+      Layer.provideMerge(OrchestrationProjectionSnapshotQueryLive),
       Layer.provideMerge(Layer.succeed(ProviderService, service)),
       Layer.provideMerge(Layer.succeed(CheckpointStore, checkpointStore)),
       Layer.provideMerge(
@@ -311,6 +313,7 @@ describe("ProviderCommandReactor", () => {
       ),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
+      Layer.provideMerge(SqlitePersistenceMemory),
     );
     const runtime = ManagedRuntime.make(layer);
     const emitRuntimeEvent = (event: ProviderRuntimeEvent) =>

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -13,6 +13,8 @@ import {
   type ProviderStartOptions,
   type ProviderSkillReference,
   type OrchestrationSession,
+  type OrchestrationProjectShell,
+  type OrchestrationThread,
   ThreadId,
   type ProviderSession,
   type RuntimeMode,
@@ -49,6 +51,7 @@ import {
   hasNativeAssistantMessagesBefore,
 } from "../handoff.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import {
   ProviderCommandReactor,
   type ProviderCommandReactorShape,
@@ -209,6 +212,7 @@ function buildGeneratedWorktreeBranchName(raw: string): string {
 
 const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const providerService = yield* ProviderService;
   const checkpointStore = yield* CheckpointStore;
   const git = yield* GitCore;
@@ -228,6 +232,25 @@ const make = Effect.gen(function* () {
 
   const threadProviderOptions = new Map<string, ProviderStartOptions>();
   const threadModelSelections = new Map<string, ModelSelection>();
+
+  const resolveThreadWorkspaceProject = Effect.fnUntraced(function* (
+    thread: Pick<OrchestrationThread, "projectId">,
+  ): Effect.fn.Return<OrchestrationProjectShell | undefined> {
+    return Option.getOrUndefined(yield* projectionSnapshotQuery.getProjectShellById(thread.projectId));
+  });
+
+  const resolveProjectedThreadWorkspaceCwd = Effect.fnUntraced(function* (
+    thread: Pick<OrchestrationThread, "projectId" | "envMode" | "worktreePath">,
+  ): Effect.fn.Return<string | undefined> {
+    const project = yield* resolveThreadWorkspaceProject(thread);
+    if (!project) {
+      return undefined;
+    }
+    return resolveThreadWorkspaceCwd({
+      thread,
+      projects: [project],
+    });
+  });
   const queuedTurnStartsByThread = new Map<
     string,
     Array<Extract<ProviderIntentEvent, { type: "thread.turn-queued" }>["payload"]>
@@ -342,8 +365,7 @@ const make = Effect.gen(function* () {
   });
 
   const resolveThread = Effect.fnUntraced(function* (threadId: ThreadId) {
-    const readModel = yield* orchestrationEngine.getReadModel();
-    return readModel.threads.find((entry) => entry.id === threadId);
+    return Option.getOrUndefined(yield* projectionSnapshotQuery.getThreadDetailById(threadId));
   });
 
   // Recovers the parent thread when older/local-only subagent rows are missing parentThreadId metadata.
@@ -355,11 +377,9 @@ const make = Effect.gen(function* () {
       return null;
     }
 
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const matchingParents = readModel.threads.filter((entry) =>
-      rawThreadId.startsWith(`subagent:${entry.id}:`),
+    return Option.getOrNull(
+      yield* projectionSnapshotQuery.findSyntheticSubagentParentThread(threadId),
     );
-    return matchingParents.toSorted((left, right) => right.id.length - left.id.length)[0] ?? null;
   });
 
   const resolveProviderSessionThread = Effect.fnUntraced(function* (threadId: ThreadId) {
@@ -527,8 +547,7 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === input.threadId);
+    const thread = yield* resolveThread(input.threadId);
     if (!thread) {
       return;
     }
@@ -546,10 +565,7 @@ const make = Effect.gen(function* () {
       Number.POSITIVE_INFINITY,
     );
     const targetTurnCount = Math.max(0, firstRemovedTurnCount - 1);
-    const cwd = resolveThreadWorkspaceCwd({
-      thread,
-      projects: readModel.projects,
-    });
+    const cwd = yield* resolveProjectedThreadWorkspaceCwd(thread);
     if (!cwd) {
       return;
     }
@@ -594,10 +610,9 @@ const make = Effect.gen(function* () {
       readonly runtimeMode?: RuntimeMode;
     },
   ) {
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === threadId);
+    const thread = yield* resolveThread(threadId);
     if (!thread) {
-      return yield* Effect.die(new Error(`Thread '${threadId}' was not found in read model.`));
+      return yield* Effect.die(new Error(`Thread '${threadId}' was not found in projection state.`));
     }
 
     const desiredRuntimeMode = options?.runtimeMode ?? thread.runtimeMode;
@@ -620,10 +635,7 @@ const make = Effect.gen(function* () {
     }
     const preferredProvider: ProviderKind = currentProvider ?? threadProvider;
     const desiredModelSelection = requestedModelSelection ?? thread.modelSelection;
-    const effectiveCwd = resolveThreadWorkspaceCwd({
-      thread,
-      projects: readModel.projects,
-    });
+    const effectiveCwd = yield* resolveProjectedThreadWorkspaceCwd(thread);
     const workspaceState = resolveThreadWorkspaceState({
       envMode: thread.envMode,
       worktreePath: thread.worktreePath,
@@ -884,16 +896,12 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      const readModel = yield* orchestrationEngine.getReadModel();
-      const currentThread = readModel.threads.find((entry) => entry.id === input.threadId);
+      const currentThread = yield* resolveThread(input.threadId);
       if (!currentThread) {
         return;
       }
 
-      const cwd = resolveThreadWorkspaceCwd({
-        thread: currentThread,
-        projects: readModel.projects,
-      });
+      const cwd = yield* resolveProjectedThreadWorkspaceCwd(currentThread);
       if (!cwd || !(yield* checkpointStore.isGitRepository(cwd))) {
         return;
       }
@@ -1096,8 +1104,7 @@ const make = Effect.gen(function* () {
     readonly modelSelection?: ModelSelection;
     readonly providerOptions?: ProviderStartOptions;
   }) {
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === input.threadId);
+    const thread = yield* resolveThread(input.threadId);
     if (!thread) {
       return;
     }
@@ -1116,10 +1123,7 @@ const make = Effect.gen(function* () {
     if (!isGenericChatThreadTitle(currentTitle) && currentTitle !== fallbackTitle) {
       return;
     }
-    const cwd = resolveThreadWorkspaceCwd({
-      thread,
-      projects: readModel.projects,
-    });
+    const cwd = yield* resolveProjectedThreadWorkspaceCwd(thread);
     const textGenerationInput = yield* resolveThreadTextGenerationInput({
       threadId: input.threadId,
       ...(input.modelSelection ? { modelSelection: input.modelSelection } : {}),
@@ -1550,15 +1554,27 @@ const make = Effect.gen(function* () {
         new Error(`Cannot edit missing user message '${payload.messageId}'.`),
       );
     }
-    const editTarget = resolveTailUserMessageEditTarget({
-      messages: originalThread.messages,
-      messageId: payload.messageId,
-      activeTurnId:
-        options?.activeTurnId ??
-        (originalThread.session?.status === "running"
-          ? (originalThread.session.activeTurnId ?? null)
-          : null),
-    });
+    const editTarget =
+      payload.removedTurnIds !== undefined && payload.rollbackTurnCount !== undefined
+        ? {
+            editable: true as const,
+            messageId: payload.messageId,
+            messageIndex: originalThread.messages.findIndex(
+              (message) => message.id === payload.messageId,
+            ),
+            mode: payload.rollbackTurnCount > 0 ? ("rollback" as const) : ("active" as const),
+            rollbackTurnCount: payload.rollbackTurnCount,
+            removedTurnIds: payload.removedTurnIds,
+          }
+        : resolveTailUserMessageEditTarget({
+            messages: originalThread.messages,
+            messageId: payload.messageId,
+            activeTurnId:
+              options?.activeTurnId ??
+              (originalThread.session?.status === "running"
+                ? (originalThread.session.activeTurnId ?? null)
+                : null),
+          });
     if (!editTarget.editable) {
       return yield* Effect.fail(
         new Error(

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../../provider/Services/ProviderService.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import { ProviderRuntimeIngestionLive } from "./ProviderRuntimeIngestion.ts";
 import {
   OrchestrationEngineService,
@@ -166,12 +167,13 @@ describe("ProviderRuntimeIngestion", () => {
     const provider = createProviderServiceHarness();
     const orchestrationLayer = OrchestrationEngineLive.pipe(
       Layer.provide(OrchestrationProjectionPipelineLive),
+      Layer.provide(OrchestrationProjectionSnapshotQueryLive),
       Layer.provide(OrchestrationEventStoreLive),
       Layer.provide(OrchestrationCommandReceiptRepositoryLive),
-      Layer.provide(SqlitePersistenceMemory),
     );
     const layer = ProviderRuntimeIngestionLive.pipe(
       Layer.provideMerge(orchestrationLayer),
+      Layer.provideMerge(OrchestrationProjectionSnapshotQueryLive),
       Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -4,13 +4,14 @@ import {
   CommandId,
   MessageId,
   type OrchestrationEvent,
+  type OrchestrationProjectShell,
   type OrchestrationProposedPlanId,
   CheckpointRef,
   isToolLifecycleItemType,
   ThreadId,
   TurnId,
   type OrchestrationThreadActivity,
-  type OrchestrationReadModel,
+  type OrchestrationThread,
   type ProviderRuntimeEvent,
   type RuntimeMode,
 } from "@t3tools/contracts";
@@ -34,6 +35,7 @@ import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/Projectio
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { isGitRepository } from "../../git/isRepo.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../Services/ProjectionSnapshotQuery.ts";
 import {
   ProviderRuntimeIngestionService,
   type ProviderRuntimeIngestionShape,
@@ -1096,6 +1098,7 @@ function runtimeEventToActivities(
 
 const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const providerService = yield* ProviderService;
   const projectionTurnRepository = yield* ProjectionTurnRepository;
 
@@ -1121,15 +1124,30 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed({ text: "", createdAt: "" }),
   });
 
+  const getThreadDetail = Effect.fnUntraced(function* (
+    threadId: ThreadId,
+  ): Effect.fn.Return<OrchestrationThread | undefined> {
+    return Option.getOrUndefined(yield* projectionSnapshotQuery.getThreadDetailById(threadId));
+  });
+
+  const getProjectShell = Effect.fnUntraced(function* (
+    thread: Pick<OrchestrationThread, "projectId">,
+  ): Effect.fn.Return<OrchestrationProjectShell | undefined> {
+    return Option.getOrUndefined(yield* projectionSnapshotQuery.getProjectShellById(thread.projectId));
+  });
+
   const isGitRepoForThread = Effect.fnUntraced(function* (threadId: ThreadId) {
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === threadId);
+    const thread = yield* getThreadDetail(threadId);
     if (!thread) {
+      return false;
+    }
+    const project = yield* getProjectShell(thread);
+    if (!project) {
       return false;
     }
     const workspaceCwd = resolveThreadWorkspaceCwd({
       thread,
-      projects: readModel.projects,
+      projects: [project],
     });
     if (!workspaceCwd) {
       return false;
@@ -1243,7 +1261,7 @@ const make = Effect.gen(function* () {
 
   const resolveAssistantCompletionMessageId = (input: {
     event: ProviderRuntimeEvent;
-    thread: OrchestrationReadModel["threads"][number];
+    thread: OrchestrationThread;
     turnId?: TurnId;
   }) =>
     Effect.gen(function* () {
@@ -1267,15 +1285,15 @@ const make = Effect.gen(function* () {
         if (knownAssistantMessageIds.size > 1) {
           const preferredKnownMessage = input.thread.messages
             .filter(
-              (message: OrchestrationReadModel["threads"][number]["messages"][number]) =>
+              (message: OrchestrationThread["messages"][number]) =>
                 message.role === "assistant" &&
                 message.turnId === input.turnId &&
                 knownAssistantMessageIds.has(message.id),
             )
             .toSorted(
               (
-                left: OrchestrationReadModel["threads"][number]["messages"][number],
-                right: OrchestrationReadModel["threads"][number]["messages"][number],
+                left: OrchestrationThread["messages"][number],
+                right: OrchestrationThread["messages"][number],
               ) => {
                 if (left.streaming !== right.streaming) {
                   return left.streaming ? -1 : 1;
@@ -1425,7 +1443,7 @@ const make = Effect.gen(function* () {
 
   const appendGeneratedImageReference = (input: {
     event: ProviderRuntimeEvent;
-    thread: OrchestrationReadModel["threads"][number];
+    thread: OrchestrationThread;
     imagePath: string;
     turnId?: TurnId;
     createdAt: string;
@@ -1664,8 +1682,7 @@ const make = Effect.gen(function* () {
     implementationThreadId: ThreadId,
     implementedAt: string,
   ) {
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const sourceThread = readModel.threads.find((entry) => entry.id === sourceThreadId);
+    const sourceThread = yield* getThreadDetail(sourceThreadId);
     const sourcePlan = sourceThread?.proposedPlans.find((entry) => entry.id === sourcePlanId);
     if (!sourceThread || !sourcePlan || sourcePlan.implementedAt !== null) {
       return;
@@ -1689,9 +1706,8 @@ const make = Effect.gen(function* () {
 
   const processRuntimeEvent = (event: ProviderRuntimeEvent) =>
     Effect.gen(function* () {
-      const readModel = yield* orchestrationEngine.getReadModel();
       const now = event.createdAt;
-      const parentThread = readModel.threads.find((entry) => entry.id === event.threadId);
+      const parentThread = yield* getThreadDetail(event.threadId);
       if (!parentThread) return;
 
       const ensureSubagentThread = (
@@ -1705,10 +1721,7 @@ const make = Effect.gen(function* () {
           const childThreadId = subagentThreadId(parentThread.id, providerThreadId);
           // A single provider event can describe the child both as a collab receiver and
           // as the event's provider thread, so re-read after any earlier dispatch in this handler.
-          const latestReadModel = yield* orchestrationEngine.getReadModel();
-          const existingThread = latestReadModel.threads.find(
-            (entry) => entry.id === childThreadId,
-          );
+          const existingThread = yield* projectionSnapshotQuery.getThreadShellById(childThreadId);
           const resolvedModelSelection =
             identity?.model && identity.modelIsRequestedHint !== true
               ? {
@@ -1717,7 +1730,7 @@ const make = Effect.gen(function* () {
                 }
               : undefined;
 
-          if (!existingThread) {
+          if (Option.isNone(existingThread)) {
             yield* orchestrationEngine.dispatch({
               type: "thread.create",
               commandId: providerCommandId(event, "subagent-thread-create"),
@@ -1775,28 +1788,31 @@ const make = Effect.gen(function* () {
 
           return {
             threadId: childThreadId,
-            thread: existingThread ?? {
-              ...parentThread,
-              id: childThreadId,
-              title: subagentThreadTitle({
-                nickname: identity?.nickname,
-                role: identity?.role,
-                providerThreadId,
+            thread: Option.match(existingThread, {
+              onSome: (thread) => thread,
+              onNone: () => ({
+                ...parentThread,
+                id: childThreadId,
+                title: subagentThreadTitle({
+                  nickname: identity?.nickname,
+                  role: identity?.role,
+                  providerThreadId,
+                }),
+                parentThreadId: parentThread.id,
+                subagentAgentId: identity?.agentId ?? null,
+                subagentNickname: identity?.nickname ?? null,
+                subagentRole: identity?.role ?? null,
+                modelSelection: resolvedModelSelection ?? parentThread.modelSelection,
+                latestTurn: null,
+                messages: [],
+                proposedPlans: [],
+                activities: [],
+                checkpoints: [],
+                session: null,
+                createdAt: now,
+                updatedAt: now,
               }),
-              parentThreadId: parentThread.id,
-              subagentAgentId: identity?.agentId ?? null,
-              subagentNickname: identity?.nickname ?? null,
-              subagentRole: identity?.role ?? null,
-              modelSelection: resolvedModelSelection ?? parentThread.modelSelection,
-              latestTurn: null,
-              messages: [],
-              proposedPlans: [],
-              activities: [],
-              checkpoints: [],
-              session: null,
-              createdAt: now,
-              updatedAt: now,
-            },
+            }),
           };
         });
 
@@ -2253,8 +2269,9 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      const readModel = yield* orchestrationEngine.getReadModel();
-      const thread = readModel.threads.find((entry) => entry.id === event.payload.threadId);
+      const thread = Option.getOrUndefined(
+        yield* projectionSnapshotQuery.getThreadShellById(event.payload.threadId),
+      );
       const activeTurnId = thread?.session?.activeTurnId ?? undefined;
       if (!activeTurnId) {
         return;

--- a/apps/server/src/orchestration/Services/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Services/OrchestrationEngine.ts
@@ -1,7 +1,7 @@
 /**
  * OrchestrationEngineService - Service interface for orchestration command handling.
  *
- * Owns command validation/dispatch and in-memory read-model updates backed by
+ * Owns command validation/dispatch and lightweight command-state updates backed by
  * `OrchestrationEventStore` persistence. It does not own provider process
  * management or transport concerns (e.g. websocket request parsing).
  *
@@ -25,13 +25,6 @@ import type { OrchestrationEventStoreError } from "../../persistence/Errors.ts";
  * OrchestrationEngineShape - Service API for orchestration command and event flow.
  */
 export interface OrchestrationEngineShape {
-  /**
-   * Read the current in-memory orchestration read model.
-   *
-   * @returns Effect containing the latest read model.
-   */
-  readonly getReadModel: () => Effect.Effect<OrchestrationReadModel, never, never>;
-
   /**
    * Replay persisted orchestration events from an exclusive sequence cursor.
    *
@@ -60,7 +53,7 @@ export interface OrchestrationEngineShape {
    * existing chat rows.
    *
    * Replays the snapshot-related projector cursors and refreshes the in-memory
-   * read model from the repaired projection snapshot.
+   * command model from projection state.
    */
   readonly repairState: () => Effect.Effect<
     OrchestrationReadModel,
@@ -79,13 +72,6 @@ export interface OrchestrationEngineShape {
 /**
  * OrchestrationEngineService - Service tag for orchestration engine access.
  *
- * @example
- * ```ts
- * const program = Effect.gen(function* () {
- *   const engine = yield* OrchestrationEngineService
- *   return yield* engine.getReadModel()
- * })
- * ```
  */
 export class OrchestrationEngineService extends ServiceMap.Service<
   OrchestrationEngineService,

--- a/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
@@ -30,6 +30,10 @@ export interface ProjectionSnapshotCounts {
   readonly threadCount: number;
 }
 
+export interface ProjectionSnapshotSequence {
+  readonly snapshotSequence: number;
+}
+
 export interface ProjectionThreadCheckpointContext {
   readonly threadId: ThreadId;
   readonly projectId: ProjectId;
@@ -54,6 +58,15 @@ export interface ProjectionFullThreadDiffContext {
  */
 export interface ProjectionSnapshotQueryShape {
   /**
+   * Read the lightweight command snapshot used to bootstrap the in-memory
+   * orchestration engine without hydrating message/activity/checkpoint bodies.
+   */
+  readonly getCommandReadModel: () => Effect.Effect<
+    OrchestrationReadModel,
+    ProjectionRepositoryError
+  >;
+
+  /**
    * Read the latest orchestration projection snapshot.
    *
    * Rehydrates from projection tables and derives snapshot sequence from
@@ -65,6 +78,14 @@ export interface ProjectionSnapshotQueryShape {
    * Read aggregate projection counts without hydrating the full read model.
    */
   readonly getCounts: () => Effect.Effect<ProjectionSnapshotCounts, ProjectionRepositoryError>;
+
+  /**
+   * Read the latest projection snapshot sequence without hydrating read-model entities.
+   */
+  readonly getSnapshotSequence: () => Effect.Effect<
+    ProjectionSnapshotSequence,
+    ProjectionRepositoryError
+  >;
 
   /**
    * Read the latest orchestration shell snapshot.
@@ -119,6 +140,13 @@ export interface ProjectionSnapshotQueryShape {
   readonly getThreadShellById: (
     threadId: ThreadId,
   ) => Effect.Effect<Option.Option<OrchestrationThreadShell>, ProjectionRepositoryError>;
+
+  /**
+   * Recover the parent thread for legacy synthetic subagent IDs.
+   */
+  readonly findSyntheticSubagentParentThread: (
+    threadId: ThreadId,
+  ) => Effect.Effect<Option.Option<OrchestrationThread>, ProjectionRepositoryError>;
 
   /**
    * Read a single active thread detail snapshot by id.

--- a/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Services/ProjectionSnapshotQuery.ts
@@ -15,6 +15,7 @@ import type {
   OrchestrationThreadDetailSnapshot,
   OrchestrationThread,
   OrchestrationThreadShell,
+  CheckpointRef,
   ProjectId,
   ThreadId,
   ThreadEnvironmentMode,
@@ -36,6 +37,16 @@ export interface ProjectionThreadCheckpointContext {
   readonly envMode: ThreadEnvironmentMode;
   readonly worktreePath: string | null;
   readonly checkpoints: ReadonlyArray<OrchestrationCheckpointSummary>;
+}
+
+export interface ProjectionFullThreadDiffContext {
+  readonly threadId: ThreadId;
+  readonly projectId: ProjectId;
+  readonly workspaceRoot: string;
+  readonly envMode: ThreadEnvironmentMode;
+  readonly worktreePath: string | null;
+  readonly latestCheckpointTurnCount: number;
+  readonly toCheckpointRef: CheckpointRef | null;
 }
 
 /**
@@ -93,6 +104,14 @@ export interface ProjectionSnapshotQueryShape {
   readonly getThreadCheckpointContext: (
     threadId: ThreadId,
   ) => Effect.Effect<Option.Option<ProjectionThreadCheckpointContext>, ProjectionRepositoryError>;
+
+  /**
+   * Read the narrow context needed to diff a whole thread through one checkpoint.
+   */
+  readonly getFullThreadDiffContext: (
+    threadId: ThreadId,
+    toTurnCount: number,
+  ) => Effect.Effect<Option.Option<ProjectionFullThreadDiffContext>, ProjectionRepositoryError>;
 
   /**
    * Read a single active thread shell row by id.

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1022,6 +1022,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           messageId: command.messageId,
           text: command.text,
+          rollbackTurnCount: editTarget.rollbackTurnCount,
+          removedTurnIds: editTarget.removedTurnIds,
           ...(command.modelSelection !== undefined
             ? { modelSelection: command.modelSelection }
             : {}),

--- a/apps/server/src/orchestration/importThreadRoute.ts
+++ b/apps/server/src/orchestration/importThreadRoute.ts
@@ -13,10 +13,11 @@ import {
   workspaceRootsEqual,
 } from "@t3tools/shared/threadWorkspace";
 import type { FileSystem, Path } from "effect";
-import { Data, Effect } from "effect";
+import { Data, Effect, Option } from "effect";
 
 import { resolveThreadWorkspaceCwd } from "../checkpointing/Utils";
 import type { OrchestrationEngineShape } from "./Services/OrchestrationEngine";
+import type { ProjectionSnapshotQueryShape } from "./Services/ProjectionSnapshotQuery";
 import type { ProviderAdapterRegistryShape } from "../provider/Services/ProviderAdapterRegistry";
 import type { ProviderServiceShape } from "../provider/Services/ProviderService";
 import { parseManagedWorktreeWorkspaceRoot } from "../workspace/managedWorktree";
@@ -59,6 +60,7 @@ export interface ImportThreadHandlerOptions {
   readonly orchestrationEngine: OrchestrationEngineShape;
   readonly path: Path.Path;
   readonly platform: NodeJS.Platform;
+  readonly projectionSnapshotQuery: ProjectionSnapshotQueryShape;
   readonly providerAdapterRegistry: ProviderAdapterRegistryShape;
   readonly providerService: ProviderServiceShape;
 }
@@ -281,11 +283,11 @@ export function makeImportThreadHandler(options: ImportThreadHandlerOptions) {
   });
 
   return Effect.fnUntraced(function* (body: ImportThreadRequest) {
-    const readModel = yield* options.orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === body.threadId);
-    if (!thread || thread.deletedAt !== null) {
+    const threadOption = yield* options.projectionSnapshotQuery.getThreadDetailById(body.threadId);
+    if (Option.isNone(threadOption)) {
       return yield* Effect.fail(importMessagesError(`Thread '${body.threadId}' was not found.`));
     }
+    const thread = threadOption.value;
 
     if (thread.session && thread.session.status !== "stopped") {
       return yield* Effect.fail(
@@ -293,12 +295,22 @@ export function makeImportThreadHandler(options: ImportThreadHandlerOptions) {
       );
     }
 
+    const projectOption = yield* options.projectionSnapshotQuery.getProjectShellById(
+      thread.projectId,
+    );
+    const project = Option.getOrNull(projectOption);
     const cwd = resolveThreadWorkspaceCwd({
       thread,
-      projects: readModel.projects,
+      projects: project
+        ? [
+            {
+              id: project.id,
+              workspaceRoot: project.workspaceRoot,
+            },
+          ]
+        : [],
     });
     const externalId = body.externalId.trim();
-    const project = readModel.projects.find((entry) => entry.id === thread.projectId);
 
     const importedProviderContext =
       (thread.modelSelection.provider === "codex" ||

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -49,7 +49,9 @@ function makeLayer(input: {
     Layer.provide(
       Layer.succeed(ProjectionSnapshotQuery, {
         getSnapshot: () => unsupported(),
+        getCommandReadModel: () => unsupported(),
         getCounts: () => unsupported(),
+        getSnapshotSequence: () => unsupported(),
         getShellSnapshot: () => unsupported(),
         getActiveProjectByWorkspaceRoot: () => unsupported(),
         getProjectShellById: () => unsupported(),
@@ -57,6 +59,7 @@ function makeLayer(input: {
         getThreadCheckpointContext: () => unsupported(),
         getFullThreadDiffContext: () => unsupported(),
         getThreadShellById: () => Effect.succeed(Option.some(input.threadShell)),
+        findSyntheticSubagentParentThread: () => unsupported(),
         getThreadDetailById: () => unsupported(),
         getThreadDetailSnapshotById: () => unsupported(),
       }),

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -1,11 +1,8 @@
-import { ThreadId, TurnId, type OrchestrationReadModel } from "@t3tools/contracts";
-import { Effect, Exit, Layer, Scope, Stream } from "effect";
+import { ThreadId, TurnId, type OrchestrationThreadShell } from "@t3tools/contracts";
+import { Effect, Exit, Layer, Option, Scope, Stream } from "effect";
 import { describe, expect, it, vi } from "vitest";
 
-import {
-  OrchestrationEngineService,
-  type OrchestrationEngineShape,
-} from "../../orchestration/Services/OrchestrationEngine";
+import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery";
 import {
   ProviderSessionDirectory,
   type ProviderSessionDirectoryShape,
@@ -24,47 +21,46 @@ async function waitFor(predicate: () => boolean): Promise<void> {
   }
 }
 
-function makeReadModel(input: {
+function makeThreadShell(input: {
   readonly threadId: ThreadId;
   readonly activeTurnId: TurnId | null;
-}): OrchestrationReadModel {
+}): OrchestrationThreadShell {
   return {
-    snapshotSequence: 0,
-    updatedAt: new Date().toISOString(),
-    projects: [],
-    threads: [
-      {
-        id: input.threadId,
-        session: input.activeTurnId
-          ? {
-              activeTurnId: input.activeTurnId,
-            }
-          : null,
-      },
-    ],
-  } as unknown as OrchestrationReadModel;
+    id: input.threadId,
+    session: input.activeTurnId
+      ? {
+          activeTurnId: input.activeTurnId,
+        }
+      : null,
+  } as unknown as OrchestrationThreadShell;
 }
 
 function makeLayer(input: {
-  readonly readModel: OrchestrationReadModel;
+  readonly threadShell: OrchestrationThreadShell;
   readonly directory: ProviderSessionDirectoryShape;
   readonly providerService: ProviderServiceShape;
 }) {
-  const orchestrationEngine: OrchestrationEngineShape = {
-    getReadModel: () => Effect.succeed(input.readModel),
-    readEvents: () => Stream.empty,
-    dispatch: () => unsupported(),
-    repairState: () => unsupported(),
-    streamDomainEvents: Stream.empty,
-  };
-
   return makeProviderSessionReaperLive({
     inactivityThresholdMs: 1,
     sweepIntervalMs: 60_000,
   }).pipe(
     Layer.provide(Layer.succeed(ProviderSessionDirectory, input.directory)),
     Layer.provide(Layer.succeed(ProviderService, input.providerService)),
-    Layer.provide(Layer.succeed(OrchestrationEngineService, orchestrationEngine)),
+    Layer.provide(
+      Layer.succeed(ProjectionSnapshotQuery, {
+        getSnapshot: () => unsupported(),
+        getCounts: () => unsupported(),
+        getShellSnapshot: () => unsupported(),
+        getActiveProjectByWorkspaceRoot: () => unsupported(),
+        getProjectShellById: () => unsupported(),
+        getFirstActiveThreadIdByProjectId: () => unsupported(),
+        getThreadCheckpointContext: () => unsupported(),
+        getFullThreadDiffContext: () => unsupported(),
+        getThreadShellById: () => Effect.succeed(Option.some(input.threadShell)),
+        getThreadDetailById: () => unsupported(),
+        getThreadDetailSnapshotById: () => unsupported(),
+      }),
+    ),
   );
 }
 
@@ -112,7 +108,7 @@ describe("ProviderSessionReaperLive", () => {
       }).pipe(
         Effect.provide(
           makeLayer({
-            readModel: makeReadModel({ threadId, activeTurnId: null }),
+            threadShell: makeThreadShell({ threadId, activeTurnId: null }),
             directory,
             providerService,
           }),
@@ -171,7 +167,7 @@ describe("ProviderSessionReaperLive", () => {
       }).pipe(
         Effect.provide(
           makeLayer({
-            readModel: makeReadModel({ threadId, activeTurnId: turnId }),
+            threadShell: makeThreadShell({ threadId, activeTurnId: turnId }),
             directory,
             providerService,
           }),

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -1,6 +1,6 @@
-import { Cause, Duration, Effect, Layer, Schedule } from "effect";
+import { Cause, Duration, Effect, Layer, Option, Schedule } from "effect";
 
-import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine";
+import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory";
 import {
   ProviderSessionReaper,
@@ -20,7 +20,7 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
   Effect.gen(function* () {
     const providerService = yield* ProviderService;
     const directory = yield* ProviderSessionDirectory;
-    const orchestrationEngine = yield* OrchestrationEngineService;
+    const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
 
     const inactivityThresholdMs = Math.max(
       1,
@@ -29,8 +29,6 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
     const sweepIntervalMs = Math.max(1, options?.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS);
 
     const sweep = Effect.gen(function* () {
-      const readModel = yield* orchestrationEngine.getReadModel();
-      const threadsById = new Map(readModel.threads.map((thread) => [thread.id, thread] as const));
       const bindings = yield* directory.listBindings();
       const now = Date.now();
 
@@ -51,7 +49,9 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
         const idleDurationMs = now - lastSeenMs;
         if (idleDurationMs < inactivityThresholdMs) continue;
 
-        const thread = threadsById.get(binding.threadId);
+        const thread = yield* projectionSnapshotQuery
+          .getThreadShellById(binding.threadId)
+          .pipe(Effect.map(Option.getOrUndefined));
         if (thread?.session?.activeTurnId != null) continue;
 
         yield* providerService.stopSession({ threadId: binding.threadId }).pipe(

--- a/apps/server/src/stream/collectUint8StreamText.test.ts
+++ b/apps/server/src/stream/collectUint8StreamText.test.ts
@@ -1,0 +1,36 @@
+import * as Effect from "effect/Effect";
+import * as Stream from "effect/Stream";
+import { describe, expect, it } from "vitest";
+
+import { collectUint8StreamText } from "./collectUint8StreamText.ts";
+
+const encoder = new TextEncoder();
+
+describe("collectUint8StreamText", () => {
+  it("collects stream chunks into text", async () => {
+    const result = await Effect.runPromise(
+      collectUint8StreamText({
+        stream: Stream.fromIterable([encoder.encode("hello "), encoder.encode("world")]),
+      }),
+    );
+
+    expect(result).toEqual({
+      text: "hello world",
+      truncated: false,
+    });
+  });
+
+  it("truncates by bytes while continuing to drain the stream", async () => {
+    const result = await Effect.runPromise(
+      collectUint8StreamText({
+        stream: Stream.fromIterable([encoder.encode("hello"), encoder.encode(" world")]),
+        maxBytes: 7,
+      }),
+    );
+
+    expect(result).toEqual({
+      text: "hello w",
+      truncated: true,
+    });
+  });
+});

--- a/apps/server/src/stream/collectUint8StreamText.ts
+++ b/apps/server/src/stream/collectUint8StreamText.ts
@@ -6,32 +6,41 @@ export interface CollectedUint8StreamText {
   readonly truncated: boolean;
 }
 
+interface CollectState {
+  readonly chunks: Uint8Array[];
+  readonly byteLength: number;
+  readonly truncated: boolean;
+}
+
 export function collectUint8StreamText<E>(input: {
   readonly stream: Stream.Stream<Uint8Array, E>;
   readonly maxBytes?: number;
 }): Effect.Effect<CollectedUint8StreamText, E> {
   const maxBytes = input.maxBytes ?? Number.POSITIVE_INFINITY;
-  const decoder = new TextDecoder();
   return Stream.runFold(
     input.stream,
-    () => ({ chunks: [] as Uint8Array[], byteLength: 0, truncated: false }),
+    (): CollectState => ({ chunks: [], byteLength: 0, truncated: false }),
     (state, chunk) => {
-      if (state.truncated || state.byteLength >= maxBytes) {
+      if (state.truncated) {
+        return state;
+      }
+
+      const remaining = maxBytes - state.byteLength;
+      if (remaining <= 0) {
         return { ...state, truncated: true };
       }
-      const remaining = maxBytes - state.byteLength;
+
       const nextChunk = chunk.byteLength <= remaining ? chunk : chunk.slice(0, remaining);
+      state.chunks.push(nextChunk);
       return {
-        chunks: [...state.chunks, nextChunk],
+        chunks: state.chunks,
         byteLength: state.byteLength + nextChunk.byteLength,
         truncated: chunk.byteLength > remaining,
       };
     },
   ).pipe(
     Effect.map((state) => ({
-      text:
-        state.chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join("") +
-        decoder.decode(),
+      text: Buffer.concat(state.chunks, state.byteLength).toString("utf8"),
       truncated: state.truncated,
     })),
   );

--- a/apps/server/src/threadRetention.ts
+++ b/apps/server/src/threadRetention.ts
@@ -3,12 +3,18 @@
 // Layer: Server maintenance
 // Exports: retention constants, stale-thread selection, and scoped job startup.
 
-import { CommandId, type OrchestrationReadModel, type ThreadId } from "@t3tools/contracts";
+import {
+  CommandId,
+  type OrchestrationReadModel,
+  type OrchestrationShellSnapshot,
+  type ThreadId,
+} from "@t3tools/contracts";
 import { Effect } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { randomUUID } from "node:crypto";
 
 import type { OrchestrationEngineShape } from "./orchestration/Services/OrchestrationEngine";
+import type { ProjectionSnapshotQueryShape } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents";
 
 export const THREAD_RETENTION_UNUSED_MS = 7 * 24 * 60 * 60 * 1000;
@@ -18,7 +24,9 @@ const THREAD_RETENTION_BATCH_SIZE = 25;
 const THREAD_RETENTION_BATCH_PAUSE_MS = 50;
 const RETENTION_COMPACT_FREE_PAGE_THRESHOLD = 8192;
 
-type RetentionThread = OrchestrationReadModel["threads"][number];
+type RetentionThread =
+  | OrchestrationReadModel["threads"][number]
+  | OrchestrationShellSnapshot["threads"][number];
 
 type RetentionMaintenanceState = "started" | "progress" | "compacting" | "completed" | "failed";
 
@@ -181,7 +189,7 @@ const compactDatabaseAfterRetention = Effect.fn("compactDatabaseAfterRetention")
 
 // Picks the same threads manual deletion can delete, while protecting active work.
 export function getInactiveThreadIdsForRetention(
-  readModel: OrchestrationReadModel,
+  readModel: Pick<OrchestrationReadModel, "threads"> | Pick<OrchestrationShellSnapshot, "threads">,
   nowMs = Date.now(),
 ): ThreadId[] {
   const cutoffMs = nowMs - THREAD_RETENTION_UNUSED_MS;
@@ -225,11 +233,11 @@ const listSoftDeletedThreadIdsFromDatabase = Effect.fn("listSoftDeletedThreadIds
 
 export const runThreadRetentionSweep = Effect.fn("runThreadRetentionSweep")(function* (
   orchestrationEngine: OrchestrationEngineShape,
+  projectionSnapshotQuery: ProjectionSnapshotQueryShape,
 ) {
-  const readModel = yield* orchestrationEngine.getReadModel();
-  const inactiveThreadIds = getInactiveThreadIdsForRetention(readModel);
+  const shellSnapshot = yield* projectionSnapshotQuery.getShellSnapshot();
+  const inactiveThreadIds = getInactiveThreadIdsForRetention(shellSnapshot);
   const purgeThreadIds = new Set<ThreadId>([
-    ...getSoftDeletedThreadIdsForRetentionPurge(readModel),
     ...(yield* listSoftDeletedThreadIdsFromDatabase().pipe(
       Effect.catch((error) =>
         Effect.logWarning("failed to list soft-deleted threads for retention purge").pipe(
@@ -373,15 +381,16 @@ export const runThreadRetentionSweep = Effect.fn("runThreadRetentionSweep")(func
 
 export const startThreadRetentionJob = Effect.fn("startThreadRetentionJob")(function* (
   orchestrationEngine: OrchestrationEngineShape,
+  projectionSnapshotQuery: ProjectionSnapshotQueryShape,
 ) {
   // Give startup/projection bootstrap a short settling window, then run one
   // cleanup promptly so desktop installs do not need to stay open for 24 hours.
   yield* Effect.gen(function* () {
     yield* Effect.sleep(THREAD_RETENTION_INITIAL_SWEEP_DELAY_MS);
-    yield* runThreadRetentionSweep(orchestrationEngine);
+    yield* runThreadRetentionSweep(orchestrationEngine, projectionSnapshotQuery);
     yield* Effect.forever(
       Effect.sleep(THREAD_RETENTION_SWEEP_INTERVAL_MS).pipe(
-        Effect.flatMap(() => runThreadRetentionSweep(orchestrationEngine)),
+        Effect.flatMap(() => runThreadRetentionSweep(orchestrationEngine, projectionSnapshotQuery)),
       ),
       { disableYield: true },
     );

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -256,6 +256,7 @@ export const makeWsRpcLayer = () =>
         orchestrationEngine,
         path,
         platform: process.platform,
+        projectionSnapshotQuery: projectionReadModelQuery,
         providerAdapterRegistry,
         providerService,
       });

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -194,6 +194,7 @@ export default function DiffPanel({
   const providerOptions = useMemo(() => getProviderStartOptions(settings), [settings]);
   const [diffRenderMode, setDiffRenderMode] = useState<DiffRenderMode>("stacked");
   const [diffWordWrap, setDiffWordWrap] = useState(settings.diffWordWrap);
+  const [diffIgnoreWhitespace, setDiffIgnoreWhitespace] = useState(true);
   const [surfaceMode, setSurfaceMode] = useState<DiffSurfaceMode>("review");
   const repoDiffScope = useRepoDiffScopeStore((store) => store.scope);
   const setRepoDiffScope = useRepoDiffScopeStore((store) => store.setScope);
@@ -343,6 +344,7 @@ export default function DiffPanel({
       threadId: activeThreadId,
       fromTurnCount: activeCheckpointRange?.fromTurnCount ?? null,
       toTurnCount: activeCheckpointRange?.toTurnCount ?? null,
+      ignoreWhitespace: diffIgnoreWhitespace,
       cacheScope: selectedTurn ? `turn:${selectedTurn.turnId}` : conversationCacheScope,
       enabled: isGitRepo && !diffEnvironmentPending,
     }),
@@ -801,6 +803,20 @@ export default function DiffPanel({
               }}
             >
               <TextWrapIcon className="size-3" />
+            </Toggle>
+            <Toggle
+              aria-label={
+                diffIgnoreWhitespace ? "Show whitespace changes" : "Hide whitespace changes"
+              }
+              title={diffIgnoreWhitespace ? "Show whitespace changes" : "Hide whitespace changes"}
+              variant="outline"
+              size="xs"
+              pressed={diffIgnoreWhitespace}
+              onPressedChange={(pressed) => {
+                setDiffIgnoreWhitespace(Boolean(pressed));
+              }}
+            >
+              <FaPlusMinus className="size-3" />
             </Toggle>
           </>
         ) : null}

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -804,22 +804,6 @@ export default function DiffPanel({
             >
               <TextWrapIcon className="size-3" />
             </Toggle>
-            <Toggle
-              aria-label={
-                diffIgnoreWhitespace ? "Show whitespace changes" : "Hide whitespace changes"
-              }
-              title={diffIgnoreWhitespace ? "Show whitespace changes" : "Hide whitespace changes"}
-              className="px-2.5"
-              variant="outline"
-              size="xs"
-              pressed={diffIgnoreWhitespace}
-              onPressedChange={(pressed) => {
-                setDiffIgnoreWhitespace(Boolean(pressed));
-              }}
-            >
-              <FaPlusMinus className="size-3" />
-              <span className="text-[11px] leading-none font-medium">Hide whitespace</span>
-            </Toggle>
           </>
         ) : null}
         {onClosePanel ? (
@@ -945,11 +929,31 @@ export default function DiffPanel({
                   </MenuRadioGroup>
                 </MenuPopup>
               </Menu>
+              {surfaceMode !== "summary" ? (
+                <Toggle
+                  aria-label={
+                    diffIgnoreWhitespace ? "Show whitespace changes" : "Hide whitespace changes"
+                  }
+                  title={
+                    diffIgnoreWhitespace ? "Show whitespace changes" : "Hide whitespace changes"
+                  }
+                  className="ml-auto shrink-0 px-2.5 self-center"
+                  variant="outline"
+                  size="xs"
+                  pressed={diffIgnoreWhitespace}
+                  onPressedChange={(pressed) => {
+                    setDiffIgnoreWhitespace(Boolean(pressed));
+                  }}
+                >
+                  <FaPlusMinus className="size-3" />
+                  <span className="text-[11px] leading-none font-medium">Hide whitespace</span>
+                </Toggle>
+              ) : null}
               {surfaceMode !== "summary" && diffCopyText ? (
                 <Button
                   variant="ghost"
                   size="xs"
-                  className="ml-auto shrink-0 gap-1.5 self-center"
+                  className="shrink-0 gap-1.5 self-center"
                   onClick={() => {
                     copyDiffToClipboard(diffCopyText, undefined);
                   }}

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -809,6 +809,7 @@ export default function DiffPanel({
                 diffIgnoreWhitespace ? "Show whitespace changes" : "Hide whitespace changes"
               }
               title={diffIgnoreWhitespace ? "Show whitespace changes" : "Hide whitespace changes"}
+              className="px-2.5"
               variant="outline"
               size="xs"
               pressed={diffIgnoreWhitespace}
@@ -817,6 +818,7 @@ export default function DiffPanel({
               }}
             >
               <FaPlusMinus className="size-3" />
+              <span className="text-[11px] leading-none font-medium">Hide whitespace</span>
             </Toggle>
           </>
         ) : null}

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -12,6 +12,7 @@ import {
   Columns2Icon,
   CopyIcon,
   DiffIcon,
+  AdjustmentsIcon,
   Rows3Icon,
   TextWrapIcon,
   XIcon,
@@ -60,7 +61,14 @@ import ChatMarkdown from "./ChatMarkdown";
 import { resolveDiffPanelThread } from "./DiffPanel.logic";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
 import { Button } from "./ui/button";
-import { Menu, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
+import {
+  Menu,
+  MenuCheckboxItem,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuTrigger,
+} from "./ui/menu";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 import { FileEntryIcon } from "./chat/FileEntryIcon";
 import { DiffStatLabel, hasNonZeroStat } from "./chat/DiffStatLabel";
@@ -929,31 +937,42 @@ export default function DiffPanel({
                   </MenuRadioGroup>
                 </MenuPopup>
               </Menu>
-              {surfaceMode !== "summary" ? (
-                <Toggle
-                  aria-label={
-                    diffIgnoreWhitespace ? "Show whitespace changes" : "Hide whitespace changes"
-                  }
-                  title={
-                    diffIgnoreWhitespace ? "Show whitespace changes" : "Hide whitespace changes"
-                  }
-                  className="ml-auto shrink-0 px-2.5 self-center"
-                  variant="outline"
-                  size="xs"
-                  pressed={diffIgnoreWhitespace}
-                  onPressedChange={(pressed) => {
-                    setDiffIgnoreWhitespace(Boolean(pressed));
-                  }}
-                >
-                  <FaPlusMinus className="size-3" />
-                  <span className="text-[11px] leading-none font-medium">Hide whitespace</span>
-                </Toggle>
+              {surfaceMode === "review" ? (
+                <Menu>
+                  <MenuTrigger
+                    render={
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        className="ml-auto shrink-0 self-center"
+                        aria-label="Diff view options"
+                        title="Diff view options"
+                      />
+                    }
+                  >
+                    <AdjustmentsIcon className="size-3.5" />
+                  </MenuTrigger>
+                  <MenuPopup align="end">
+                    <MenuCheckboxItem
+                      checked={diffIgnoreWhitespace}
+                      variant="switch"
+                      onCheckedChange={(checked) => {
+                        setDiffIgnoreWhitespace(checked === true);
+                      }}
+                    >
+                      Ignore whitespace-only changes
+                    </MenuCheckboxItem>
+                  </MenuPopup>
+                </Menu>
               ) : null}
               {surfaceMode !== "summary" && diffCopyText ? (
                 <Button
                   variant="ghost"
                   size="xs"
-                  className="shrink-0 gap-1.5 self-center"
+                  className={cn(
+                    "shrink-0 gap-1.5 self-center",
+                    surfaceMode !== "review" && "ml-auto",
+                  )}
                   onClick={() => {
                     copyDiffToClipboard(diffCopyText, undefined);
                   }}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -34,7 +34,9 @@ export type MessagesTimelineRow =
       inlineWorkGroupId?: string;
       durationStart: string;
       showCompletionDivider: boolean;
+      completionSummary: string | null;
       showAssistantCopyButton: boolean;
+      assistantCopyStreaming: boolean;
       assistantTurnDiffSummary?: TurnDiffSummary | undefined;
       revertTurnCount?: number | undefined;
     }
@@ -150,7 +152,10 @@ export function deriveTerminalAssistantMessageIds(
 export function deriveMessagesTimelineRows(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
   completionDividerBeforeEntryId: string | null;
+  completionSummary?: string | null;
   isWorking: boolean;
+  activeTurnInProgress?: boolean;
+  activeTurnId?: TurnId | null;
   activeTurnStartedAt: string | null;
   turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
   revertTurnCountByUserMessageId: ReadonlyMap<MessageId, number>;
@@ -249,6 +254,15 @@ export function deriveMessagesTimelineRows(input: {
       flushPendingWorkGroup();
     }
 
+    const assistantTurnStillInProgress =
+      timelineEntry.message.role === "assistant" &&
+      input.activeTurnInProgress === true &&
+      input.activeTurnId != null &&
+      timelineEntry.message.turnId === input.activeTurnId;
+    const showCompletionDivider =
+      timelineEntry.message.role === "assistant" &&
+      input.completionDividerBeforeEntryId === timelineEntry.id;
+
     nextRows.push({
       kind: "message",
       id: timelineEntry.id,
@@ -258,12 +272,12 @@ export function deriveMessagesTimelineRows(input: {
       ...(inlineWorkGroupId ? { inlineWorkGroupId } : {}),
       durationStart:
         durationStartByMessageId.get(timelineEntry.message.id) ?? timelineEntry.message.createdAt,
-      showCompletionDivider:
-        timelineEntry.message.role === "assistant" &&
-        input.completionDividerBeforeEntryId === timelineEntry.id,
+      showCompletionDivider,
+      completionSummary: showCompletionDivider ? (input.completionSummary ?? null) : null,
       showAssistantCopyButton:
         timelineEntry.message.role === "assistant" &&
         terminalAssistantMessageIds.has(timelineEntry.message.id),
+      assistantCopyStreaming: timelineEntry.message.streaming || assistantTurnStillInProgress,
       assistantTurnDiffSummary:
         timelineEntry.message.role === "assistant"
           ? input.turnDiffSummaryByAssistantMessageId.get(timelineEntry.message.id)
@@ -428,7 +442,9 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
         a.inlineWorkGroupId === bm.inlineWorkGroupId &&
         a.durationStart === bm.durationStart &&
         a.showCompletionDivider === bm.showCompletionDivider &&
+        a.completionSummary === bm.completionSummary &&
         a.showAssistantCopyButton === bm.showAssistantCopyButton &&
+        a.assistantCopyStreaming === bm.assistantCopyStreaming &&
         a.assistantTurnDiffSummary === bm.assistantTurnDiffSummary &&
         a.revertTurnCount === bm.revertTurnCount
       );

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -313,7 +313,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       deriveMessagesTimelineRows({
         timelineEntries,
         completionDividerBeforeEntryId,
+        completionSummary,
         isWorking,
+        activeTurnInProgress,
+        activeTurnId,
         activeTurnStartedAt,
         turnDiffSummaryByAssistantMessageId,
         revertTurnCountByUserMessageId,
@@ -321,7 +324,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [
       timelineEntries,
       completionDividerBeforeEntryId,
+      completionSummary,
       isWorking,
+      activeTurnInProgress,
+      activeTurnId,
       activeTurnStartedAt,
       turnDiffSummaryByAssistantMessageId,
       revertTurnCountByUserMessageId,
@@ -665,7 +671,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           const assistantCopyState = resolveAssistantMessageCopyState({
             text: row.message.text ?? null,
             showCopyButton: row.showAssistantCopyButton,
-            streaming: row.message.streaming,
+            streaming: row.assistantCopyStreaming,
           });
           const turnSummary = row.assistantTurnDiffSummary;
           const fileDiffStatByPath = new Map(
@@ -736,7 +742,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     className="text-muted-foreground/80"
                     style={{ fontSize: chatTypographyStyle.fontSize }}
                   >
-                    {completionSummary ? `Response • ${completionSummary}` : "Response"}
+                    {row.completionSummary ? `Response • ${row.completionSummary}` : "Response"}
                   </span>
                   <span className="h-px flex-1 bg-border" />
                 </div>
@@ -1059,16 +1065,23 @@ function useStableRows(rows: MessagesTimelineRow[]): MessagesTimelineRow[] {
 // Keep the live clock scoped to tiny leaf components so active Claude turns do
 // not force the full transcript tree to re-render every second.
 function WorkingTimer({ createdAt }: { createdAt: string }) {
-  const [nowMs, setNowMs] = useState(() => Date.now());
+  const textRef = useRef<HTMLSpanElement>(null);
+  const initialText = formatWorkingTimerNow(createdAt);
+
   useEffect(() => {
-    const id = window.setInterval(() => {
-      setNowMs(Date.now());
-    }, 1000);
+    const updateText = () => {
+      if (textRef.current) {
+        textRef.current.textContent = formatWorkingTimerNow(createdAt);
+      }
+    };
+    updateText();
+    const id = window.setInterval(updateText, 1000);
     return () => {
       window.clearInterval(id);
     };
   }, [createdAt]);
-  return <>{formatWorkingTimer(createdAt, new Date(nowMs).toISOString()) ?? "0s"}</>;
+
+  return <span ref={textRef}>{initialText}</span>;
 }
 
 function LiveMessageMeta({
@@ -1080,25 +1093,27 @@ function LiveMessageMeta({
   durationStart: string;
   timestampFormat: TimestampFormat;
 }) {
-  const [nowMs, setNowMs] = useState(() => Date.now());
+  const textRef = useRef<HTMLSpanElement>(null);
+  const initialText = formatLiveMessageMetaNow(createdAt, durationStart, timestampFormat);
+
   useEffect(() => {
-    const id = window.setInterval(() => {
-      setNowMs(Date.now());
-    }, 1000);
+    const updateText = () => {
+      if (textRef.current) {
+        textRef.current.textContent = formatLiveMessageMetaNow(
+          createdAt,
+          durationStart,
+          timestampFormat,
+        );
+      }
+    };
+    updateText();
+    const id = window.setInterval(updateText, 1000);
     return () => {
       window.clearInterval(id);
     };
-  }, [durationStart]);
+  }, [createdAt, durationStart, timestampFormat]);
 
-  return (
-    <>
-      {formatMessageMeta(
-        createdAt,
-        formatElapsed(durationStart, new Date(nowMs).toISOString()),
-        timestampFormat,
-      )}
-    </>
-  );
+  return <span ref={textRef}>{initialText}</span>;
 }
 
 function formatWorkingTimer(startIso: string, endIso: string): string | null {
@@ -1122,6 +1137,22 @@ function formatWorkingTimer(startIso: string, endIso: string): string | null {
   }
 
   return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+function formatWorkingTimerNow(startIso: string): string {
+  return formatWorkingTimer(startIso, new Date().toISOString()) ?? "0s";
+}
+
+function formatLiveMessageMetaNow(
+  createdAt: string,
+  durationStart: string,
+  timestampFormat: TimestampFormat,
+): string {
+  return formatMessageMeta(
+    createdAt,
+    formatElapsed(durationStart, new Date().toISOString()),
+    timestampFormat,
+  );
 }
 
 function formatMessageMeta(

--- a/apps/web/src/lib/providerReactQuery.test.ts
+++ b/apps/web/src/lib/providerReactQuery.test.ts
@@ -33,6 +33,7 @@ describe("providerQueryKeys.checkpointDiff", () => {
       threadId,
       fromTurnCount: 1,
       toTurnCount: 2,
+      ignoreWhitespace: true,
     } as const;
 
     expect(
@@ -44,6 +45,27 @@ describe("providerQueryKeys.checkpointDiff", () => {
       providerQueryKeys.checkpointDiff({
         ...baseInput,
         cacheScope: "turn:new-turn",
+      }),
+    );
+  });
+
+  it("includes ignoreWhitespace so whitespace modes do not collide", () => {
+    const baseInput = {
+      threadId,
+      fromTurnCount: 1,
+      toTurnCount: 2,
+      cacheScope: "turn:abc",
+    } as const;
+
+    expect(
+      providerQueryKeys.checkpointDiff({
+        ...baseInput,
+        ignoreWhitespace: true,
+      }),
+    ).not.toEqual(
+      providerQueryKeys.checkpointDiff({
+        ...baseInput,
+        ignoreWhitespace: false,
       }),
     );
   });
@@ -59,6 +81,7 @@ describe("checkpointDiffQueryOptions", () => {
       threadId,
       fromTurnCount: 3,
       toTurnCount: 4,
+      ignoreWhitespace: true,
       cacheScope: "turn:abc",
     });
 
@@ -69,6 +92,7 @@ describe("checkpointDiffQueryOptions", () => {
       threadId,
       fromTurnCount: 3,
       toTurnCount: 4,
+      ignoreWhitespace: true,
     });
     expect(getFullThreadDiff).not.toHaveBeenCalled();
   });
@@ -82,6 +106,7 @@ describe("checkpointDiffQueryOptions", () => {
       threadId,
       fromTurnCount: 0,
       toTurnCount: 2,
+      ignoreWhitespace: false,
       cacheScope: "thread:all",
     });
 
@@ -91,6 +116,7 @@ describe("checkpointDiffQueryOptions", () => {
     expect(getFullThreadDiff).toHaveBeenCalledWith({
       threadId,
       toTurnCount: 2,
+      ignoreWhitespace: false,
     });
     expect(getTurnDiff).not.toHaveBeenCalled();
   });
@@ -104,6 +130,7 @@ describe("checkpointDiffQueryOptions", () => {
       threadId,
       fromTurnCount: 4,
       toTurnCount: 3,
+      ignoreWhitespace: true,
       cacheScope: "turn:invalid",
     });
 
@@ -121,6 +148,7 @@ describe("checkpointDiffQueryOptions", () => {
       threadId,
       fromTurnCount: 1,
       toTurnCount: 2,
+      ignoreWhitespace: true,
       cacheScope: "turn:abc",
     });
     const retry = options.retry;
@@ -144,6 +172,7 @@ describe("checkpointDiffQueryOptions", () => {
       threadId,
       fromTurnCount: 1,
       toTurnCount: 2,
+      ignoreWhitespace: true,
       cacheScope: "turn:abc",
     });
     const retryDelay = options.retryDelay;

--- a/apps/web/src/lib/providerReactQuery.ts
+++ b/apps/web/src/lib/providerReactQuery.ts
@@ -16,6 +16,7 @@ interface CheckpointDiffQueryInput {
   threadId: ThreadId | null;
   fromTurnCount: number | null;
   toTurnCount: number | null;
+  ignoreWhitespace: boolean;
   cacheScope?: string | null;
   enabled?: boolean;
 }
@@ -29,6 +30,7 @@ export const providerQueryKeys = {
       input.threadId,
       input.fromTurnCount,
       input.toTurnCount,
+      input.ignoreWhitespace,
       input.cacheScope ?? null,
     ] as const,
 };
@@ -38,6 +40,7 @@ function decodeCheckpointDiffRequest(input: CheckpointDiffQueryInput) {
     return Schema.decodeUnknownOption(OrchestrationGetFullThreadDiffInput)({
       threadId: input.threadId,
       toTurnCount: input.toTurnCount,
+      ignoreWhitespace: input.ignoreWhitespace,
     }).pipe(Option.map((fields) => ({ kind: "fullThreadDiff" as const, input: fields })));
   }
 
@@ -45,6 +48,7 @@ function decodeCheckpointDiffRequest(input: CheckpointDiffQueryInput) {
     threadId: input.threadId,
     fromTurnCount: input.fromTurnCount,
     toTurnCount: input.toTurnCount,
+    ignoreWhitespace: input.ignoreWhitespace,
   }).pipe(Option.map((fields) => ({ kind: "turnDiff" as const, input: fields })));
 }
 

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -9,6 +9,7 @@ import {
   ModelSelection,
   OrchestrationCommand,
   OrchestrationEvent,
+  OrchestrationGetFullThreadDiffInput,
   OrchestrationGetTurnDiffInput,
   OrchestrationLatestTurn,
   OrchestrationReadModel,
@@ -25,6 +26,7 @@ import {
 } from "./orchestration";
 
 const decodeTurnDiffInput = Schema.decodeUnknownEffect(OrchestrationGetTurnDiffInput);
+const decodeFullThreadDiffInput = Schema.decodeUnknownEffect(OrchestrationGetFullThreadDiffInput);
 const decodeThreadTurnDiff = Schema.decodeUnknownEffect(ThreadTurnDiff);
 const decodeProjectCreateCommand = Schema.decodeUnknownEffect(ProjectCreateCommand);
 const decodeProjectCreatedPayload = Schema.decodeUnknownEffect(ProjectCreatedPayload);
@@ -161,9 +163,23 @@ it.effect("parses turn diff input when fromTurnCount <= toTurnCount", () =>
       threadId: "thread-1",
       fromTurnCount: 1,
       toTurnCount: 2,
+      ignoreWhitespace: true,
     });
     assert.strictEqual(parsed.fromTurnCount, 1);
     assert.strictEqual(parsed.toTurnCount, 2);
+    assert.strictEqual(parsed.ignoreWhitespace, true);
+  }),
+);
+
+it.effect("parses full thread diff input with optional whitespace flag", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeFullThreadDiffInput({
+      threadId: "thread-1",
+      toTurnCount: 2,
+      ignoreWhitespace: false,
+    });
+    assert.strictEqual(parsed.toTurnCount, 2);
+    assert.strictEqual(parsed.ignoreWhitespace, false);
   }),
 );
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1387,6 +1387,8 @@ export const ThreadMessageEditResendRequestedPayload = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
   text: TrimmedNonEmptyString.check(Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_INPUT_CHARS)),
+  rollbackTurnCount: Schema.optional(NonNegativeInt),
+  removedTurnIds: Schema.optional(Schema.Array(TurnId)),
   modelSelection: Schema.optional(ModelSelection),
   providerOptions: Schema.optional(ProviderStartOptions),
   assistantDeliveryMode: Schema.optional(AssistantDeliveryMode),
@@ -1679,7 +1681,10 @@ const OrchestrationRepairStateResult = OrchestrationReadModel;
 export type OrchestrationRepairStateResult = typeof OrchestrationRepairStateResult.Type;
 
 export const OrchestrationGetTurnDiffInput = TurnCountRange.mapFields(
-  Struct.assign({ threadId: ThreadId }),
+  Struct.assign({
+    threadId: ThreadId,
+    ignoreWhitespace: Schema.optional(Schema.Boolean),
+  }),
   { unsafePreserveChecks: true },
 );
 export type OrchestrationGetTurnDiffInput = typeof OrchestrationGetTurnDiffInput.Type;
@@ -1690,6 +1695,7 @@ export type OrchestrationGetTurnDiffResult = typeof OrchestrationGetTurnDiffResu
 export const OrchestrationGetFullThreadDiffInput = Schema.Struct({
   threadId: ThreadId,
   toTurnCount: NonNegativeInt,
+  ignoreWhitespace: Schema.optional(Schema.Boolean),
 });
 export type OrchestrationGetFullThreadDiffInput = typeof OrchestrationGetFullThreadDiffInput.Type;
 


### PR DESCRIPTION
## Summary

- Speeds up checkpoint diff loading by removing redundant checkpoint ref probes and adding a narrow full-thread diff context query.
- Optimizes streamed byte collection to avoid repeated array copies and per-chunk decoding.
- Reduces startup/background read-model pressure by moving session reaping, thread retention, and import-thread lookup paths onto targeted projection reads.
- Reduces chat timeline render churn by keeping timer updates out of React state and projecting assistant row activity state into derived row data.

## Validation

- `bun run --cwd apps/server test src/checkpointing/Layers/CheckpointDiffQuery.test.ts src/orchestration/Layers/ProjectionSnapshotQuery.test.ts src/stream/collectUint8StreamText.test.ts src/provider/Layers/ProviderSessionReaper.test.ts src/threadRetention.test.ts src/orchestration/Layers/ProviderRuntimeIngestion.test.ts`
- `bun run --cwd apps/web test src/components/chat/MessagesTimeline.logic.test.ts src/components/chat/MessagesTimeline.test.tsx`
- `git diff --check`

## Notes

The deeper engine/reactor migration remains intentionally out of this PR. Those paths still need dedicated projection query helpers before removing the full in-memory read model entirely.
