### PR TITLE
Fix blurry UI text on Windows/Linux at fractional display scaling

### DIFF
--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -5,6 +5,7 @@
 
 import { useCallback, useEffect, useSyncExternalStore } from "react";
 import { isElectron } from "../env";
+import { isMacPlatform } from "../lib/utils";
 import {
   DEFAULT_THEME_STATE,
   type ChromeTheme,
@@ -156,6 +157,7 @@ function applyThemeState(state: ThemeState, suppressTransitions = false) {
   const activeTheme = resolveThemePack(state, variant);
   const cssVariableBuild = buildThemeCssVariables(activeTheme, variant, {
     electron: isElectron,
+    isMac: isMacPlatform(typeof navigator === "undefined" ? "" : navigator.platform),
   });
 
   root.classList.toggle("dark", variant === "dark");

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -993,8 +993,8 @@ diffs-container {
 
 .chat-composer-surface {
   background: var(--composer-surface);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: var(--app-composer-backdrop-filter, none);
+  -webkit-backdrop-filter: var(--app-composer-backdrop-filter, none);
 }
 
 .sidebar-segmented-picker {

--- a/apps/web/src/theme/theme.logic.ts
+++ b/apps/web/src/theme/theme.logic.ts
@@ -655,13 +655,19 @@ export function resolveThemeVariant(mode: ThemeMode, systemDark: boolean): Theme
 export function buildThemeCssVariables(
   pack: ThemePack,
   variant: ThemeVariant,
-  options?: { electron?: boolean },
+  options?: { electron?: boolean; isMac?: boolean },
 ): ThemeCssVariableBuild {
   const resolvedTokens = buildResolvedThemeTokens(pack, variant);
   const codexVariables = resolvedTokens.codexVariables;
   const readCodexVariable = (name: string) => getRequiredVariable(codexVariables, name);
+  // The translucent shell relies on macOS window vibrancy as its backing
+  // material. Windows/Linux have no equivalent, so a translucent shell there
+  // leaves the transparent body and backdrop-filter surfaces bleeding through
+  // and (on fractional DPI) rendering blurry. Restrict translucency to macOS.
   const material: WindowMaterial =
-    options?.electron === true && !pack.theme.opaqueWindows ? "translucent" : "opaque";
+    options?.electron === true && options?.isMac === true && !pack.theme.opaqueWindows
+      ? "translucent"
+      : "opaque";
   const warningColor = variant === "dark" ? "#f5b44a" : "#d97706";
   const sidebarSurfaceUnder = readCodexVariable("--color-background-surface-under");
   const sidebarRaisedSurface = readCodexVariable("--color-background-elevated-primary");
@@ -691,7 +697,12 @@ export function buildThemeCssVariables(
         ? "transparent"
         : readCodexVariable("--color-background-surface-under"),
     "--app-composer-focus-border": composerFocusBorder,
-    "--app-composer-picker-backdrop-filter": "blur(32px)",
+    // Frosted blur only when the shell is translucent (macOS). On an opaque
+    // shell these promote the surface to a GPU layer that Chromium rasterizes at
+    // the wrong scale on fractional DPI (Windows), so text reads blurry until a
+    // repaint. Keep them "none" off macOS.
+    "--app-composer-backdrop-filter": material === "translucent" ? "blur(16px)" : "none",
+    "--app-composer-picker-backdrop-filter": material === "translucent" ? "blur(32px)" : "none",
     "--app-composer-picker-surface": composerPickerMenuSurface,
     "--app-chat-code-surface": chatCodeSurface,
     "--app-user-message-background": chatCodeSurface,


### PR DESCRIPTION
## Summary

On Windows/Linux with fractional display scaling (e.g. 125% / 150%), UI text
renders blurry — most visibly the composer prompt bar, which only snaps sharp
once you click into it.

**Cause:** the translucent window material and its `backdrop-filter` surfaces
(composer, sidebar) are enabled whenever the app runs in Electron, regardless of
OS. That material is designed around macOS vibrancy, which Windows/Linux don't
have. The frosted surfaces get promoted to their own GPU compositor layers, and
on fractional DPI Chromium rasterizes those layers at the wrong scale — so their
contents (including text) stay blurry until the layer is repainted (focus, caret,
hover).

This restricts the translucent material (and its backdrop blur) to macOS. On
Windows/Linux the shell is opaque and crisp — consistent with how the settings
surface already opts out of the blur.

## Changes

- **`apps/web/src/theme/theme.logic.ts`** — `material` is `translucent` only on
  macOS (was: any Electron). The composer backdrop-filter variables
  (`--app-composer-backdrop-filter`, `--app-composer-picker-backdrop-filter`)
  now follow the material and resolve to `none` on an opaque shell.
- **`apps/web/src/hooks/useTheme.ts`** — passes `isMac` into
  `buildThemeCssVariables`.
- **`apps/web/src/index.css`** — `.chat-composer-surface` uses the
  material-driven `--app-composer-backdrop-filter` instead of a hardcoded
  `blur(16px)`.

Side effect: because the opaque material gives the body an opaque background, the
window also stops rendering see-through on Windows.

## Test plan

- **macOS:** vibrancy + frosted sidebar/composer unchanged.
- **Windows @ 125%:** composer, sidebar, and headings are crisp without needing
  focus; window is opaque.
- Light and dark themes both render correctly.
- `buildThemeCssVariables` unit tests pass (the Electron-only case still resolves
  to the opaque material).

## Notes

- Transient popovers/menus still use `backdrop-blur` and would show the same
  fractional-DPI behavior while open; they can be gated the same way in a
  follow-up if desired.
