### PR TITLE
Skip incompatible desktop update releases

### DIFF
--- a/apps/desktop/src/githubUpdateFeed.test.ts
+++ b/apps/desktop/src/githubUpdateFeed.test.ts
@@ -6,6 +6,8 @@ import {
   resolveGitHubUpdateSource,
 } from "./githubUpdateFeed";
 
+const dpCodeAssets = (version: string) => [{ name: `DP-Code-${version}-arm64.zip` }];
+
 describe("resolveGitHubUpdateSource", () => {
   it("returns null for non-github providers", () => {
     expect(resolveGitHubUpdateSource({ provider: "generic" })).toBeNull();
@@ -31,8 +33,18 @@ describe("pickLatestStableGitHubRelease", () => {
   it("chooses the highest stable semver release instead of the first entry", () => {
     expect(
       pickLatestStableGitHubRelease([
-        { tag_name: "v0.0.30", draft: false, prerelease: false },
-        { tag_name: "v0.0.31", draft: false, prerelease: false },
+        {
+          tag_name: "v0.0.30",
+          draft: false,
+          prerelease: false,
+          assets: dpCodeAssets("0.0.30"),
+        },
+        {
+          tag_name: "v0.0.31",
+          draft: false,
+          prerelease: false,
+          assets: dpCodeAssets("0.0.31"),
+        },
       ]),
     ).toEqual({
       tag: "v0.0.31",
@@ -43,16 +55,32 @@ describe("pickLatestStableGitHubRelease", () => {
   it("ignores drafts, prereleases, and invalid tags", () => {
     expect(
       pickLatestStableGitHubRelease([
-        { tag_name: "v0.0.32-beta.1", draft: false, prerelease: true },
-        { tag_name: "build-123", draft: false, prerelease: false },
-        { tag_name: "v0.0.31", draft: true, prerelease: false },
-        { tag_name: "v0.0.30", draft: false, prerelease: false },
+        {
+          tag_name: "v0.0.32-beta.1",
+          draft: false,
+          prerelease: true,
+          assets: dpCodeAssets("0.0.32"),
+        },
+        { tag_name: "build-123", draft: false, prerelease: false, assets: dpCodeAssets("0.0.33") },
+        {
+          tag_name: "v0.0.31",
+          draft: true,
+          prerelease: false,
+          assets: dpCodeAssets("0.0.31"),
+        },
+        {
+          tag_name: "v0.0.30",
+          draft: false,
+          prerelease: false,
+          assets: dpCodeAssets("0.0.30"),
+        },
       ]),
     ).toEqual({
       tag: "v0.0.30",
       version: "0.0.30",
     });
   });
+
 });
 
 describe("buildGitHubReleaseDownloadBaseUrl", () => {

--- a/apps/desktop/src/githubUpdateFeed.ts
+++ b/apps/desktop/src/githubUpdateFeed.ts
@@ -9,6 +9,7 @@ type GitHubReleaseRecord = {
   readonly tag_name?: unknown;
   readonly draft?: unknown;
   readonly prerelease?: unknown;
+  readonly assets?: unknown;
 };
 
 export type LatestGitHubRelease = {
@@ -46,6 +47,21 @@ function compareParsedVersions(left: ParsedVersion, right: ParsedVersion): numbe
     return left.minor - right.minor;
   }
   return left.patch - right.patch;
+}
+
+function hasDpCodeDesktopAsset(release: GitHubReleaseRecord, version: string): boolean {
+  if (!Array.isArray(release.assets)) {
+    return false;
+  }
+
+  const dpCodeArtifactPrefix = `DP-Code-${version}-`;
+  return release.assets.some((asset) => {
+    if (!asset || typeof asset !== "object") {
+      return false;
+    }
+    const name = (asset as { name?: unknown }).name;
+    return typeof name === "string" && name.startsWith(dpCodeArtifactPrefix);
+  });
 }
 
 function getGitHubApiBaseUrl(source: GitHubUpdateSource): URL {
@@ -97,11 +113,16 @@ export function pickLatestStableGitHubRelease(
       continue;
     }
 
+    const versionString = `${version.major}.${version.minor}.${version.patch}`;
+    if (!hasDpCodeDesktopAsset(release, versionString)) {
+      continue;
+    }
+
     if (bestVersion === null || compareParsedVersions(version, bestVersion) > 0) {
       bestVersion = version;
       best = {
         tag,
-        version: `${version.major}.${version.minor}.${version.patch}`,
+        version: versionString,
       };
     }
   }


### PR DESCRIPTION
## Summary

- Skip GitHub desktop releases that do not include DP Code desktop artifacts before selecting the updater feed tag.
- Update existing updater-feed tests with realistic DP Code release assets for the new compatibility check.

## Root Cause

Existing DP Code installs resolve the latest stable GitHub Release and point `electron-updater` at that tag. `v0.0.51` is branded as Synara and ships a macOS app bundle with `com.t3tools.synara`, while existing DP Code installs expect `com.t3tools.dpcode`. Squirrel.Mac downloads the ZIP, cannot find a matching update bundle, relaunches the old app, and shows the update button again.

## Impact

This prevents future DP Code builds from selecting an incompatible branded release as their update target. Existing `0.0.50` installs still need a release-side recovery: either publish a compatible DP Code bundle with the original bundle id, or ask users to install Synara manually.

## Validation

- `bun run --cwd apps/desktop test src/githubUpdateFeed.test.ts`
