### PR TITLE
Add capped project pinning to the sidebar and orchestration flow

### DIFF
--- a/apps/server/integration/orchestrationEngine.integration.test.ts
+++ b/apps/server/integration/orchestrationEngine.integration.test.ts
@@ -816,7 +816,6 @@ it.live("reverts to an earlier checkpoint and trims checkpoint projections + git
           entry.latestTurn?.turnId === "turn-2" &&
           entry.checkpoints.length === 2 &&
           entry.activities.some((activity) => activity.turnId === "turn-2"),
-        8000,
       );
 
       yield* harness.engine.dispatch({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -128,7 +128,7 @@ async function waitForThread(
     }>;
     activities: ReadonlyArray<{ kind: string }>;
   }) => boolean,
-  timeoutMs = 20_000,
+  timeoutMs = 30_000,
 ) {
   const deadline = Date.now() + timeoutMs;
   const poll = async (): Promise<{
@@ -158,7 +158,7 @@ async function waitForThread(
 async function waitForEvent(
   engine: OrchestrationEngineShape,
   predicate: (event: { type: string }) => boolean,
-  timeoutMs = 20_000,
+  timeoutMs = 30_000,
 ) {
   const deadline = Date.now() + timeoutMs;
   const poll = async () => {
@@ -209,7 +209,7 @@ function gitShowFileAtRef(cwd: string, ref: string, filePath: string): string {
   return runGit(cwd, ["show", `${ref}:${filePath}`]);
 }
 
-async function waitForGitRefExists(cwd: string, ref: string, timeoutMs = 20_000) {
+async function waitForGitRefExists(cwd: string, ref: string, timeoutMs = 30_000) {
   const deadline = Date.now() + timeoutMs;
   const poll = async (): Promise<void> => {
     if (gitRefExists(cwd, ref)) {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2489,6 +2489,7 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
             runOnWorktreeCreate: false,
           },
         ],
+        isPinned: true,
         defaultModelSelection: {
           provider: "codex",
           model: "gpt-5",
@@ -2498,10 +2499,12 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
       const projectRows = yield* sql<{
         readonly scriptsJson: string;
         readonly defaultModelSelection: string;
+        readonly isPinned: number;
       }>`
         SELECT
           scripts_json AS "scriptsJson",
-          default_model_selection_json AS "defaultModelSelection"
+          default_model_selection_json AS "defaultModelSelection",
+          is_pinned AS "isPinned"
         FROM projection_projects
         WHERE project_id = 'project-scripts'
       `;
@@ -2510,6 +2513,7 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
           scriptsJson:
             '[{"id":"script-1","name":"Build","command":"bun run build","icon":"build","runOnWorktreeCreate":false}]',
           defaultModelSelection: '{"provider":"codex","model":"gpt-5"}',
+          isPinned: 1,
         },
       ]);
     }),

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -301,6 +301,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           createdAt: "2026-02-24T00:00:00.000Z",
           updatedAt: "2026-02-24T00:00:01.000Z",
           deletedAt: null,
+          isPinned: false,
         },
       ]);
       assert.deepEqual(snapshot.threads, [

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -74,6 +74,7 @@ const ProjectionProjectDbRowSchema = ProjectionProject.mapFields(
   Struct.assign({
     defaultModelSelection: Schema.NullOr(ModelSelectionJsonUnknown),
     scripts: Schema.fromJsonString(Schema.Array(ProjectScript)),
+    isPinned: Schema.Number,
   }),
 );
 const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
@@ -396,6 +397,7 @@ function toProjectedProjectShell(row: ProjectionProjectDbRow): OrchestrationProj
     workspaceRoot: row.workspaceRoot,
     defaultModelSelection: row.defaultModelSelection,
     scripts: row.scripts,
+    isPinned: row.isPinned > 0,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -590,6 +592,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           workspace_root AS "workspaceRoot",
           default_model_selection_json AS "defaultModelSelection",
           scripts_json AS "scripts",
+          is_pinned AS "isPinned",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           deleted_at AS "deletedAt"
@@ -934,6 +937,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           workspace_root AS "workspaceRoot",
           default_model_selection_json AS "defaultModelSelection",
           scripts_json AS "scripts",
+          is_pinned AS "isPinned",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           deleted_at AS "deletedAt"
@@ -972,6 +976,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           workspace_root AS "workspaceRoot",
           default_model_selection_json AS "defaultModelSelection",
           scripts_json AS "scripts",
+          is_pinned AS "isPinned",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           deleted_at AS "deletedAt"
@@ -1527,6 +1532,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             workspaceRoot: row.workspaceRoot,
             defaultModelSelection: row.defaultModelSelection,
             scripts: row.scripts,
+            isPinned: row.isPinned > 0,
             createdAt: row.createdAt,
             updatedAt: row.updatedAt,
             deletedAt: row.deletedAt,
@@ -1687,6 +1693,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             workspaceRoot: row.workspaceRoot,
             defaultModelSelection: row.defaultModelSelection,
             scripts: row.scripts,
+            isPinned: row.isPinned > 0,
             createdAt: row.createdAt,
             updatedAt: row.updatedAt,
             deletedAt: row.deletedAt,
@@ -1910,6 +1917,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
               workspaceRoot: row.workspaceRoot,
               defaultModelSelection: row.defaultModelSelection,
               scripts: row.scripts,
+              isPinned: row.isPinned > 0,
               createdAt: row.createdAt,
               updatedAt: row.updatedAt,
               deletedAt: row.deletedAt,

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -270,6 +270,67 @@ describe("decider project scripts", () => {
     expect((event.payload as { scripts?: unknown[] }).scripts).toEqual(scripts);
   });
 
+  it("rejects pinning more than three active projects", async () => {
+    const now = new Date().toISOString();
+    let readModel = createEmptyReadModel(now);
+
+    for (const index of [1, 2, 3, 4]) {
+      readModel = await Effect.runPromise(
+        projectEvent(readModel, {
+          sequence: index,
+          eventId: asEventId(`evt-project-pin-${index}`),
+          aggregateKind: "project",
+          aggregateId: asProjectId(`project-pin-${index}`),
+          type: "project.created",
+          occurredAt: now,
+          commandId: CommandId.makeUnsafe(`cmd-project-pin-${index}`),
+          causationEventId: null,
+          correlationId: CommandId.makeUnsafe(`cmd-project-pin-${index}`),
+          metadata: {},
+          payload: {
+            projectId: asProjectId(`project-pin-${index}`),
+            title: `Project Pin ${index}`,
+            workspaceRoot: `/tmp/project-pin-${index}`,
+            defaultModelSelection: null,
+            scripts: [],
+            isPinned: index <= 3,
+            createdAt: now,
+            updatedAt: now,
+          },
+        }),
+      );
+    }
+
+    await expect(
+      Effect.runPromise(
+        decideOrchestrationCommand({
+          command: {
+            type: "project.meta.update",
+            commandId: CommandId.makeUnsafe("cmd-project-pin-fourth"),
+            projectId: asProjectId("project-pin-4"),
+            isPinned: true,
+          },
+          readModel,
+        }),
+      ),
+    ).rejects.toThrow("Only 3 projects can be pinned at once.");
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "project.meta.update",
+          commandId: CommandId.makeUnsafe("cmd-project-repin-existing"),
+          projectId: asProjectId("project-pin-1"),
+          isPinned: true,
+        },
+        readModel,
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event.type).toBe("project.meta-updated");
+  });
+
   it("emits user message and turn-start-requested events for thread.turn.start", async () => {
     const now = new Date().toISOString();
     const initial = createEmptyReadModel(now);

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -3,7 +3,11 @@ import type {
   OrchestrationEvent,
   OrchestrationReadModel,
 } from "@t3tools/contracts";
-import { PINNED_MESSAGES_MAX_COUNT, TurnId } from "@t3tools/contracts";
+import {
+  MAX_PINNED_PROJECTS,
+  PINNED_MESSAGES_MAX_COUNT,
+  TurnId,
+} from "@t3tools/contracts";
 import {
   deriveAssociatedWorktreeMetadata,
   deriveAssociatedWorktreeMetadataPatch,
@@ -69,6 +73,71 @@ function omitNullUserInputAnswers(
 ) {
   return Object.fromEntries(
     Object.entries(command.answers).filter(([, answer]) => answer !== null && answer !== undefined),
+  );
+}
+
+function countPinnedProjects(
+  readModel: OrchestrationReadModel,
+  options?: { readonly excludeProjectIds?: ReadonlySet<string> },
+): number {
+  return readModel.projects.filter(
+    (project) =>
+      project.deletedAt === null &&
+      project.kind === "project" &&
+      project.isPinned === true &&
+      !options?.excludeProjectIds?.has(project.id),
+  ).length;
+}
+
+function validateProjectPinLimit(input: {
+  readonly command: Extract<
+    OrchestrationCommand,
+    { type: "project.create" | "project.meta.update" }
+  >;
+  readonly readModel: OrchestrationReadModel;
+  readonly projectId: OrchestrationEvent["aggregateId"];
+  readonly nextKind: "project" | "chat";
+  readonly nextDeletedAt?: string | null;
+  readonly wasPinned?: boolean;
+  readonly staleProjectIds?: ReadonlySet<string>;
+}): Effect.Effect<void, OrchestrationCommandInvariantError> {
+  if (input.command.isPinned !== true) {
+    return Effect.void;
+  }
+
+  if (input.nextKind !== "project") {
+    return Effect.fail(
+      new OrchestrationCommandInvariantError({
+        commandType: input.command.type,
+        detail: `Only projects can be pinned.`,
+      }),
+    );
+  }
+
+  if (input.nextDeletedAt !== undefined && input.nextDeletedAt !== null) {
+    return Effect.fail(
+      new OrchestrationCommandInvariantError({
+        commandType: input.command.type,
+        detail: `Deleted project '${input.projectId}' cannot be pinned.`,
+      }),
+    );
+  }
+
+  if (input.wasPinned === true) {
+    return Effect.void;
+  }
+
+  const excludeProjectIds = new Set<string>([input.projectId, ...(input.staleProjectIds ?? [])]);
+  const pinnedProjectCount = countPinnedProjects(input.readModel, { excludeProjectIds });
+  if (pinnedProjectCount < MAX_PINNED_PROJECTS) {
+    return Effect.void;
+  }
+
+  return Effect.fail(
+    new OrchestrationCommandInvariantError({
+      commandType: input.command.type,
+      detail: `Only ${MAX_PINNED_PROJECTS} projects can be pinned at once.`,
+    }),
   );
 }
 
@@ -152,12 +221,12 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         projectId: command.projectId,
       });
       const events: Array<Omit<OrchestrationEvent, "sequence">> = [];
+      const staleProjects: Array<OrchestrationReadModel["projects"][number]> = [];
       if ((command.kind ?? "project") === "project") {
         const existingProjects = listActiveProjectsByWorkspaceRoot(
           readModel,
           command.workspaceRoot,
         );
-        const staleProjects: Array<(typeof existingProjects)[number]> = [];
         for (const existingProject of existingProjects) {
           const remainingThreads = listThreadsByProjectId(readModel, existingProject.id).filter(
             (thread) => thread.deletedAt === null,
@@ -189,6 +258,13 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           });
         }
       }
+      yield* validateProjectPinLimit({
+        command,
+        readModel,
+        projectId: command.projectId,
+        nextKind: command.kind ?? "project",
+        staleProjectIds: new Set(staleProjects.map((project) => project.id)),
+      });
 
       events.push({
         ...withEventBase({
@@ -205,6 +281,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           workspaceRoot: command.workspaceRoot,
           defaultModelSelection: command.defaultModelSelection ?? null,
           scripts: [],
+          isPinned: command.isPinned,
           createdAt: command.createdAt,
           updatedAt: command.createdAt,
         },
@@ -213,7 +290,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "project.meta.update": {
-      yield* requireProject({
+      const existingProject = yield* requireProject({
         readModel,
         command,
         projectId: command.projectId,
@@ -226,6 +303,14 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           excludeProjectId: command.projectId,
         });
       }
+      yield* validateProjectPinLimit({
+        command,
+        readModel,
+        projectId: command.projectId,
+        nextKind: command.kind ?? existingProject.kind ?? "project",
+        nextDeletedAt: existingProject.deletedAt,
+        wasPinned: existingProject.isPinned === true,
+      });
       const occurredAt = nowIso();
       return {
         ...withEventBase({
@@ -244,6 +329,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
             ? { defaultModelSelection: command.defaultModelSelection }
             : {}),
           ...(command.scripts !== undefined ? { scripts: command.scripts } : {}),
+          ...(command.isPinned !== undefined ? { isPinned: command.isPinned } : {}),
           updatedAt: occurredAt,
         },
       };

--- a/apps/server/src/orchestration/projectMetadataProjection.ts
+++ b/apps/server/src/orchestration/projectMetadataProjection.ts
@@ -34,6 +34,7 @@ export const applyProjectMetadataProjection = (input: {
           workspaceRoot: input.event.payload.workspaceRoot,
           defaultModelSelection: input.event.payload.defaultModelSelection,
           scripts: input.event.payload.scripts,
+          isPinned: input.event.payload.isPinned ?? false,
           createdAt: input.event.payload.createdAt,
           updatedAt: input.event.payload.updatedAt,
           deletedAt: null,
@@ -59,6 +60,9 @@ export const applyProjectMetadataProjection = (input: {
               : {}),
             ...(input.event.payload.scripts !== undefined
               ? { scripts: input.event.payload.scripts }
+              : {}),
+            ...(input.event.payload.isPinned !== undefined
+              ? { isPinned: input.event.payload.isPinned }
               : {}),
             updatedAt: input.event.payload.updatedAt,
           });

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -234,6 +234,7 @@ export function projectEvent(
             workspaceRoot: payload.workspaceRoot,
             defaultModelSelection: payload.defaultModelSelection,
             scripts: payload.scripts,
+            isPinned: payload.isPinned ?? false,
             createdAt: payload.createdAt,
             updatedAt: payload.updatedAt,
             deletedAt: null,
@@ -267,6 +268,7 @@ export function projectEvent(
                     ? { defaultModelSelection: payload.defaultModelSelection }
                     : {}),
                   ...(payload.scripts !== undefined ? { scripts: payload.scripts } : {}),
+                  ...(payload.isPinned !== undefined ? { isPinned: payload.isPinned } : {}),
                   updatedAt: payload.updatedAt,
                 }
               : project,

--- a/apps/server/src/persistence/Layers/ProjectionProjects.ts
+++ b/apps/server/src/persistence/Layers/ProjectionProjects.ts
@@ -1,6 +1,7 @@
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 import { Effect, Layer, Schema, Struct } from "effect";
+import * as SchemaGetter from "effect/SchemaGetter";
 
 import { ModelSelection, ProjectScript } from "@t3tools/contracts";
 import { toPersistenceSqlError } from "../Errors.ts";
@@ -12,10 +13,18 @@ import {
   type ProjectionProjectRepositoryShape,
 } from "../Services/ProjectionProjects.ts";
 
+const SqliteBoolean = Schema.Number.pipe(
+  Schema.decodeTo(Schema.Boolean, {
+    decode: SchemaGetter.transform((value) => value !== 0),
+    encode: SchemaGetter.transform((value) => (value ? 1 : 0)),
+  }),
+);
+
 const ProjectionProjectDbRow = ProjectionProject.mapFields(
   Struct.assign({
     defaultModelSelection: Schema.NullOr(Schema.fromJsonString(ModelSelection)),
     scripts: Schema.fromJsonString(Schema.Array(ProjectScript)),
+    isPinned: SqliteBoolean,
   }),
 );
 type ProjectionProjectDbRow = typeof ProjectionProjectDbRow.Type;
@@ -34,6 +43,7 @@ const makeProjectionProjectRepository = Effect.gen(function* () {
           workspace_root,
           default_model_selection_json,
           scripts_json,
+          is_pinned,
           created_at,
           updated_at,
           deleted_at
@@ -45,6 +55,7 @@ const makeProjectionProjectRepository = Effect.gen(function* () {
           ${row.workspaceRoot},
           ${row.defaultModelSelection !== null ? JSON.stringify(row.defaultModelSelection) : null},
           ${JSON.stringify(row.scripts)},
+          ${row.isPinned ? 1 : 0},
           ${row.createdAt},
           ${row.updatedAt},
           ${row.deletedAt}
@@ -56,6 +67,7 @@ const makeProjectionProjectRepository = Effect.gen(function* () {
           workspace_root = excluded.workspace_root,
           default_model_selection_json = excluded.default_model_selection_json,
           scripts_json = excluded.scripts_json,
+          is_pinned = excluded.is_pinned,
           created_at = excluded.created_at,
           updated_at = excluded.updated_at,
           deleted_at = excluded.deleted_at
@@ -74,6 +86,7 @@ const makeProjectionProjectRepository = Effect.gen(function* () {
           workspace_root AS "workspaceRoot",
           default_model_selection_json AS "defaultModelSelection",
           scripts_json AS "scripts",
+          is_pinned AS "isPinned",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           deleted_at AS "deletedAt"
@@ -94,6 +107,7 @@ const makeProjectionProjectRepository = Effect.gen(function* () {
           workspace_root AS "workspaceRoot",
           default_model_selection_json AS "defaultModelSelection",
           scripts_json AS "scripts",
+          is_pinned AS "isPinned",
           created_at AS "createdAt",
           updated_at AS "updatedAt",
           deleted_at AS "deletedAt"

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -33,6 +33,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
           model: "gpt-5.4",
         },
         scripts: [],
+        isPinned: false,
         createdAt: "2026-03-24T00:00:00.000Z",
         updatedAt: "2026-03-24T00:00:00.000Z",
         deletedAt: null,

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -53,6 +53,7 @@ import Migration0037 from "./Migrations/037_ProjectionSnapshotCapIndexes.ts";
 import Migration0038 from "./Migrations/038_ReconcileLegacySidechatSource.ts";
 import Migration0039 from "./Migrations/039_ReconcileLegacyPinnedThreads.ts";
 import Migration0040 from "./Migrations/040_ProjectionThreadsPinnedMessagesNotes.ts";
+import Migration0041 from "./Migrations/041_ProjectionProjectsPinned.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -105,6 +106,7 @@ export const migrationEntries = [
   [38, "ReconcileLegacySidechatSource", Migration0038],
   [39, "ReconcileLegacyPinnedThreads", Migration0039],
   [40, "ProjectionThreadsPinnedMessagesNotes", Migration0040],
+  [41, "ProjectionProjectsPinned", Migration0041],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/041_ProjectionProjectsPinned.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionProjectsPinned.ts
@@ -1,0 +1,19 @@
+/**
+ * Adds durable pin state to projected projects so project sidebar pins survive
+ * browser restarts and can be reflected in shell snapshots.
+ */
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    ALTER TABLE projection_projects
+    ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0
+  `.pipe(
+    Effect.catchTag("SqlError", (error) =>
+      String(error).includes("duplicate column name") ? Effect.void : Effect.fail(error),
+    ),
+  );
+});

--- a/apps/server/src/persistence/Services/ProjectionProjects.ts
+++ b/apps/server/src/persistence/Services/ProjectionProjects.ts
@@ -25,6 +25,7 @@ export const ProjectionProject = Schema.Struct({
   workspaceRoot: Schema.String,
   defaultModelSelection: Schema.NullOr(ModelSelection),
   scripts: Schema.Array(ProjectScript),
+  isPinned: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
   deletedAt: Schema.NullOr(IsoDateTime),

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildProjectThreadTree,
+  derivePinnedProjectIdsForSidebar,
   derivePinnedThreadIdsForSidebar,
   deriveSidebarProjectData,
   describeAddProjectError,
@@ -9,12 +10,14 @@ import {
   findWorkspaceRootMatch,
   getFallbackThreadIdAfterDelete,
   getVisibleSidebarEntriesForPreview,
+  orderPinnedProjectsForSidebar,
   getPinnedThreadsForSidebar,
   getNextVisibleSidebarThreadId,
   getSidebarThreadIdForJumpCommand,
   getSidebarThreadIdsToPrewarm,
   getRenderedThreadsForSidebarProject,
   groupSidebarThreadsByProjectId,
+  isLatestPinnedProjectMutation,
   getUnpinnedThreadsForSidebar,
   getVisibleSidebarThreadIds,
   getVisibleThreadsForProject,
@@ -335,6 +338,22 @@ describe("add-project error helpers", () => {
 });
 
 describe("pin helpers", () => {
+  const makeProject = (id: string): Project =>
+    ({
+      id: id as ProjectId,
+      kind: "project",
+      name: id,
+      remoteName: id,
+      folderName: id,
+      localName: null,
+      cwd: `/tmp/${id}`,
+      defaultModelSelection: null,
+      expanded: true,
+      createdAt: "2026-03-09T10:00:00.000Z",
+      updatedAt: "2026-03-09T10:00:00.000Z",
+      scripts: [],
+    }) satisfies Project;
+
   const makeThread = (id: string): Thread =>
     ({
       id: id as ThreadId,
@@ -404,9 +423,36 @@ describe("pin helpers", () => {
     ).toEqual(["thread-1"]);
   });
 
+  it("derives at most three pinned projects and keeps persisted order first", () => {
+    const projects = [
+      { ...makeProject("project-1"), isPinned: true },
+      { ...makeProject("project-2"), isPinned: true },
+      { ...makeProject("project-3"), isPinned: true },
+      { ...makeProject("project-4"), isPinned: true },
+    ];
+
+    expect(
+      derivePinnedProjectIdsForSidebar({
+        projects,
+        persistedPinnedProjectIds: ["project-3" as ProjectId, "project-1" as ProjectId],
+        optimisticPinnedStateByProjectId: new Map([["project-1" as ProjectId, false]]),
+      }),
+    ).toEqual(["project-3", "project-2", "project-4"]);
+  });
+
+  it("moves pinned projects to the top while preserving unpinned order", () => {
+    const projects = [makeProject("project-1"), makeProject("project-2"), makeProject("project-3")];
+
+    expect(
+      orderPinnedProjectsForSidebar(projects, ["project-3" as ProjectId, "project-1" as ProjectId]),
+    ).toEqual([projects[2], projects[0], projects[1]]);
+  });
+
   it("rejects stale pin mutation versions so old failures cannot roll back newer clicks", () => {
     const threadId = "thread-1" as ThreadId;
     const latestMutationVersionByThreadId = new Map<ThreadId, number>([[threadId, 2]]);
+    const projectId = "project-1" as ProjectId;
+    const latestMutationVersionByProjectId = new Map<ProjectId, number>([[projectId, 2]]);
 
     expect(
       isLatestPinnedThreadMutation({
@@ -420,6 +466,20 @@ describe("pin helpers", () => {
         threadId,
         requestVersion: 2,
         latestMutationVersionByThreadId,
+      }),
+    ).toBe(true);
+    expect(
+      isLatestPinnedProjectMutation({
+        projectId,
+        requestVersion: 1,
+        latestMutationVersionByProjectId,
+      }),
+    ).toBe(false);
+    expect(
+      isLatestPinnedProjectMutation({
+        projectId,
+        requestVersion: 2,
+        latestMutationVersionByProjectId,
       }),
     ).toBe(true);
   });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -2,11 +2,22 @@
 // Purpose: Shared sidebar sorting and status helpers used by the thread list UI.
 // Exports: Sidebar row state derivation, add-project error helpers, sort utilities, and visibility helpers.
 
-import type { KeybindingCommand, ProjectId, ThreadId } from "@t3tools/contracts";
+import {
+  MAX_PINNED_PROJECTS,
+  type KeybindingCommand,
+  type ProjectId,
+  type ThreadId,
+} from "@t3tools/contracts";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "../appSettings";
 import { resolveRestorableThreadRoute, type LastThreadRoute } from "../chatRouteRestore";
 import type { ChatMessage, Project, SidebarThreadSummary, Thread } from "../types";
 import { cn } from "../lib/utils";
+import {
+  derivePinnedIds,
+  getPinnedItems,
+  isLatestPinMutation,
+  orderPinnedItemsFirst,
+} from "../pinning.logic";
 import {
   SIDEBAR_ROW_ACTIVE_CLASS_NAME,
   SIDEBAR_ROW_HOVER_CLASS_NAME,
@@ -664,25 +675,11 @@ export function getVisibleSidebarEntriesForPreview<
   };
 }
 
-// Preserve the persisted pin order while discarding ids that no longer exist locally.
 export function getPinnedThreadsForSidebar<T extends Pick<Thread, "id">>(
   threads: readonly T[],
   pinnedThreadIds: readonly T["id"][],
 ): T[] {
-  const threadById = new Map(threads.map((thread) => [thread.id, thread] as const));
-  const seen = new Set<T["id"]>();
-  const pinnedThreads: T[] = [];
-
-  for (const threadId of pinnedThreadIds) {
-    if (seen.has(threadId)) continue;
-    seen.add(threadId);
-    const thread = threadById.get(threadId);
-    if (thread) {
-      pinnedThreads.push(thread);
-    }
-  }
-
-  return pinnedThreads;
+  return getPinnedItems(threads, pinnedThreadIds);
 }
 
 // Resolve the visible pinned ids from server state, local legacy pins, and pending user clicks.
@@ -691,23 +688,11 @@ export function derivePinnedThreadIdsForSidebar<T extends Pick<Thread, "id" | "i
   readonly persistedPinnedThreadIds: readonly T["id"][];
   readonly optimisticPinnedStateByThreadId: ReadonlyMap<T["id"], boolean>;
 }): T["id"][] {
-  const next = new Set<T["id"]>();
-
-  for (const thread of input.threads) {
-    const optimisticPinned = input.optimisticPinnedStateByThreadId.get(thread.id);
-    if (optimisticPinned ?? thread.isPinned === true) {
-      next.add(thread.id);
-    }
-  }
-
-  for (const threadId of input.persistedPinnedThreadIds) {
-    if (input.optimisticPinnedStateByThreadId.get(threadId) === false) {
-      continue;
-    }
-    next.add(threadId);
-  }
-
-  return [...next];
+  return derivePinnedIds({
+    items: input.threads,
+    persistedPinnedIds: input.persistedPinnedThreadIds,
+    optimisticPinnedStateById: input.optimisticPinnedStateByThreadId,
+  });
 }
 
 // Only the newest pin mutation may roll back optimistic state after rapid clicks.
@@ -716,7 +701,45 @@ export function isLatestPinnedThreadMutation<T>(input: {
   readonly requestVersion: number;
   readonly latestMutationVersionByThreadId: ReadonlyMap<T, number>;
 }): boolean {
-  return input.latestMutationVersionByThreadId.get(input.threadId) === input.requestVersion;
+  return isLatestPinMutation({
+    id: input.threadId,
+    requestVersion: input.requestVersion,
+    latestMutationVersionById: input.latestMutationVersionByThreadId,
+  });
+}
+
+export function isLatestPinnedProjectMutation<T>(input: {
+  readonly projectId: T;
+  readonly requestVersion: number;
+  readonly latestMutationVersionByProjectId: ReadonlyMap<T, number>;
+}): boolean {
+  return isLatestPinMutation({
+    id: input.projectId,
+    requestVersion: input.requestVersion,
+    latestMutationVersionById: input.latestMutationVersionByProjectId,
+  });
+}
+
+export function derivePinnedProjectIdsForSidebar<
+  T extends Pick<Project, "id" | "isPinned">,
+>(input: {
+  readonly projects: readonly T[];
+  readonly persistedPinnedProjectIds: readonly T["id"][];
+  readonly optimisticPinnedStateByProjectId: ReadonlyMap<T["id"], boolean>;
+}): T["id"][] {
+  return derivePinnedIds({
+    items: input.projects,
+    persistedPinnedIds: input.persistedPinnedProjectIds,
+    optimisticPinnedStateById: input.optimisticPinnedStateByProjectId,
+    maxCount: MAX_PINNED_PROJECTS,
+  });
+}
+
+export function orderPinnedProjectsForSidebar<T extends Pick<Project, "id">>(
+  projects: readonly T[],
+  pinnedProjectIds: readonly T["id"][],
+): T[] {
+  return orderPinnedItemsFirst(projects, pinnedProjectIds);
 }
 
 // Hide globally pinned rows from the per-project lists so the sidebar doesn't duplicate chats.

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   type LucideIcon,
   NewThreadIcon,
   PencilIcon,
+  PinIcon,
   SearchIcon,
   SettingsIcon,
   TerminalIcon,
@@ -59,6 +60,7 @@ import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-
 import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
 import {
+  MAX_PINNED_PROJECTS,
   type DesktopUpdateState,
   type OrchestrationShellSnapshot,
   PROVIDER_DISPLAY_NAMES,
@@ -193,16 +195,19 @@ import { isNonEmpty as isNonEmptyString } from "effect/String";
 import {
   describeAddProjectError,
   buildProjectThreadTree,
+  derivePinnedProjectIdsForSidebar,
   deriveSidebarProjectData,
   derivePinnedThreadIdsForSidebar,
   extractDuplicateProjectCreateProjectId,
   findWorkspaceRootMatch,
   getFallbackThreadIdAfterDelete,
   getPinnedThreadsForSidebar,
+  orderPinnedProjectsForSidebar,
   getNextVisibleSidebarThreadId,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarEntriesForPreview,
   groupSidebarThreadsByProjectId,
+  isLatestPinnedProjectMutation,
   isLatestPinnedThreadMutation,
   pruneExpandedProjectThreadListsForCollapsedProjects,
   recoverExistingAddProjectTarget,
@@ -264,6 +269,7 @@ import {
 import { THREAD_DRAG_MIME } from "./chat-drop-overlay/ChatPaneDropOverlay";
 import { useTemporaryThreadStore } from "../temporaryThreadStore";
 import { useThreadActivationController } from "../hooks/useThreadActivationController";
+import { usePinnedProjectsStore } from "../pinnedProjectsStore";
 import { usePinnedThreadsStore } from "../pinnedThreadsStore";
 import { retainThreadDetailSubscription } from "../threadDetailSubscriptionRetention";
 import { useWorkspaceStore, workspaceThreadId } from "../workspaceStore";
@@ -312,6 +318,7 @@ type ProjectContextMenuId =
   | "open-in-finder"
   | "copy-path"
   | "rename"
+  | "toggle-pin"
   | "archive-threads"
   | "delete-threads"
   | "delete";
@@ -1176,6 +1183,10 @@ export default function Sidebar() {
   const draftThreadsByThreadId = useComposerDraftStore((store) => store.draftThreadsByThreadId);
   const temporaryThreadIds = useTemporaryThreadStore((store) => store.temporaryThreadIds);
   const clearTemporaryThread = useTemporaryThreadStore((store) => store.clearTemporaryThread);
+  const persistedPinnedProjectIds = usePinnedProjectsStore((store) => store.pinnedProjectIds);
+  const pinProjectLocally = usePinnedProjectsStore((store) => store.pinProject);
+  const unpinProject = usePinnedProjectsStore((store) => store.unpinProject);
+  const prunePinnedProjects = usePinnedProjectsStore((store) => store.prunePinnedProjects);
   const persistedPinnedThreadIds = usePinnedThreadsStore((store) => store.pinnedThreadIds);
   const pinThreadLocally = usePinnedThreadsStore((store) => store.pinThread);
   const unpinThread = usePinnedThreadsStore((store) => store.unpinThread);
@@ -1355,6 +1366,8 @@ export default function Sidebar() {
     new Map<ThreadId, { release: () => void; timeoutId: number }>(),
   );
   const legacyPinMigrationThreadIdsRef = useRef(new Set<ThreadId>());
+  const optimisticPinnedStateByProjectIdRef = useRef(new Map<ProjectId, boolean>());
+  const latestPinnedMutationVersionByProjectIdRef = useRef(new Map<ProjectId, number>());
   const optimisticPinnedStateByThreadIdRef = useRef(new Map<ThreadId, boolean>());
   const latestPinnedMutationVersionByThreadIdRef = useRef(new Map<ThreadId, number>());
   const [desktopUpdateState, setDesktopUpdateState] = useState<DesktopUpdateState | null>(null);
@@ -1363,6 +1376,9 @@ export default function Sidebar() {
   const [installingDesktopUpdate, setInstallingDesktopUpdate] = useState(false);
   const [optimisticPinnedStateByThreadId, setOptimisticPinnedStateByThreadId] = useState<
     ReadonlyMap<ThreadId, boolean>
+  >(() => new Map());
+  const [optimisticPinnedStateByProjectId, setOptimisticPinnedStateByProjectId] = useState<
+    ReadonlyMap<ProjectId, boolean>
   >(() => new Map());
   // Dedupes the manual-download fallback toast so a single failure surfaced by
   // both the click handler and the install-watchdog push only notifies once.
@@ -1639,6 +1655,152 @@ export default function Sidebar() {
     () => new Map(projects.map((project) => [project.id, project] as const)),
     [projects],
   );
+  const projectByIdRef = useRef(projectById);
+  useEffect(() => {
+    projectByIdRef.current = projectById;
+  }, [projectById]);
+  const setOptimisticProjectPinned = useCallback((projectId: ProjectId, isPinned: boolean) => {
+    optimisticPinnedStateByProjectIdRef.current.set(projectId, isPinned);
+    setOptimisticPinnedStateByProjectId((current) => {
+      if (current.get(projectId) === isPinned) {
+        return current;
+      }
+      const next = new Map(current);
+      next.set(projectId, isPinned);
+      return next;
+    });
+  }, []);
+  const clearOptimisticProjectPinned = useCallback((projectId: ProjectId) => {
+    optimisticPinnedStateByProjectIdRef.current.delete(projectId);
+    setOptimisticPinnedStateByProjectId((current) => {
+      if (!current.has(projectId)) {
+        return current;
+      }
+      const next = new Map(current);
+      next.delete(projectId);
+      return next;
+    });
+  }, []);
+  const dispatchProjectPinnedState = useCallback(
+    async (projectId: ProjectId, isPinned: boolean) => {
+      const api = readNativeApi();
+      if (!api) return;
+      await api.orchestration.dispatchCommand({
+        type: "project.meta.update",
+        commandId: newCommandId(),
+        projectId,
+        isPinned,
+      });
+    },
+    [],
+  );
+  const setProjectPinned = useCallback(
+    async (projectId: ProjectId, isPinned: boolean) => {
+      const api = readNativeApi();
+      if (!api) return;
+      const project = projectByIdRef.current.get(projectId);
+      if (!project || project.kind !== "project") {
+        return;
+      }
+      const requestVersion =
+        (latestPinnedMutationVersionByProjectIdRef.current.get(projectId) ?? 0) + 1;
+      latestPinnedMutationVersionByProjectIdRef.current.set(projectId, requestVersion);
+
+      setOptimisticProjectPinned(projectId, isPinned);
+      if (isPinned) {
+        const accepted = pinProjectLocally(projectId);
+        if (!accepted) {
+          clearOptimisticProjectPinned(projectId);
+          toastManager.add({
+            type: "warning",
+            title: "Project pin limit reached",
+            description: `You can pin up to ${MAX_PINNED_PROJECTS} projects.`,
+          });
+          return;
+        }
+      } else {
+        unpinProject(projectId);
+      }
+
+      try {
+        await dispatchProjectPinnedState(projectId, isPinned);
+      } catch (error) {
+        if (
+          !isLatestPinnedProjectMutation({
+            projectId,
+            requestVersion,
+            latestMutationVersionByProjectId: latestPinnedMutationVersionByProjectIdRef.current,
+          })
+        ) {
+          return;
+        }
+
+        const confirmedPinned = projectByIdRef.current.get(projectId)?.isPinned === true;
+        if (confirmedPinned) {
+          pinProjectLocally(projectId);
+        } else {
+          unpinProject(projectId);
+        }
+        clearOptimisticProjectPinned(projectId);
+        throw error;
+      }
+    },
+    [
+      clearOptimisticProjectPinned,
+      dispatchProjectPinnedState,
+      pinProjectLocally,
+      setOptimisticProjectPinned,
+      unpinProject,
+    ],
+  );
+  const toggleProjectPinned = useCallback(
+    (projectId: ProjectId) => {
+      const optimisticPinned = optimisticPinnedStateByProjectIdRef.current.get(projectId);
+      const locallyPinned = usePinnedProjectsStore.getState().pinnedProjectIds.includes(projectId);
+      const serverPinned = projectByIdRef.current.get(projectId)?.isPinned === true;
+      const isPinned = optimisticPinned ?? (locallyPinned || serverPinned);
+      void setProjectPinned(projectId, !isPinned).catch((error) => {
+        console.error("Failed to update pinned project state", {
+          projectId,
+          error,
+        });
+        toastManager.add({
+          type: "error",
+          title: isPinned ? "Unable to unpin project" : "Unable to pin project",
+          description: error instanceof Error ? error.message : undefined,
+        });
+      });
+    },
+    [setProjectPinned],
+  );
+  useEffect(() => {
+    if (optimisticPinnedStateByProjectId.size === 0) {
+      return;
+    }
+
+    const serverPinnedStateByProjectId = new Map(
+      projects.map((project) => [project.id, project.isPinned === true] as const),
+    );
+    setOptimisticPinnedStateByProjectId((current) => {
+      let next: Map<ProjectId, boolean> | null = null;
+      const confirmedProjectIds: ProjectId[] = [];
+      for (const [projectId, desiredPinned] of current) {
+        const serverPinned = serverPinnedStateByProjectId.get(projectId);
+        if (serverPinned !== undefined && serverPinned !== desiredPinned) {
+          continue;
+        }
+        next ??= new Map(current);
+        next.delete(projectId);
+        confirmedProjectIds.push(projectId);
+      }
+      if (next) {
+        for (const projectId of confirmedProjectIds) {
+          optimisticPinnedStateByProjectIdRef.current.delete(projectId);
+        }
+      }
+      return next ?? current;
+    });
+  }, [optimisticPinnedStateByProjectId, projects]);
   const workspaceRows = useMemo(
     () =>
       workspacePages.map((workspace) => {
@@ -3369,6 +3531,10 @@ export default function Sidebar() {
         setRenamingProjectName(project.localName ?? project.name);
         return;
       }
+      if (clicked === "toggle-pin") {
+        toggleProjectPinned(projectId);
+        return;
+      }
       if (clicked === "archive-threads") {
         await archiveAllThreadsInProject(projectId);
         return;
@@ -3442,6 +3608,7 @@ export default function Sidebar() {
       deleteAllThreadsInProject,
       projectById,
       sidebarThreads,
+      toggleProjectPinned,
     ],
   );
 
@@ -3619,12 +3786,26 @@ export default function Sidebar() {
       }),
     [activeChatPreviewEntry?.rowId, chatThreadListExpanded, visibleChatPreviewEntries],
   );
-  const standardProjects = useMemo(
+  const standardProjectsBase = useMemo(
     () =>
       sortedProjects.filter(
         (project) => project.kind === "project" && !isHomeChatContainerProject(project, homeDir),
       ),
     [homeDir, sortedProjects],
+  );
+  const pinnedProjectIds = useMemo(
+    () =>
+      derivePinnedProjectIdsForSidebar({
+        projects: standardProjectsBase,
+        persistedPinnedProjectIds,
+        optimisticPinnedStateByProjectId,
+      }),
+    [optimisticPinnedStateByProjectId, persistedPinnedProjectIds, standardProjectsBase],
+  );
+  const pinnedProjectIdSet = useMemo(() => new Set(pinnedProjectIds), [pinnedProjectIds]);
+  const standardProjects = useMemo(
+    () => orderPinnedProjectsForSidebar(standardProjectsBase, pinnedProjectIds),
+    [pinnedProjectIds, standardProjectsBase],
   );
   const projectEmptyState = resolveProjectEmptyState({
     projectCount: standardProjects.length,
@@ -3676,6 +3857,13 @@ export default function Sidebar() {
     }
     prunePinnedThreads(sidebarThreads.map((thread) => thread.id));
   }, [prunePinnedThreads, sidebarThreads, threadsHydrated]);
+
+  useEffect(() => {
+    if (!shouldPrunePinnedThreads({ threadsHydrated })) {
+      return;
+    }
+    prunePinnedProjects(standardProjectsBase.map((project) => project.id));
+  }, [prunePinnedProjects, standardProjectsBase, threadsHydrated]);
 
   useEffect(() => {
     if (!threadsHydrated || persistedPinnedThreadIds.length === 0) {
@@ -4716,6 +4904,7 @@ export default function Sidebar() {
     dragHandleProps: SortableProjectHandleProps | null,
   ) {
     const isRenamingProject = renamingProjectId === project.id;
+    const isProjectPinned = pinnedProjectIdSet.has(project.id);
     const projectSidebarData = standardProjectSidebarDataById.get(project.id);
     if (!projectSidebarData) {
       return null;
@@ -4736,7 +4925,7 @@ export default function Sidebar() {
             size="sm"
             className={cn(
               SIDEBAR_HEADER_ROW_CLASS_NAME,
-              "transition-[padding] duration-150 ease-out hover:bg-[var(--sidebar-accent)] group-hover/project-header:bg-[var(--sidebar-accent)] group-hover/project-header:pr-[4.75rem] group-hover/project-header:text-[var(--sidebar-accent-foreground)] group-focus-within/project-header:pr-[4.75rem]",
+              "transition-[padding] duration-150 ease-out hover:bg-[var(--sidebar-accent)] group-hover/project-header:bg-[var(--sidebar-accent)] group-hover/project-header:pr-[6.5rem] group-hover/project-header:text-[var(--sidebar-accent-foreground)] group-focus-within/project-header:pr-[6.5rem]",
               isManualProjectSorting ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
             )}
             {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.attributes : {})}
@@ -4807,6 +4996,12 @@ export default function Sidebar() {
                   <span className="truncate font-system-ui text-[length:var(--app-font-size-ui,12px)] font-normal text-muted-foreground/79">
                     {project.name}
                   </span>
+                  {isProjectPinned ? (
+                    <PinIcon
+                      aria-hidden="true"
+                      className="size-3 shrink-0 text-muted-foreground/48"
+                    />
+                  ) : null}
                   {project.localName ? (
                     <span className="shrink-0 truncate text-[length:var(--app-font-size-ui,12px)] text-muted-foreground/40">
                       {project.folderName}
@@ -4817,6 +5012,19 @@ export default function Sidebar() {
             </div>
           </SidebarMenuButton>
           <SidebarSectionToolbar placement="overlay" revealOnHover>
+            <SidebarIconButton
+              icon={PinIcon}
+              label={isProjectPinned ? `Unpin ${project.name}` : `Pin ${project.name}`}
+              aria-pressed={isProjectPinned}
+              tooltip={isProjectPinned ? "Unpin project" : "Pin project"}
+              tooltipSide="top"
+              className={isProjectPinned ? "text-foreground/80" : undefined}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                toggleProjectPinned(project.id);
+              }}
+            />
             <SidebarIconButton
               icon={TerminalIcon}
               label={`Create new terminal thread in ${project.name}`}
@@ -5591,6 +5799,9 @@ export default function Sidebar() {
   const projectContextMenuHasArchivableThreads = projectContextMenuThreads.some(
     (thread) => thread.archivedAt == null,
   );
+  const projectContextMenuIsPinned = projectContextMenuProject
+    ? pinnedProjectIdSet.has(projectContextMenuProject.id)
+    : false;
 
   return (
     <>
@@ -5958,7 +6169,7 @@ export default function Sidebar() {
                   >
                     <SidebarMenu className="gap-3">
                       <SortableContext
-                        items={sortedProjects.map((project) => project.id)}
+                        items={standardProjects.map((project) => project.id)}
                         strategy={verticalListSortingStrategy}
                       >
                         {standardProjects.map((project) => (
@@ -6209,6 +6420,18 @@ export default function Sidebar() {
               >
                 <ProjectContextMenuIcon icon={PencilIcon} />
                 <span>Edit name</span>
+              </MenuItem>
+              <MenuItem
+                className={PROJECT_CONTEXT_MENU_ITEM_CLASS_NAME}
+                onClick={() =>
+                  void handleProjectContextMenuAction(
+                    projectContextMenuState.projectId,
+                    "toggle-pin",
+                  )
+                }
+              >
+                <ProjectContextMenuIcon icon={PinIcon} />
+                <span>{projectContextMenuIsPinned ? "Unpin project" : "Pin project"}</span>
               </MenuItem>
               {projectContextMenuHasArchivableThreads ? (
                 <MenuItem

--- a/apps/web/src/components/ThreadPinToggleButton.tsx
+++ b/apps/web/src/components/ThreadPinToggleButton.tsx
@@ -14,15 +14,17 @@ import { IconButton } from "./ui/icon-button";
 export function ThreadPinToggleButton({
   pinned,
   presentation,
+  targetLabel = "thread",
   toneClassName,
   onToggle,
 }: {
   pinned: boolean;
   presentation: "overlay" | "inline" | "leading";
+  targetLabel?: string;
   toneClassName?: string;
   onToggle: (event: React.MouseEvent<HTMLButtonElement> | React.MouseEvent) => void;
 }) {
-  const label = pinned ? "Unpin thread" : "Pin thread";
+  const label = `${pinned ? "Unpin" : "Pin"} ${targetLabel}`;
 
   return (
     <IconButton

--- a/apps/web/src/pinnedProjectsStore.test.ts
+++ b/apps/web/src/pinnedProjectsStore.test.ts
@@ -1,0 +1,42 @@
+// FILE: pinnedProjectsStore.test.ts
+// Purpose: Verifies the capped pinned-project store mutates ids predictably.
+// Layer: UI state store test
+
+import { beforeEach, describe, expect, it } from "vitest";
+import { ProjectId } from "@t3tools/contracts";
+import { usePinnedProjectsStore } from "./pinnedProjectsStore";
+
+describe("usePinnedProjectsStore", () => {
+  beforeEach(() => {
+    usePinnedProjectsStore.setState({ pinnedProjectIds: [] });
+  });
+
+  it("pins newest project ids first and rejects a fourth pin", () => {
+    expect(usePinnedProjectsStore.getState().pinProject("project-1" as ProjectId)).toBe(true);
+    expect(usePinnedProjectsStore.getState().pinProject("project-2" as ProjectId)).toBe(true);
+    expect(usePinnedProjectsStore.getState().pinProject("project-3" as ProjectId)).toBe(true);
+    expect(usePinnedProjectsStore.getState().pinProject("project-4" as ProjectId)).toBe(false);
+
+    expect(usePinnedProjectsStore.getState().pinnedProjectIds).toEqual([
+      "project-3",
+      "project-2",
+      "project-1",
+    ]);
+  });
+
+  it("unpins and prunes project ids that are no longer present", () => {
+    usePinnedProjectsStore.setState({
+      pinnedProjectIds: [
+        "project-3" as ProjectId,
+        "project-2" as ProjectId,
+        "project-1" as ProjectId,
+      ],
+    });
+
+    usePinnedProjectsStore.getState().unpinProject("project-2" as ProjectId);
+    expect(usePinnedProjectsStore.getState().pinnedProjectIds).toEqual(["project-3", "project-1"]);
+
+    usePinnedProjectsStore.getState().prunePinnedProjects(["project-1" as ProjectId]);
+    expect(usePinnedProjectsStore.getState().pinnedProjectIds).toEqual(["project-1"]);
+  });
+});

--- a/apps/web/src/pinnedProjectsStore.ts
+++ b/apps/web/src/pinnedProjectsStore.ts
@@ -1,0 +1,81 @@
+// FILE: pinnedProjectsStore.ts
+// Purpose: Persists sidebar project pin ids with the shared pin ordering cap.
+// Layer: UI state store
+// Exports: usePinnedProjectsStore
+
+import { MAX_PINNED_PROJECTS, type ProjectId } from "@t3tools/contracts";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { normalizePinnedIds, pinId, prunePinnedIds, unpinId } from "./pinning.logic";
+
+interface PinnedProjectsStoreState {
+  pinnedProjectIds: ProjectId[];
+  pinProject: (projectId: ProjectId) => boolean;
+  unpinProject: (projectId: ProjectId) => void;
+  prunePinnedProjects: (projectIds: readonly ProjectId[]) => void;
+}
+
+const PINNED_PROJECTS_STORAGE_KEY = "synara:pinned-projects:v1";
+const PINNED_PROJECTS_OPTIONS = { maxCount: MAX_PINNED_PROJECTS } as const;
+
+export const usePinnedProjectsStore = create<PinnedProjectsStoreState>()(
+  persist(
+    (set, get) => ({
+      pinnedProjectIds: [],
+      pinProject: (projectId) => {
+        if (projectId.length === 0) return false;
+        const result = pinId(get().pinnedProjectIds, projectId, PINNED_PROJECTS_OPTIONS);
+        if (result.rejected) {
+          return false;
+        }
+        if (result.changed) {
+          set({ pinnedProjectIds: result.pinnedIds });
+        }
+        return true;
+      },
+      unpinProject: (projectId) => {
+        if (projectId.length === 0) return;
+        set((state) => {
+          const result = unpinId(state.pinnedProjectIds, projectId);
+          if (!result.changed) {
+            return state;
+          }
+          return {
+            pinnedProjectIds: result.pinnedIds,
+          };
+        });
+      },
+      prunePinnedProjects: (projectIds) => {
+        set((state) => {
+          const nextPinnedProjectIds = prunePinnedIds(state.pinnedProjectIds, projectIds).slice(
+            0,
+            MAX_PINNED_PROJECTS,
+          );
+          return nextPinnedProjectIds.length === state.pinnedProjectIds.length &&
+            nextPinnedProjectIds.every((id, index) => id === state.pinnedProjectIds[index])
+            ? state
+            : { pinnedProjectIds: nextPinnedProjectIds };
+        });
+      },
+    }),
+    {
+      name: PINNED_PROJECTS_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        pinnedProjectIds: normalizePinnedIds(state.pinnedProjectIds, PINNED_PROJECTS_OPTIONS),
+      }),
+      merge: (persistedState, currentState) => {
+        const candidate =
+          (
+            persistedState as
+              | Partial<Pick<PinnedProjectsStoreState, "pinnedProjectIds">>
+              | undefined
+          )?.pinnedProjectIds ?? [];
+        return {
+          ...currentState,
+          pinnedProjectIds: normalizePinnedIds(candidate, PINNED_PROJECTS_OPTIONS),
+        };
+      },
+    },
+  ),
+);

--- a/apps/web/src/pinnedThreadsStore.ts
+++ b/apps/web/src/pinnedThreadsStore.ts
@@ -6,6 +6,7 @@
 import { type ThreadId } from "@t3tools/contracts";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
+import { normalizePinnedIds, pinId, prunePinnedIds, unpinId } from "./pinning.logic";
 
 interface PinnedThreadsStoreState {
   pinnedThreadIds: ThreadId[];
@@ -17,21 +18,6 @@ interface PinnedThreadsStoreState {
 
 const PINNED_THREADS_STORAGE_KEY = "synara:pinned-threads:v1";
 
-function normalizePinnedThreadIds(threadIds: readonly ThreadId[]): ThreadId[] {
-  const seen = new Set<ThreadId>();
-  const normalized: ThreadId[] = [];
-
-  for (const threadId of threadIds) {
-    if (threadId.length === 0 || seen.has(threadId)) {
-      continue;
-    }
-    seen.add(threadId);
-    normalized.push(threadId);
-  }
-
-  return normalized;
-}
-
 export const usePinnedThreadsStore = create<PinnedThreadsStoreState>()(
   persist(
     (set) => ({
@@ -39,22 +25,24 @@ export const usePinnedThreadsStore = create<PinnedThreadsStoreState>()(
       pinThread: (threadId) => {
         if (threadId.length === 0) return;
         set((state) => {
-          if (state.pinnedThreadIds.includes(threadId)) {
+          const result = pinId(state.pinnedThreadIds, threadId);
+          if (!result.changed) {
             return state;
           }
           return {
-            pinnedThreadIds: [threadId, ...state.pinnedThreadIds],
+            pinnedThreadIds: result.pinnedIds,
           };
         });
       },
       unpinThread: (threadId) => {
         if (threadId.length === 0) return;
         set((state) => {
-          if (!state.pinnedThreadIds.includes(threadId)) {
+          const result = unpinId(state.pinnedThreadIds, threadId);
+          if (!result.changed) {
             return state;
           }
           return {
-            pinnedThreadIds: state.pinnedThreadIds.filter((candidate) => candidate !== threadId),
+            pinnedThreadIds: result.pinnedIds,
           };
         });
       },
@@ -62,21 +50,14 @@ export const usePinnedThreadsStore = create<PinnedThreadsStoreState>()(
         if (threadId.length === 0) return;
         set((state) => {
           if (state.pinnedThreadIds.includes(threadId)) {
-            return {
-              pinnedThreadIds: state.pinnedThreadIds.filter((candidate) => candidate !== threadId),
-            };
+            return { pinnedThreadIds: unpinId(state.pinnedThreadIds, threadId).pinnedIds };
           }
-          return {
-            pinnedThreadIds: [threadId, ...state.pinnedThreadIds],
-          };
+          return { pinnedThreadIds: pinId(state.pinnedThreadIds, threadId).pinnedIds };
         });
       },
       prunePinnedThreads: (threadIds) => {
-        const allowedThreadIds = new Set(threadIds);
         set((state) => {
-          const nextPinnedThreadIds = state.pinnedThreadIds.filter((threadId) =>
-            allowedThreadIds.has(threadId),
-          );
+          const nextPinnedThreadIds = prunePinnedIds(state.pinnedThreadIds, threadIds);
           return nextPinnedThreadIds.length === state.pinnedThreadIds.length
             ? state
             : { pinnedThreadIds: nextPinnedThreadIds };
@@ -87,7 +68,7 @@ export const usePinnedThreadsStore = create<PinnedThreadsStoreState>()(
       name: PINNED_THREADS_STORAGE_KEY,
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
-        pinnedThreadIds: normalizePinnedThreadIds(state.pinnedThreadIds),
+        pinnedThreadIds: normalizePinnedIds(state.pinnedThreadIds),
       }),
       merge: (persistedState, currentState) => {
         const candidate =
@@ -95,7 +76,7 @@ export const usePinnedThreadsStore = create<PinnedThreadsStoreState>()(
             ?.pinnedThreadIds ?? [];
         return {
           ...currentState,
-          pinnedThreadIds: normalizePinnedThreadIds(candidate),
+          pinnedThreadIds: normalizePinnedIds(candidate),
         };
       },
     },

--- a/apps/web/src/pinning.logic.test.ts
+++ b/apps/web/src/pinning.logic.test.ts
@@ -1,0 +1,60 @@
+// FILE: pinning.logic.test.ts
+// Purpose: Verifies shared sidebar pin normalization, limits, and ordering.
+// Layer: UI state logic test
+
+import { describe, expect, it } from "vitest";
+import { derivePinnedIds, orderPinnedItemsFirst, pinId, prunePinnedIds } from "./pinning.logic";
+
+describe("pinning.logic", () => {
+  it("pins newest ids first and rejects ids beyond the configured cap", () => {
+    const existing = ["project-3", "project-2", "project-1"];
+
+    expect(pinId(existing, "project-4", { maxCount: 3 })).toEqual({
+      pinnedIds: existing,
+      changed: false,
+      rejected: true,
+    });
+    expect(pinId(existing, "project-2", { maxCount: 3 })).toEqual({
+      pinnedIds: existing,
+      changed: false,
+      rejected: false,
+    });
+    expect(pinId(["project-2"], "project-1", { maxCount: 3 }).pinnedIds).toEqual([
+      "project-1",
+      "project-2",
+    ]);
+  });
+
+  it("derives pinned ids from persisted order, server pins, and optimistic overrides", () => {
+    const items = [
+      { id: "project-1", isPinned: true },
+      { id: "project-2", isPinned: true },
+      { id: "project-3", isPinned: false },
+      { id: "project-4", isPinned: true },
+    ];
+
+    expect(
+      derivePinnedIds({
+        items,
+        persistedPinnedIds: ["project-3", "project-missing"],
+        optimisticPinnedStateById: new Map([
+          ["project-1", false],
+          ["project-3", true],
+        ]),
+        maxCount: 3,
+      }),
+    ).toEqual(["project-3", "project-2", "project-4"]);
+  });
+
+  it("orders pinned items first without changing unpinned item order", () => {
+    const items: Array<{ id: string }> = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
+
+    expect(
+      orderPinnedItemsFirst<string, { id: string }>(items, ["c", "a"]).map((item) => item.id),
+    ).toEqual(["c", "a", "b", "d"]);
+  });
+
+  it("prunes missing ids and removes duplicates", () => {
+    expect(prunePinnedIds(["a", "b", "a", "c"], ["c", "a"])).toEqual(["a", "c"]);
+  });
+});

--- a/apps/web/src/pinning.logic.ts
+++ b/apps/web/src/pinning.logic.ts
@@ -1,0 +1,149 @@
+// FILE: pinning.logic.ts
+// Purpose: Shared immutable helpers for sidebar pin id order, pruning, and optimistic merges.
+// Layer: UI state logic
+// Exports: pinned id normalization, mutation helpers, and pinned item derivation.
+
+export type PinLimitResult<TId extends string> = {
+  pinnedIds: TId[];
+  changed: boolean;
+  rejected: boolean;
+};
+
+export function normalizePinnedIds<TId extends string>(
+  ids: readonly TId[],
+  options?: { maxCount?: number },
+): TId[] {
+  const seen = new Set<TId>();
+  const normalized: TId[] = [];
+  const maxCount = Math.max(0, options?.maxCount ?? Number.POSITIVE_INFINITY);
+
+  for (const id of ids) {
+    if (normalized.length >= maxCount) {
+      break;
+    }
+    if (id.length === 0 || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    normalized.push(id);
+  }
+
+  return normalized;
+}
+
+export function pinId<TId extends string>(
+  ids: readonly TId[],
+  id: TId,
+  options?: { maxCount?: number },
+): PinLimitResult<TId> {
+  const normalized = normalizePinnedIds(ids, options);
+  if (id.length === 0) {
+    return { pinnedIds: normalized, changed: normalized.length !== ids.length, rejected: true };
+  }
+  if (normalized.includes(id)) {
+    return { pinnedIds: normalized, changed: normalized.length !== ids.length, rejected: false };
+  }
+  if (options?.maxCount !== undefined && normalized.length >= options.maxCount) {
+    return { pinnedIds: normalized, changed: false, rejected: true };
+  }
+  return { pinnedIds: [id, ...normalized], changed: true, rejected: false };
+}
+
+export function unpinId<TId extends string>(ids: readonly TId[], id: TId): PinLimitResult<TId> {
+  const normalized = normalizePinnedIds(ids);
+  const pinnedIds = normalized.filter((candidate) => candidate !== id);
+  return {
+    pinnedIds,
+    changed: pinnedIds.length !== normalized.length || normalized.length !== ids.length,
+    rejected: false,
+  };
+}
+
+export function prunePinnedIds<TId extends string>(
+  ids: readonly TId[],
+  allowedIds: readonly TId[],
+): TId[] {
+  const allowedIdSet = new Set(allowedIds);
+  return normalizePinnedIds(ids).filter((id) => allowedIdSet.has(id));
+}
+
+// Persisted order wins when present; server-only pins are appended in current sidebar order.
+export function derivePinnedIds<
+  TId extends string,
+  TItem extends { id: TId; isPinned?: boolean | undefined },
+>(input: {
+  readonly items: readonly TItem[];
+  readonly persistedPinnedIds: readonly TId[];
+  readonly optimisticPinnedStateById: ReadonlyMap<TId, boolean>;
+  readonly maxCount?: number;
+}): TId[] {
+  const itemIds = new Set(input.items.map((item) => item.id));
+  const pinnedIds: TId[] = [];
+  const addPinnedId = (id: TId) => {
+    if (input.maxCount !== undefined && pinnedIds.length >= input.maxCount) {
+      return;
+    }
+    if (itemIds.has(id) && !pinnedIds.includes(id)) {
+      pinnedIds.push(id);
+    }
+  };
+
+  for (const id of input.persistedPinnedIds) {
+    if (input.optimisticPinnedStateById.get(id) === false) {
+      continue;
+    }
+    addPinnedId(id);
+  }
+
+  for (const item of input.items) {
+    const optimisticPinned = input.optimisticPinnedStateById.get(item.id);
+    const isPinned = optimisticPinned ?? item.isPinned === true;
+    if (isPinned) {
+      addPinnedId(item.id);
+    }
+  }
+
+  return pinnedIds;
+}
+
+export function getPinnedItems<TId extends string, TItem extends { id: TId }>(
+  items: readonly TItem[],
+  pinnedIds: readonly TId[],
+): TItem[] {
+  const itemById = new Map(items.map((item) => [item.id, item] as const));
+  const pinnedItems: TItem[] = [];
+  const seen = new Set<TId>();
+
+  for (const id of pinnedIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const item = itemById.get(id);
+    if (item) {
+      pinnedItems.push(item);
+    }
+  }
+
+  return pinnedItems;
+}
+
+export function orderPinnedItemsFirst<TId extends string, TItem extends { id: TId }>(
+  items: readonly TItem[],
+  pinnedIds: readonly TId[],
+): TItem[] {
+  if (pinnedIds.length === 0) {
+    return [...items];
+  }
+  const pinnedIdSet = new Set(pinnedIds);
+  return [
+    ...getPinnedItems(items, pinnedIds),
+    ...items.filter((item) => !pinnedIdSet.has(item.id)),
+  ];
+}
+
+export function isLatestPinMutation<TId>(input: {
+  readonly id: TId;
+  readonly requestVersion: number;
+  readonly latestMutationVersionById: ReadonlyMap<TId, number>;
+}): boolean {
+  return input.latestMutationVersionById.get(input.id) === input.requestVersion;
+}

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -633,6 +633,7 @@ function normalizeProjectFromReadModel(
     previous.cwd === incoming.workspaceRoot &&
     previous.defaultModelSelection === defaultModelSelection &&
     previous.expanded === expanded &&
+    (previous.isPinned ?? false) === (incoming.isPinned ?? false) &&
     previous.createdAt === incoming.createdAt &&
     previous.updatedAt === incoming.updatedAt &&
     previous.scripts === scripts
@@ -650,6 +651,7 @@ function normalizeProjectFromReadModel(
     cwd: incoming.workspaceRoot,
     defaultModelSelection,
     expanded,
+    isPinned: incoming.isPinned ?? false,
     createdAt: incoming.createdAt,
     updatedAt: incoming.updatedAt,
     scripts,
@@ -685,6 +687,7 @@ function normalizeProjectFromShell(
     previous.cwd === incoming.workspaceRoot &&
     previous.defaultModelSelection === defaultModelSelection &&
     previous.expanded === expanded &&
+    (previous.isPinned ?? false) === (incoming.isPinned ?? false) &&
     previous.createdAt === incoming.createdAt &&
     previous.updatedAt === incoming.updatedAt &&
     previous.scripts === scripts
@@ -702,6 +705,7 @@ function normalizeProjectFromShell(
     cwd: incoming.workspaceRoot,
     defaultModelSelection,
     expanded,
+    isPinned: incoming.isPinned ?? false,
     createdAt: incoming.createdAt,
     updatedAt: incoming.updatedAt,
     scripts,
@@ -2983,6 +2987,7 @@ function applyOrchestrationEvent(
         workspaceRoot: event.payload.workspaceRoot,
         defaultModelSelection: event.payload.defaultModelSelection,
         scripts: event.payload.scripts,
+        isPinned: event.payload.isPinned ?? false,
         createdAt: event.payload.createdAt,
         updatedAt: event.payload.updatedAt,
         deletedAt: null,
@@ -3005,6 +3010,7 @@ function applyOrchestrationEvent(
             ? event.payload.defaultModelSelection
             : existingProject.defaultModelSelection,
         scripts: event.payload.scripts ?? existingProject.scripts,
+        isPinned: event.payload.isPinned ?? existingProject.isPinned ?? false,
         createdAt: existingProject.createdAt ?? event.payload.updatedAt,
         updatedAt: event.payload.updatedAt,
         deletedAt: null,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -133,6 +133,7 @@ export interface Project {
   cwd: string;
   defaultModelSelection: ModelSelection | null;
   expanded: boolean;
+  isPinned?: boolean;
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
   scripts: ProjectScript[];

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -270,6 +270,7 @@ it.effect("decodes historical project.created payloads with a default provider",
       updatedAt: "2026-01-01T00:00:00.000Z",
     });
     assert.strictEqual(parsed.defaultModelSelection?.provider, "codex");
+    assert.strictEqual(parsed.isPinned, false);
   }),
 );
 
@@ -281,9 +282,11 @@ it.effect("decodes project.meta-updated payloads with explicit default provider"
         provider: "claudeAgent",
         model: "claude-opus-4-6",
       },
+      isPinned: true,
       updatedAt: "2026-01-01T00:00:00.000Z",
     });
     assert.strictEqual(parsed.defaultModelSelection?.provider, "claudeAgent");
+    assert.strictEqual(parsed.isPinned, true);
   }),
 );
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -250,6 +250,7 @@ export type OrchestrationMessageSource = typeof OrchestrationMessageSource.Type;
 export const PROVIDER_SEND_TURN_MAX_INPUT_CHARS = 120_000;
 export const PROVIDER_SEND_TURN_MAX_ATTACHMENTS = 8;
 export const PROVIDER_SEND_TURN_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+export const MAX_PINNED_PROJECTS = 3;
 const PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS = 14_000_000;
 const CHAT_ATTACHMENT_ID_MAX_CHARS = 128;
 export const CHAT_ASSISTANT_SELECTION_TEXT_MAX_CHARS = 4_000;
@@ -336,6 +337,7 @@ export const OrchestrationProject = Schema.Struct({
   workspaceRoot: TrimmedNonEmptyString,
   defaultModelSelection: Schema.NullOr(ModelSelection),
   scripts: Schema.Array(ProjectScript),
+  isPinned: Schema.optional(Schema.Boolean).pipe(Schema.withDecodingDefault(() => false)),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
   deletedAt: Schema.NullOr(IsoDateTime),
@@ -349,6 +351,7 @@ export const OrchestrationProjectShell = Schema.Struct({
   workspaceRoot: TrimmedNonEmptyString,
   defaultModelSelection: Schema.NullOr(ModelSelection),
   scripts: Schema.Array(ProjectScript),
+  isPinned: Schema.optional(Schema.Boolean).pipe(Schema.withDecodingDefault(() => false)),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
 });
@@ -704,6 +707,7 @@ export const ProjectCreateCommand = Schema.Struct({
     Schema.withDecodingDefault(() => false),
   ),
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
+  isPinned: Schema.optional(Schema.Boolean).pipe(Schema.withDecodingDefault(() => false)),
   createdAt: IsoDateTime,
 });
 
@@ -716,6 +720,7 @@ const ProjectMetaUpdateCommand = Schema.Struct({
   workspaceRoot: Schema.optional(TrimmedNonEmptyString),
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
   scripts: Schema.optional(Schema.Array(ProjectScript)),
+  isPinned: Schema.optional(Schema.Boolean),
 });
 
 const ProjectDeleteCommand = Schema.Struct({
@@ -1256,6 +1261,7 @@ export const ProjectCreatedPayload = Schema.Struct({
   workspaceRoot: TrimmedNonEmptyString,
   defaultModelSelection: Schema.NullOr(ModelSelection),
   scripts: Schema.Array(ProjectScript),
+  isPinned: Schema.optional(Schema.Boolean).pipe(Schema.withDecodingDefault(() => false)),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
 });
@@ -1267,6 +1273,7 @@ export const ProjectMetaUpdatedPayload = Schema.Struct({
   workspaceRoot: Schema.optional(TrimmedNonEmptyString),
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
   scripts: Schema.optional(Schema.Array(ProjectScript)),
+  isPinned: Schema.optional(Schema.Boolean),
   updatedAt: IsoDateTime,
 });
 


### PR DESCRIPTION
## Summary
- Add durable project pinning end to end, with a max of three pinned projects and pinned projects ordered to the top of the sidebar.
- Share the pin normalization, ordering, and mutation logic between threads and projects to keep the behavior consistent.
- Persist project pin state through orchestration events, projections, snapshot queries, and SQLite storage.
- Update the sidebar UI to pin and unpin projects from the row actions and context menu, with optimistic updates and limit feedback.

## Testing
- Added unit and integration coverage for project pin limits, ordering, projection snapshots, and persistence.
- Full validation passed: `bun fmt`, `bun lint`, `bun typecheck`, `bun run test`, and `git diff --check`.