### PR TITLE
Add Claude Opus 4.8 ultracode support

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -291,11 +291,14 @@ function normalizeClaudeStreamMessages(cause: Cause.Cause<Error>): ReadonlyArray
 
 function getEffectiveClaudeCodeEffort(
   effort: ClaudeCodeEffort | null | undefined,
-): Exclude<ClaudeCodeEffort, "ultrathink"> | null {
+): Exclude<ClaudeCodeEffort, "ultrathink" | "ultracode"> | null {
   if (!effort) {
     return null;
   }
-  return effort === "ultrathink" ? null : effort;
+  if (effort === "ultrathink") {
+    return null;
+  }
+  return effort === "ultracode" ? "xhigh" : effort;
 }
 
 function isClaudeInterruptedMessage(message: string): boolean {
@@ -3192,12 +3195,14 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             ? modelSelection.options.thinking
             : undefined;
         const effectiveEffort = getEffectiveClaudeCodeEffort(effort);
+        const ultracode = effort === "ultracode" && hasEffortLevel(caps, "xhigh");
         const permissionMode =
           toPermissionMode(providerOptions?.permissionMode) ??
           (input.runtimeMode === "full-access" ? "bypassPermissions" : undefined);
         const settings = {
           ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
           ...(fastMode ? { fastMode: true } : {}),
+          ...(ultracode ? { ultracode: true } : {}),
         };
         const claudeSubagents = buildClaudeSdkSubagents();
 
@@ -3360,6 +3365,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 ? { maxThinkingTokens: providerOptions.maxThinkingTokens }
                 : {}),
               ...(fastMode ? { fastMode: true } : {}),
+              ...(ultracode ? { ultracode: true } : {}),
             },
           },
           providerRefs: {},

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -880,7 +880,8 @@ function normalizeProviderModelOptions(
     claudeCandidate?.effort === "high" ||
     claudeCandidate?.effort === "xhigh" ||
     claudeCandidate?.effort === "max" ||
-    claudeCandidate?.effort === "ultrathink"
+    claudeCandidate?.effort === "ultrathink" ||
+    claudeCandidate?.effort === "ultracode"
       ? claudeCandidate.effort
       : undefined;
   const claudeFastMode =

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -11,6 +11,7 @@ export const CLAUDE_CODE_EFFORT_OPTIONS = [
   "xhigh",
   "max",
   "ultrathink",
+  "ultracode",
 ] as const;
 export type ClaudeCodeEffort = (typeof CLAUDE_CODE_EFFORT_OPTIONS)[number];
 export const GEMINI_THINKING_LEVEL_OPTIONS = ["LOW", "HIGH"] as const;
@@ -259,6 +260,28 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
   ],
   claudeAgent: [
     {
+      slug: "claude-opus-4-8",
+      name: "Claude Opus 4.8",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "low", label: "Low" },
+          { value: "medium", label: "Medium" },
+          { value: "high", label: "High", isDefault: true },
+          { value: "xhigh", label: "Extra High" },
+          { value: "max", label: "Max" },
+          { value: "ultrathink", label: "Ultrathink" },
+          { value: "ultracode", label: "Ultracode" },
+        ],
+        supportsFastMode: true,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: ["ultrathink"],
+        contextWindowOptions: [
+          { value: "200k", label: "200k", isDefault: true },
+          { value: "1m", label: "1M" },
+        ],
+      },
+    },
+    {
       slug: "claude-opus-4-7",
       name: "Claude Opus 4.7",
       capabilities: {
@@ -269,6 +292,7 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
           { value: "xhigh", label: "Extra High" },
           { value: "max", label: "Max" },
           { value: "ultrathink", label: "Ultrathink" },
+          { value: "ultracode", label: "Ultracode" },
         ],
         supportsFastMode: true,
         supportsThinkingToggle: false,
@@ -550,7 +574,10 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
   claudeAgent: {
-    opus: "claude-opus-4-7",
+    opus: "claude-opus-4-8",
+    "opus-4.8": "claude-opus-4-8",
+    "claude-opus-4.8": "claude-opus-4-8",
+    "claude-opus-4-8-20260528": "claude-opus-4-8",
     "opus-4.7": "claude-opus-4-7",
     "claude-opus-4.7": "claude-opus-4-7",
     "claude-opus-4-7-20260416": "claude-opus-4-7",


### PR DESCRIPTION
Summary
- Add Claude Opus 4.8 with 200k and 1M context options.
- Include the full supported Claude effort menu, including ultracode.
- Update the Claude Agent SDK to a version that exposes the ultracode session setting.
- Map ultracode to xhigh effort plus the Claude Code ultracode setting, which enables dynamic workflow orchestration.

Validation
- Not run per request.