### PR TITLE
feat(web): add UI density setting for sidebar and composer spacing

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -692,6 +692,7 @@ describe("AppSettingsSchema", () => {
       ),
     ).toMatchObject({
       claudeBinaryPath: "",
+      uiDensity: "comfortable",
       chatFontSizePx: DEFAULT_CHAT_FONT_SIZE_PX,
       codexBinaryPath: "/usr/local/bin/codex",
       codexHomePath: "",

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -32,6 +32,10 @@ import {
 import { ensureNativeApi } from "./nativeApi";
 import { providerDiscoveryQueryKeys } from "./lib/providerDiscoveryReactQuery";
 import { serverQueryKeys, serverSettingsQueryOptions } from "./lib/serverReactQuery";
+import {
+  DEFAULT_UI_DENSITY,
+  normalizeUiDensity as normalizeUiDensityValue,
+} from "./lib/appDensity";
 
 const APP_SETTINGS_STORAGE_KEY = "synara:app-settings:v1";
 const SERVER_SETTINGS_MIGRATION_STORAGE_KEY = "t3code:server-settings-migrated:v1";
@@ -73,6 +77,10 @@ export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "manu
 export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
+
+export const UiDensity = Schema.Literals(["compact", "comfortable", "spacious"]);
+export type UiDensity = typeof UiDensity.Type;
+export { DEFAULT_UI_DENSITY };
 
 export function getDefaultNativeFontSmoothing(platform = globalThis.navigator?.platform ?? "") {
   return /mac|iphone|ipad|ipod/i.test(platform);
@@ -123,6 +131,7 @@ const withDefaults =
 
 export const AppSettingsSchema = Schema.Struct({
   claudeBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
+  uiDensity: UiDensity.pipe(withDefaults(() => DEFAULT_UI_DENSITY)),
   chatFontSizePx: Schema.Number.pipe(withDefaults(() => DEFAULT_CHAT_FONT_SIZE_PX)),
   chatCodeFontFamily: Schema.String.check(Schema.isMaxLength(256)).pipe(withDefaults(() => "")),
   terminalFontSizePx: Schema.Number.pipe(withDefaults(() => DEFAULT_TERMINAL_FONT_SIZE_PX)),
@@ -407,6 +416,7 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
       settings.openCodeBinaryPath,
     ),
     piBinaryPath: normalizeProviderBinaryPathOverride("pi", settings.piBinaryPath),
+    uiDensity: normalizeUiDensityValue(settings.uiDensity),
     chatFontSizePx: normalizeChatFontSizePx(settings.chatFontSizePx),
     terminalFontSizePx: normalizeTerminalFontSizePx(settings.terminalFontSizePx),
     terminalFontFamily: normalizeTerminalFontFamily(settings.terminalFontFamily),

--- a/apps/web/src/components/chat/composerPickerStyles.ts
+++ b/apps/web/src/components/chat/composerPickerStyles.ts
@@ -98,7 +98,8 @@ export const CHAT_MAIN_VIEWPORT_SHELL_CLASS_NAME =
 /** Shared max width for the chat column (transcript + composer). */
 export const CHAT_COLUMN_MAX_WIDTH_CLASS_NAME = COMPOSER_MAX_WIDTH_CLASS_NAME;
 /** Horizontal padding shared by the transcript and composer columns. */
-export const CHAT_COLUMN_GUTTER_CLASS_NAME = "px-3 sm:px-5";
+export const CHAT_COLUMN_GUTTER_CLASS_NAME =
+  "px-[var(--app-density-chat-gutter-x,0.75rem)] sm:px-[var(--app-density-chat-gutter-x-lg,1.25rem)]";
 /** Centers the chat column and applies the shared max width. */
 export const CHAT_COLUMN_FRAME_CLASS_NAME = `mx-auto w-full min-w-0 ${COMPOSER_MAX_WIDTH_CLASS_NAME}`;
 
@@ -223,13 +224,28 @@ export const COMPOSER_EDITOR_TEXT_CLASS_NAME = "text-[length:var(--app-font-size
 export const COMPOSER_EDITOR_TYPOGRAPHY_CLASS_NAME = `font-system-ui ${COMPOSER_EDITOR_TEXT_CLASS_NAME} ${COMPOSER_EDITOR_LINE_HEIGHT_CLASS_NAME}`;
 /** Muted empty-state copy for the composer prompt editor. */
 export const COMPOSER_PLACEHOLDER_TEXT_CLASS_NAME = "text-muted-foreground/40";
-export const COMPOSER_EDITOR_MIN_HEIGHT_CLASS_NAME = "min-h-[2lh]";
+export const COMPOSER_EDITOR_MIN_HEIGHT_CLASS_NAME =
+  "min-h-[var(--app-density-composer-editor-min-height,2lh)]";
 /** Lexical wraps lines in `<p>` nodes; reset default margins so text sits flush above the footer. */
 export const COMPOSER_EDITOR_CONTENT_RESET_CLASS_NAME = "[&_p]:m-0";
 /** Shared padding around the composer prompt editor. */
-export const COMPOSER_EDITOR_PADDING_CLASS_NAME = "relative pl-3 pr-3.5 pt-3 pb-2";
+export const COMPOSER_EDITOR_PADDING_CLASS_NAME = [
+  "relative",
+  "pl-[var(--app-density-composer-editor-padding-x,0.75rem)]",
+  "pr-[var(--app-density-composer-editor-padding-x-end,0.875rem)]",
+  "pt-[var(--app-density-composer-editor-padding-top,0.75rem)]",
+  "pb-[var(--app-density-composer-editor-padding-bottom,0.5rem)]",
+].join(" ");
 /** Bottom bar row — flush to the composer shell edges. */
-export const COMPOSER_FOOTER_ROW_CLASS_NAME =
-  "flex items-center justify-between pl-1.5 pr-2 pb-1.5";
-export const COMPOSER_FOOTER_APPROVAL_ROW_CLASS_NAME =
-  "flex items-center justify-end gap-2 pl-1.5 pr-2 pb-1.5";
+export const COMPOSER_FOOTER_ROW_CLASS_NAME = [
+  "flex items-center justify-between",
+  "pl-[var(--app-density-composer-footer-padding,0.375rem)]",
+  "pr-[var(--app-density-composer-editor-padding-x-end,0.875rem)]",
+  "pb-[var(--app-density-composer-footer-padding,0.375rem)]",
+].join(" ");
+export const COMPOSER_FOOTER_APPROVAL_ROW_CLASS_NAME = [
+  "flex items-center justify-end gap-2",
+  "pl-[var(--app-density-composer-footer-padding,0.375rem)]",
+  "pr-[var(--app-density-composer-editor-padding-x-end,0.875rem)]",
+  "pb-[var(--app-density-composer-footer-padding,0.375rem)]",
+].join(" ");

--- a/apps/web/src/hooks/useAppDensity.ts
+++ b/apps/web/src/hooks/useAppDensity.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+
+import { normalizeUiDensity, getDensityCssVariables, type DensityCssVariable } from "../lib/appDensity";
+import { useAppSettings } from "../appSettings";
+
+const DENSITY_CSS_VARIABLES = Object.keys(
+  getDensityCssVariables(),
+) as readonly DensityCssVariable[];
+
+export function useAppDensity() {
+  const { settings } = useAppSettings();
+  const uiDensity = normalizeUiDensity(settings.uiDensity);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const rootStyle = root.style;
+    const variableValues = getDensityCssVariables(uiDensity);
+
+    for (const cssVariable of DENSITY_CSS_VARIABLES) {
+      rootStyle.setProperty(cssVariable, variableValues[cssVariable]);
+    }
+    root.dataset.uiDensity = uiDensity;
+
+    return () => {
+      for (const cssVariable of DENSITY_CSS_VARIABLES) {
+        rootStyle.removeProperty(cssVariable);
+      }
+      delete root.dataset.uiDensity;
+    };
+  }, [uiDensity]);
+}

--- a/apps/web/src/lib/appDensity.test.ts
+++ b/apps/web/src/lib/appDensity.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_UI_DENSITY,
+  getDensityCssVariables,
+  getDensityScale,
+  normalizeUiDensity,
+} from "./appDensity";
+
+describe("appDensity", () => {
+  it("normalizes unknown values to the default density", () => {
+    expect(normalizeUiDensity("spacious")).toBe("spacious");
+    expect(normalizeUiDensity("invalid")).toBe(DEFAULT_UI_DENSITY);
+    expect(normalizeUiDensity(undefined)).toBe(DEFAULT_UI_DENSITY);
+  });
+
+  it("maps density modes to scale factors", () => {
+    expect(getDensityScale("compact")).toBe(0.85);
+    expect(getDensityScale("comfortable")).toBe(1);
+    expect(getDensityScale("spacious")).toBe(1.15);
+  });
+
+  it("derives scaled spacing variables from the active density", () => {
+    const compact = getDensityCssVariables("compact");
+    const comfortable = getDensityCssVariables("comfortable");
+
+    expect(compact["--density-scale"]).toBe("0.85");
+    expect(comfortable["--density-scale"]).toBe("1");
+    expect(compact["--app-density-row-height"]).toBe("1.4875rem");
+    expect(comfortable["--app-density-row-height"]).toBe("1.75rem");
+    expect(compact["--app-density-composer-editor-min-height"]).toBe("calc(2lh * 0.85)");
+  });
+});

--- a/apps/web/src/lib/appDensity.ts
+++ b/apps/web/src/lib/appDensity.ts
@@ -1,0 +1,66 @@
+export const UI_DENSITY_MODES = ["compact", "comfortable", "spacious"] as const;
+export type UiDensity = (typeof UI_DENSITY_MODES)[number];
+
+export const DEFAULT_UI_DENSITY: UiDensity = "comfortable";
+
+const DENSITY_SCALE_BY_MODE: Record<UiDensity, number> = {
+  compact: 0.85,
+  comfortable: 1,
+  spacious: 1.15,
+};
+
+const BASE_ROW_HEIGHT_REM = 1.75;
+const BASE_ROW_PADDING_Y_REM = 0.125;
+const BASE_ROW_GAP_REM = 0.5;
+const BASE_SETTINGS_ROW_PADDING_Y_REM = 0.625;
+const BASE_CHAT_GUTTER_X_REM = 0.75;
+const BASE_CHAT_GUTTER_X_LG_REM = 1.25;
+const BASE_COMPOSER_EDITOR_PADDING_TOP_REM = 0.75;
+const BASE_COMPOSER_EDITOR_PADDING_BOTTOM_REM = 0.5;
+const BASE_COMPOSER_EDITOR_PADDING_X_REM = 0.75;
+const BASE_COMPOSER_EDITOR_PADDING_X_END_REM = 0.875;
+const BASE_COMPOSER_FOOTER_PADDING_REM = 0.375;
+
+function scaleRem(baseRem: number, scale: number): string {
+  return `${baseRem * scale}rem`;
+}
+
+export function isUiDensity(value: unknown): value is UiDensity {
+  return typeof value === "string" && (UI_DENSITY_MODES as readonly string[]).includes(value);
+}
+
+export function normalizeUiDensity(value: unknown, fallback = DEFAULT_UI_DENSITY): UiDensity {
+  return isUiDensity(value) ? value : fallback;
+}
+
+export function getDensityScale(mode: UiDensity = DEFAULT_UI_DENSITY): number {
+  return DENSITY_SCALE_BY_MODE[mode];
+}
+
+export function getDensityCssVariables(mode: UiDensity = DEFAULT_UI_DENSITY) {
+  const scale = getDensityScale(mode);
+
+  return {
+    "--density-scale": String(scale),
+    "--app-density-row-height": scaleRem(BASE_ROW_HEIGHT_REM, scale),
+    "--app-density-row-padding-y": scaleRem(BASE_ROW_PADDING_Y_REM, scale),
+    "--app-density-row-gap": scaleRem(BASE_ROW_GAP_REM, scale),
+    "--app-density-settings-row-padding-y": scaleRem(BASE_SETTINGS_ROW_PADDING_Y_REM, scale),
+    "--app-density-chat-gutter-x": scaleRem(BASE_CHAT_GUTTER_X_REM, scale),
+    "--app-density-chat-gutter-x-lg": scaleRem(BASE_CHAT_GUTTER_X_LG_REM, scale),
+    "--app-density-composer-editor-min-height": `calc(2lh * ${scale})`,
+    "--app-density-composer-editor-padding-top": scaleRem(BASE_COMPOSER_EDITOR_PADDING_TOP_REM, scale),
+    "--app-density-composer-editor-padding-bottom": scaleRem(
+      BASE_COMPOSER_EDITOR_PADDING_BOTTOM_REM,
+      scale,
+    ),
+    "--app-density-composer-editor-padding-x": scaleRem(BASE_COMPOSER_EDITOR_PADDING_X_REM, scale),
+    "--app-density-composer-editor-padding-x-end": scaleRem(
+      BASE_COMPOSER_EDITOR_PADDING_X_END_REM,
+      scale,
+    ),
+    "--app-density-composer-footer-padding": scaleRem(BASE_COMPOSER_FOOTER_PADDING_REM, scale),
+  } as const;
+}
+
+export type DensityCssVariable = keyof ReturnType<typeof getDensityCssVariables>;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -67,6 +67,7 @@ import {
   useRetainedThreadDetailIds,
 } from "../threadDetailSubscriptionRetention";
 import { getThreadFromState } from "../threadDerivation";
+import { useAppDensity } from "../hooks/useAppDensity";
 import { useAppTypography } from "../hooks/useAppTypography";
 import { useSyncDesktopTopBarTrafficLightGutterZoom } from "../hooks/useDesktopTopBarGutter";
 import { useTheme } from "../hooks/useTheme";
@@ -145,6 +146,7 @@ export const Route = createRootRouteWithContext<{
 
 function RootRouteView() {
   useAppTypography();
+  useAppDensity();
   useNativeFontSmoothing();
   useSyncDesktopTopBarTrafficLightGutterZoom();
   useTheme();

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -41,6 +41,8 @@ import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
 import {
   type AppSettings,
+  DEFAULT_UI_DENSITY,
+  type UiDensity,
   MAX_CHAT_FONT_SIZE_PX,
   MAX_TERMINAL_FONT_SIZE_PX,
   getCustomModelsForProvider,
@@ -153,6 +155,28 @@ import { formatWorktreePathForDisplay } from "../worktreeCleanup";
 import { sameProviderOrder } from "../providerOrdering";
 
 // ── Settings taxonomy ──────────────────────────────────────────────────────
+
+const UI_DENSITY_OPTIONS = [
+  {
+    value: "compact",
+    label: "Compact",
+    description: "Tighter spacing in the sidebar, composer, and settings rows.",
+  },
+  {
+    value: "comfortable",
+    label: "Comfortable",
+    description: "Balanced spacing for everyday use.",
+  },
+  {
+    value: "spacious",
+    label: "Spacious",
+    description: "More breathing room across the main workspace surfaces.",
+  },
+] as const satisfies ReadonlyArray<{
+  value: UiDensity;
+  label: string;
+  description: string;
+}>;
 
 const THEME_OPTIONS = [
   {
@@ -851,6 +875,7 @@ function SettingsRouteView() {
     ...(settings.showWorkspaceSection !== defaults.showWorkspaceSection
       ? ["Workspace section"]
       : []),
+    ...(settings.uiDensity !== defaults.uiDensity ? ["UI density"] : []),
     ...(settings.chatFontSizePx !== defaults.chatFontSizePx ? ["Base font size"] : []),
     ...(settings.terminalFontSizePx !== defaults.terminalFontSizePx ? ["Terminal font size"] : []),
     ...(settings.terminalFontFamily !== defaults.terminalFontFamily ? ["Terminal font"] : []),
@@ -1683,6 +1708,36 @@ function SettingsRouteView() {
         </div>
 
         <SettingsCard>
+          <SettingsRow
+            title="UI density"
+            description="Control spacing in the sidebar, composer, chat gutters, and settings rows without changing font size."
+            resetAction={
+              settings.uiDensity !== defaults.uiDensity ? (
+                <SettingResetButton
+                  label="UI density"
+                  onClick={() =>
+                    updateSettings({
+                      uiDensity: DEFAULT_UI_DENSITY,
+                    })
+                  }
+                />
+              ) : null
+            }
+            control={
+              <SettingsSegmentedControl
+                value={settings.uiDensity}
+                onValueChange={(value) => {
+                  if (value !== "compact" && value !== "comfortable" && value !== "spacious") {
+                    return;
+                  }
+                  updateSettings({ uiDensity: value });
+                }}
+                ariaLabel="UI density"
+                options={UI_DENSITY_OPTIONS}
+              />
+            }
+          />
+
           <SettingsRow
             title="Base font size"
             description="Adjust the app text base in pixels. Chat and UI typography scale proportionally from this value."

--- a/apps/web/src/settingsPanelStyles.ts
+++ b/apps/web/src/settingsPanelStyles.ts
@@ -33,7 +33,8 @@ export const SETTINGS_CARD_CLASS_NAME = [
 ].join(" ");
 
 /** Row padding inside a settings card. */
-export const SETTINGS_CARD_ROW_CLASS_NAME = "px-3 py-2.5";
+export const SETTINGS_CARD_ROW_CLASS_NAME =
+  "px-3 py-[var(--app-density-settings-row-padding-y,0.625rem)]";
 
 /** Row title — same UI font/size as the description; weight and color differ. */
 export const SETTINGS_CARD_ROW_TITLE_CLASS_NAME =

--- a/apps/web/src/sidebarRowStyles.ts
+++ b/apps/web/src/sidebarRowStyles.ts
@@ -4,13 +4,15 @@
 // Exports: row dimension, radius, hover/active, header + thread row class names
 
 /** Compact sidebar row height shared by projects, threads, chats, and settings nav. */
-export const SIDEBAR_ROW_HEIGHT_CLASS_NAME = "h-7";
+export const SIDEBAR_ROW_HEIGHT_CLASS_NAME =
+  "min-h-[var(--app-density-row-height,1.75rem)] h-[var(--app-density-row-height,1.75rem)]";
 
 export const SIDEBAR_ROW_RADIUS_CLASS_NAME = "rounded-md";
 
-export const SIDEBAR_ROW_PADDING_CLASS_NAME = "px-2 py-0.5";
+export const SIDEBAR_ROW_PADDING_CLASS_NAME =
+  "px-2 py-[var(--app-density-row-padding-y,0.125rem)]";
 
-export const SIDEBAR_ROW_GAP_CLASS_NAME = "gap-2";
+export const SIDEBAR_ROW_GAP_CLASS_NAME = "gap-[var(--app-density-row-gap,0.5rem)]";
 
 export const SIDEBAR_ROW_TEXT_CLASS_NAME = "text-[length:var(--app-font-size-ui,12px)] font-normal";
 


### PR DESCRIPTION
## Summary

Adds a **UI density** preference (`compact` / `comfortable` / `spacious`) so users can tune layout spacing across the main workspace without changing font size.

This follows the same persistence and application pattern as existing appearance controls like base font size: stored in local app settings (`synara:app-settings:v1`), applied via CSS variables on `:root`, and exposed in **Settings → Appearance**.

## What changed

- New `uiDensity` setting in `AppSettingsSchema` (default: `comfortable`)
- Pure density helpers in `lib/appDensity.ts` with unit tests
- `useAppDensity` hook mirrors `useAppTypography` and sets `--density-scale` plus derived spacing tokens
- Shared layout tokens updated to consume density variables:
  - Sidebar rows (`sidebarRowStyles.ts`)
  - Settings rows (`settingsPanelStyles.ts`)
  - Chat gutters, composer padding, and composer min-height (`composerPickerStyles.ts`)
- Segmented control added to the Appearance panel

## Why this approach

- **Density is spacing, not color** — kept separate from `synara:theme` share packs (accent/surface/fonts)
- **Consistent with Synara patterns** — local-only UI preference, same storage path as font size and diff wrap
- **Small, focused diff** — no server changes, no provider changes, no theme share-string changes

## Scales

| Mode | `--density-scale` |
|------|-------------------|
| Compact | 0.85 |
| Comfortable | 1.0 |
| Spacious | 1.15 |

## How to test

```sh
bun install
bun run dev
```

1. Open **Settings → Appearance**
2. Switch **UI density** between Compact, Comfortable, and Spacious
3. Confirm sidebar row height/padding, settings rows, chat gutters, and composer padding update immediately
4. Reload the app and confirm the choice persists

Optional DevTools check:

```js
document.documentElement.dataset.uiDensity
getComputedStyle(document.documentElement).getPropertyValue('--density-scale')
```

## Verification

- `bun run test src/lib/appDensity.test.ts` (apps/web)
- `bun run test src/appSettings.test.ts -t "fills decoding defaults"` (apps/web)
- `bun run typecheck --filter=t3`

---

Implemented with assistance from **Grok Build** using **Composer 2.5**.