### PR TITLE
[codex] Add recent view switcher and harden migrations

### DIFF
--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -95,6 +95,12 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+alt+r", command: "chat.newCursor", when: "!terminalFocus" },
   { key: "mod+alt+g", command: "chat.newGemini", when: "!terminalFocus" },
   { key: "mod+\\", command: "chat.split", when: "!terminalFocus" },
+  // Recent-view switcher (Ctrl+Tab) is an installed-app feature only: Electron and
+  // standalone PWA windows have no tab strip, so the chord reaches the page. In a normal
+  // browser tab, Ctrl+Tab / Ctrl+Shift+Tab are reserved for browser tab switching and are
+  // not deliverable/preventable by page JS, so the switcher silently won't open there.
+  { key: "ctrl+tab", command: "view.recent.next", when: "!terminalFocus" },
+  { key: "ctrl+shift+tab", command: "view.recent.previous", when: "!terminalFocus" },
   { key: "mod+1", command: "thread.jump.1", when: "!terminalFocus && !terminalWorkspaceOpen" },
   { key: "mod+2", command: "thread.jump.2", when: "!terminalFocus && !terminalWorkspaceOpen" },
   { key: "mod+3", command: "thread.jump.3", when: "!terminalFocus && !terminalWorkspaceOpen" },

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -1,4 +1,7 @@
 import * as Http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import type { OrchestrationReadModel } from "@t3tools/contracts";
@@ -7,7 +10,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Command from "effect/unstable/cli/Command";
 import { FetchHttpClient } from "effect/unstable/http";
-import { beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 import { NetService } from "@t3tools/shared/Net";
 
 import { ServerConfig, type ServerConfigShape } from "./config";
@@ -37,6 +40,14 @@ const serverStart = Effect.acquireRelease(
   () => Effect.sync(() => stop()),
 );
 const findAvailablePort = vi.fn((preferred: number) => Effect.succeed(preferred));
+let defaultSynaraHome = "";
+const tempHomes = new Set<string>();
+
+function makeTempHome(prefix = "synara-main-test-"): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempHomes.add(directory);
+  return directory;
+}
 
 // Shared service layer used by this CLI test suite.
 const testLayer = Layer.mergeAll(
@@ -66,17 +77,14 @@ const testLayer = Layer.mergeAll(
 
 const runCli = (
   args: ReadonlyArray<string>,
-  env: Record<string, string> = {
-    SYNARA_HOME: "/tmp/synara-test-home",
-    T3CODE_NO_BROWSER: "true",
-  },
+  env: Record<string, string> = {},
 ) => {
   const program = Command.runWith(t3Cli, { version: "0.0.0-test" })(args).pipe(
     Effect.provide(
       ConfigProvider.layer(
         ConfigProvider.fromEnv({
           env: {
-            SYNARA_HOME: "/tmp/synara-test-home",
+            SYNARA_HOME: defaultSynaraHome,
             T3CODE_NO_BROWSER: "true",
             ...env,
           },
@@ -89,15 +97,25 @@ const runCli = (
 
 beforeEach(() => {
   vi.clearAllMocks();
+  defaultSynaraHome = makeTempHome();
   resolvedConfig = null;
   start.mockImplementation(() => undefined);
   stop.mockImplementation(() => undefined);
   findAvailablePort.mockImplementation((preferred: number) => Effect.succeed(preferred));
 });
 
+afterEach(() => {
+  for (const directory of tempHomes) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+  tempHomes.clear();
+});
+
 it.layer(testLayer)("server CLI command", (it) => {
   it.effect("parses all CLI flags and wires scoped start/stop", () =>
     Effect.gen(function* () {
+      const flagHome = makeTempHome("synara-main-flag-");
+
       yield* runCli([
         "--mode",
         "desktop",
@@ -106,7 +124,7 @@ it.layer(testLayer)("server CLI command", (it) => {
         "--host",
         "0.0.0.0",
         "--home-dir",
-        "/tmp/t3-cli-home",
+        flagHome,
         "--dev-url",
         "http://127.0.0.1:5173",
         "--no-browser",
@@ -118,8 +136,8 @@ it.layer(testLayer)("server CLI command", (it) => {
       assert.equal(resolvedConfig?.mode, "desktop");
       assert.equal(resolvedConfig?.port, 4010);
       assert.equal(resolvedConfig?.host, "0.0.0.0");
-      assert.equal(resolvedConfig?.baseDir, "/tmp/t3-cli-home");
-      assert.equal(resolvedConfig?.stateDir, "/tmp/t3-cli-home/dev");
+      assert.equal(resolvedConfig?.baseDir, flagHome);
+      assert.equal(resolvedConfig?.stateDir, path.join(flagHome, "dev"));
       assert.equal(resolvedConfig?.devUrl?.toString(), "http://127.0.0.1:5173/");
       assert.equal(resolvedConfig?.noBrowser, true);
       assert.equal(resolvedConfig?.authToken, "auth-secret");
@@ -141,11 +159,13 @@ it.layer(testLayer)("server CLI command", (it) => {
 
   it.effect("uses env fallbacks when flags are not provided", () =>
     Effect.gen(function* () {
+      const envHome = makeTempHome("synara-main-env-");
+
       yield* runCli([], {
         T3CODE_MODE: "desktop",
         T3CODE_PORT: "4999",
         T3CODE_HOST: "100.88.10.4",
-        SYNARA_HOME: "/tmp/synara-env-home",
+        SYNARA_HOME: envHome,
         VITE_DEV_SERVER_URL: "http://localhost:5173",
         T3CODE_NO_BROWSER: "true",
         T3CODE_AUTH_TOKEN: "env-token",
@@ -155,8 +175,8 @@ it.layer(testLayer)("server CLI command", (it) => {
       assert.equal(resolvedConfig?.mode, "desktop");
       assert.equal(resolvedConfig?.port, 4999);
       assert.equal(resolvedConfig?.host, "100.88.10.4");
-      assert.equal(resolvedConfig?.baseDir, "/tmp/synara-env-home");
-      assert.equal(resolvedConfig?.stateDir, "/tmp/synara-env-home/dev");
+      assert.equal(resolvedConfig?.baseDir, envHome);
+      assert.equal(resolvedConfig?.stateDir, path.join(envHome, "dev"));
       assert.equal(resolvedConfig?.devUrl?.toString(), "http://localhost:5173/");
       assert.equal(resolvedConfig?.noBrowser, true);
       assert.equal(resolvedConfig?.authToken, "env-token");

--- a/apps/server/src/persistence/Migrations/036_ProjectionThreadsPinned.ts
+++ b/apps/server/src/persistence/Migrations/036_ProjectionThreadsPinned.ts
@@ -5,15 +5,17 @@
 import * as Effect from "effect/Effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
+import { columnExists } from "./schemaHelpers.ts";
+
 export default Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
+
+  if (yield* columnExists(sql, "projection_threads", "is_pinned")) {
+    return;
+  }
 
   yield* sql`
     ALTER TABLE projection_threads
     ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0
-  `.pipe(
-    Effect.catchTag("SqlError", (error) =>
-      String(error).includes("duplicate column name") ? Effect.void : Effect.fail(error),
-    ),
-  );
+  `;
 });

--- a/apps/server/src/persistence/Migrations/039_ReconcileLegacyPinnedThreads.ts
+++ b/apps/server/src/persistence/Migrations/039_ReconcileLegacyPinnedThreads.ts
@@ -6,16 +6,12 @@
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as Effect from "effect/Effect";
 
+import { columnExists } from "./schemaHelpers.ts";
+
 export default Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
 
-  const columns = yield* sql<{ name: string }>`
-    SELECT name
-    FROM pragma_table_info('projection_threads')
-    WHERE name = 'is_pinned'
-  `;
-
-  if (columns.length > 0) {
+  if (yield* columnExists(sql, "projection_threads", "is_pinned")) {
     return;
   }
 

--- a/apps/server/src/persistence/Migrations/040_ProjectionThreadsPinnedMessagesNotes.test.ts
+++ b/apps/server/src/persistence/Migrations/040_ProjectionThreadsPinnedMessagesNotes.test.ts
@@ -1,0 +1,50 @@
+import { assert, it } from "@effect/vitest";
+import { Effect } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { describe } from "vitest";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const projectionThreadsColumnNames = (sql: SqlClient.SqlClient) =>
+  sql<{ readonly name: string }>`
+    SELECT name FROM pragma_table_info('projection_threads')
+  `.pipe(Effect.map((rows) => rows.map((row) => row.name)));
+
+describe("040_ProjectionThreadsPinnedMessagesNotes", () => {
+  it.effect("adds pinned message and note columns", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 39 });
+
+      const beforeColumns = yield* projectionThreadsColumnNames(sql);
+      assert.notInclude(beforeColumns, "pinned_messages_json");
+      assert.notInclude(beforeColumns, "notes");
+
+      yield* runMigrations({ toMigrationInclusive: 40 });
+
+      const afterColumns = yield* projectionThreadsColumnNames(sql);
+      assert.include(afterColumns, "pinned_messages_json");
+      assert.include(afterColumns, "notes");
+    }).pipe(Effect.provide(NodeSqliteClient.layerMemory())),
+  );
+
+  it.effect("fills in the second column when the first already exists", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 39 });
+      yield* sql`
+        ALTER TABLE projection_threads
+        ADD COLUMN pinned_messages_json TEXT
+      `;
+
+      yield* runMigrations({ toMigrationInclusive: 40 });
+
+      const columns = yield* projectionThreadsColumnNames(sql);
+      assert.include(columns, "pinned_messages_json");
+      assert.include(columns, "notes");
+    }).pipe(Effect.provide(NodeSqliteClient.layerMemory())),
+  );
+});

--- a/apps/server/src/persistence/Migrations/040_ProjectionThreadsPinnedMessagesNotes.ts
+++ b/apps/server/src/persistence/Migrations/040_ProjectionThreadsPinnedMessagesNotes.ts
@@ -7,24 +7,22 @@
 import * as Effect from "effect/Effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
+import { columnExists } from "./schemaHelpers.ts";
+
 export default Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
 
-  yield* sql`
-    ALTER TABLE projection_threads
-    ADD COLUMN pinned_messages_json TEXT
-  `.pipe(
-    Effect.catchTag("SqlError", (error) =>
-      String(error).includes("duplicate column name") ? Effect.void : Effect.fail(error),
-    ),
-  );
+  if (!(yield* columnExists(sql, "projection_threads", "pinned_messages_json"))) {
+    yield* sql`
+      ALTER TABLE projection_threads
+      ADD COLUMN pinned_messages_json TEXT
+    `;
+  }
 
-  yield* sql`
-    ALTER TABLE projection_threads
-    ADD COLUMN notes TEXT
-  `.pipe(
-    Effect.catchTag("SqlError", (error) =>
-      String(error).includes("duplicate column name") ? Effect.void : Effect.fail(error),
-    ),
-  );
+  if (!(yield* columnExists(sql, "projection_threads", "notes"))) {
+    yield* sql`
+      ALTER TABLE projection_threads
+      ADD COLUMN notes TEXT
+    `;
+  }
 });

--- a/apps/server/src/persistence/Migrations/041_ProjectionProjectsPinned.test.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionProjectsPinned.test.ts
@@ -1,0 +1,43 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { runMigrations } from "../Migrations.ts";
+import * as NodeSqliteClient from "../NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+const projectionProjectsColumnNames = (sql: SqlClient.SqlClient) =>
+  sql<{ readonly name: string }>`
+    SELECT name FROM pragma_table_info('projection_projects')
+  `.pipe(Effect.map((rows) => rows.map((row) => row.name)));
+
+layer("041_ProjectionProjectsPinned", (it) => {
+  it.effect("adds durable project pin state", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations({ toMigrationInclusive: 40 });
+
+      const beforeColumns = yield* projectionProjectsColumnNames(sql);
+      assert.notInclude(beforeColumns, "is_pinned");
+
+      yield* runMigrations();
+
+      const afterColumns = yield* projectionProjectsColumnNames(sql);
+      assert.include(afterColumns, "is_pinned");
+    }),
+  );
+
+  it.effect("is a no-op when project pin state already exists", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations();
+      yield* runMigrations();
+
+      const columns = yield* projectionProjectsColumnNames(sql);
+      assert.include(columns, "is_pinned");
+    }),
+  );
+});

--- a/apps/server/src/persistence/Migrations/041_ProjectionProjectsPinned.ts
+++ b/apps/server/src/persistence/Migrations/041_ProjectionProjectsPinned.ts
@@ -5,15 +5,17 @@
 import * as Effect from "effect/Effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
+import { columnExists } from "./schemaHelpers.ts";
+
 export default Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
+
+  if (yield* columnExists(sql, "projection_projects", "is_pinned")) {
+    return;
+  }
 
   yield* sql`
     ALTER TABLE projection_projects
     ADD COLUMN is_pinned INTEGER NOT NULL DEFAULT 0
-  `.pipe(
-    Effect.catchTag("SqlError", (error) =>
-      String(error).includes("duplicate column name") ? Effect.void : Effect.fail(error),
-    ),
-  );
+  `;
 });

--- a/apps/server/src/persistence/Migrations/schemaHelpers.ts
+++ b/apps/server/src/persistence/Migrations/schemaHelpers.ts
@@ -1,0 +1,21 @@
+// FILE: schemaHelpers.ts
+// Purpose: Shared SQLite schema-introspection helpers for idempotent migrations.
+// Layer: Server persistence migrations
+// Exports: columnExists
+
+import * as Effect from "effect/Effect";
+import type * as SqlClient from "effect/unstable/sql/SqlClient";
+
+// Checks SQLite table metadata without relying on driver-specific duplicate-column errors.
+export const columnExists = (
+  sql: SqlClient.SqlClient,
+  tableName: string,
+  columnName: string,
+) =>
+  sql<{ readonly exists: number }>`
+    SELECT EXISTS(
+      SELECT 1
+      FROM pragma_table_info(${tableName})
+      WHERE name = ${columnName}
+    ) AS "exists"
+  `.pipe(Effect.map(([row]) => row?.exists === 1));

--- a/apps/web/src/components/RecentViewSwitcher.tsx
+++ b/apps/web/src/components/RecentViewSwitcher.tsx
@@ -1,0 +1,112 @@
+// FILE: RecentViewSwitcher.tsx
+// Purpose: Render the transient Ctrl+Tab recent-view overlay.
+// Layer: UI component
+// Exports: RecentViewSwitcher plus item shape used by the chat route shell.
+
+import {
+  MessageCircleIcon,
+  PinIcon,
+  PlugIcon,
+  SettingsIcon,
+  TerminalSquareIcon,
+  WindowIcon,
+} from "../lib/icons";
+import { cn } from "../lib/utils";
+import type { RecentViewDisplayEntry } from "../recentViews.logic";
+
+type RecentViewSwitcherIconKind = "thread" | "terminal" | "workspace" | "settings" | "plugins";
+
+function RecentViewIcon(props: { kind: RecentViewSwitcherIconKind; className?: string }) {
+  const className = cn("size-4", props.className);
+  switch (props.kind) {
+    case "terminal":
+      return <TerminalSquareIcon className={className} aria-hidden="true" />;
+    case "workspace":
+      return <WindowIcon className={className} aria-hidden="true" />;
+    case "settings":
+      return <SettingsIcon className={className} aria-hidden="true" />;
+    case "plugins":
+      return <PlugIcon className={className} aria-hidden="true" />;
+    case "thread":
+      return <MessageCircleIcon className={className} aria-hidden="true" />;
+  }
+}
+
+function iconKindForEntry(entry: RecentViewDisplayEntry): RecentViewSwitcherIconKind {
+  if (entry.kind === "thread") {
+    return entry.isTerminal ? "terminal" : "thread";
+  }
+  return entry.kind;
+}
+
+export function RecentViewSwitcher(props: {
+  entries: ReadonlyArray<RecentViewDisplayEntry>;
+  selectedIndex: number;
+}) {
+  if (props.entries.length === 0) {
+    return null;
+  }
+
+  const selectedIndex =
+    props.selectedIndex >= 0 && props.selectedIndex < props.entries.length
+      ? props.selectedIndex
+      : 0;
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-[90] flex items-start justify-center pt-[14vh]">
+      <div
+        role="listbox"
+        aria-label="Recent views"
+        aria-activedescendant={`recent-view-switcher-${selectedIndex}`}
+        className="w-[min(34rem,calc(100vw-2rem))] overflow-hidden rounded-lg border border-border/70 bg-popover/95 p-1.5 text-popover-foreground shadow-2xl shadow-black/30 backdrop-blur-xl"
+      >
+        {props.entries.map((entry, index) => {
+          const selected = index === selectedIndex;
+          return (
+            <div
+              key={entry.key}
+              id={`recent-view-switcher-${index}`}
+              role="option"
+              aria-selected={selected}
+              className={cn(
+                "flex h-14 items-center gap-3 rounded-lg px-3 transition-colors",
+                selected ? "bg-primary text-primary-foreground" : "text-foreground/88",
+              )}
+            >
+              <div
+                className={cn(
+                  "flex size-8 shrink-0 items-center justify-center rounded-md border",
+                  selected
+                    ? "border-primary-foreground/25 bg-primary-foreground/15"
+                    : "border-border/80 bg-muted/60 text-muted-foreground",
+                )}
+              >
+                <RecentViewIcon kind={iconKindForEntry(entry)} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm font-medium leading-5">{entry.title}</div>
+                <div
+                  className={cn(
+                    "truncate text-xs leading-4",
+                    selected ? "text-primary-foreground/72" : "text-muted-foreground",
+                  )}
+                >
+                  {entry.subtitle}
+                </div>
+              </div>
+              {entry.isPinned ? (
+                <PinIcon
+                  className={cn(
+                    "size-3.5 shrink-0",
+                    selected ? "text-primary-foreground/75" : "text-muted-foreground",
+                  )}
+                  aria-hidden="true"
+                />
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -271,6 +271,7 @@ import { useTemporaryThreadStore } from "../temporaryThreadStore";
 import { useThreadActivationController } from "../hooks/useThreadActivationController";
 import { usePinnedProjectsStore } from "../pinnedProjectsStore";
 import { usePinnedThreadsStore } from "../pinnedThreadsStore";
+import { useThreadDetailPrewarm } from "../threadDetailPrewarm";
 import { retainThreadDetailSubscription } from "../threadDetailSubscriptionRetention";
 import { useWorkspaceStore, workspaceThreadId } from "../workspaceStore";
 import type {
@@ -303,7 +304,6 @@ const EMPTY_THREAD_JUMP_LABELS = new Map<ThreadId, string>();
 const EMPTY_SHORTCUT_PARTS: readonly string[] = [];
 const ADD_PROJECT_SNAPSHOT_CATCH_UP_MAX_ATTEMPTS = 6;
 const ADD_PROJECT_SNAPSHOT_CATCH_UP_DELAY_MS = 50;
-const THREAD_INTENT_PREWARM_RELEASE_MS = 10_000;
 const ADD_PROJECT_EXISTING_SYNC_ERROR =
   "This folder is already linked, but the existing project has not synced into the sidebar yet. Try again in a moment.";
 const DebugFeatureFlagsMenu = import.meta.env.DEV
@@ -1362,9 +1362,6 @@ export default function Sidebar() {
   const renamingProjectInputRef = useRef<HTMLInputElement | null>(null);
   const dragInProgressRef = useRef(false);
   const suppressProjectClickAfterDragRef = useRef(false);
-  const intentThreadRetentionByIdRef = useRef(
-    new Map<ThreadId, { release: () => void; timeoutId: number }>(),
-  );
   const legacyPinMigrationThreadIdsRef = useRef(new Set<ThreadId>());
   const optimisticPinnedStateByProjectIdRef = useRef(new Map<ProjectId, boolean>());
   const latestPinnedMutationVersionByProjectIdRef = useRef(new Map<ProjectId, number>());
@@ -2573,34 +2570,7 @@ export default function Sidebar() {
     [openRenameThreadDialog],
   );
 
-  const prewarmThreadDetailForIntent = useCallback((threadId: ThreadId) => {
-    const previous = intentThreadRetentionByIdRef.current.get(threadId);
-    if (previous) {
-      window.clearTimeout(previous.timeoutId);
-      previous.release();
-    }
-
-    const release = retainThreadDetailSubscription(threadId);
-    const timeoutId = window.setTimeout(() => {
-      const current = intentThreadRetentionByIdRef.current.get(threadId);
-      if (!current || current.release !== release) return;
-      current.release();
-      intentThreadRetentionByIdRef.current.delete(threadId);
-    }, THREAD_INTENT_PREWARM_RELEASE_MS);
-
-    intentThreadRetentionByIdRef.current.set(threadId, { release, timeoutId });
-  }, []);
-
-  useEffect(
-    () => () => {
-      for (const entry of intentThreadRetentionByIdRef.current.values()) {
-        window.clearTimeout(entry.timeoutId);
-        entry.release();
-      }
-      intentThreadRetentionByIdRef.current.clear();
-    },
-    [],
-  );
+  const { prewarmThreadDetail: prewarmThreadDetailForIntent } = useThreadDetailPrewarm();
 
   const primeThreadActivation = useCallback(
     (event: ReactPointerEvent<HTMLElement>, threadId: ThreadId) => {

--- a/apps/web/src/hooks/useRecentViewSwitcher.ts
+++ b/apps/web/src/hooks/useRecentViewSwitcher.ts
@@ -1,0 +1,388 @@
+// FILE: useRecentViewSwitcher.ts
+// Purpose: Own the Ctrl+Tab recent-primary-view MRU wiring for the chat shell.
+// Layer: UI hook
+// Exports: useRecentViewSwitcher
+
+import { ThreadId, type ProjectId } from "@t3tools/contracts";
+import { useLocation, useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useComposerDraftStore } from "../composerDraftStore";
+import { usePinnedThreadsStore } from "../pinnedThreadsStore";
+import {
+  buildRecentViewDisplayEntries,
+  deriveCurrentRecentView,
+  pruneRecentViews,
+  recentViewKey,
+  resolveRecentViewNavigationIndex,
+  type RecentView,
+  type RecentViewAvailability,
+  type RecentViewDisplayEntry,
+  type RecentViewThreadDraftSummary,
+} from "../recentViews.logic";
+import { resolveRecentThreadSplitActivation } from "../recentViewActivation.logic";
+import { useRecentViewsStore } from "../recentViewsStore";
+import { collectLeaves } from "../splitView.logic";
+import { useSplitViewStore } from "../splitViewStore";
+import { useStore } from "../store";
+import { useThreadDetailPrewarm } from "../threadDetailPrewarm";
+import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
+import { useWorkspaceStore } from "../workspaceStore";
+import type { useHandleNewThread } from "./useHandleNewThread";
+
+type NewThreadContext = ReturnType<typeof useHandleNewThread>;
+
+const EMPTY_RECENT_VIEW_ENTRIES: RecentViewDisplayEntry[] = [];
+
+interface RecentViewSwitcherState {
+  selectedIndex: number;
+  selectedKey: string;
+}
+
+interface UseRecentViewSwitcherInput {
+  activeContextThreadId: NewThreadContext["activeContextThreadId"];
+  activeDraftThread: NewThreadContext["activeDraftThread"];
+  projects: NewThreadContext["projects"];
+}
+
+// Encapsulates recent-view persistence, pruning, prewarm, and activation.
+export function useRecentViewSwitcher(input: UseRecentViewSwitcherInput) {
+  const navigate = useNavigate();
+  const pathname = useLocation({ select: (location) => location.pathname });
+  const routeThreadId = useParams({
+    strict: false,
+    select: (params) => (params.threadId ? ThreadId.makeUnsafe(params.threadId) : null),
+  });
+  const routeWorkspaceId = useParams({
+    strict: false,
+    select: (params) => (typeof params.workspaceId === "string" ? params.workspaceId : null),
+  });
+  const routeSearch = useSearch({ strict: false }) as Record<string, unknown>;
+  const [recentSwitcherState, setRecentSwitcherState] =
+    useState<RecentViewSwitcherState | null>(null);
+  const recentViews = useRecentViewsStore((state) => state.recentViews);
+  const recordRecentView = useRecentViewsStore((state) => state.recordRecentView);
+  const pruneRecentViewsStore = useRecentViewsStore((state) => state.pruneRecentViews);
+  const { prewarmThreadDetail, prewarmThreadDetails } = useThreadDetailPrewarm();
+  const persistedPinnedThreadIds = usePinnedThreadsStore((state) => state.pinnedThreadIds);
+  const workspacePages = useWorkspaceStore((state) => state.workspacePages);
+  const draftThreadsByThreadId = useComposerDraftStore((state) => state.draftThreadsByThreadId);
+  const sidebarThreadSummaryById = useStore((state) => state.sidebarThreadSummaryById);
+  const terminalStateByThreadId = useTerminalStateStore((state) => state.terminalStateByThreadId);
+  const openChatThreadPage = useTerminalStateStore((state) => state.openChatThreadPage);
+  const openTerminalThreadPage = useTerminalStateStore((state) => state.openTerminalThreadPage);
+  const threadsHydrated = useStore((state) => state.threadsHydrated);
+  const routeSplitViewId =
+    typeof routeSearch.splitViewId === "string" ? routeSearch.splitViewId : undefined;
+  const settingsSection =
+    typeof routeSearch.section === "string" ? routeSearch.section : undefined;
+  const currentRecentView = useMemo(
+    () =>
+      deriveCurrentRecentView({
+        pathname,
+        routeThreadId,
+        activeThreadId: routeThreadId
+          ? (input.activeContextThreadId ?? routeThreadId)
+          : null,
+        routeWorkspaceId,
+        splitViewId: routeSplitViewId,
+        settingsSection,
+      }),
+    [
+      input.activeContextThreadId,
+      pathname,
+      routeSplitViewId,
+      routeThreadId,
+      routeWorkspaceId,
+      settingsSection,
+    ],
+  );
+  const currentRecentViewKey = currentRecentView ? recentViewKey(currentRecentView) : null;
+  const recentThreadIds = useMemo(
+    () => recentViews.flatMap((view) => (view.kind === "thread" ? [view.threadId] : [])),
+    [recentViews],
+  );
+  const switcherOpen = recentSwitcherState !== null;
+  const recentViewEntries = useMemo<RecentViewDisplayEntry[]>(() => {
+    if (!switcherOpen) {
+      return EMPTY_RECENT_VIEW_ENTRIES;
+    }
+    const terminalThreadIds = new Set<ThreadId>();
+    for (const view of recentViews) {
+      if (view.kind !== "thread") continue;
+      const terminalState = selectThreadTerminalState(terminalStateByThreadId, view.threadId);
+      if (terminalState.entryPoint === "terminal") {
+        terminalThreadIds.add(view.threadId);
+      }
+    }
+    const draftThreadsById: Record<string, RecentViewThreadDraftSummary> = {};
+    for (const [threadId, draftThread] of Object.entries(draftThreadsByThreadId)) {
+      draftThreadsById[threadId] = {
+        id: ThreadId.makeUnsafe(threadId),
+        projectId: draftThread.projectId,
+      };
+    }
+    if (input.activeDraftThread && input.activeContextThreadId) {
+      draftThreadsById[input.activeContextThreadId] = {
+        id: input.activeContextThreadId,
+        projectId: input.activeDraftThread.projectId,
+      };
+    }
+    return buildRecentViewDisplayEntries({
+      recentViews,
+      currentView: currentRecentView,
+      threadsById: sidebarThreadSummaryById,
+      draftThreadsById,
+      projects: input.projects,
+      pinnedThreadIds: persistedPinnedThreadIds,
+      workspacePages,
+      terminalThreadIds,
+    });
+  }, [
+    input.activeContextThreadId,
+    input.activeDraftThread,
+    currentRecentView,
+    draftThreadsByThreadId,
+    input.projects,
+    persistedPinnedThreadIds,
+    recentViews,
+    sidebarThreadSummaryById,
+    switcherOpen,
+    terminalStateByThreadId,
+    workspacePages,
+  ]);
+  const currentRecentViewRef = useRef<RecentView | null>(currentRecentView);
+  const recentSwitcherStateRef = useRef<RecentViewSwitcherState | null>(recentSwitcherState);
+  const recentViewsRef = useRef(recentViews);
+  const activeContextThreadIdRef = useRef(input.activeContextThreadId);
+  const activeDraftThreadRef = useRef(input.activeDraftThread);
+  const didHydrationPruneRef = useRef(false);
+
+  useEffect(() => {
+    currentRecentViewRef.current = currentRecentView;
+  }, [currentRecentView]);
+
+  useEffect(() => {
+    recentSwitcherStateRef.current = recentSwitcherState;
+  }, [recentSwitcherState]);
+
+  useEffect(() => {
+    recentViewsRef.current = recentViews;
+  }, [recentViews]);
+
+  useEffect(() => {
+    activeContextThreadIdRef.current = input.activeContextThreadId;
+  }, [input.activeContextThreadId]);
+
+  useEffect(() => {
+    activeDraftThreadRef.current = input.activeDraftThread;
+  }, [input.activeDraftThread]);
+
+  const buildRecentViewAvailability = useCallback((): RecentViewAvailability => {
+    const sidebarThreadSummaryById = useStore.getState().sidebarThreadSummaryById;
+    const draftThreadsByThreadId = useComposerDraftStore.getState().draftThreadsByThreadId;
+    const splitViewsById = useSplitViewStore.getState().splitViewsById;
+    const workspacePages = useWorkspaceStore.getState().workspacePages;
+    const activeContextThreadId = activeContextThreadIdRef.current;
+    const activeDraftThread = activeDraftThreadRef.current;
+
+    const availableThreadIds = new Set<ThreadId>();
+    for (const threadId of Object.keys(sidebarThreadSummaryById)) {
+      availableThreadIds.add(ThreadId.makeUnsafe(threadId));
+    }
+    for (const threadId of Object.keys(draftThreadsByThreadId)) {
+      availableThreadIds.add(ThreadId.makeUnsafe(threadId));
+    }
+    if (activeDraftThread && activeContextThreadId) {
+      availableThreadIds.add(activeContextThreadId);
+    }
+
+    const availableWorkspaceIds = new Set(workspacePages.map((workspace) => workspace.id));
+    const availableSplitViewIds = new Set(
+      Object.keys(splitViewsById).filter((splitViewId) => Boolean(splitViewsById[splitViewId])),
+    );
+    const threadIdsBySplitViewId = new Map<string, Set<ThreadId>>();
+    for (const [splitViewId, splitView] of Object.entries(splitViewsById)) {
+      if (!splitView) continue;
+      const threadIds = new Set<ThreadId>();
+      for (const leaf of collectLeaves(splitView.root)) {
+        if (leaf.threadId) {
+          threadIds.add(leaf.threadId);
+        }
+      }
+      threadIdsBySplitViewId.set(splitViewId, threadIds);
+    }
+
+    return {
+      availableThreadIds,
+      availableWorkspaceIds,
+      availableSplitViewIds,
+      threadIdsBySplitViewId,
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!currentRecentView) return;
+    recordRecentView(currentRecentView);
+  }, [currentRecentView, currentRecentViewKey, recordRecentView]);
+
+  useEffect(() => {
+    prewarmThreadDetails(recentThreadIds);
+  }, [prewarmThreadDetails, recentThreadIds]);
+
+  useEffect(() => {
+    if (!threadsHydrated || didHydrationPruneRef.current) return;
+    didHydrationPruneRef.current = true;
+    pruneRecentViewsStore(buildRecentViewAvailability());
+  }, [buildRecentViewAvailability, pruneRecentViewsStore, threadsHydrated]);
+
+  const activateRecentView = useCallback(
+    (view: RecentView) => {
+      switch (view.kind) {
+        case "thread": {
+          if (!buildRecentViewAvailability().availableThreadIds.has(view.threadId)) {
+            return;
+          }
+          prewarmThreadDetail(view.threadId);
+          const splitActivation = resolveRecentThreadSplitActivation({
+            view,
+            splitViewsById: useSplitViewStore.getState().splitViewsById,
+          });
+          if (splitActivation) {
+            useSplitViewStore
+              .getState()
+              .setFocusedPane(splitActivation.splitViewId, splitActivation.paneId);
+          }
+          const terminalState = selectThreadTerminalState(
+            useTerminalStateStore.getState().terminalStateByThreadId,
+            view.threadId,
+          );
+          if (terminalState.entryPoint === "terminal") {
+            openTerminalThreadPage(view.threadId);
+          } else {
+            openChatThreadPage(view.threadId);
+          }
+          void navigate({
+            to: "/$threadId",
+            params: { threadId: view.threadId },
+            search: () =>
+              splitActivation ? { splitViewId: splitActivation.splitViewId } : {},
+          });
+          return;
+        }
+        case "workspace": {
+          const workspaceExists = useWorkspaceStore
+            .getState()
+            .workspacePages.some((workspace) => workspace.id === view.workspaceId);
+          if (!workspaceExists) {
+            return;
+          }
+          void navigate({
+            to: "/workspace/$workspaceId",
+            params: { workspaceId: view.workspaceId },
+          });
+          return;
+        }
+        case "settings":
+          void navigate({
+            to: "/settings",
+            search: () => (view.section ? { section: view.section } : {}),
+          });
+          return;
+        case "plugins":
+          void navigate({ to: "/plugins" });
+          return;
+      }
+    },
+    [
+      buildRecentViewAvailability,
+      navigate,
+      openChatThreadPage,
+      openTerminalThreadPage,
+      prewarmThreadDetail,
+    ],
+  );
+
+  const commitRecentSwitcherSelection = useCallback(() => {
+    const state = recentSwitcherStateRef.current;
+    if (!state) return;
+    const views = recentViewsRef.current;
+    const view =
+      views.find((candidate) => recentViewKey(candidate) === state.selectedKey) ??
+      views[state.selectedIndex];
+    setRecentSwitcherState(null);
+    if (!view) return;
+    activateRecentView(view);
+  }, [activateRecentView]);
+
+  const cancelRecentSwitcher = useCallback(() => {
+    setRecentSwitcherState(null);
+  }, []);
+
+  const openOrAdvanceRecentSwitcher = useCallback(
+    (direction: "next" | "previous") => {
+      const currentState = recentSwitcherStateRef.current;
+      let views = recentViewsRef.current;
+      if (currentState === null) {
+        const availability = buildRecentViewAvailability();
+        pruneRecentViewsStore(availability);
+        views = pruneRecentViews(views, availability);
+      }
+      const selectedIndex = resolveRecentViewNavigationIndex({
+        recentViews: views,
+        currentView: currentRecentViewRef.current,
+        selectedKey: currentState?.selectedKey,
+        direction,
+      });
+
+      if (selectedIndex === null) {
+        return false;
+      }
+
+      const selectedView = views[selectedIndex];
+      if (!selectedView) {
+        return false;
+      }
+
+      if (selectedView.kind === "thread") {
+        prewarmThreadDetail(selectedView.threadId);
+      }
+
+      setRecentSwitcherState({
+        selectedIndex,
+        selectedKey: recentViewKey(selectedView),
+      });
+      return true;
+    },
+    [buildRecentViewAvailability, prewarmThreadDetail, pruneRecentViewsStore],
+  );
+
+  useEffect(() => {
+    const onWindowKeyUp = (event: KeyboardEvent) => {
+      if (!recentSwitcherStateRef.current || event.ctrlKey) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      commitRecentSwitcherSelection();
+    };
+    const onWindowBlur = () => {
+      commitRecentSwitcherSelection();
+    };
+
+    window.addEventListener("keyup", onWindowKeyUp, { capture: true });
+    window.addEventListener("blur", onWindowBlur);
+    return () => {
+      window.removeEventListener("keyup", onWindowKeyUp, { capture: true });
+      window.removeEventListener("blur", onWindowBlur);
+    };
+  }, [commitRecentSwitcherSelection]);
+
+  return {
+    recentSwitcherState,
+    recentViewEntries,
+    openOrAdvanceRecentSwitcher,
+    commitRecentSwitcherSelection,
+    cancelRecentSwitcher,
+  };
+}

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -54,6 +54,21 @@ function modShortcut(
   };
 }
 
+function ctrlShortcut(
+  key: string,
+  overrides: Partial<Omit<KeybindingShortcut, "key">> = {},
+): KeybindingShortcut {
+  return {
+    key,
+    metaKey: false,
+    ctrlKey: true,
+    shiftKey: false,
+    altKey: false,
+    modKey: false,
+    ...overrides,
+  };
+}
+
 function whenIdentifier(name: string): KeybindingWhenNode {
   return { type: "identifier", name };
 }
@@ -191,6 +206,16 @@ const DEFAULT_BINDINGS = compile([
   {
     shortcut: modShortcut("g", { altKey: true }),
     command: "chat.newGemini",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
+    shortcut: ctrlShortcut("tab"),
+    command: "view.recent.next",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
+    shortcut: ctrlShortcut("tab", { shiftKey: true }),
+    command: "view.recent.previous",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   {
@@ -430,6 +455,38 @@ describe("split/new/close terminal shortcuts", () => {
     assert.isFalse(
       isTerminalNewShortcut(event({ key: "m", ctrlKey: true }), keybindings, {
         platform: "Linux",
+      }),
+    );
+  });
+});
+
+describe("recent view shortcuts", () => {
+  it("resolves Ctrl+Tab outside terminal focus", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "Tab", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "view.recent.next",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({ key: "Tab", ctrlKey: true, shiftKey: true }),
+        DEFAULT_BINDINGS,
+        {
+          platform: "MacIntel",
+          context: { terminalFocus: false },
+        },
+      ),
+      "view.recent.previous",
+    );
+  });
+
+  it("does not resolve Ctrl+Tab while a terminal has focus", () => {
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "Tab", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
       }),
     );
   });

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -113,6 +113,20 @@ export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
     shortcut: commandShortcut("\\"),
     whenAst: whenNotTerminalFocus,
   },
+  // Installed-app only (Electron / standalone PWA). Browsers reserve Ctrl+Tab and
+  // Ctrl+Shift+Tab for tab switching and won't deliver them to the page, so the
+  // recent-view switcher does not open in a normal browser tab. Uses literal Ctrl
+  // (not mod) on purpose so it stays Ctrl+Tab on macOS too, matching Arc/Helium.
+  {
+    command: "view.recent.next",
+    shortcut: commandShortcut("tab", { ctrlKey: true, modKey: false }),
+    whenAst: whenNotTerminalFocus,
+  },
+  {
+    command: "view.recent.previous",
+    shortcut: commandShortcut("tab", { ctrlKey: true, shiftKey: true, modKey: false }),
+    whenAst: whenNotTerminalFocus,
+  },
   {
     command: "modelPicker.toggle",
     shortcut: commandShortcut("m", { shiftKey: true }),

--- a/apps/web/src/recentViewActivation.logic.test.ts
+++ b/apps/web/src/recentViewActivation.logic.test.ts
@@ -1,0 +1,87 @@
+// FILE: recentViewActivation.logic.test.ts
+// Purpose: Verifies split-pane restoration for Ctrl+Tab recent thread activation.
+// Layer: UI state logic test
+
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+import type { SplitView } from "./splitViewStore";
+import { resolveRecentThreadSplitActivation } from "./recentViewActivation.logic";
+
+const PROJECT_ID = ProjectId.makeUnsafe("project-1");
+
+function threadId(value: string): ThreadId {
+  return ThreadId.makeUnsafe(value);
+}
+
+function makeSplitView(input: {
+  id: string;
+  focusedPane: "empty" | "thread";
+  threadId: ThreadId;
+}): SplitView {
+  const emptyPaneId = `${input.id}-empty`;
+  const threadPaneId = `${input.id}-thread`;
+  const panel = {
+    panel: null,
+    diffTurnId: null,
+    diffFilePath: null,
+    hasOpenedPanel: false,
+    lastOpenPanel: "browser" as const,
+  };
+
+  return {
+    id: input.id,
+    sourceThreadId: input.threadId,
+    ownerProjectId: PROJECT_ID,
+    focusedPaneId: input.focusedPane === "empty" ? emptyPaneId : threadPaneId,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    root: {
+      kind: "split",
+      id: `${input.id}-root`,
+      direction: "horizontal",
+      ratio: 0.5,
+      first: { kind: "leaf", id: emptyPaneId, threadId: null, panel },
+      second: { kind: "leaf", id: threadPaneId, threadId: input.threadId, panel },
+    },
+  };
+}
+
+describe("recent view activation", () => {
+  it("resolves the pane containing a recent split thread even when another pane is focused", () => {
+    const targetThreadId = threadId("thread-target");
+    const splitView = makeSplitView({
+      id: "split-1",
+      focusedPane: "empty",
+      threadId: targetThreadId,
+    });
+
+    expect(
+      resolveRecentThreadSplitActivation({
+        view: { kind: "thread", threadId: targetThreadId, splitViewId: "split-1" },
+        splitViewsById: { "split-1": splitView },
+      }),
+    ).toEqual({
+      splitViewId: "split-1",
+      paneId: "split-1-thread",
+    });
+  });
+
+  it("falls back when the saved split no longer contains the recent thread", () => {
+    expect(
+      resolveRecentThreadSplitActivation({
+        view: {
+          kind: "thread",
+          threadId: threadId("thread-missing"),
+          splitViewId: "split-1",
+        },
+        splitViewsById: {
+          "split-1": makeSplitView({
+            id: "split-1",
+            focusedPane: "thread",
+            threadId: threadId("thread-other"),
+          }),
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/recentViewActivation.logic.ts
+++ b/apps/web/src/recentViewActivation.logic.ts
@@ -1,0 +1,34 @@
+// FILE: recentViewActivation.logic.ts
+// Purpose: Pure activation helpers for restoring recent thread views.
+// Layer: UI state logic
+// Exports: split-pane resolution for Ctrl+Tab recent-view activation.
+
+import {
+  resolveSplitViewPaneIdForThread,
+  type PaneId,
+  type SplitView,
+  type SplitViewId,
+} from "./splitViewStore";
+import type { RecentView } from "./recentViews.logic";
+
+export interface RecentThreadSplitActivation {
+  splitViewId: SplitViewId;
+  paneId: PaneId;
+}
+
+export function resolveRecentThreadSplitActivation(input: {
+  view: RecentView;
+  splitViewsById: Readonly<Record<SplitViewId, SplitView | undefined>>;
+}): RecentThreadSplitActivation | null {
+  if (input.view.kind !== "thread" || !input.view.splitViewId) {
+    return null;
+  }
+
+  const splitView = input.splitViewsById[input.view.splitViewId];
+  if (!splitView) {
+    return null;
+  }
+
+  const paneId = resolveSplitViewPaneIdForThread(splitView, input.view.threadId);
+  return paneId ? { splitViewId: input.view.splitViewId, paneId } : null;
+}

--- a/apps/web/src/recentViews.logic.test.ts
+++ b/apps/web/src/recentViews.logic.test.ts
@@ -1,0 +1,134 @@
+// FILE: recentViews.logic.test.ts
+// Purpose: Verifies Ctrl+Tab recent-view MRU behavior without rendering React.
+// Layer: UI state logic test
+
+import { describe, expect, it } from "vitest";
+import { ThreadId } from "@t3tools/contracts";
+import {
+  deriveCurrentRecentView,
+  pruneRecentViews,
+  recentViewKey,
+  resolveRecentViewNavigationIndex,
+  upsertRecentView,
+  type RecentView,
+} from "./recentViews.logic";
+
+function threadId(value: string): ThreadId {
+  return ThreadId.makeUnsafe(value);
+}
+
+describe("recent view MRU logic", () => {
+  it("moves reopened views to the front and caps the list at five", () => {
+    const recentViews = ["thread-1", "thread-2", "thread-3", "thread-4", "thread-5"].map((id) => ({
+      kind: "thread" as const,
+      threadId: threadId(id),
+    }));
+
+    const reopened = upsertRecentView(recentViews, {
+      kind: "thread",
+      threadId: threadId("thread-3"),
+    });
+    expect(reopened.map(recentViewKey)).toEqual([
+      "thread:thread-3",
+      "thread:thread-1",
+      "thread:thread-2",
+      "thread:thread-4",
+      "thread:thread-5",
+    ]);
+
+    const withSixth = upsertRecentView(reopened, {
+      kind: "workspace",
+      workspaceId: "workspace-1",
+    });
+    expect(withSixth.map(recentViewKey)).toEqual([
+      "workspace:workspace-1",
+      "thread:thread-3",
+      "thread:thread-1",
+      "thread:thread-2",
+      "thread:thread-4",
+    ]);
+  });
+
+  it("prunes deleted views and downgrades missing split views to plain threads", () => {
+    const recentViews: RecentView[] = [
+      { kind: "thread", threadId: threadId("thread-1"), splitViewId: "split-missing" },
+      { kind: "thread", threadId: threadId("thread-deleted") },
+      { kind: "workspace", workspaceId: "workspace-deleted" },
+      { kind: "plugins" },
+    ];
+
+    const pruned = pruneRecentViews(recentViews, {
+      availableThreadIds: new Set([threadId("thread-1")]),
+      availableWorkspaceIds: new Set(["workspace-1"]),
+      availableSplitViewIds: new Set(["split-1"]),
+    });
+
+    expect(pruned).toEqual([
+      { kind: "thread", threadId: threadId("thread-1") },
+      { kind: "plugins" },
+    ]);
+  });
+
+  it("downgrades split views that no longer contain the saved thread", () => {
+    const pruned = pruneRecentViews(
+      [{ kind: "thread", threadId: threadId("thread-1"), splitViewId: "split-1" }],
+      {
+        availableThreadIds: new Set([threadId("thread-1"), threadId("thread-2")]),
+        availableWorkspaceIds: new Set(),
+        availableSplitViewIds: new Set(["split-1"]),
+        threadIdsBySplitViewId: new Map([["split-1", new Set([threadId("thread-2")])]]),
+      },
+    );
+
+    expect(pruned).toEqual([{ kind: "thread", threadId: threadId("thread-1") }]);
+  });
+
+  it("selects the previous MRU entry on the first forward cycle", () => {
+    const recentViews: RecentView[] = [
+      { kind: "thread", threadId: threadId("thread-current") },
+      { kind: "settings" },
+      { kind: "workspace", workspaceId: "workspace-1" },
+    ];
+
+    expect(
+      resolveRecentViewNavigationIndex({
+        recentViews,
+        currentView: recentViews[0] ?? null,
+        direction: "next",
+      }),
+    ).toBe(1);
+    expect(
+      resolveRecentViewNavigationIndex({
+        recentViews,
+        currentView: recentViews[0] ?? null,
+        selectedKey: recentViewKey(recentViews[1] as RecentView),
+        direction: "previous",
+      }),
+    ).toBe(0);
+  });
+
+  it("derives only primary route views", () => {
+    expect(
+      deriveCurrentRecentView({
+        pathname: "/thread-1",
+        routeThreadId: threadId("thread-1"),
+        activeThreadId: threadId("thread-focused"),
+        routeWorkspaceId: null,
+        splitViewId: "split-1",
+      }),
+    ).toEqual({
+      kind: "thread",
+      threadId: threadId("thread-focused"),
+      splitViewId: "split-1",
+    });
+
+    expect(
+      deriveCurrentRecentView({
+        pathname: "/",
+        routeThreadId: null,
+        activeThreadId: null,
+        routeWorkspaceId: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/recentViews.logic.ts
+++ b/apps/web/src/recentViews.logic.ts
@@ -1,0 +1,276 @@
+// FILE: recentViews.logic.ts
+// Purpose: Pure helpers for the Ctrl+Tab recent primary-view switcher.
+// Layer: UI state logic
+// Exports: recent view types plus MRU update, pruning, and display derivation helpers
+
+import type { ProjectId, ThreadId } from "@t3tools/contracts";
+import type { Project, SidebarThreadSummary } from "./types";
+
+export const MAX_RECENT_VIEWS = 5;
+
+export type RecentView =
+  | {
+      kind: "thread";
+      threadId: ThreadId;
+      splitViewId?: string | undefined;
+    }
+  | {
+      kind: "workspace";
+      workspaceId: string;
+    }
+  | {
+      kind: "settings";
+      section?: string | undefined;
+    }
+  | {
+      kind: "plugins";
+    };
+
+export interface RecentViewDisplayEntry {
+  key: string;
+  view: RecentView;
+  kind: RecentView["kind"];
+  title: string;
+  subtitle: string;
+  isCurrent: boolean;
+  isPinned: boolean;
+  isSplit: boolean;
+  isTerminal: boolean;
+}
+
+export interface RecentViewWorkspaceSummary {
+  id: string;
+  title: string;
+}
+
+export interface RecentViewThreadDraftSummary {
+  id: ThreadId;
+  projectId: ProjectId;
+  title?: string | undefined;
+  isPinned?: boolean | undefined;
+}
+
+export interface RecentViewAvailability {
+  availableThreadIds: ReadonlySet<ThreadId>;
+  availableWorkspaceIds: ReadonlySet<string>;
+  availableSplitViewIds: ReadonlySet<string>;
+  threadIdsBySplitViewId?: ReadonlyMap<string, ReadonlySet<ThreadId>> | undefined;
+}
+
+const SETTINGS_LABELS: Readonly<Record<string, string>> = {
+  general: "General",
+  appearance: "Appearance",
+  providers: "Providers",
+  keybindings: "Keybindings",
+};
+
+function normalizeOptionalId(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function recentViewKey(view: RecentView): string {
+  switch (view.kind) {
+    case "thread":
+      return view.splitViewId
+        ? `thread:${view.threadId}:split:${view.splitViewId}`
+        : `thread:${view.threadId}`;
+    case "workspace":
+      return `workspace:${view.workspaceId}`;
+    case "settings":
+      return view.section ? `settings:${view.section}` : "settings";
+    case "plugins":
+      return "plugins";
+  }
+}
+
+export function deriveCurrentRecentView(input: {
+  pathname: string;
+  routeThreadId: ThreadId | null;
+  activeThreadId: ThreadId | null;
+  routeWorkspaceId: string | null;
+  splitViewId?: string | undefined;
+  settingsSection?: string | undefined;
+}): RecentView | null {
+  const splitViewId = normalizeOptionalId(input.splitViewId);
+
+  if (input.pathname.startsWith("/workspace/") && input.routeWorkspaceId) {
+    return {
+      kind: "workspace",
+      workspaceId: input.routeWorkspaceId,
+    };
+  }
+
+  if (input.pathname === "/settings") {
+    const section = normalizeOptionalId(input.settingsSection);
+    return {
+      kind: "settings",
+      ...(section ? { section } : {}),
+    };
+  }
+
+  if (input.pathname === "/plugins") {
+    return { kind: "plugins" };
+  }
+
+  if (input.routeThreadId) {
+    return {
+      kind: "thread",
+      threadId: input.activeThreadId ?? input.routeThreadId,
+      ...(splitViewId ? { splitViewId } : {}),
+    };
+  }
+
+  return null;
+}
+
+export function upsertRecentView(
+  recentViews: readonly RecentView[],
+  view: RecentView,
+  limit = MAX_RECENT_VIEWS,
+): RecentView[] {
+  const key = recentViewKey(view);
+  const deduped = recentViews.filter((entry) => recentViewKey(entry) !== key);
+  return [view, ...deduped].slice(0, limit);
+}
+
+export function pruneRecentViews(
+  recentViews: readonly RecentView[],
+  availability: RecentViewAvailability,
+  limit = MAX_RECENT_VIEWS,
+): RecentView[] {
+  const nextViews: RecentView[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const view of recentViews) {
+    const normalized = normalizeAvailableView(view, availability);
+    if (!normalized) continue;
+
+    const key = recentViewKey(normalized);
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    nextViews.push(normalized);
+
+    if (nextViews.length >= limit) break;
+  }
+
+  return nextViews;
+}
+
+function normalizeAvailableView(
+  view: RecentView,
+  availability: RecentViewAvailability,
+): RecentView | null {
+  switch (view.kind) {
+    case "thread": {
+      if (!availability.availableThreadIds.has(view.threadId)) {
+        return null;
+      }
+      if (view.splitViewId) {
+        const splitThreadIds = availability.threadIdsBySplitViewId?.get(view.splitViewId);
+        const splitStillContainsThread = splitThreadIds ? splitThreadIds.has(view.threadId) : true;
+        if (
+          !availability.availableSplitViewIds.has(view.splitViewId) ||
+          !splitStillContainsThread
+        ) {
+          return { kind: "thread", threadId: view.threadId };
+        }
+      }
+      return view;
+    }
+    case "workspace":
+      return availability.availableWorkspaceIds.has(view.workspaceId) ? view : null;
+    case "settings":
+    case "plugins":
+      return view;
+  }
+}
+
+export function resolveRecentViewNavigationIndex(input: {
+  recentViews: readonly RecentView[];
+  currentView: RecentView | null;
+  selectedKey?: string | null | undefined;
+  direction: "next" | "previous";
+}): number | null {
+  const { recentViews, currentView, selectedKey, direction } = input;
+  if (recentViews.length < 2) {
+    return null;
+  }
+
+  const delta = direction === "next" ? 1 : -1;
+  const preferredKey = selectedKey ?? (currentView ? recentViewKey(currentView) : null);
+  const preferredIndex =
+    preferredKey === null
+      ? -1
+      : recentViews.findIndex((view) => recentViewKey(view) === preferredKey);
+  const startIndex = preferredIndex >= 0 ? preferredIndex : 0;
+  return (startIndex + delta + recentViews.length) % recentViews.length;
+}
+
+export function buildRecentViewDisplayEntries(input: {
+  recentViews: readonly RecentView[];
+  currentView: RecentView | null;
+  threadsById: Readonly<Record<string, SidebarThreadSummary | undefined>>;
+  draftThreadsById?: Readonly<Record<string, RecentViewThreadDraftSummary | undefined>>;
+  projects: readonly Project[];
+  pinnedThreadIds: readonly ThreadId[];
+  workspacePages: readonly RecentViewWorkspaceSummary[];
+  terminalThreadIds?: ReadonlySet<ThreadId>;
+}): RecentViewDisplayEntry[] {
+  const currentKey = input.currentView ? recentViewKey(input.currentView) : null;
+  const projectNameById = new Map(input.projects.map((project) => [project.id, project.name]));
+  const workspaceNameById = new Map(
+    input.workspacePages.map((workspace) => [workspace.id, workspace.title]),
+  );
+  const pinnedThreadIds = new Set(input.pinnedThreadIds);
+
+  return input.recentViews.map((view) => {
+    const key = recentViewKey(view);
+    const base = {
+      key,
+      view,
+      kind: view.kind,
+      isCurrent: key === currentKey,
+      isPinned: false,
+      isSplit: view.kind === "thread" && Boolean(view.splitViewId),
+      isTerminal: view.kind === "thread" && (input.terminalThreadIds?.has(view.threadId) ?? false),
+    };
+
+    switch (view.kind) {
+      case "thread": {
+        const thread = input.threadsById[view.threadId] ?? input.draftThreadsById?.[view.threadId];
+        const projectName = thread ? projectNameById.get(thread.projectId) : null;
+        const title = normalizeOptionalId(thread?.title) ?? "New chat";
+        const subtitleParts = [
+          projectName ?? "Chat",
+          base.isTerminal ? "Terminal" : "Chat",
+          base.isSplit ? "Split" : null,
+        ].filter((part): part is string => Boolean(part));
+        return {
+          ...base,
+          title,
+          subtitle: subtitleParts.join(" · "),
+          isPinned: pinnedThreadIds.has(view.threadId) || Boolean(thread?.isPinned),
+        };
+      }
+      case "workspace":
+        return {
+          ...base,
+          title: workspaceNameById.get(view.workspaceId) ?? "Workspace",
+          subtitle: "Terminal workspace",
+        };
+      case "settings":
+        return {
+          ...base,
+          title: "Settings",
+          subtitle: view.section ? (SETTINGS_LABELS[view.section] ?? view.section) : "App settings",
+        };
+      case "plugins":
+        return {
+          ...base,
+          title: "Plugins",
+          subtitle: "Extensions and integrations",
+        };
+    }
+  });
+}

--- a/apps/web/src/recentViewsStore.ts
+++ b/apps/web/src/recentViewsStore.ts
@@ -1,0 +1,128 @@
+// FILE: recentViewsStore.ts
+// Purpose: Persist the Ctrl+Tab recent primary views MRU used by the chat shell.
+// Layer: UI state store
+// Exports: useRecentViewsStore
+
+import type { ThreadId } from "@t3tools/contracts";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import {
+  type RecentView,
+  type RecentViewAvailability,
+  MAX_RECENT_VIEWS,
+  pruneRecentViews,
+  recentViewKey,
+  upsertRecentView,
+} from "./recentViews.logic";
+import { createMemoryStorage } from "./lib/storage";
+
+interface RecentViewsStoreState {
+  recentViews: RecentView[];
+  recordRecentView: (view: RecentView) => void;
+  pruneRecentViews: (availability: RecentViewAvailability) => void;
+}
+
+const RECENT_VIEWS_STORAGE_KEY = "synara:recent-views:v1";
+
+function normalizeOptionalId(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function normalizeRecentView(input: unknown): RecentView | null {
+  if (!input || typeof input !== "object") return null;
+  const record = input as Record<string, unknown>;
+
+  if (record.kind === "thread") {
+    const threadId = normalizeOptionalId(record.threadId);
+    if (!threadId) return null;
+    const splitViewId = normalizeOptionalId(record.splitViewId);
+    return {
+      kind: "thread",
+      threadId: threadId as ThreadId,
+      ...(splitViewId ? { splitViewId } : {}),
+    };
+  }
+
+  if (record.kind === "workspace") {
+    const workspaceId = normalizeOptionalId(record.workspaceId);
+    return workspaceId ? { kind: "workspace", workspaceId } : null;
+  }
+
+  if (record.kind === "settings") {
+    const section = normalizeOptionalId(record.section);
+    return { kind: "settings", ...(section ? { section } : {}) };
+  }
+
+  if (record.kind === "plugins") {
+    return { kind: "plugins" };
+  }
+
+  return null;
+}
+
+function normalizeRecentViews(input: unknown): RecentView[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  const nextViews: RecentView[] = [];
+  for (const item of input) {
+    const view = normalizeRecentView(item);
+    if (!view) continue;
+    const key = recentViewKey(view);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    nextViews.push(view);
+  }
+  return nextViews.slice(0, MAX_RECENT_VIEWS);
+}
+
+function recentViewsEqual(left: readonly RecentView[], right: readonly RecentView[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((view, index) => {
+      const other = right[index];
+      return other !== undefined && recentViewKey(view) === recentViewKey(other);
+    })
+  );
+}
+
+export const useRecentViewsStore = create<RecentViewsStoreState>()(
+  persist(
+    (set) => ({
+      recentViews: [],
+      recordRecentView: (view) => {
+        set((state) => {
+          const nextRecentViews = upsertRecentView(state.recentViews, view);
+          return recentViewsEqual(state.recentViews, nextRecentViews)
+            ? state
+            : { recentViews: nextRecentViews };
+        });
+      },
+      pruneRecentViews: (availability) => {
+        set((state) => {
+          const nextRecentViews = pruneRecentViews(state.recentViews, availability);
+          return recentViewsEqual(state.recentViews, nextRecentViews)
+            ? state
+            : { recentViews: nextRecentViews };
+        });
+      },
+    }),
+    {
+      name: RECENT_VIEWS_STORAGE_KEY,
+      storage: createJSONStorage(() =>
+        typeof localStorage === "undefined" ? createMemoryStorage() : localStorage,
+      ),
+      partialize: (state) => ({
+        recentViews: normalizeRecentViews(state.recentViews),
+      }),
+      merge: (persistedState, currentState) => {
+        const candidate =
+          (persistedState as Partial<Pick<RecentViewsStoreState, "recentViews">> | undefined)
+            ?.recentViews ?? [];
+        return {
+          ...currentState,
+          recentViews: normalizeRecentViews(candidate),
+        };
+      },
+    },
+  ),
+);

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,7 +1,7 @@
-import { type ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
 import { useQuery } from "@tanstack/react-query";
 import { Outlet, createFileRoute, useLocation, useNavigate } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   goBackInAppHistory,
@@ -9,12 +9,14 @@ import {
   resolveAppNavigationState,
 } from "../appNavigation";
 import ShortcutsDialog from "../components/ShortcutsDialog";
+import { RecentViewSwitcher } from "../components/RecentViewSwitcher";
 import { shouldRenderTerminalWorkspace } from "../components/ChatView.logic";
 import ThreadSidebar from "../components/Sidebar";
 import { isElectron } from "../env";
 import { useHandleNewChat } from "../hooks/useHandleNewChat";
 import { useDisposableThreadLifecycle } from "../hooks/useDisposableThreadLifecycle";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useRecentViewSwitcher } from "../hooks/useRecentViewSwitcher";
 import { useLatestProjectStore } from "../latestProjectStore";
 import {
   resolveCurrentProjectTargetId,
@@ -213,6 +215,10 @@ function resolveBrowserNavigationShortcut(
   return null;
 }
 
+function isRecentViewSwitcherCommitKey(event: KeyboardEvent): boolean {
+  return event.key === "Enter" || event.key === " " || event.key === "Spacebar";
+}
+
 function ChatRouteGlobalShortcuts() {
   const navigate = useNavigate();
   const pathname = useLocation({ select: (location) => location.pathname });
@@ -221,6 +227,7 @@ function ChatRouteGlobalShortcuts() {
   const [shortcutsDialogOpen, setShortcutsDialogOpen] = useState(false);
   const clearSelection = useThreadSelectionStore((state) => state.clearSelection);
   const selectedThreadIdsSize = useThreadSelectionStore((state) => state.selectedThreadIds.size);
+  const terminalStateByThreadId = useTerminalStateStore((state) => state.terminalStateByThreadId);
   const {
     activeContextThreadId,
     activeDraftThread,
@@ -229,6 +236,17 @@ function ChatRouteGlobalShortcuts() {
     handleNewThread,
     projects,
   } = useHandleNewThread();
+  const {
+    recentSwitcherState,
+    recentViewEntries,
+    openOrAdvanceRecentSwitcher,
+    commitRecentSwitcherSelection,
+    cancelRecentSwitcher,
+  } = useRecentViewSwitcher({
+    activeContextThreadId,
+    activeDraftThread,
+    projects,
+  });
   const { handleNewChat } = useHandleNewChat();
   const latestProjectId = useLatestProjectStore((state) => state.latestProjectId);
   const setLatestProjectId = useLatestProjectStore((state) => state.setLatestProjectId);
@@ -239,11 +257,9 @@ function ChatRouteGlobalShortcuts() {
   const keybindings = serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
   const platform = typeof navigator === "undefined" ? "" : navigator.platform;
   const providerStatuses = serverConfigQuery.data?.providers ?? [];
-  const activeThreadTerminalState = useTerminalStateStore((state) =>
-    activeContextThreadId
-      ? selectThreadTerminalState(state.terminalStateByThreadId, activeContextThreadId)
-      : null,
-  );
+  const activeThreadTerminalState = activeContextThreadId
+    ? selectThreadTerminalState(terminalStateByThreadId, activeContextThreadId)
+    : null;
   const terminalOpen = activeThreadTerminalState?.terminalOpen ?? false;
   const allowProjectFallback = pathname !== "/";
   const activeProject =
@@ -279,6 +295,20 @@ function ChatRouteGlobalShortcuts() {
         terminalOpen,
         terminalWorkspaceOpen,
       };
+
+      if (recentSwitcherState && event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        cancelRecentSwitcher();
+        return;
+      }
+
+      if (recentSwitcherState && isRecentViewSwitcherCommitKey(event)) {
+        event.preventDefault();
+        event.stopPropagation();
+        commitRecentSwitcherSelection();
+        return;
+      }
 
       const isShortcutsHelpShortcut =
         (event.metaKey || event.ctrlKey) &&
@@ -324,6 +354,15 @@ function ChatRouteGlobalShortcuts() {
       }
 
       if (!command) return;
+
+      if (command === "view.recent.next" || command === "view.recent.previous") {
+        event.preventDefault();
+        event.stopPropagation();
+        // Ignore auto-repeat: holding Ctrl+Tab should not race-advance the selection.
+        if (event.repeat) return;
+        openOrAdvanceRecentSwitcher(command === "view.recent.next" ? "next" : "previous");
+        return;
+      }
 
       if (command === "chat.newChat" || command === "chat.newLocal") {
         event.preventDefault();
@@ -437,7 +476,9 @@ function ChatRouteGlobalShortcuts() {
     activeProjectId,
     activeThread,
     allowProjectFallback,
+    cancelRecentSwitcher,
     clearSelection,
+    commitRecentSwitcherSelection,
     currentProjectId,
     handleNewChat,
     handleNewThread,
@@ -447,8 +488,10 @@ function ChatRouteGlobalShortcuts() {
     appSettings.codexBinaryPath,
     appSettings.cursorBinaryPath,
     appSettings.geminiBinaryPath,
+    openOrAdvanceRecentSwitcher,
     providerStatuses,
     projects,
+    recentSwitcherState,
     selectedThreadIdsSize,
     terminalOpen,
     terminalWorkspaceOpen,
@@ -476,18 +519,26 @@ function ChatRouteGlobalShortcuts() {
   }, [navigate, toggleSidebar]);
 
   return (
-    <ShortcutsDialog
-      open={shortcutsDialogOpen}
-      onOpenChange={setShortcutsDialogOpen}
-      keybindings={keybindings}
-      projectScripts={activeProjectScripts}
-      platform={platform}
-      context={{
-        terminalFocus: isTerminalFocused(),
-        terminalOpen,
-        terminalWorkspaceOpen,
-      }}
-    />
+    <>
+      <ShortcutsDialog
+        open={shortcutsDialogOpen}
+        onOpenChange={setShortcutsDialogOpen}
+        keybindings={keybindings}
+        projectScripts={activeProjectScripts}
+        platform={platform}
+        context={{
+          terminalFocus: isTerminalFocused(),
+          terminalOpen,
+          terminalWorkspaceOpen,
+        }}
+      />
+      {recentSwitcherState ? (
+        <RecentViewSwitcher
+          entries={recentViewEntries}
+          selectedIndex={recentSwitcherState.selectedIndex}
+        />
+      ) : null}
+    </>
   );
 }
 

--- a/apps/web/src/shortcutsSheet.ts
+++ b/apps/web/src/shortcutsSheet.ts
@@ -106,6 +106,16 @@ const AVAILABLE_NOW_DEFINITIONS: readonly ShortcutDefinition[] = [
     description: "Open the current conversation in a second pane.",
   },
   {
+    command: "view.recent.previous",
+    label: "Previous recent view",
+    description: "Cycle backward through recently opened primary views.",
+  },
+  {
+    command: "view.recent.next",
+    label: "Next recent view",
+    description: "Cycle forward through recently opened primary views.",
+  },
+  {
     command: "modelPicker.toggle",
     label: "Model picker",
     description: "Open the composer provider and model picker.",

--- a/apps/web/src/threadDetailPrewarm.test.ts
+++ b/apps/web/src/threadDetailPrewarm.test.ts
@@ -1,0 +1,105 @@
+// FILE: threadDetailPrewarm.test.ts
+// Purpose: Verifies short-lived prewarming for fast thread-detail navigation.
+// Layer: Web subscription utility test
+
+import { ThreadId } from "@t3tools/contracts";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createThreadDetailPrewarmController } from "./threadDetailPrewarm";
+
+function threadId(value: string): ThreadId {
+  return ThreadId.makeUnsafe(value);
+}
+
+function makeRetainSpy() {
+  const retainedThreadIds: ThreadId[] = [];
+  const releasedThreadIds: ThreadId[] = [];
+  const retainThreadDetailSubscription = vi.fn((threadId: ThreadId) => {
+    retainedThreadIds.push(threadId);
+    return () => {
+      releasedThreadIds.push(threadId);
+    };
+  });
+
+  return {
+    retainThreadDetailSubscription,
+    retainedThreadIds,
+    releasedThreadIds,
+  };
+}
+
+describe("thread detail prewarm", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retains a target thread immediately and releases it after the prewarm window", () => {
+    vi.useFakeTimers();
+    const retain = makeRetainSpy();
+    const thread = threadId("thread-1");
+    const controller = createThreadDetailPrewarmController({
+      retainThreadDetailSubscription: retain.retainThreadDetailSubscription,
+      releaseMs: 1000,
+    });
+
+    controller.prewarmThreadDetail(thread);
+
+    expect(retain.retainedThreadIds).toEqual([thread]);
+    expect(retain.releasedThreadIds).toEqual([]);
+
+    vi.advanceTimersByTime(999);
+    expect(retain.releasedThreadIds).toEqual([]);
+
+    vi.advanceTimersByTime(1);
+    expect(retain.releasedThreadIds).toEqual([thread]);
+  });
+
+  it("refreshes an existing retain without incrementing the retention count", () => {
+    vi.useFakeTimers();
+    const retain = makeRetainSpy();
+    const thread = threadId("thread-2");
+    const controller = createThreadDetailPrewarmController({
+      retainThreadDetailSubscription: retain.retainThreadDetailSubscription,
+      releaseMs: 1000,
+    });
+
+    controller.prewarmThreadDetail(thread);
+    vi.advanceTimersByTime(500);
+    controller.prewarmThreadDetail(thread);
+
+    expect(retain.retainedThreadIds).toEqual([thread]);
+
+    vi.advanceTimersByTime(999);
+    expect(retain.releasedThreadIds).toEqual([]);
+
+    vi.advanceTimersByTime(1);
+    expect(retain.releasedThreadIds).toEqual([thread]);
+  });
+
+  it("bounds the warm set and releases entries that leave the prewarm list", () => {
+    vi.useFakeTimers();
+    const retain = makeRetainSpy();
+    const threadOne = threadId("thread-1");
+    const threadTwo = threadId("thread-2");
+    const threadThree = threadId("thread-3");
+    const threadFour = threadId("thread-4");
+    const controller = createThreadDetailPrewarmController({
+      retainThreadDetailSubscription: retain.retainThreadDetailSubscription,
+      releaseMs: 1000,
+      maxRetainedThreads: 2,
+    });
+
+    controller.prewarmThreadDetails([threadOne, threadTwo, threadOne, threadThree]);
+
+    expect(retain.retainedThreadIds).toEqual([threadOne, threadTwo]);
+    expect(retain.releasedThreadIds).toEqual([]);
+
+    controller.prewarmThreadDetails([threadTwo, threadFour]);
+
+    expect(retain.retainedThreadIds).toEqual([threadOne, threadTwo, threadFour]);
+    expect(retain.releasedThreadIds).toEqual([threadOne]);
+
+    controller.dispose();
+
+    expect(retain.releasedThreadIds).toEqual([threadOne, threadTwo, threadFour]);
+  });
+});

--- a/apps/web/src/threadDetailPrewarm.ts
+++ b/apps/web/src/threadDetailPrewarm.ts
@@ -1,0 +1,153 @@
+// FILE: threadDetailPrewarm.ts
+// Purpose: Short-lived thread-detail subscription prewarm controller for navigation intent.
+// Layer: Web subscription utility
+// Exports: Pure controller factory plus a React hook backed by thread-detail retention.
+
+import type { ThreadId } from "@t3tools/contracts";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { retainThreadDetailSubscription } from "./threadDetailSubscriptionRetention";
+
+export const THREAD_DETAIL_PREWARM_RELEASE_MS = 10_000;
+export const THREAD_DETAIL_PREWARM_LIMIT = 5;
+
+type TimeoutHandle = ReturnType<typeof setTimeout>;
+type RetainThreadDetailSubscription = (threadId: ThreadId) => () => void;
+
+interface ThreadDetailPrewarmClock {
+  setTimeout(callback: () => void, delayMs: number): TimeoutHandle;
+  clearTimeout(timeoutId: TimeoutHandle): void;
+}
+
+interface RetainedThreadPrewarmEntry {
+  release: () => void;
+  timeoutId: TimeoutHandle;
+}
+
+export interface ThreadDetailPrewarmController {
+  prewarmThreadDetail(threadId: ThreadId): void;
+  prewarmThreadDetails(threadIds: readonly ThreadId[]): void;
+  dispose(): void;
+}
+
+export interface ThreadDetailPrewarmControllerOptions {
+  retainThreadDetailSubscription?: RetainThreadDetailSubscription | undefined;
+  releaseMs?: number | undefined;
+  maxRetainedThreads?: number | undefined;
+  clock?: ThreadDetailPrewarmClock | undefined;
+}
+
+const DEFAULT_CLOCK: ThreadDetailPrewarmClock = {
+  setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+  clearTimeout: (timeoutId) => clearTimeout(timeoutId),
+};
+
+function uniqueThreadIds(threadIds: readonly ThreadId[], limit: number): ThreadId[] {
+  const nextThreadIds: ThreadId[] = [];
+  const seenThreadIds = new Set<ThreadId>();
+
+  for (const threadId of threadIds) {
+    if (seenThreadIds.has(threadId)) {
+      continue;
+    }
+    seenThreadIds.add(threadId);
+    nextThreadIds.push(threadId);
+    if (nextThreadIds.length >= limit) {
+      break;
+    }
+  }
+
+  return nextThreadIds;
+}
+
+export function createThreadDetailPrewarmController(
+  options: ThreadDetailPrewarmControllerOptions = {},
+): ThreadDetailPrewarmController {
+  const retainThreadDetail =
+    options.retainThreadDetailSubscription ?? retainThreadDetailSubscription;
+  const releaseMs = options.releaseMs ?? THREAD_DETAIL_PREWARM_RELEASE_MS;
+  const maxRetainedThreads = options.maxRetainedThreads ?? THREAD_DETAIL_PREWARM_LIMIT;
+  const clock = options.clock ?? DEFAULT_CLOCK;
+  const retainedThreadById = new Map<ThreadId, RetainedThreadPrewarmEntry>();
+
+  const releaseThread = (threadId: ThreadId) => {
+    const entry = retainedThreadById.get(threadId);
+    if (!entry) {
+      return;
+    }
+    clock.clearTimeout(entry.timeoutId);
+    entry.release();
+    retainedThreadById.delete(threadId);
+  };
+
+  const prewarmThreadDetail = (threadId: ThreadId) => {
+    const existing = retainedThreadById.get(threadId);
+    if (existing) {
+      clock.clearTimeout(existing.timeoutId);
+    }
+
+    const release = existing?.release ?? retainThreadDetail(threadId);
+    const timeoutId = clock.setTimeout(() => {
+      const current = retainedThreadById.get(threadId);
+      if (!current || current.release !== release) {
+        return;
+      }
+      current.release();
+      retainedThreadById.delete(threadId);
+    }, releaseMs);
+
+    retainedThreadById.set(threadId, { release, timeoutId });
+  };
+
+  return {
+    prewarmThreadDetail,
+    prewarmThreadDetails(threadIds) {
+      const nextThreadIds = uniqueThreadIds(threadIds, maxRetainedThreads);
+      const nextThreadIdSet = new Set(nextThreadIds);
+
+      for (const threadId of nextThreadIds) {
+        prewarmThreadDetail(threadId);
+      }
+      for (const threadId of [...retainedThreadById.keys()]) {
+        if (!nextThreadIdSet.has(threadId)) {
+          releaseThread(threadId);
+        }
+      }
+    },
+    dispose() {
+      for (const threadId of [...retainedThreadById.keys()]) {
+        releaseThread(threadId);
+      }
+    },
+  };
+}
+
+export function useThreadDetailPrewarm(): Omit<ThreadDetailPrewarmController, "dispose"> {
+  const controllerRef = useRef<ThreadDetailPrewarmController | null>(null);
+  if (controllerRef.current === null) {
+    controllerRef.current = createThreadDetailPrewarmController();
+  }
+
+  useEffect(
+    () => () => {
+      controllerRef.current?.dispose();
+      controllerRef.current = null;
+    },
+    [],
+  );
+
+  const prewarmThreadDetail = useCallback((threadId: ThreadId) => {
+    controllerRef.current?.prewarmThreadDetail(threadId);
+  }, []);
+
+  const prewarmThreadDetails = useCallback((threadIds: readonly ThreadId[]) => {
+    controllerRef.current?.prewarmThreadDetails(threadIds);
+  }, []);
+
+  return useMemo(
+    () => ({
+      prewarmThreadDetail,
+      prewarmThreadDetails,
+    }),
+    [prewarmThreadDetail, prewarmThreadDetails],
+  );
+}

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -148,6 +148,18 @@ it.effect("parses keybinding rules", () =>
       command: "chat.visible.previous",
     });
     assert.strictEqual(parsedVisiblePrevious.command, "chat.visible.previous");
+
+    const parsedRecentNext = yield* decode(KeybindingRule, {
+      key: "ctrl+tab",
+      command: "view.recent.next",
+    });
+    assert.strictEqual(parsedRecentNext.command, "view.recent.next");
+
+    const parsedRecentPrevious = yield* decode(KeybindingRule, {
+      key: "ctrl+shift+tab",
+      command: "view.recent.previous",
+    });
+    assert.strictEqual(parsedRecentPrevious.command, "view.recent.previous");
   }),
 );
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -38,6 +38,8 @@ const STATIC_KEYBINDING_COMMANDS = [
   "chat.newCursor",
   "chat.newGemini",
   "chat.split",
+  "view.recent.next",
+  "view.recent.previous",
   "thread.jump.1",
   "thread.jump.2",
   "thread.jump.3",


### PR DESCRIPTION
## Summary
- Add Ctrl+Tab / Ctrl+Shift+Tab recent-view switching for the five most recent primary views.
- Persist and prune recent views across chats, split views, workspaces, settings, and plugins.
- Add an Arc/Helium-style overlay with pinned/split/terminal labels.
- Prewarm recent thread detail subscriptions for faster switches.
- Fix split restoration so recent split entries focus the pane containing the selected thread before navigation.
- Harden pinned-state SQLite migrations by checking schema metadata before adding columns, instead of relying on duplicate-column error strings.
- Isolate server CLI tests with temporary Synara homes instead of fixed `/tmp` paths.

## Validation
- `bun run test src/recentViewActivation.logic.test.ts src/recentViews.logic.test.ts src/threadDetailPrewarm.test.ts src/keybindings.test.ts` in `apps/web`
- `bun run test src/splitViewStore.test.ts src/hooks/useThreadActivationController.test.ts src/recentViewActivation.logic.test.ts` in `apps/web`
- `bun run test src/keybindings.test.ts` in `packages/contracts`
- `bun run build` in `apps/web`
- `bun run test src/persistence/Migrations/039_ReconcileLegacyPinnedThreads.test.ts src/persistence/Migrations/040_ProjectionThreadsPinnedMessagesNotes.test.ts src/persistence/Migrations/041_ProjectionProjectsPinned.test.ts src/main.test.ts` in `apps/server`
- `git diff --check`
- Isolated browser smoke: Home, Settings, Plugins loaded with no console errors

## Notes
- Did not include the unrelated local `apps/server/src/orchestration/decider.ts` import-formatting change.
- Did not run `bun fmt`, `bun lint`, or `bun typecheck` because repo instructions require an explicit request for those checks.
