### PR TITLE
Improve Opencode provider support

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -30,7 +30,7 @@
     "@earendil-works/pi-coding-agent": "^0.74.0",
     "@effect/platform-node": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
-    "@opencode-ai/sdk": "^1.14.48",
+    "@opencode-ai/sdk": "^1.15.13",
     "@pierre/diffs": "^1.1.0-beta.16",
     "effect": "catalog:",
     "node-pty": "^1.1.0",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -109,6 +109,10 @@ function createMockOpenCodeRuntime(options?: {
   readonly events?: AsyncIterable<unknown>;
   readonly prompt?: (input: Record<string, unknown>) => Promise<unknown>;
   readonly promptAsync?: (input: Record<string, unknown>) => Promise<unknown>;
+  readonly commandList?: () => Promise<{
+    data?: ReadonlyArray<{ name: string; description?: string }>;
+  }>;
+  readonly commandLists?: ReadonlyArray<ReadonlyArray<{ name: string; description?: string }>>;
   readonly messages?: () => Promise<{
     data: Array<{ info: Record<string, unknown>; parts: Part[] }>;
   }>;
@@ -161,7 +165,11 @@ function createMockOpenCodeRuntime(options?: {
     question: {
       reply: async () => ({ data: null }),
     },
+    command: {
+      list: options?.commandList ?? (async () => ({ data: [] })),
+    },
   };
+  let createClientCallCount = 0;
 
   const unexpectedOperation = (operation: string) =>
     Effect.fail(
@@ -170,6 +178,20 @@ function createMockOpenCodeRuntime(options?: {
         detail: `Unexpected runtime operation: ${operation}`,
       }),
     );
+
+  const createOpenCodeSdkClient: OpenCodeRuntimeShape["createOpenCodeSdkClient"] = () => {
+    const commandList = options?.commandLists?.[createClientCallCount];
+    createClientCallCount += 1;
+    if (!commandList) {
+      return client as unknown as OpencodeClient;
+    }
+    return {
+      ...client,
+      command: {
+        list: async () => ({ data: commandList }),
+      },
+    } as unknown as OpencodeClient;
+  };
 
   const runtime: OpenCodeRuntimeShape = {
     startOpenCodeServerProcess: () => unexpectedOperation("startOpenCodeServerProcess"),
@@ -180,7 +202,7 @@ function createMockOpenCodeRuntime(options?: {
         external: true,
       }),
     runOpenCodeCommand: () => unexpectedOperation("runOpenCodeCommand"),
-    createOpenCodeSdkClient: () => client as unknown as OpencodeClient,
+    createOpenCodeSdkClient,
     loadOpenCodeInventory: () =>
       Effect.succeed(
         options?.inventory ?? {
@@ -1056,6 +1078,126 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
       "opencode/minimax-m2.5-free",
       "opencode-go/kimi-k2.6",
     ]);
+  });
+
+  it("does not reuse an unrelated active OpenCode session for command discovery", async () => {
+    const runtime = createMockOpenCodeRuntime({
+      commandLists: [[{ name: "wrong-thread" }], [{ name: "review", description: "Review code" }]],
+    });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const listCommands = adapter.listCommands;
+        if (!listCommands) {
+          throw new Error("Expected OpenCode adapter to support command listing.");
+        }
+
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId: asThreadId("thread-active"),
+          runtimeMode: "full-access",
+        });
+
+        return yield* listCommands({
+          provider: "opencode",
+          cwd: process.cwd(),
+        });
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({ runtime: runtime.runtime }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(result).toEqual({
+      commands: [{ name: "review", description: "Review code" }],
+      source: "opencode",
+      cached: false,
+    });
+  });
+
+  it("reuses the matching active OpenCode thread for command discovery", async () => {
+    const threadId = asThreadId("thread-command-discovery");
+    const runtime = createMockOpenCodeRuntime({
+      commandLists: [[{ name: "active-thread-command" }], [{ name: "scoped-client-command" }]],
+    });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const listCommands = adapter.listCommands;
+        if (!listCommands) {
+          throw new Error("Expected OpenCode adapter to support command listing.");
+        }
+
+        yield* adapter.startSession({
+          provider: "opencode",
+          threadId,
+          runtimeMode: "full-access",
+        });
+
+        return yield* listCommands({
+          provider: "opencode",
+          threadId,
+          cwd: process.cwd(),
+        });
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({ runtime: runtime.runtime }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.commands.map((command) => command.name)).toEqual(["active-thread-command"]);
+  });
+
+  it("returns no OpenCode commands when command discovery is unsupported", async () => {
+    const runtime = createMockOpenCodeRuntime({
+      commandList: async () => {
+        throw new Error("status=404 body={}");
+      },
+    });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const listCommands = adapter.listCommands;
+        if (!listCommands) {
+          throw new Error("Expected OpenCode adapter to support command listing.");
+        }
+
+        return yield* listCommands({
+          provider: "opencode",
+          cwd: process.cwd(),
+        });
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({ runtime: runtime.runtime }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(result).toEqual({
+      commands: [],
+      source: "unsupported",
+      cached: false,
+    });
   });
 
   it("pins the initial model on new OpenCode sessions", async () => {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -6,6 +6,7 @@ import {
   type ProviderKind,
   type ProviderComposerCapabilities,
   type ProviderListAgentsResult,
+  type ProviderListCommandsResult,
   type ProviderListModelsResult,
   type ProviderRuntimeEvent,
   type ProviderSession,
@@ -1594,6 +1595,24 @@ function flattenOpenCodeAgents(agents: ReadonlyArray<Agent>): ProviderListAgents
       };
     })
     .toSorted((left, right) => left.displayName.localeCompare(right.displayName));
+}
+
+type OpenCodeCommand = Awaited<ReturnType<OpencodeClient["command"]["list"]>>["data"] extends
+  | ReadonlyArray<infer TCommand>
+  | undefined
+  ? TCommand
+  : never;
+
+function flattenOpenCodeCommands(
+  commands: ReadonlyArray<OpenCodeCommand>,
+): ProviderListCommandsResult["commands"] {
+  return commands
+    .filter((command) => command.name.trim().length > 0)
+    .map((command) => ({
+      name: command.name.trim(),
+      ...(command.description?.trim() ? { description: command.description.trim() } : {}),
+    }))
+    .toSorted((left, right) => left.name.localeCompare(right.name));
 }
 
 function buildOpenCodeThreadSnapshot(input: {
@@ -3406,6 +3425,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                   binaryPath,
                   cliSpec: adapterConfig.cliSpec,
                   ...(serverUrl ? { serverUrl } : {}),
+                  ...(provider === "opencode" && providerOptions?.experimentalWebSockets
+                    ? { experimentalWebSockets: true }
+                    : {}),
                 });
                 const client = openCodeRuntime.createOpenCodeSdkClient({
                   baseUrl: server.url,
@@ -3946,31 +3968,22 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           };
         });
 
-      const withDiscoveryInventory = <A>(
+      const withDiscoveryClient = <A>(
         input: {
           readonly binaryPath?: string | null;
+          readonly cwd?: string | null;
         },
         fn: (input: {
           readonly client: OpencodeClient;
-          readonly inventory: OpenCodeInventory;
-          readonly credentialProviderIDs: ReadonlyArray<string>;
+          readonly activeContext?: OpenCodeSessionContext;
         }) => Effect.Effect<A, ProviderAdapterRequestError>,
       ): Effect.Effect<A, ProviderAdapterRequestError> =>
         Effect.gen(function* () {
           const activeContext = [...sessions.values()][0];
           if (activeContext) {
-            const inventory = yield* openCodeRuntime
-              .loadOpenCodeInventory(activeContext.client)
-              .pipe(Effect.mapError(toAdapterRequestError));
-            replaceModelContextLimits(activeContext, buildOpenCodeModelContextLimitMap(inventory));
-            const credentialProviderIDs = yield* openCodeRuntime.loadOpenCodeCredentialProviderIDs(
-              activeContext.client,
-              adapterConfig.cliSpec,
-            );
             return yield* fn({
               client: activeContext.client,
-              inventory,
-              credentialProviderIDs,
+              activeContext,
             });
           }
 
@@ -3984,21 +3997,47 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                 .pipe(Effect.mapError(toAdapterRequestError));
               const client = openCodeRuntime.createOpenCodeSdkClient({
                 baseUrl: server.url,
-                directory: serverConfig.cwd,
+                directory: input.cwd?.trim() || serverConfig.cwd,
                 cliSpec: adapterConfig.cliSpec,
               });
-              const inventory = yield* openCodeRuntime
-                .loadOpenCodeInventory(client)
-                .pipe(Effect.mapError(toAdapterRequestError));
-              const credentialProviderIDs =
-                yield* openCodeRuntime.loadOpenCodeCredentialProviderIDs(
-                  client,
-                  adapterConfig.cliSpec,
-                );
-              return yield* fn({ client, inventory, credentialProviderIDs });
+              return yield* fn({ client });
             }),
           );
         });
+
+      const withDiscoveryInventory = <A>(
+        input: {
+          readonly binaryPath?: string | null;
+          readonly cwd?: string | null;
+        },
+        fn: (input: {
+          readonly client: OpencodeClient;
+          readonly inventory: OpenCodeInventory;
+          readonly credentialProviderIDs: ReadonlyArray<string>;
+        }) => Effect.Effect<A, ProviderAdapterRequestError>,
+      ): Effect.Effect<A, ProviderAdapterRequestError> =>
+        withDiscoveryClient(input, ({ activeContext, client }) =>
+          Effect.gen(function* () {
+            const inventory = yield* openCodeRuntime.loadOpenCodeInventory(client).pipe(
+              Effect.mapError(toAdapterRequestError),
+            );
+            if (activeContext) {
+              replaceModelContextLimits(
+                activeContext,
+                buildOpenCodeModelContextLimitMap(inventory),
+              );
+            }
+            const credentialProviderIDs = yield* openCodeRuntime.loadOpenCodeCredentialProviderIDs(
+              client,
+              adapterConfig.cliSpec,
+            );
+            return yield* fn({
+              client,
+              inventory,
+              credentialProviderIDs,
+            });
+          }),
+        );
 
       const listModels: NonNullable<OpenCodeAdapterShape["listModels"]> = (input) => {
         const binaryPath = input.binaryPath?.trim() || adapterConfig.defaultBinaryPath;
@@ -4069,6 +4108,21 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           }),
         );
 
+      const listCommands: NonNullable<OpenCodeAdapterShape["listCommands"]> = (input) =>
+        withDiscoveryClient({ cwd: input.cwd }, ({ client }) =>
+          runOpenCodeSdk("command.list", () => client.command.list()).pipe(
+            Effect.mapError(toAdapterRequestError),
+            Effect.map(
+              (commands) =>
+                ({
+                  commands: flattenOpenCodeCommands(commands.data ?? []),
+                  source: adapterConfig.fallbackModelSource,
+                  cached: false,
+                }) satisfies ProviderListCommandsResult,
+            ),
+          ),
+        );
+
       const getComposerCapabilities: NonNullable<
         OpenCodeAdapterShape["getComposerCapabilities"]
       > = () =>
@@ -4076,7 +4130,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           provider,
           supportsSkillMentions: false,
           supportsSkillDiscovery: false,
-          supportsNativeSlashCommandDiscovery: false,
+          supportsNativeSlashCommandDiscovery: provider === "opencode",
           supportsPluginMentions: false,
           supportsPluginDiscovery: false,
           supportsRuntimeModelList: true,
@@ -4100,6 +4154,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         capabilities: {
           sessionModelSwitch: "in-session",
           supportsRuntimeModelList: true,
+          supportsNativeSlashCommandDiscovery: provider === "opencode",
         },
         startSession,
         sendTurn,
@@ -4117,6 +4172,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         stopAll,
         listModels,
         listAgents,
+        ...(provider === "opencode" ? { listCommands } : {}),
         getComposerCapabilities,
         get streamEvents() {
           return Stream.fromQueue(runtimeEvents);

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -3972,6 +3972,9 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         input: {
           readonly binaryPath?: string | null;
           readonly cwd?: string | null;
+          readonly serverUrl?: string | null;
+          readonly serverPassword?: string | null;
+          readonly experimentalWebSockets?: boolean;
         },
         fn: (input: {
           readonly client: OpencodeClient;
@@ -3989,16 +3992,23 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
 
           return yield* Effect.scoped(
             Effect.gen(function* () {
+              const serverUrl = input.serverUrl?.trim();
+              const serverPassword = input.serverPassword?.trim();
               const server = yield* openCodeRuntime
                 .connectToOpenCodeServer({
                   binaryPath: input.binaryPath?.trim() || adapterConfig.defaultBinaryPath,
                   cliSpec: adapterConfig.cliSpec,
+                  ...(serverUrl ? { serverUrl } : {}),
+                  ...(provider === "opencode" && input.experimentalWebSockets
+                    ? { experimentalWebSockets: true }
+                    : {}),
                 })
                 .pipe(Effect.mapError(toAdapterRequestError));
               const client = openCodeRuntime.createOpenCodeSdkClient({
                 baseUrl: server.url,
                 directory: input.cwd?.trim() || serverConfig.cwd,
                 cliSpec: adapterConfig.cliSpec,
+                ...(server.external && serverPassword ? { serverPassword } : {}),
               });
               return yield* fn({ client });
             }),
@@ -4109,18 +4119,26 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         );
 
       const listCommands: NonNullable<OpenCodeAdapterShape["listCommands"]> = (input) =>
-        withDiscoveryClient({ cwd: input.cwd }, ({ client }) =>
-          runOpenCodeSdk("command.list", () => client.command.list()).pipe(
-            Effect.mapError(toAdapterRequestError),
-            Effect.map(
-              (commands) =>
-                ({
-                  commands: flattenOpenCodeCommands(commands.data ?? []),
-                  source: adapterConfig.fallbackModelSource,
-                  cached: false,
-                }) satisfies ProviderListCommandsResult,
+        withDiscoveryClient(
+          {
+            binaryPath: input.binaryPath,
+            cwd: input.cwd,
+            serverUrl: input.serverUrl,
+            serverPassword: input.serverPassword,
+            experimentalWebSockets: input.experimentalWebSockets,
+          },
+          ({ client }) =>
+            runOpenCodeSdk("command.list", () => client.command.list()).pipe(
+              Effect.mapError(toAdapterRequestError),
+              Effect.map(
+                (commands) =>
+                  ({
+                    commands: flattenOpenCodeCommands(commands.data ?? []),
+                    source: adapterConfig.fallbackModelSource,
+                    cached: false,
+                  }) satisfies ProviderListCommandsResult,
+              ),
             ),
-          ),
         );
 
       const getComposerCapabilities: NonNullable<

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1615,6 +1615,23 @@ function flattenOpenCodeCommands(
     .toSorted((left, right) => left.name.localeCompare(right.name));
 }
 
+function redactOpenCodeRequestDetail(detail: string): string {
+  return detail
+    .replace(/authorization["':=\s]+(?:basic\s+)?[^"',}\s]+/gi, "authorization=[redacted]")
+    .replace(/basic\s+[a-z0-9+/=]+/gi, "Basic [redacted]");
+}
+
+function isUnsupportedOpenCodeCommandListError(cause: OpenCodeRuntimeError): boolean {
+  const detail = cause.detail.toLowerCase();
+  return (
+    detail.includes("status=404") ||
+    detail.includes("404") ||
+    detail.includes("not found") ||
+    detail.includes("method not found") ||
+    detail.includes("unknown method")
+  );
+}
+
 function buildOpenCodeThreadSnapshot(input: {
   readonly threadId: ThreadId;
   readonly messages: ReadonlyArray<OpenCodeMessageSnapshot>;
@@ -3970,11 +3987,13 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
 
       const withDiscoveryClient = <A>(
         input: {
+          readonly threadId?: string | null;
           readonly binaryPath?: string | null;
           readonly cwd?: string | null;
           readonly serverUrl?: string | null;
           readonly serverPassword?: string | null;
           readonly experimentalWebSockets?: boolean;
+          readonly reuseAnyActiveContext?: boolean;
         },
         fn: (input: {
           readonly client: OpencodeClient;
@@ -3982,8 +4001,18 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         }) => Effect.Effect<A, ProviderAdapterRequestError>,
       ): Effect.Effect<A, ProviderAdapterRequestError> =>
         Effect.gen(function* () {
-          const activeContext = [...sessions.values()][0];
-          if (activeContext) {
+          const requestedCwd = input.cwd?.trim();
+          const requestedServerUrl = input.serverUrl?.trim();
+          const activeContext = input.threadId
+            ? sessions.get(ThreadId.makeUnsafe(input.threadId))
+            : input.reuseAnyActiveContext
+              ? [...sessions.values()][0]
+              : undefined;
+          if (
+            activeContext &&
+            (!requestedCwd || requestedCwd === activeContext.directory) &&
+            (!requestedServerUrl || requestedServerUrl === activeContext.server.url)
+          ) {
             return yield* fn({
               client: activeContext.client,
               activeContext,
@@ -4026,27 +4055,32 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           readonly credentialProviderIDs: ReadonlyArray<string>;
         }) => Effect.Effect<A, ProviderAdapterRequestError>,
       ): Effect.Effect<A, ProviderAdapterRequestError> =>
-        withDiscoveryClient(input, ({ activeContext, client }) =>
-          Effect.gen(function* () {
-            const inventory = yield* openCodeRuntime.loadOpenCodeInventory(client).pipe(
-              Effect.mapError(toAdapterRequestError),
-            );
-            if (activeContext) {
-              replaceModelContextLimits(
-                activeContext,
-                buildOpenCodeModelContextLimitMap(inventory),
+        withDiscoveryClient(
+          {
+            ...input,
+            reuseAnyActiveContext: true,
+          },
+          ({ activeContext, client }) =>
+            Effect.gen(function* () {
+              const inventory = yield* openCodeRuntime.loadOpenCodeInventory(client).pipe(
+                Effect.mapError(toAdapterRequestError),
               );
-            }
-            const credentialProviderIDs = yield* openCodeRuntime.loadOpenCodeCredentialProviderIDs(
-              client,
-              adapterConfig.cliSpec,
-            );
-            return yield* fn({
-              client,
-              inventory,
-              credentialProviderIDs,
-            });
-          }),
+              if (activeContext) {
+                replaceModelContextLimits(
+                  activeContext,
+                  buildOpenCodeModelContextLimitMap(inventory),
+                );
+              }
+              const credentialProviderIDs = yield* openCodeRuntime.loadOpenCodeCredentialProviderIDs(
+                client,
+                adapterConfig.cliSpec,
+              );
+              return yield* fn({
+                client,
+                inventory,
+                credentialProviderIDs,
+              });
+            }),
         );
 
       const listModels: NonNullable<OpenCodeAdapterShape["listModels"]> = (input) => {
@@ -4121,6 +4155,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
       const listCommands: NonNullable<OpenCodeAdapterShape["listCommands"]> = (input) =>
         withDiscoveryClient(
           {
+            threadId: input.threadId,
             binaryPath: input.binaryPath,
             cwd: input.cwd,
             serverUrl: input.serverUrl,
@@ -4137,6 +4172,21 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                     source: adapterConfig.fallbackModelSource,
                     cached: false,
                   }) satisfies ProviderListCommandsResult,
+              ),
+              Effect.catch((cause) =>
+                isUnsupportedOpenCodeCommandListError(cause)
+                  ? Effect.succeed({
+                      commands: [],
+                      source: "unsupported",
+                      cached: false,
+                    } satisfies ProviderListCommandsResult)
+                  : Effect.fail(
+                      new ProviderAdapterRequestError({
+                        provider,
+                        method: cause.operation,
+                        detail: redactOpenCodeRequestDetail(cause.detail),
+                      }),
+                    ),
               ),
             ),
         );

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -165,6 +165,7 @@ export interface OpenCodeRuntimeShape {
     readonly port?: number;
     readonly hostname?: string;
     readonly timeoutMs?: number;
+    readonly experimentalWebSockets?: boolean;
   }) => Effect.Effect<OpenCodeServerProcess, OpenCodeRuntimeError, Scope.Scope>;
   readonly connectToOpenCodeServer: (input: {
     readonly binaryPath: string;
@@ -173,6 +174,7 @@ export interface OpenCodeRuntimeShape {
     readonly port?: number;
     readonly hostname?: string;
     readonly timeoutMs?: number;
+    readonly experimentalWebSockets?: boolean;
   }) => Effect.Effect<OpenCodeServerConnection, OpenCodeRuntimeError, Scope.Scope>;
   readonly runOpenCodeCommand: (input: {
     readonly binaryPath: string;
@@ -651,6 +653,19 @@ export function buildOpenCodePermissionRules(runtimeMode: RuntimeMode): Permissi
   ];
 }
 
+export function buildOpenCodeServerProcessEnv(input: {
+  readonly cliSpec?: OpenCodeCompatibleCliSpec;
+  readonly experimentalWebSockets?: boolean;
+  readonly baseEnv?: NodeJS.ProcessEnv;
+}): NodeJS.ProcessEnv {
+  const cliSpec = input.cliSpec ?? OPENCODE_CLI_SPEC;
+  return {
+    ...(input.baseEnv ?? process.env),
+    [cliSpec.configContentEnvVar]: JSON.stringify({}),
+    ...(input.experimentalWebSockets ? { OPENCODE_EXPERIMENTAL_WEBSOCKETS: "true" } : {}),
+  };
+}
+
 export function toOpenCodePermissionReply(
   decision: ProviderApprovalDecision,
 ): "once" | "always" | "reject" {
@@ -765,10 +780,10 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       const child = yield* spawner
         .spawn(
           ChildProcess.make(input.binaryPath, args, {
-            env: {
-              ...process.env,
-              [cliSpec.configContentEnvVar]: JSON.stringify({}),
-            },
+            env: buildOpenCodeServerProcessEnv({
+              cliSpec,
+              experimentalWebSockets: input.experimentalWebSockets,
+            }),
             detached: false,
             killSignal: "SIGKILL",
             forceKillAfter: "1500 millis",
@@ -894,6 +909,9 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       ...(input.port !== undefined ? { port: input.port } : {}),
       ...(input.hostname !== undefined ? { hostname: input.hostname } : {}),
       ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+      ...(input.experimentalWebSockets !== undefined
+        ? { experimentalWebSockets: input.experimentalWebSockets }
+        : {}),
     }).pipe(
       Effect.map((server) => ({
         url: server.url,

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -775,7 +775,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
           ),
         ));
       const timeoutMs = input.timeoutMs ?? DEFAULT_OPENCODE_SERVER_TIMEOUT_MS;
-      const args = ["serve", `--hostname=${hostname}`, `--port=${port}`];
+      const args = ["serve", "--hostname", hostname, "--port", String(port)];
 
       const child = yield* spawner
         .spawn(

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -25,6 +25,7 @@ import {
   normalizeProviderOrder,
 } from "./providerOrdering";
 import { ensureNativeApi } from "./nativeApi";
+import { providerDiscoveryQueryKeys } from "./lib/providerDiscoveryReactQuery";
 import { serverQueryKeys, serverSettingsQueryOptions } from "./lib/serverReactQuery";
 
 const APP_SETTINGS_STORAGE_KEY = "synara:app-settings:v1";
@@ -352,6 +353,19 @@ function hasOwn<Key extends keyof AppSettings>(patch: Partial<AppSettings>, key:
   return Object.prototype.hasOwnProperty.call(patch, key);
 }
 
+function touchesProviderDiscoverySettings(patch: Partial<AppSettings>): boolean {
+  return (
+    hasOwn(patch, "kiloBinaryPath") ||
+    hasOwn(patch, "kiloServerPassword") ||
+    hasOwn(patch, "kiloServerUrl") ||
+    hasOwn(patch, "openCodeBinaryPath") ||
+    hasOwn(patch, "openCodeExperimentalWebSockets") ||
+    hasOwn(patch, "openCodeServerPassword") ||
+    hasOwn(patch, "openCodeServerUrl") ||
+    hasOwn(patch, "piAgentDir")
+  );
+}
+
 function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): ServerSettingsPatch {
   const providers: MutableServerSettingsProvidersPatch = {};
   const serverPatch: MutableServerSettingsPatch = {};
@@ -501,6 +515,7 @@ function buildInitialServerSettingsMigrationPatch(settings: AppSettings): Server
     "kiloServerPassword",
     "kiloServerUrl",
     "openCodeBinaryPath",
+    "openCodeExperimentalWebSockets",
     "openCodeServerPassword",
     "openCodeServerUrl",
     "piAgentDir",
@@ -896,6 +911,9 @@ export function useAppSettings() {
   const updateSettings = useCallback(
     (patch: Partial<AppSettings>) => {
       setSettings((prev) => normalizeAppSettings({ ...prev, ...patch }));
+      if (touchesProviderDiscoverySettings(patch)) {
+        void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
+      }
 
       const serverPatch = appSettingsPatchToServerSettingsPatch(patch);
       if (isServerSettingsPatchEmpty(serverPatch)) {
@@ -916,6 +934,7 @@ export function useAppSettings() {
 
   const resetSettings = useCallback(() => {
     setSettings(DEFAULT_APP_SETTINGS);
+    void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
     const serverPatch = appSettingsPatchToServerSettingsPatch(defaults);
     void ensureNativeApi()
       .server.updateSettings(serverPatch)

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -115,6 +115,7 @@ export const AppSettingsSchema = Schema.Struct({
   openCodeServerPassword: Schema.String.check(Schema.isMaxLength(4096)).pipe(
     withDefaults(() => ""),
   ),
+  openCodeExperimentalWebSockets: Schema.Boolean.pipe(withDefaults(() => false)),
   defaultThreadEnvMode: EnvMode.pipe(withDefaults(() => "local" as const satisfies EnvMode)),
   confirmThreadDelete: Schema.Boolean.pipe(withDefaults(() => true)),
   confirmThreadArchive: Schema.Boolean.pipe(withDefaults(() => false)),
@@ -322,6 +323,7 @@ function serverSettingsToAppSettings(settings: ServerSettings): Partial<AppSetti
     kiloServerPassword: settings.providers.kilo.serverPassword,
     kiloServerUrl: settings.providers.kilo.serverUrl,
     openCodeBinaryPath: settings.providers.opencode.binaryPath,
+    openCodeExperimentalWebSockets: settings.providers.opencode.experimentalWebSockets,
     openCodeServerPassword: settings.providers.opencode.serverPassword,
     openCodeServerUrl: settings.providers.opencode.serverUrl,
     piAgentDir: settings.providers.pi.agentDir,
@@ -442,6 +444,7 @@ function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): Ser
   }
   if (
     hasOwn(patch, "openCodeBinaryPath") ||
+    hasOwn(patch, "openCodeExperimentalWebSockets") ||
     hasOwn(patch, "openCodeServerUrl") ||
     hasOwn(patch, "openCodeServerPassword") ||
     hasOwn(patch, "customOpenCodeModels")
@@ -449,6 +452,9 @@ function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): Ser
     providers.opencode = {
       ...(hasOwn(patch, "openCodeBinaryPath")
         ? { binaryPath: patch.openCodeBinaryPath ?? "" }
+        : {}),
+      ...(hasOwn(patch, "openCodeExperimentalWebSockets")
+        ? { experimentalWebSockets: Boolean(patch.openCodeExperimentalWebSockets) }
         : {}),
       ...(hasOwn(patch, "openCodeServerUrl") ? { serverUrl: patch.openCodeServerUrl ?? "" } : {}),
       ...(hasOwn(patch, "openCodeServerPassword")
@@ -704,12 +710,19 @@ export function getProviderStartOptions(
     | "kiloServerPassword"
     | "kiloServerUrl"
     | "openCodeBinaryPath"
+    | "openCodeExperimentalWebSockets"
     | "openCodeServerPassword"
     | "openCodeServerUrl"
     | "piAgentDir"
     | "piBinaryPath"
   >,
 ): ProviderStartOptions | undefined {
+  const hasOpenCodeStartOptions = Boolean(
+    settings.openCodeBinaryPath ||
+      settings.openCodeExperimentalWebSockets ||
+      settings.openCodeServerUrl ||
+      settings.openCodeServerPassword,
+  );
   const providerOptions: ProviderStartOptions = {
     ...(settings.codexBinaryPath || settings.codexHomePath
       ? {
@@ -757,10 +770,13 @@ export function getProviderStartOptions(
           },
         }
       : {}),
-    ...(settings.openCodeBinaryPath || settings.openCodeServerUrl || settings.openCodeServerPassword
+    ...(hasOpenCodeStartOptions
       ? {
           opencode: {
             ...(settings.openCodeBinaryPath ? { binaryPath: settings.openCodeBinaryPath } : {}),
+            ...(settings.openCodeExperimentalWebSockets
+              ? { experimentalWebSockets: true }
+              : {}),
             ...(settings.openCodeServerUrl ? { serverUrl: settings.openCodeServerUrl } : {}),
             ...(settings.openCodeServerPassword
               ? { serverPassword: settings.openCodeServerPassword }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2404,10 +2404,6 @@ export default function ChatView({
           ? providerOptionsForDispatch?.opencode?.experimentalWebSockets
           : undefined,
       agentDir: selectedProvider === "pi" ? settings.piAgentDir || null : null,
-      query:
-        composerTriggerKind === "slash-command" || composerTriggerKind === "slash-model"
-          ? (composerTrigger?.query ?? "")
-          : "",
       enabled:
         (composerTriggerKind === "slash-command" || composerTriggerKind === "slash-model") &&
         supportsNativeSlashCommandDiscovery(providerComposerCapabilitiesQuery.data) &&

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2377,6 +2377,28 @@ export default function ChatView({
       provider: selectedProvider,
       cwd: composerSkillCwd,
       threadId,
+      binaryPath:
+        selectedProvider === "opencode"
+          ? providerOptionsForDispatch?.opencode?.binaryPath
+          : selectedProvider === "kilo"
+            ? providerOptionsForDispatch?.kilo?.binaryPath
+            : null,
+      serverUrl:
+        selectedProvider === "opencode"
+          ? providerOptionsForDispatch?.opencode?.serverUrl
+          : selectedProvider === "kilo"
+            ? providerOptionsForDispatch?.kilo?.serverUrl
+            : null,
+      serverPassword:
+        selectedProvider === "opencode"
+          ? providerOptionsForDispatch?.opencode?.serverPassword
+          : selectedProvider === "kilo"
+            ? providerOptionsForDispatch?.kilo?.serverPassword
+            : null,
+      experimentalWebSockets:
+        selectedProvider === "opencode"
+          ? providerOptionsForDispatch?.opencode?.experimentalWebSockets
+          : undefined,
       agentDir: selectedProvider === "pi" ? settings.piAgentDir || null : null,
       query:
         composerTriggerKind === "slash-command" || composerTriggerKind === "slash-model"

--- a/apps/web/src/components/composer-nodes/index.tsx
+++ b/apps/web/src/components/composer-nodes/index.tsx
@@ -305,8 +305,8 @@ export class ComposerSkillNode extends TextNode {
     return false;
   }
 
-  override canInsertTextAfter(): false {
-    return false;
+  override canInsertTextAfter(): true {
+    return true;
   }
 
   override isTextEntity(): true {

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -48,8 +48,13 @@ export const providerDiscoveryQueryKeys = {
   all: ["provider-discovery"] as const,
   composerCapabilities: (provider: ProviderKind) =>
     ["provider-discovery", "composer-capabilities", provider] as const,
-  commands: (provider: ProviderKind, cwd: string | null, query: string, agentDir: string | null) =>
-    ["provider-discovery", "commands", provider, cwd, query, agentDir] as const,
+  commands: (
+    provider: ProviderKind,
+    cwd: string | null,
+    query: string,
+    agentDir: string | null,
+    connectionKey: string | null,
+  ) => ["provider-discovery", "commands", provider, cwd, query, agentDir, connectionKey] as const,
   skills: (provider: ProviderKind, cwd: string | null, query: string, agentDir: string | null) =>
     ["provider-discovery", "skills", provider, cwd, query, agentDir] as const,
   plugins: (provider: ProviderKind, cwd: string | null) =>
@@ -113,16 +118,27 @@ export function providerCommandsQueryOptions(input: {
   provider: ProviderKind;
   cwd: string | null;
   threadId?: string | null;
+  binaryPath?: string | null;
+  serverUrl?: string | null;
+  serverPassword?: string | null;
+  experimentalWebSockets?: boolean;
   agentDir?: string | null;
   query: string;
   enabled?: boolean;
 }) {
+  const connectionKey = JSON.stringify({
+    binaryPath: input.binaryPath ?? null,
+    serverUrl: input.serverUrl ?? null,
+    serverPassword: input.serverPassword ?? null,
+    experimentalWebSockets: input.experimentalWebSockets ?? null,
+  });
   return queryOptions({
     queryKey: providerDiscoveryQueryKeys.commands(
       input.provider,
       input.cwd,
       input.query,
       input.agentDir ?? null,
+      connectionKey,
     ),
     queryFn: async () => {
       const api = ensureNativeApi();
@@ -133,6 +149,12 @@ export function providerCommandsQueryOptions(input: {
         provider: input.provider,
         cwd: input.cwd,
         ...(input.threadId ? { threadId: input.threadId } : {}),
+        ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
+        ...(input.serverUrl ? { serverUrl: input.serverUrl } : {}),
+        ...(input.serverPassword ? { serverPassword: input.serverPassword } : {}),
+        ...(input.experimentalWebSockets !== undefined
+          ? { experimentalWebSockets: input.experimentalWebSockets }
+          : {}),
         ...(input.agentDir ? { agentDir: input.agentDir } : {}),
       });
     },

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -51,10 +51,9 @@ export const providerDiscoveryQueryKeys = {
   commands: (
     provider: ProviderKind,
     cwd: string | null,
-    query: string,
     agentDir: string | null,
     connectionKey: string | null,
-  ) => ["provider-discovery", "commands", provider, cwd, query, agentDir, connectionKey] as const,
+  ) => ["provider-discovery", "commands", provider, cwd, agentDir, connectionKey] as const,
   skills: (provider: ProviderKind, cwd: string | null, query: string, agentDir: string | null) =>
     ["provider-discovery", "skills", provider, cwd, query, agentDir] as const,
   plugins: (provider: ProviderKind, cwd: string | null) =>
@@ -123,20 +122,18 @@ export function providerCommandsQueryOptions(input: {
   serverPassword?: string | null;
   experimentalWebSockets?: boolean;
   agentDir?: string | null;
-  query: string;
   enabled?: boolean;
 }) {
   const connectionKey = JSON.stringify({
     binaryPath: input.binaryPath ?? null,
     serverUrl: input.serverUrl ?? null,
-    serverPassword: input.serverPassword ?? null,
+    hasServerPassword: Boolean(input.serverPassword),
     experimentalWebSockets: input.experimentalWebSockets ?? null,
   });
   return queryOptions({
     queryKey: providerDiscoveryQueryKeys.commands(
       input.provider,
       input.cwd,
-      input.query,
       input.agentDir ?? null,
       connectionKey,
     ),

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -195,6 +195,8 @@ type InstallProviderSettings = {
   serverPasswordKey?: "kiloServerPassword" | "openCodeServerPassword";
   serverPasswordPlaceholder?: string;
   serverPasswordDescription?: ReactNode;
+  experimentalWebSocketsKey?: "openCodeExperimentalWebSockets";
+  experimentalWebSocketsDescription?: ReactNode;
   agentDirKey?: "piAgentDir";
   agentDirPlaceholder?: string;
   agentDirDescription?: ReactNode;
@@ -405,6 +407,9 @@ const INSTALL_PROVIDER_SETTINGS: readonly InstallProviderSettings[] = [
     serverPasswordKey: "openCodeServerPassword",
     serverPasswordPlaceholder: "OpenCode server password",
     serverPasswordDescription: "Optional password for an externally managed OpenCode server.",
+    experimentalWebSocketsKey: "openCodeExperimentalWebSockets",
+    experimentalWebSocketsDescription:
+      "Use Opencode's experimental OpenAI response WebSocket transport for managed local servers.",
   },
   {
     provider: "pi",
@@ -670,7 +675,10 @@ function SettingsRouteView() {
     grok: Boolean(settings.grokBinaryPath),
     kilo: Boolean(settings.kiloBinaryPath || settings.kiloServerUrl || settings.kiloServerPassword),
     opencode: Boolean(
-      settings.openCodeBinaryPath || settings.openCodeServerUrl || settings.openCodeServerPassword,
+      settings.openCodeBinaryPath ||
+        settings.openCodeExperimentalWebSockets ||
+        settings.openCodeServerUrl ||
+        settings.openCodeServerPassword,
     ),
     pi: Boolean(settings.piBinaryPath || settings.piAgentDir),
   });
@@ -738,6 +746,7 @@ function SettingsRouteView() {
   const kiloServerUrl = settings.kiloServerUrl;
   const kiloServerPassword = settings.kiloServerPassword;
   const openCodeBinaryPath = settings.openCodeBinaryPath;
+  const openCodeExperimentalWebSockets = settings.openCodeExperimentalWebSockets;
   const openCodeServerUrl = settings.openCodeServerUrl;
   const openCodeServerPassword = settings.openCodeServerPassword;
   const piBinaryPath = settings.piBinaryPath;
@@ -863,6 +872,7 @@ function SettingsRouteView() {
     settings.codexBinaryPath !== defaults.codexBinaryPath ||
     settings.codexHomePath !== defaults.codexHomePath ||
     settings.openCodeBinaryPath !== defaults.openCodeBinaryPath ||
+    settings.openCodeExperimentalWebSockets !== defaults.openCodeExperimentalWebSockets ||
     settings.openCodeServerUrl !== defaults.openCodeServerUrl ||
     settings.openCodeServerPassword !== defaults.openCodeServerPassword ||
     settings.piBinaryPath !== defaults.piBinaryPath ||
@@ -2611,6 +2621,7 @@ function SettingsRouteView() {
                     kiloServerUrl: defaults.kiloServerUrl,
                     kiloServerPassword: defaults.kiloServerPassword,
                     openCodeBinaryPath: defaults.openCodeBinaryPath,
+                    openCodeExperimentalWebSockets: defaults.openCodeExperimentalWebSockets,
                     openCodeServerUrl: defaults.openCodeServerUrl,
                     openCodeServerPassword: defaults.openCodeServerPassword,
                     piAgentDir: defaults.piAgentDir,
@@ -2656,6 +2667,8 @@ function SettingsRouteView() {
                                 ? settings.piBinaryPath !== defaults.piBinaryPath ||
                                   settings.piAgentDir !== defaults.piAgentDir
                                 : settings.openCodeBinaryPath !== defaults.openCodeBinaryPath ||
+                                  settings.openCodeExperimentalWebSockets !==
+                                    defaults.openCodeExperimentalWebSockets ||
                                   settings.openCodeServerUrl !== defaults.openCodeServerUrl ||
                                   settings.openCodeServerPassword !==
                                     defaults.openCodeServerPassword;
@@ -2973,6 +2986,33 @@ function SettingsRouteView() {
                                     {providerSettings.serverPasswordDescription}
                                   </span>
                                 ) : null}
+                              </label>
+                            ) : null}
+
+                            {providerSettings.experimentalWebSocketsKey ? (
+                              <label
+                                htmlFor={`provider-install-${providerSettings.experimentalWebSocketsKey}`}
+                                className="flex items-start justify-between gap-3 rounded-md border border-border/70 bg-background/60 px-3 py-2"
+                              >
+                                <span className="min-w-0">
+                                  <span className="block text-xs font-medium text-foreground">
+                                    OpenAI response WebSockets
+                                  </span>
+                                  {providerSettings.experimentalWebSocketsDescription ? (
+                                    <span className="mt-1 block text-xs text-muted-foreground">
+                                      {providerSettings.experimentalWebSocketsDescription}
+                                    </span>
+                                  ) : null}
+                                </span>
+                                <Switch
+                                  id={`provider-install-${providerSettings.experimentalWebSocketsKey}`}
+                                  checked={openCodeExperimentalWebSockets}
+                                  onCheckedChange={(checked) =>
+                                    updateSettings({
+                                      openCodeExperimentalWebSockets: Boolean(checked),
+                                    })
+                                  }
+                                />
                               </label>
                             ) : null}
                           </div>

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
         "@earendil-works/pi-coding-agent": "^0.74.0",
         "@effect/platform-node": "catalog:",
         "@effect/sql-sqlite-bun": "catalog:",
-        "@opencode-ai/sdk": "^1.14.48",
+        "@opencode-ai/sdk": "^1.15.13",
         "@pierre/diffs": "^1.1.0-beta.16",
         "effect": "catalog:",
         "node-pty": "^1.1.0",
@@ -726,7 +726,7 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.48", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-wKM86jCzV/ZApyWrdm3uP8XdWcS0LMbu3FV+OWz1ChiGGg1wiIWNGMJs5CY8/QX2/rUuZrd1Q1DqvdamZ0zLeg=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.15.13", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -169,6 +169,7 @@ export const OpenCodeProviderStartOptions = Schema.Struct({
   binaryPath: Schema.optional(TrimmedNonEmptyString),
   serverUrl: Schema.optional(TrimmedNonEmptyString),
   serverPassword: Schema.optional(TrimmedNonEmptyString),
+  experimentalWebSockets: Schema.optional(Schema.Boolean),
 });
 
 export const KiloProviderStartOptions = Schema.Struct({

--- a/packages/contracts/src/providerDiscovery.ts
+++ b/packages/contracts/src/providerDiscovery.ts
@@ -91,6 +91,10 @@ export const ProviderListCommandsInput = Schema.Struct({
   provider: ProviderDiscoveryKind,
   cwd: TrimmedNonEmptyString,
   threadId: Schema.optional(TrimmedNonEmptyString),
+  binaryPath: Schema.optional(TrimmedNonEmptyString),
+  serverUrl: Schema.optional(TrimmedNonEmptyString),
+  serverPassword: Schema.optional(TrimmedNonEmptyString),
+  experimentalWebSockets: Schema.optional(Schema.Boolean),
   agentDir: Schema.optional(TrimmedNonEmptyString),
   forceReload: Schema.optional(Schema.Boolean),
 });

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -54,6 +54,7 @@ export const OpenCodeServerProviderSettings = Schema.Struct({
   binaryPath: StringSetting.pipe(Schema.withDecodingDefault(() => "opencode")),
   serverUrl: StringSetting.pipe(Schema.withDecodingDefault(() => "")),
   serverPassword: StringSetting.pipe(Schema.withDecodingDefault(() => "")),
+  experimentalWebSockets: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
 });
 export type OpenCodeServerProviderSettings = typeof OpenCodeServerProviderSettings.Type;
 
@@ -148,6 +149,7 @@ export const ServerSettingsPatch = Schema.Struct({
           ...ProviderSettingsBasePatch,
           serverUrl: Schema.optionalKey(StringSetting),
           serverPassword: Schema.optionalKey(StringSetting),
+          experimentalWebSockets: Schema.optionalKey(Schema.Boolean),
         }),
       ),
       pi: Schema.optionalKey(


### PR DESCRIPTION
## Summary

- Update Opencode provider support for the newer SDK and managed-server environment options.
- Add native Opencode slash command discovery so provider commands appear in the composer.
- Allow slash command chips to accept follow-up text after selection.

## Validation

- Ran focused provider/runtime tests locally.
- Ran focused web settings and composer tests locally.
- Verified Opencode provider startup, thread creation, and native command execution against an isolated local server.
