### PR TITLE
Add Claude Fable 5 support

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -425,6 +425,31 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("forwards xhigh effort for Claude Fable 5", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-fable-5",
+          options: {
+            effort: "xhigh",
+          },
+        },
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.effort, "xhigh");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("forwards supported max effort for Sonnet 4.6", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -260,6 +260,28 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
   ],
   claudeAgent: [
     {
+      slug: "claude-fable-5",
+      name: "Claude Fable 5",
+      capabilities: {
+        reasoningEffortLevels: [
+          { value: "low", label: "Low" },
+          { value: "medium", label: "Medium" },
+          { value: "high", label: "High", isDefault: true },
+          { value: "xhigh", label: "Extra High" },
+          { value: "max", label: "Max" },
+          { value: "ultrathink", label: "Ultrathink" },
+          { value: "ultracode", label: "Ultracode" },
+        ],
+        supportsFastMode: false,
+        supportsThinkingToggle: false,
+        promptInjectedEffortLevels: ["ultrathink"],
+        contextWindowOptions: [
+          { value: "200k", label: "200k", isDefault: true },
+          { value: "1m", label: "1M" },
+        ],
+      },
+    },
+    {
       slug: "claude-opus-4-8",
       name: "Claude Opus 4.8",
       capabilities: {
@@ -579,6 +601,9 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string,
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
   claudeAgent: {
+    fable: "claude-fable-5",
+    "fable-5": "claude-fable-5",
+    "claude-fable-5": "claude-fable-5",
     opus: "claude-opus-4-8",
     "opus-4.8": "claude-opus-4-8",
     "claude-opus-4.8": "claude-opus-4-8",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -60,6 +60,8 @@ describe("normalizeModelSlug", () => {
   });
 
   it("uses provider-specific aliases", () => {
+    expect(normalizeModelSlug("fable", "claudeAgent")).toBe("claude-fable-5");
+    expect(normalizeModelSlug("fable-5", "claudeAgent")).toBe("claude-fable-5");
     expect(normalizeModelSlug("sonnet", "claudeAgent")).toBe("claude-sonnet-4-6");
     expect(normalizeModelSlug("opus-4.6", "claudeAgent")).toBe("claude-opus-4-6");
     expect(normalizeModelSlug("claude-haiku-4-5-20251001", "claudeAgent")).toBe("claude-haiku-4-5");
@@ -91,6 +93,7 @@ describe("resolveModelSlug", () => {
     expect(resolveModelSlugForProvider("claudeAgent", undefined)).toBe(
       DEFAULT_MODEL_BY_PROVIDER.claudeAgent,
     );
+    expect(resolveModelSlugForProvider("claudeAgent", "fable")).toBe("claude-fable-5");
     expect(resolveModelSlugForProvider("claudeAgent", "sonnet")).toBe("claude-sonnet-4-6");
     expect(resolveModelSlugForProvider("claudeAgent", "gpt-5.3-codex")).toBe(
       DEFAULT_MODEL_BY_PROVIDER.claudeAgent,
@@ -126,10 +129,17 @@ describe("resolveSelectableModel", () => {
   it("resolves provider-specific aliases after normalization", () => {
     expect(
       resolveSelectableModel("claudeAgent", "sonnet", [
+        { slug: "claude-fable-5", name: "Claude Fable 5" },
         { slug: "claude-opus-4-6", name: "Claude Opus 4.6" },
         { slug: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
       ]),
     ).toBe("claude-sonnet-4-6");
+    expect(
+      resolveSelectableModel("claudeAgent", "fable", [
+        { slug: "claude-fable-5", name: "Claude Fable 5" },
+        { slug: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+      ]),
+    ).toBe("claude-fable-5");
   });
 
   it("returns null for empty input", () => {
@@ -184,6 +194,18 @@ describe("getModelCapabilities reasoningEffortLevels", () => {
       "high",
       "max",
       "ultrathink",
+    ]);
+  });
+
+  it("returns claude effort options for Fable 5", () => {
+    expect(values("claudeAgent", "claude-fable-5")).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+      "ultrathink",
+      "ultracode",
     ]);
   });
 
@@ -463,6 +485,19 @@ describe("normalizeClaudeModelOptions", () => {
         contextWindow: "1m",
       }),
     ).toEqual({
+      contextWindow: "1m",
+    });
+  });
+
+  it("preserves Fable 5 extra-high effort and 1M context", () => {
+    expect(
+      normalizeClaudeModelOptions("claude-fable-5", {
+        effort: "xhigh",
+        fastMode: true,
+        contextWindow: "1m",
+      }),
+    ).toEqual({
+      effort: "xhigh",
       contextWindow: "1m",
     });
   });


### PR DESCRIPTION
## Summary

- Add Claude Fable 5 to the shared Claude model catalog.
- Add Fable aliases so typed selections like `fable` and `fable-5` resolve correctly.
- Cover capabilities and launch-option forwarding for Fable extra-high effort.

## Verification

- `bun run --filter @t3tools/shared test -- src/model.test.ts`
- `bun run --filter t3 test -- src/provider/Layers/ClaudeAdapter.test.ts -t "Claude Fable 5"`
- Started isolated dev server on `http://localhost:8891/` and confirmed Vite served the updated contracts module with `claude-fable-5` / `Claude Fable 5`.
