### PR TITLE
fix(desktop): hydrate Windows env from the registry

### DIFF
--- a/apps/desktop/src/syncShellEnvironment.test.ts
+++ b/apps/desktop/src/syncShellEnvironment.test.ts
@@ -174,7 +174,47 @@ describe("syncShellEnvironment", () => {
     expect(env.PATH).toBe("/opt/homebrew/bin:/usr/bin");
   });
 
-  it("does nothing outside macOS and Linux", () => {
+  it("hydrates PATH and missing variables from the Windows registry", () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "C:\\Windows\\system32",
+    };
+    const readWindowsEnvironment = vi.fn(() => ({
+      PATH: "C:\\Windows\\system32;C:\\Users\\ramar\\.local\\bin",
+      CLAUDE_CONFIG_DIR: "C:\\Users\\ramar\\.config\\claude",
+    }));
+
+    syncShellEnvironment(env, {
+      platform: "win32",
+      readWindowsEnvironment,
+    });
+
+    expect(readWindowsEnvironment).toHaveBeenCalledTimes(1);
+    expect(env.PATH).toBe("C:\\Windows\\system32;C:\\Users\\ramar\\.local\\bin");
+    expect(env.CLAUDE_CONFIG_DIR).toBe("C:\\Users\\ramar\\.config\\claude");
+  });
+
+  it("merges Windows PATH but preserves variables already in the environment", () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "C:\\Windows\\system32",
+      CLAUDE_CONFIG_DIR: "C:\\already\\set",
+    };
+    const readWindowsEnvironment = vi.fn(() => ({
+      PATH: "C:\\Users\\ramar\\.local\\bin",
+      CLAUDE_CONFIG_DIR: "C:\\Users\\ramar\\.config\\claude",
+      GEMINI_API_KEY: "from-registry",
+    }));
+
+    syncShellEnvironment(env, {
+      platform: "win32",
+      readWindowsEnvironment,
+    });
+
+    expect(env.PATH).toBe("C:\\Users\\ramar\\.local\\bin;C:\\Windows\\system32");
+    expect(env.CLAUDE_CONFIG_DIR).toBe("C:\\already\\set");
+    expect(env.GEMINI_API_KEY).toBe("from-registry");
+  });
+
+  it("does nothing on unsupported platforms", () => {
     const env: NodeJS.ProcessEnv = {
       SHELL: "/bin/zsh",
       PATH: "/usr/bin",
@@ -186,7 +226,7 @@ describe("syncShellEnvironment", () => {
     }));
 
     syncShellEnvironment(env, {
-      platform: "win32",
+      platform: "freebsd",
       readEnvironment,
     });
 

--- a/apps/desktop/src/syncShellEnvironment.ts
+++ b/apps/desktop/src/syncShellEnvironment.ts
@@ -7,7 +7,9 @@ import {
   mergePathEntries,
   readPathFromLaunchctl,
   readEnvironmentFromLoginShell,
+  readWindowsPersistentEnvironment,
   type ShellEnvironmentReader,
+  type WindowsEnvironmentReader,
 } from "@t3tools/shared/shell";
 
 const LOGIN_SHELL_ENV_NAMES = [
@@ -24,20 +26,58 @@ function logShellEnvironmentWarning(message: string, error?: unknown): void {
   console.warn(`[desktop] ${message}`, error instanceof Error ? error.message : (error ?? ""));
 }
 
+// Windows GUI processes inherit a (possibly stale) environment block instead of a login
+// shell. Hydrate PATH and any missing variables from the persisted registry environment so
+// CLI providers resolve the same config the user's terminal sees (e.g. CLAUDE_CONFIG_DIR).
+function syncWindowsEnvironment(
+  env: NodeJS.ProcessEnv,
+  readWindowsEnvironment: WindowsEnvironmentReader,
+  logWarning: (message: string, error?: unknown) => void,
+): void {
+  try {
+    const persisted = readWindowsEnvironment();
+
+    const mergedPath = mergePathEntries(persisted.PATH, env.PATH, "win32");
+    if (mergedPath) {
+      env.PATH = mergedPath;
+    }
+
+    for (const [name, value] of Object.entries(persisted)) {
+      if (name.toUpperCase() === "PATH") continue;
+      if (value && env[name] === undefined) {
+        env[name] = value;
+      }
+    }
+  } catch (error) {
+    logWarning("Failed to synchronize the desktop Windows environment.", error);
+  }
+}
+
 export function syncShellEnvironment(
   env: NodeJS.ProcessEnv = process.env,
   options: {
     platform?: NodeJS.Platform;
     readEnvironment?: ShellEnvironmentReader;
     readLaunchctlPath?: typeof readPathFromLaunchctl;
+    readWindowsEnvironment?: WindowsEnvironmentReader;
     userShell?: string;
     logWarning?: (message: string, error?: unknown) => void;
   } = {},
 ): void {
   const platform = options.platform ?? process.platform;
+  const logWarning = options.logWarning ?? logShellEnvironmentWarning;
+
+  if (platform === "win32") {
+    syncWindowsEnvironment(
+      env,
+      options.readWindowsEnvironment ?? readWindowsPersistentEnvironment,
+      logWarning,
+    );
+    return;
+  }
+
   if (platform !== "darwin" && platform !== "linux") return;
 
-  const logWarning = options.logWarning ?? logShellEnvironmentWarning;
   const readEnvironment = options.readEnvironment ?? readEnvironmentFromLoginShell;
   const shellEnvironment: Partial<Record<string, string>> = {};
 

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -4,9 +4,11 @@ import {
   extractPathFromShellOutput,
   listLoginShellCandidates,
   mergePathEntries,
+  mergeWindowsScopes,
   readEnvironmentFromLoginShell,
   readPathFromLaunchctl,
   readPathFromLoginShell,
+  readWindowsPersistentEnvironment,
   resolveLoginShell,
 } from "./shell";
 
@@ -193,5 +195,48 @@ describe("mergePathEntries", () => {
     expect(mergePathEntries("C:\\Tools;C:\\Windows", "C:\\Windows;C:\\Git", "win32")).toBe(
       "C:\\Tools;C:\\Windows;C:\\Git",
     );
+  });
+});
+
+describe("mergeWindowsScopes", () => {
+  it("composes PATH as machine then user and lets user variables win", () => {
+    const merged = mergeWindowsScopes(
+      { Path: "C:\\Windows\\system32", FOO: "machine" },
+      { Path: "C:\\Users\\ramar\\.local\\bin", FOO: "user", CLAUDE_CONFIG_DIR: "C:\\cfg" },
+    );
+
+    expect(merged.PATH).toBe("C:\\Windows\\system32;C:\\Users\\ramar\\.local\\bin");
+    expect(merged.FOO).toBe("user");
+    expect(merged.CLAUDE_CONFIG_DIR).toBe("C:\\cfg");
+  });
+
+  it("ignores empty values and a missing scope", () => {
+    const merged = mergeWindowsScopes({ Path: "C:\\Windows", EMPTY: "  " }, {});
+
+    expect(merged.PATH).toBe("C:\\Windows");
+    expect(merged.EMPTY).toBeUndefined();
+  });
+});
+
+describe("readWindowsPersistentEnvironment", () => {
+  it("parses the registry dump and merges machine + user scopes", () => {
+    const execFile = vi.fn(() =>
+      JSON.stringify({
+        machine: { Path: "C:\\Windows\\system32" },
+        user: { Path: "C:\\Users\\ramar\\.local\\bin", CLAUDE_CONFIG_DIR: "C:\\cfg" },
+      }),
+    );
+
+    const result = readWindowsPersistentEnvironment(execFile);
+
+    expect(execFile).toHaveBeenCalledTimes(1);
+    expect(result.PATH).toBe("C:\\Windows\\system32;C:\\Users\\ramar\\.local\\bin");
+    expect(result.CLAUDE_CONFIG_DIR).toBe("C:\\cfg");
+  });
+
+  it("returns an empty object when the dump is not valid JSON", () => {
+    const execFile = vi.fn(() => "not json");
+
+    expect(readWindowsPersistentEnvironment(execFile)).toEqual({});
   });
 });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -189,3 +189,81 @@ export const readEnvironmentFromLoginShell: ShellEnvironmentReader = (
 
   return environment;
 };
+
+// Windows has no login-shell to probe; the user's persisted environment lives in the
+// registry (HKCU + HKLM). A GUI process launched from a stale Explorer inherits an
+// outdated environment block, so we read the registry directly to pick up current values.
+
+function isPathName(name: string): boolean {
+  return name.toUpperCase() === "PATH";
+}
+
+// Merge the Machine and User registry scopes the way Windows composes the environment:
+// User scope wins for ordinary variables, and PATH is Machine entries followed by User entries.
+export function mergeWindowsScopes(
+  machine: Partial<Record<string, string>>,
+  user: Partial<Record<string, string>>,
+): Partial<Record<string, string>> {
+  const merged: Partial<Record<string, string>> = {};
+
+  const assignNonPath = (source: Partial<Record<string, string>>): void => {
+    for (const [name, value] of Object.entries(source)) {
+      if (isPathName(name)) continue;
+      const trimmed = trimNonEmpty(value);
+      if (trimmed) {
+        merged[name] = trimmed;
+      }
+    }
+  };
+  assignNonPath(machine);
+  assignNonPath(user);
+
+  const scopePath = (source: Partial<Record<string, string>>): string | undefined => {
+    for (const [name, value] of Object.entries(source)) {
+      if (isPathName(name)) return trimNonEmpty(value);
+    }
+    return undefined;
+  };
+  const combinedPath = [scopePath(machine), scopePath(user)]
+    .filter((value): value is string => Boolean(value))
+    .join(";");
+  if (combinedPath) {
+    merged.PATH = combinedPath;
+  }
+
+  return merged;
+}
+
+export type WindowsEnvironmentReader = (
+  execFile?: ExecFileSyncLike,
+) => Partial<Record<string, string>>;
+
+const WINDOWS_ENVIRONMENT_SCRIPT = [
+  "$ErrorActionPreference='Stop';",
+  "function dump($s){$m=[ordered]@{};$v=[Environment]::GetEnvironmentVariables($s);",
+  "foreach($k in $v.Keys){$m[[string]$k]=[Environment]::ExpandEnvironmentVariables([string]$v[$k])};$m}",
+  "$o=[ordered]@{machine=(dump 'Machine');user=(dump 'User')};",
+  "[Console]::Out.Write(($o|ConvertTo-Json -Compress -Depth 3))",
+].join("");
+
+export const readWindowsPersistentEnvironment: WindowsEnvironmentReader = (
+  execFile = execFileSync,
+) => {
+  const output = execFile(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", WINDOWS_ENVIRONMENT_SCRIPT],
+    { encoding: "utf8", timeout: 5000 },
+  );
+
+  let parsed: {
+    machine?: Partial<Record<string, string>>;
+    user?: Partial<Record<string, string>>;
+  };
+  try {
+    parsed = JSON.parse(output.trim());
+  } catch {
+    return {};
+  }
+
+  return mergeWindowsScopes(parsed.machine ?? {}, parsed.user ?? {});
+};


### PR DESCRIPTION
## What Changed

`syncShellEnvironment` now handles Windows. It previously early-returned on any
non-macOS/Linux platform, so the desktop never hydrated its environment there.
Added a `win32` branch that reads the persisted **User + Machine** registry
environment and:

- merges it into `PATH`
- fills in any variable not already set in the process env (e.g. `CLAUDE_CONFIG_DIR`)

The registry read sits behind an injectable reader (`readWindowsPersistentEnvironment`),
so the merge logic is unit-tested without touching a real registry.

## Why

On Windows, GUI apps inherit Electron's launch-time environment block, not the
user's current shell/registry environment. So a CLI provider the app spawns can
miss config the user's terminal already has — most visibly `CLAUDE_CONFIG_DIR`,
which Claude Code needs to locate its credentials. The symptom was Claude showing
a false "not authenticated" / greyed-out **Sign In** even though `claude` was
logged in from a terminal on the same machine. macOS and Linux already avoid this
via the login-shell sync; this brings Windows to parity.

## Tests

- `packages/shared`: unit tests for `mergeWindowsScopes` (scope precedence + PATH
  composition) and `readWindowsPersistentEnvironment` (registry-dump parsing and
  bad-JSON fallback).
- `apps/desktop`: `syncShellEnvironment` win32 tests (hydrates PATH + missing vars;
  preserves variables already in the environment).
- Full `shared` + `desktop` suites, `typecheck`, `oxlint`, and `oxfmt --check` pass.

The injectable seams and JSON parsing are covered cross-platform; the actual
PowerShell registry read only runs on Windows, so that live path hasn't been
exercised on CI hardware.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] No UI changes
- [ ] No animation/interaction changes

🤖 *This content was generated with AI assistance using Claude Opus 4.8.*
