### PR TITLE
Remove redundant completion divider; dedupe turn "Worked for" label

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -155,9 +155,7 @@ import {
   deriveWorkLogEntries,
   hasActionableProposedPlan,
   hasLiveTurnTailWork,
-  hasToolActivityForTurn,
   isLatestTurnSettled,
-  formatElapsed,
   WORK_LOG_PRESENTATION_VERSION,
   type ActiveTaskListState,
 } from "../session-logic";
@@ -1846,10 +1844,6 @@ export default function ChatView({
         : rawWorkLogEntries,
     [activeThread?.id, hasWorkLogSubagents, rawWorkLogEntries, relevantWorkLogThreads],
   );
-  const latestTurnHasToolActivity = useMemo(
-    () => hasToolActivityForTurn(threadActivities, activeLatestTurn?.turnId),
-    [activeLatestTurn?.turnId, threadActivities],
-  );
   const pendingApprovals = useMemo(
     () => derivePendingApprovals(threadActivities),
     [threadActivities],
@@ -2330,51 +2324,6 @@ export default function ChatView({
     return byUserMessageId;
   }, [inferredCheckpointTurnCountByTurnId, timelineEntries, turnDiffSummaryByAssistantMessageId]);
 
-  const completionSummary = useMemo(() => {
-    if (!latestTurnSettled) return null;
-    if (!activeLatestTurn?.startedAt) return null;
-    if (!activeLatestTurn.completedAt) return null;
-    if (!latestTurnHasToolActivity) return null;
-
-    const elapsed = formatElapsed(activeLatestTurn.startedAt, activeLatestTurn.completedAt);
-    return elapsed ? `Worked for ${elapsed}` : null;
-  }, [
-    activeLatestTurn?.completedAt,
-    activeLatestTurn?.startedAt,
-    latestTurnHasToolActivity,
-    latestTurnSettled,
-  ]);
-  const completionDividerBeforeEntryId = useMemo(() => {
-    if (!latestTurnSettled) return null;
-    if (!activeLatestTurn?.startedAt) return null;
-    if (!activeLatestTurn.completedAt) return null;
-    if (!completionSummary) return null;
-
-    const turnStartedAt = Date.parse(activeLatestTurn.startedAt);
-    const turnCompletedAt = Date.parse(activeLatestTurn.completedAt);
-    if (Number.isNaN(turnStartedAt)) return null;
-    if (Number.isNaN(turnCompletedAt)) return null;
-
-    let inRangeMatch: string | null = null;
-    let fallbackMatch: string | null = null;
-    for (const timelineEntry of timelineEntries) {
-      if (timelineEntry.kind !== "message") continue;
-      if (timelineEntry.message.role !== "assistant") continue;
-      const messageAt = Date.parse(timelineEntry.message.createdAt);
-      if (Number.isNaN(messageAt) || messageAt < turnStartedAt) continue;
-      fallbackMatch = timelineEntry.id;
-      if (messageAt <= turnCompletedAt) {
-        inRangeMatch = timelineEntry.id;
-      }
-    }
-    return inRangeMatch ?? fallbackMatch;
-  }, [
-    activeLatestTurn?.completedAt,
-    activeLatestTurn?.startedAt,
-    completionSummary,
-    latestTurnSettled,
-    timelineEntries,
-  ]);
   const threadWorkspaceCwd = activeProject
     ? resolveSharedThreadWorkspaceCwd({
         projectCwd: activeProject.cwd,
@@ -8288,8 +8237,6 @@ export default function ChatView({
                     activeTurnStartedAt={activeWorkStartedAt}
                     listRef={legendListRef}
                     timelineEntries={timelineEntries}
-                    completionDividerBeforeEntryId={completionDividerBeforeEntryId}
-                    completionSummary={completionSummary}
                     turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
                     onOpenTurnDiff={onOpenTurnDiff}
                     onOpenThread={onNavigateToThread}

--- a/apps/web/src/components/chat/ChatTranscriptPane.browser.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.browser.tsx
@@ -85,8 +85,6 @@ function TranscriptPerfHarness(props: { onTranscriptRender: () => void }) {
           activeTurnInProgress={false}
           activeTurnStartedAt={null}
           chatFontSizePx={15}
-          completionDividerBeforeEntryId={null}
-          completionSummary={null}
           emptyStateProjectName={undefined}
           expandedWorkGroups={EMPTY_WORK_GROUPS}
           hasMessages
@@ -169,8 +167,6 @@ describe("ChatTranscriptPane", () => {
         activeTurnInProgress={false}
         activeTurnStartedAt={null}
         chatFontSizePx={15}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         emptyStateProjectName={undefined}
         hasMessages
         isRevertingCheckpoint={false}

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -29,8 +29,6 @@ interface ChatTranscriptPaneProps {
   activeTurnStartedAt: string | null;
   bottomContentInsetPx?: ComponentProps<typeof MessagesTimeline>["bottomContentInsetPx"];
   chatFontSizePx: number;
-  completionDividerBeforeEntryId: string | null;
-  completionSummary: string | null;
   emptyStateProjectName: string | undefined;
   expandedWorkGroups?: Record<string, boolean>;
   hasMessages: boolean;
@@ -74,8 +72,6 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
   activeTurnStartedAt,
   bottomContentInsetPx,
   chatFontSizePx,
-  completionDividerBeforeEntryId,
-  completionSummary,
   emptyStateProjectName,
   expandedWorkGroups,
   hasMessages,
@@ -130,8 +126,6 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
           activeTurnStartedAt={activeTurnStartedAt}
           listRef={listRef}
           timelineEntries={timelineEntries}
-          completionDividerBeforeEntryId={completionDividerBeforeEntryId}
-          completionSummary={completionSummary}
           turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
           onOpenTurnDiff={onOpenTurnDiff}
           onOpenThread={onOpenThread}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -253,8 +253,6 @@ describe("computeStableMessagesTimelineRows", () => {
         ],
         inlineWorkGroupId: "activity-command",
         durationStart: "2026-05-09T10:00:01.000Z",
-        showCompletionDivider: false,
-        completionSummary: null,
         showAssistantCopyButton: false,
         assistantCopyStreaming: true,
       },
@@ -526,7 +524,6 @@ describe("deriveMessagesTimelineRows", () => {
   type MessageTimelineRow = Extract<MessagesTimelineRow, { kind: "message" }>;
 
   const baseInput = {
-    completionDividerBeforeEntryId: null as string | null,
     isWorking: false,
     activeTurnStartedAt: null as string | null,
     turnDiffSummaryByAssistantMessageId: new Map(),

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -48,8 +48,6 @@ export type MessagesTimelineRow =
       collapsedTurnItems?: CollapsedTurnItem[];
       collapsedWorkElapsed?: string | null;
       durationStart: string;
-      showCompletionDivider: boolean;
-      completionSummary: string | null;
       showAssistantCopyButton: boolean;
       assistantCopyStreaming: boolean;
       assistantTurnDiffSummary?: TurnDiffSummary | undefined;
@@ -197,8 +195,6 @@ export function deriveTerminalAssistantMessageIds(
 // t3code behavior of attaching trailing work groups to the adjacent assistant reply.
 export function deriveMessagesTimelineRows(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
-  completionDividerBeforeEntryId: string | null;
-  completionSummary?: string | null;
   isWorking: boolean;
   activeTurnInProgress?: boolean;
   activeTurnId?: TurnId | null | undefined;
@@ -307,9 +303,6 @@ export function deriveMessagesTimelineRows(input: {
       input.activeTurnInProgress === true &&
       input.activeTurnId != null &&
       timelineEntry.message.turnId === input.activeTurnId;
-    const showCompletionDivider =
-      timelineEntry.message.role === "assistant" &&
-      input.completionDividerBeforeEntryId === timelineEntry.id;
 
     nextRows.push({
       kind: "message",
@@ -320,8 +313,6 @@ export function deriveMessagesTimelineRows(input: {
       ...(inlineWorkGroupId ? { inlineWorkGroupId } : {}),
       durationStart:
         durationStartByMessageId.get(timelineEntry.message.id) ?? timelineEntry.message.createdAt,
-      showCompletionDivider,
-      completionSummary: showCompletionDivider ? (input.completionSummary ?? null) : null,
       showAssistantCopyButton:
         timelineEntry.message.role === "assistant" &&
         terminalAssistantMessageIds.has(timelineEntry.message.id),
@@ -454,10 +445,6 @@ function collapseSettledTurns(
             folded.assistantTurnDiffSummary,
             row.assistantTurnDiffSummary ?? folded.assistantTurnDiffSummary,
           );
-        }
-        if (folded.showCompletionDivider && !row.showCompletionDivider) {
-          row.showCompletionDivider = true;
-          row.completionSummary = folded.completionSummary;
         }
         // Work that preceded a narration message was attached as its inline
         // entries; keep it ahead of the narration text in chronological order.
@@ -643,8 +630,6 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
         collapsedTurnItemsEqual(a.collapsedTurnItems, bm.collapsedTurnItems) &&
         a.collapsedWorkElapsed === bm.collapsedWorkElapsed &&
         a.durationStart === bm.durationStart &&
-        a.showCompletionDivider === bm.showCompletionDivider &&
-        a.completionSummary === bm.completionSummary &&
         a.showAssistantCopyButton === bm.showAssistantCopyButton &&
         a.assistantCopyStreaming === bm.assistantCopyStreaming &&
         a.assistantTurnDiffSummary === bm.assistantTurnDiffSummary &&

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -90,8 +90,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -135,8 +133,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -179,8 +175,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -242,8 +236,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -304,8 +296,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -352,8 +342,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:32.000Z"
         expandedWorkGroups={{}}
@@ -403,8 +391,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -463,8 +449,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -507,8 +491,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -555,8 +537,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -607,8 +587,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -659,8 +637,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -704,8 +680,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -749,8 +723,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -795,8 +767,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -838,8 +808,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -895,8 +863,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -953,8 +919,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:31.000Z"
         expandedWorkGroups={{}}
@@ -1065,8 +1029,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -1129,8 +1091,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-05-09T16:31:25.000Z"
         expandedWorkGroups={{}}
@@ -1241,8 +1201,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -1311,8 +1269,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:31.000Z"
         expandedWorkGroups={{}}
@@ -1416,8 +1372,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{ "entry-inline-tools-expanded": true }}
@@ -1475,8 +1429,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={
           new Map([
             [
@@ -1545,8 +1497,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -1598,8 +1548,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-05-09T10:07:00.000Z"
         expandedWorkGroups={{}}
@@ -1646,8 +1594,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -1693,8 +1639,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -1740,8 +1684,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -1787,8 +1729,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -1833,8 +1773,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={new Map()}
         nowIso="2026-03-17T19:12:30.000Z"
         expandedWorkGroups={{}}
@@ -1895,8 +1833,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={
           new Map([
             [
@@ -1983,8 +1919,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={
           new Map([
             [
@@ -2058,8 +1992,6 @@ describe("MessagesTimeline", () => {
             },
           },
         ]}
-        completionDividerBeforeEntryId={null}
-        completionSummary={null}
         turnDiffSummaryByAssistantMessageId={
           new Map([
             [

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -176,8 +176,6 @@ interface MessagesTimelineProps {
   emptyStateContent?: ReactNode;
   listRef?: RefObject<LegendListRef | null>;
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
-  completionDividerBeforeEntryId: string | null;
-  completionSummary: string | null;
   turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
   nowIso?: string;
   expandedWorkGroups?: Record<string, boolean>;
@@ -217,8 +215,6 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   followLiveOutput = false,
   listRef,
   timelineEntries,
-  completionDividerBeforeEntryId,
-  completionSummary,
   turnDiffSummaryByAssistantMessageId,
   nowIso,
   expandedWorkGroups,
@@ -330,8 +326,6 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     () =>
       deriveMessagesTimelineRows({
         timelineEntries,
-        completionDividerBeforeEntryId,
-        completionSummary,
         isWorking,
         activeTurnInProgress,
         activeTurnId,
@@ -341,8 +335,6 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       }),
     [
       timelineEntries,
-      completionDividerBeforeEntryId,
-      completionSummary,
       isWorking,
       activeTurnInProgress,
       activeTurnId,
@@ -820,7 +812,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   >
                     <CollapsibleTrigger
                       data-scroll-anchor-ignore={isTailContentRow ? true : undefined}
-                      className="inline-flex items-center gap-1 pb-2 text-left text-muted-foreground/70 transition-colors duration-200 hover:text-muted-foreground/90"
+                      // -ml-0.5 optically aligns the leading "W" with the reply
+                      // text below: the box is already flush, but the W glyph
+                      // carries a left side-bearing that reads as an inset.
+                      className="-ml-0.5 inline-flex items-center gap-1 pb-2 text-left text-muted-foreground/70 transition-colors duration-200 hover:text-muted-foreground/90"
                       style={{ fontSize: chatTypographyStyle.fontSize }}
                     >
                       <span>
@@ -871,18 +866,6 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     </CollapsiblePanel>
                   </Collapsible>
                   <div className="h-px w-full bg-border" />
-                </div>
-              )}
-              {row.showCompletionDivider && (
-                <div className="my-3 flex items-center gap-3">
-                  <span className="h-px flex-1 bg-border" />
-                  <span
-                    className="text-muted-foreground/80"
-                    style={{ fontSize: chatTypographyStyle.fontSize }}
-                  >
-                    {row.completionSummary ? `Response • ${row.completionSummary}` : "Response"}
-                  </span>
-                  <span className="h-px flex-1 bg-border" />
                 </div>
               )}
               <div className="group min-w-0 py-0.5">

--- a/apps/web/src/components/timelineHeight.test.ts
+++ b/apps/web/src/components/timelineHeight.test.ts
@@ -200,19 +200,6 @@ describe("estimateTimelineMessageHeight", () => {
       ),
     );
   });
-
-  it("accounts for the completion divider in assistant message estimates", () => {
-    expect(
-      estimateTimelineMessageHeight(
-        {
-          role: "assistant",
-          text: "done",
-          showCompletionDivider: true,
-        },
-        { timelineWidthPx: 768 },
-      ),
-    ).toBe(138);
-  });
 });
 
 describe("estimateChangedFilesSummaryHeight", () => {

--- a/apps/web/src/components/timelineHeight.ts
+++ b/apps/web/src/components/timelineHeight.ts
@@ -36,7 +36,6 @@ const MIN_ASSISTANT_CHARS_PER_LINE = 20;
 const ASSISTANT_INLINE_CODE_WIDTH_MULTIPLIER = 1.2;
 const ASSISTANT_INLINE_CODE_WRAP_OVERHEAD_CHARS = 2;
 const INLINE_CODE_SPAN_REGEX = /`([^`\n]+)`/g;
-const COMPLETION_DIVIDER_HEIGHT_PX = 40;
 const TURN_DIFF_SUMMARY_CHROME_HEIGHT_PX = 76;
 const TURN_DIFF_TREE_ROW_HEIGHT_PX = 24;
 const TURN_DIFF_TREE_ROW_GAP_PX = 2;
@@ -65,7 +64,6 @@ interface TimelineMessageHeightInput {
   diffSummaryAllDirectoriesExpanded?: boolean;
   inlineToolEntries?: ReadonlyArray<TimelineWorkEntryHeightInput>;
   inlineToolExpanded?: boolean;
-  showCompletionDivider?: boolean;
 }
 
 interface TimelineHeightEstimateLayout {
@@ -278,7 +276,6 @@ export function estimateTimelineMessageHeight(
     return (
       ASSISTANT_BASE_HEIGHT_PX +
       estimatedLines * lineHeightPx +
-      (message.showCompletionDivider ? COMPLETION_DIVIDER_HEIGHT_PX : 0) +
       changedFilesHeight +
       inlineToolPreviewHeight
     );

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -21,7 +21,6 @@ import {
   findLatestProposedPlan,
   findSidebarProposedPlan,
   hasActionableProposedPlan,
-  hasToolActivityForTurn,
   isLatestTurnSettled,
 } from "./session-logic";
 
@@ -2168,27 +2167,6 @@ describe("deriveWorkLogEntries context window handling", () => {
 
     expect(entries).toHaveLength(1);
     expect(entries[0]?.label).toBe("Compacting context");
-  });
-});
-
-describe("hasToolActivityForTurn", () => {
-  it("returns false when turn id is missing", () => {
-    const activities: OrchestrationThreadActivity[] = [
-      makeActivity({ id: "tool-1", turnId: "turn-1", kind: "tool.completed", tone: "tool" }),
-    ];
-
-    expect(hasToolActivityForTurn(activities, undefined)).toBe(false);
-    expect(hasToolActivityForTurn(activities, null)).toBe(false);
-  });
-
-  it("returns true only for matching tool activity in the target turn", () => {
-    const activities: OrchestrationThreadActivity[] = [
-      makeActivity({ id: "tool-1", turnId: "turn-1", kind: "tool.completed", tone: "tool" }),
-      makeActivity({ id: "info-1", turnId: "turn-2", kind: "turn.completed", tone: "info" }),
-    ];
-
-    expect(hasToolActivityForTurn(activities, TurnId.makeUnsafe("turn-1"))).toBe(true);
-    expect(hasToolActivityForTurn(activities, TurnId.makeUnsafe("turn-2"))).toBe(false);
   });
 });
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -155,7 +155,7 @@ export type TimelineEntry =
       entry: WorkLogEntry;
     };
 
-export function formatDuration(durationMs: number): string {
+function formatDuration(durationMs: number): string {
   if (!Number.isFinite(durationMs) || durationMs < 0) return "0ms";
   if (durationMs < 1_000) return `${Math.max(1, Math.round(durationMs))}ms`;
   if (durationMs < 10_000) return `${(durationMs / 1_000).toFixed(1)}s`;
@@ -1667,14 +1667,6 @@ function compareActivityLifecycleRank(kind: string): number {
     return 2;
   }
   return 1;
-}
-
-export function hasToolActivityForTurn(
-  activities: ReadonlyArray<OrchestrationThreadActivity>,
-  turnId: TurnId | null | undefined,
-): boolean {
-  if (!turnId) return false;
-  return activities.some((activity) => activity.turnId === turnId && activity.tone === "tool");
 }
 
 export function deriveTimelineEntries(


### PR DESCRIPTION
A settled turn rendered both the collapsed "Worked for" disclosure (with the open/close toggle) and a separate centered "Response • Worked for Xs" divider. Any turn with tool activity always collapses into the disclosure, so the divider's label was always redundant on the same row.

Remove the completion-divider feature entirely: the two props, the row fields, the ChatView derivation (completionSummary / completionDividerBeforeEntryId), the render block, and the height-estimate contribution. Only the toggle label remains, consistent across all turns.

Also nudge the disclosure header left (-ml-0.5) so the leading "W" optically aligns with the reply text, and drop now-orphaned helpers: hasToolActivityForTurn (and its tests) plus the dead formatDuration export.

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
