### PR TITLE
fix(claude): stop thinking_tokens telemetry from flooding the conversation timeline

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1572,6 +1572,76 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("ignores thinking_tokens telemetry and de-dupes unknown Claude system subtypes", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.takeUntil((event) => event.type === "task.progress"),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+
+      // High-frequency reasoning telemetry — must never reach the timeline.
+      for (let i = 0; i < 3; i += 1) {
+        harness.query.emit({
+          type: "system",
+          subtype: "thinking_tokens",
+          estimated_tokens: 50 * (i + 1),
+          estimated_tokens_delta: 50,
+          session_id: "sdk-session-thinking",
+          uuid: `thinking-${i}`,
+        } as unknown as SDKMessage);
+      }
+
+      // Same unknown subtype emitted twice — must surface exactly one warning.
+      for (let i = 0; i < 2; i += 1) {
+        harness.query.emit({
+          type: "system",
+          subtype: "future_unknown_subtype",
+          session_id: "sdk-session-unknown",
+          uuid: `unknown-${i}`,
+        } as unknown as SDKMessage);
+      }
+
+      // Sentinel that produces a real event so the collector terminates.
+      harness.query.emit({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "task-sentinel",
+        description: "sentinel",
+        usage: { total_tokens: 1, tool_uses: 0, duration_ms: 1 },
+        session_id: "sdk-session-sentinel",
+        uuid: "task-progress-sentinel",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const warnings = runtimeEvents.filter((event) => event.type === "runtime.warning");
+
+      assert.equal(warnings.length, 1);
+      assert.equal(
+        warnings.every(
+          (event) =>
+            event.type === "runtime.warning" && !event.payload.message.includes("thinking_tokens"),
+        ),
+        true,
+      );
+      if (warnings[0]?.type === "runtime.warning") {
+        assert.equal(warnings[0].payload.message.includes("future_unknown_subtype"), true);
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("maps Claude TodoWrite tool input into shared turn plan updates", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -215,6 +215,10 @@ interface ClaudeSessionContext {
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
   stopped: boolean;
+  // Unrecognized SDK message kinds already surfaced as a runtime warning. Newer
+  // Claude SDKs stream high-frequency telemetry (e.g. `thinking_tokens`); de-duping
+  // here keeps a single unknown kind from flooding the conversation timeline.
+  readonly warnedUnhandledSdkKinds: Set<string>;
 }
 
 interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
@@ -1619,6 +1623,24 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         });
       });
 
+    // Surfaces each distinct unrecognized SDK message kind at most once per session.
+    // Without this, high-frequency telemetry the adapter doesn't model (notably the
+    // `thinking_tokens` system subtype streamed on every reasoning tick) turns into a
+    // "Runtime warning" timeline entry per message and floods the conversation.
+    const warnUnhandledSdkKind = (
+      context: ClaudeSessionContext,
+      kind: string,
+      message: string,
+      detail: unknown,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (context.warnedUnhandledSdkKinds.has(kind)) {
+          return;
+        }
+        context.warnedUnhandledSdkKinds.add(kind);
+        yield* emitRuntimeWarning(context, message, detail);
+      });
+
     const emitProposedPlanCompleted = (
       context: ClaudeSessionContext,
       input: {
@@ -2415,6 +2437,15 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           return;
         }
 
+        // Benign high-frequency telemetry we intentionally don't project. `thinking_tokens`
+        // streams on every reasoning tick while extended thinking is active; `task_updated`
+        // is an incremental task patch already covered by task_started/progress/completed.
+        // Short-circuit before allocating an event stamp so they can't flood the timeline
+        // (or churn allocations) with "Runtime warning" entries.
+        if (message.subtype === "thinking_tokens" || message.subtype === "task_updated") {
+          return;
+        }
+
         const stamp = yield* makeEventStamp();
         const base = {
           eventId: stamp.eventId,
@@ -2596,8 +2627,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             });
             return;
           default:
-            yield* emitRuntimeWarning(
+            yield* warnUnhandledSdkKind(
               context,
+              `system:${message.subtype}`,
               `Unhandled Claude system message subtype '${message.subtype}'.`,
               message,
             );
@@ -2710,8 +2742,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             yield* handleSdkTelemetryMessage(context, message);
             return;
           default:
-            yield* emitRuntimeWarning(
+            yield* warnUnhandledSdkKind(
               context,
+              `type:${message.type}`,
               `Unhandled Claude SDK message type '${message.type}'.`,
               message,
             );
@@ -3331,6 +3364,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           lastAssistantUuid: resumeState?.resumeSessionAt,
           lastThreadStartedId: undefined,
           stopped: false,
+          warnedUnhandledSdkKinds: new Set(),
         };
         yield* Ref.set(contextRef, context);
         sessions.set(threadId, context);


### PR DESCRIPTION
## Problem

Sessions using the **Claude** provider flood the conversation timeline with hundreds-to-thousands of "Runtime warning" entries. On one machine the projection DB held **606+** such activities in a single sitting — by far the most frequent activity kind, all reading `Unhandled Claude system message subtype 'thinking_tokens'.`

Root cause: the Claude Agent SDK streams `system` messages with `subtype: "thinking_tokens"` on every reasoning tick while extended thinking is active (a running token counter — `{ estimated_tokens, estimated_tokens_delta }`), plus occasional `task_updated` task patches. `handleSystemMessage` in `ClaudeAdapter.ts` had no case for these, so each fell through to the `default:` branch and emitted a `runtime.warning` domain event — which `ProviderRuntimeIngestion` projects into a timeline activity titled "Runtime warning".

These never show up in the log files because they're projection/domain events, not logger output — which makes the flood easy to miss when grepping logs.

## Fix

- **Short-circuit benign high-frequency telemetry** (`thinking_tokens`, `task_updated`) before allocating an event stamp / `base` object. `thinking_tokens` fires per reasoning tick, so this also avoids per-tick allocation churn.
- **Dedup unknown SDK message kinds**: both "unhandled" default branches now route through a new `warnUnhandledSdkKind` helper backed by a session-level `warnedUnhandledSdkKinds` set, so any *future* unhandled kind (the SDK still has several unhandled `system` subtypes — `session_state_changed`, `memory_recall`, `notification`, …) surfaces **once per session** instead of flooding.
- Added a regression test: `thinking_tokens` produces zero warnings, and a repeated unknown subtype produces exactly one.

## Verification

- `apps/server` vitest: **60/60 pass** (incl. the new test)
- `bun fmt`, `bun lint` (0 errors), `bun typecheck` (8/8 packages) — all green

🤖 *Generated with AI assistance using Claude Opus 4.8.*
