### PR TITLE
[codex] Fix settings back navigation and legacy sidechat migration

### DIFF
--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -50,6 +50,7 @@ import Migration0034 from "./Migrations/034_AuthAccessManagement.ts";
 import Migration0035 from "./Migrations/035_NormalizeLegacyModelSelectionOptions.ts";
 import Migration0036 from "./Migrations/036_ProjectionThreadsPinned.ts";
 import Migration0037 from "./Migrations/037_ProjectionSnapshotCapIndexes.ts";
+import Migration0038 from "./Migrations/038_ReconcileLegacySidechatSource.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -99,6 +100,7 @@ export const migrationEntries = [
   [35, "NormalizeLegacyModelSelectionOptions", Migration0035],
   [36, "ProjectionThreadsPinned", Migration0036],
   [37, "ProjectionSnapshotCapIndexes", Migration0037],
+  [38, "ReconcileLegacySidechatSource", Migration0038],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/038_ReconcileLegacySidechatSource.test.ts
+++ b/apps/server/src/persistence/Migrations/038_ReconcileLegacySidechatSource.test.ts
@@ -1,0 +1,48 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+const projectionThreadsColumnNames = (sql: SqlClient.SqlClient) =>
+  sql<{ readonly name: string }>`
+    SELECT name FROM pragma_table_info('projection_threads')
+  `.pipe(Effect.map((rows) => rows.map((row) => row.name)));
+
+layer("038_ReconcileLegacySidechatSource", (it) => {
+  it.effect("heals legacy DBs whose tracker skipped Synara migration 33", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 32 });
+      yield* sql`
+        INSERT INTO effect_sql_migrations (migration_id, name)
+        VALUES (33, 'BackfillMissingLiveThreadProjects')
+      `;
+      yield* runMigrations({ toMigrationInclusive: 37 });
+
+      const beforeColumns = yield* projectionThreadsColumnNames(sql);
+      assert.notInclude(beforeColumns, "sidechat_source_thread_id");
+
+      yield* runMigrations();
+
+      const afterColumns = yield* projectionThreadsColumnNames(sql);
+      assert.include(afterColumns, "sidechat_source_thread_id");
+    }),
+  );
+
+  it.effect("is a no-op when sidechat source already exists", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations();
+      yield* runMigrations();
+
+      const columns = yield* projectionThreadsColumnNames(sql);
+      assert.include(columns, "sidechat_source_thread_id");
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/038_ReconcileLegacySidechatSource.ts
+++ b/apps/server/src/persistence/Migrations/038_ReconcileLegacySidechatSource.ts
@@ -1,0 +1,12 @@
+/**
+ * Repairs imported legacy DBs whose migration tracker already used ID 33 for
+ * a pre-Synara migration, causing Synara's sidechat source column migration to
+ * be skipped even though read-model queries now require the column.
+ */
+import * as Effect from "effect/Effect";
+
+import ProjectionThreadsSidechatSource from "./033_ProjectionThreadsSidechatSource.ts";
+
+export default Effect.gen(function* () {
+  yield* ProjectionThreadsSidechatSource;
+});

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -24,6 +24,7 @@ import {
   pruneExpandedProjectThreadListsForCollapsedProjects,
   recoverExistingAddProjectTarget,
   resolveProjectEmptyState,
+  resolveSettingsBackTarget,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
@@ -156,6 +157,51 @@ describe("resolveSidebarNewThreadEnvMode", () => {
         defaultEnvMode: "worktree",
       }),
     ).toBe("local");
+  });
+});
+
+describe("resolveSettingsBackTarget", () => {
+  it("returns the remembered live thread route", () => {
+    expect(
+      resolveSettingsBackTarget({
+        lastThreadRoute: {
+          threadId: "thread-remembered",
+          splitViewId: "split-live",
+        },
+        availableThreadIds: new Set(["thread-remembered", "thread-latest"]),
+        availableSplitViewIds: new Set(["split-live"]),
+        latestThreadId: "thread-latest",
+      }),
+    ).toEqual({
+      kind: "thread",
+      threadId: "thread-remembered",
+      splitViewId: "split-live",
+    });
+  });
+
+  it("falls back to the latest sidebar thread when the remembered route is stale", () => {
+    expect(
+      resolveSettingsBackTarget({
+        lastThreadRoute: {
+          threadId: "thread-missing",
+        },
+        availableThreadIds: new Set(["thread-latest"]),
+        latestThreadId: "thread-latest",
+      }),
+    ).toEqual({
+      kind: "thread",
+      threadId: "thread-latest",
+    });
+  });
+
+  it("falls back to home when no thread target is available", () => {
+    expect(
+      resolveSettingsBackTarget({
+        lastThreadRoute: null,
+        availableThreadIds: new Set(),
+        latestThreadId: null,
+      }),
+    ).toEqual({ kind: "home" });
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -4,6 +4,7 @@
 
 import type { KeybindingCommand, ProjectId, ThreadId } from "@t3tools/contracts";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "../appSettings";
+import { resolveRestorableThreadRoute, type LastThreadRoute } from "../chatRouteRestore";
 import type { ChatMessage, Project, SidebarThreadSummary, Thread } from "../types";
 import { cn } from "../lib/utils";
 import {
@@ -170,6 +171,48 @@ export function resolveSidebarNewThreadEnvMode(input: {
   defaultEnvMode: SidebarNewThreadEnvMode;
 }): SidebarNewThreadEnvMode {
   return input.requestedEnvMode ?? input.defaultEnvMode;
+}
+
+export type SettingsBackTarget =
+  | {
+      kind: "thread";
+      threadId: string;
+      splitViewId?: string | undefined;
+    }
+  | {
+      kind: "home";
+    };
+
+export function resolveSettingsBackTarget(input: {
+  lastThreadRoute: LastThreadRoute | null;
+  availableThreadIds: ReadonlySet<string>;
+  latestThreadId: string | null;
+  availableSplitViewIds?: ReadonlySet<string>;
+}): SettingsBackTarget {
+  const restorableRoute = resolveRestorableThreadRoute({
+    lastThreadRoute: input.lastThreadRoute,
+    availableThreadIds: input.availableThreadIds,
+    ...(input.availableSplitViewIds
+      ? { availableSplitViewIds: input.availableSplitViewIds }
+      : {}),
+  });
+
+  if (restorableRoute) {
+    return {
+      kind: "thread",
+      threadId: restorableRoute.threadId,
+      splitViewId: restorableRoute.splitViewId,
+    };
+  }
+
+  if (input.latestThreadId) {
+    return {
+      kind: "thread",
+      threadId: input.latestThreadId,
+    };
+  }
+
+  return { kind: "home" };
 }
 
 // Drops remembered "show more" state for projects that are currently collapsed.

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -200,6 +200,7 @@ import {
   recoverExistingAddProjectTarget,
   DEBUG_FEATURE_FLAGS_MENU_STORAGE_KEY,
   resolveProjectEmptyState,
+  resolveSettingsBackTarget,
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
   resolveThreadRowTrailingReserveClass,
@@ -213,7 +214,7 @@ import {
   sortProjectsForSidebar,
   sortThreadsForSidebar,
 } from "./Sidebar.logic";
-import { resolveRestorableThreadRoute, type LastThreadRoute } from "../chatRouteRestore";
+import type { LastThreadRoute } from "../chatRouteRestore";
 import { resolveSubagentPresentationForThread } from "../lib/subagentPresentation";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { DESKTOP_TOP_BAR_TRAFFIC_LIGHT_GUTTER_CLASS } from "~/hooks/useDesktopTopBarGutter";
@@ -1724,6 +1725,42 @@ export default function Sidebar() {
     [navigate],
   );
 
+  const resolveBackToThreadTarget = useCallback(() => {
+    const latestThread =
+      sortThreadsForSidebar(sidebarThreads, appSettings.sidebarThreadSortOrder)[0] ?? null;
+    return resolveSettingsBackTarget({
+      lastThreadRoute,
+      availableThreadIds: new Set(Object.keys(sidebarThreadSummaryById)),
+      availableSplitViewIds: new Set(
+        Object.keys(splitViewsById).filter((splitViewId) => splitViewsById[splitViewId]),
+      ),
+      latestThreadId: latestThread?.id ?? null,
+    });
+  }, [
+    appSettings.sidebarThreadSortOrder,
+    lastThreadRoute,
+    sidebarThreadSummaryById,
+    sidebarThreads,
+    splitViewsById,
+  ]);
+
+  const handleBackToAppFromSettings = useCallback(() => {
+    const target = resolveBackToThreadTarget();
+
+    if (target.kind === "thread") {
+      void navigate({
+        to: "/$threadId",
+        params: { threadId: ThreadId.makeUnsafe(target.threadId) },
+        search: () => ({
+          splitViewId: target.splitViewId,
+        }),
+      });
+      return;
+    }
+
+    void navigate({ to: "/" });
+  }, [navigate, resolveBackToThreadTarget]);
+
   const handleSidebarViewChange = useCallback(
     (view: "threads" | "workspace") => {
       if (view === "workspace") {
@@ -1735,29 +1772,14 @@ export default function Sidebar() {
         return;
       }
 
-      const restorableRoute = resolveRestorableThreadRoute({
-        lastThreadRoute,
-        availableThreadIds: new Set(Object.keys(sidebarThreadSummaryById)),
-      });
-      if (restorableRoute) {
+      const target = resolveBackToThreadTarget();
+      if (target.kind === "thread") {
         void navigate({
           to: "/$threadId",
-          params: { threadId: ThreadId.makeUnsafe(restorableRoute.threadId) },
+          params: { threadId: ThreadId.makeUnsafe(target.threadId) },
           search: () => ({
-            splitViewId: restorableRoute.splitViewId,
+            splitViewId: target.splitViewId,
           }),
-        });
-        return;
-      }
-
-      const latestThread = sortThreadsForSidebar(
-        sidebarThreads,
-        appSettings.sidebarThreadSortOrder,
-      )[0];
-      if (latestThread) {
-        void navigate({
-          to: "/$threadId",
-          params: { threadId: latestThread.id },
         });
         return;
       }
@@ -1765,14 +1787,11 @@ export default function Sidebar() {
       void handleNewChat({ fresh: true });
     },
     [
-      appSettings.sidebarThreadSortOrder,
       handleNewChat,
-      lastThreadRoute,
       navigate,
       navigateToWorkspace,
+      resolveBackToThreadTarget,
       routeWorkspaceId,
-      sidebarThreadSummaryById,
-      sidebarThreads,
       workspacePages,
     ],
   );
@@ -5360,7 +5379,7 @@ export default function Sidebar() {
           <SidebarGroup className="p-0">
             <SettingsSidebarNav
               activeSection={activeSettingsSection}
-              onBack={() => handleSidebarViewChange("threads")}
+              onBack={handleBackToAppFromSettings}
               onSelectSection={(section) => {
                 void navigate({
                   to: "/settings",


### PR DESCRIPTION
## What changed

- Added a reconciliation migration that reruns the sidechat source column migration for legacy databases whose migration tracker reused ID 33.
- Centralized settings/back-to-thread target resolution and reused it for both settings back navigation and the sidebar thread/workspace switch.
- Added focused tests for the legacy migration repair and settings back target selection.

## Why

Imported legacy databases can appear fully migrated while still missing `projection_threads.sidechat_source_thread_id`, which breaks read-model queries that expect the column. Settings back navigation also needed to avoid stale thread/split-view targets and fall back predictably.

## Validation

- `bun run test src/components/Sidebar.logic.test.ts` from `apps/web`: 71 passed
- `bun run test src/persistence/Migrations/038_ReconcileLegacySidechatSource.test.ts` from `apps/server`: 2 passed

Note: full `bun fmt`, `bun lint`, and `bun typecheck` were not run because repo instructions say not to run those heavyweight checks unless explicitly requested in the current conversation.
