### PR TITLE
Split composer model and options pickers

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -333,6 +333,7 @@ import { deriveAgentActivityTimelineState } from "./chat/agentActivity.logic";
 import { ComposerSlashStatusDialog } from "./chat/ComposerSlashStatusDialog";
 import { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { AVAILABLE_PROVIDER_OPTIONS, ProviderModelPicker } from "./chat/ProviderModelPicker";
+import { ComposerModelEffortPicker } from "./chat/ComposerModelEffortPicker";
 import { TraitsPicker } from "./chat/TraitsPicker";
 import { ComposerCommandItem, ComposerCommandMenu } from "./chat/ComposerCommandMenu";
 import {
@@ -6909,18 +6910,38 @@ export default function ChatView({
       }),
     [runtimeUsageContextWindow, composerTraitSelection.contextWindow, selectedProvider],
   );
+  const useSplitComposerPickerControls = isLocalDraftThread && !hasThreadStarted;
   const composerModelPickerWidthClassName = isComposerFooterCompact ? "w-32" : "w-36 sm:w-44";
   const composerOptionsPickerWidthClassName = isComposerFooterCompact ? "w-28" : "w-32";
+  const composerModelEffortPickerWidthClassName = isComposerFooterCompact ? "w-40" : "w-44 sm:w-52";
+  const isComposerModelEffortPickerOpen = isModelPickerOpen || isTraitsPickerOpen;
+  const handleComposerModelEffortPickerOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        handleModelPickerOpenChange(true);
+      } else {
+        setIsModelPickerOpen(false);
+        setIsTraitsPickerOpen(false);
+      }
+    },
+    [handleModelPickerOpenChange],
+  );
   const composerPickerControls = showComposerModelBootstrapSkeleton ? (
-    <>
-      {selectedProviderRuntimeModelDiscoveryPending ? (
-        <ComposerModelLoadingControl widthClassName={composerModelPickerWidthClassName} />
-      ) : (
-        <ComposerControlSkeleton widthClassName={composerModelPickerWidthClassName} />
-      )}
-      <ComposerControlSkeleton widthClassName={composerOptionsPickerWidthClassName} />
-    </>
-  ) : (
+    useSplitComposerPickerControls ? (
+      <>
+        {selectedProviderRuntimeModelDiscoveryPending ? (
+          <ComposerModelLoadingControl widthClassName={composerModelPickerWidthClassName} />
+        ) : (
+          <ComposerControlSkeleton widthClassName={composerModelPickerWidthClassName} />
+        )}
+        <ComposerControlSkeleton widthClassName={composerOptionsPickerWidthClassName} />
+      </>
+    ) : selectedProviderRuntimeModelDiscoveryPending ? (
+      <ComposerModelLoadingControl widthClassName={composerModelEffortPickerWidthClassName} />
+    ) : (
+      <ComposerControlSkeleton widthClassName={composerModelEffortPickerWidthClassName} />
+    )
+  ) : useSplitComposerPickerControls ? (
     <>
       <ProviderModelPicker
         compact={isComposerFooterCompact}
@@ -6957,6 +6978,33 @@ export default function ChatView({
         shortcutLabel={traitsPickerShortcutLabel}
       />
     </>
+  ) : (
+    <ComposerModelEffortPicker
+      compact={isComposerFooterCompact}
+      provider={selectedProvider}
+      model={selectedModelForPickerWithCustomFallback}
+      lockedProvider={lockedProvider}
+      providers={providerStatuses}
+      modelOptionsByProvider={modelOptionsByProvider}
+      loadingModelProviders={{
+        cursor: cursorModelDiscoveryPending,
+        kilo: kiloModelDiscoveryPending,
+      }}
+      hiddenProviders={settings.hiddenProviders}
+      providerOrder={settings.providerOrder}
+      threadId={threadId}
+      runtimeModel={selectedRuntimeModel}
+      runtimeModels={runtimeModelsByProvider[selectedProvider]}
+      runtimeAgents={dynamicAgents}
+      modelOptions={selectedProviderModelOptions}
+      prompt={prompt}
+      onPromptChange={setPromptFromTraits}
+      onProviderModelChange={onProviderModelSelect}
+      onSelectionCommitted={scheduleComposerFocus}
+      open={isComposerModelEffortPickerOpen}
+      onOpenChange={handleComposerModelEffortPickerOpenChange}
+      shortcutLabel={modelPickerShortcutLabel}
+    />
   );
   const toggleFastMode = useCallback(() => {
     if (!composerTraitSelection.caps.supportsFastMode) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -332,8 +332,8 @@ import { buildTurnDiffSummaryByAssistantMessageId } from "./chat/MessagesTimelin
 import { deriveAgentActivityTimelineState } from "./chat/agentActivity.logic";
 import { ComposerSlashStatusDialog } from "./chat/ComposerSlashStatusDialog";
 import { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
-import { AVAILABLE_PROVIDER_OPTIONS } from "./chat/ProviderModelPicker";
-import { ComposerModelEffortPicker } from "./chat/ComposerModelEffortPicker";
+import { AVAILABLE_PROVIDER_OPTIONS, ProviderModelPicker } from "./chat/ProviderModelPicker";
+import { TraitsPicker } from "./chat/TraitsPicker";
 import { ComposerCommandItem, ComposerCommandMenu } from "./chat/ComposerCommandMenu";
 import {
   ComposerLocalDirectoryMenu,
@@ -2950,8 +2950,6 @@ export default function ChatView({
     () => shortcutLabelForCommand(keybindings, "chat.split"),
     [keybindings],
   );
-  // The combined picker uses the same configurable keybinding command that the
-  // keydown handler resolves, keeping synced keybindings and tooltip labels aligned.
   const modelPickerShortcutLabel = useMemo(
     () =>
       shortcutLabelForCommand(keybindings, "modelPicker.toggle") ??
@@ -2963,6 +2961,10 @@ export default function ChatView({
         altKey: false,
         modKey: true,
       }),
+    [keybindings],
+  );
+  const traitsPickerShortcutLabel = useMemo(
+    () => shortcutLabelForCommand(keybindings, "traitsPicker.toggle"),
     [keybindings],
   );
   const onToggleDiff = useCallback(() => {
@@ -6907,55 +6909,54 @@ export default function ChatView({
       }),
     [runtimeUsageContextWindow, composerTraitSelection.contextWindow, selectedProvider],
   );
-  const composerModelEffortPickerWidthClassName = isComposerFooterCompact ? "w-40" : "w-44 sm:w-52";
-  const isComposerModelEffortPickerOpen = isModelPickerOpen || isTraitsPickerOpen;
-  // Both shortcuts (Mod+Shift+M and Mod+Shift+E) now drop into the same combined
-  // surface; clear both mirrors on close so the existing keyboard handler stays
-  // in sync without needing to know about the new picker.
-  const handleComposerModelEffortPickerOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        handleModelPickerOpenChange(true);
-      } else {
-        setIsModelPickerOpen(false);
-        setIsTraitsPickerOpen(false);
-      }
-    },
-    [handleModelPickerOpenChange],
-  );
-  const composerModelEffortPickerControl = showComposerModelBootstrapSkeleton ? (
-    selectedProviderRuntimeModelDiscoveryPending ? (
-      <ComposerModelLoadingControl widthClassName={composerModelEffortPickerWidthClassName} />
-    ) : (
-      <ComposerControlSkeleton widthClassName={composerModelEffortPickerWidthClassName} />
-    )
+  const composerModelPickerWidthClassName = isComposerFooterCompact ? "w-32" : "w-36 sm:w-44";
+  const composerOptionsPickerWidthClassName = isComposerFooterCompact ? "w-28" : "w-32";
+  const composerPickerControls = showComposerModelBootstrapSkeleton ? (
+    <>
+      {selectedProviderRuntimeModelDiscoveryPending ? (
+        <ComposerModelLoadingControl widthClassName={composerModelPickerWidthClassName} />
+      ) : (
+        <ComposerControlSkeleton widthClassName={composerModelPickerWidthClassName} />
+      )}
+      <ComposerControlSkeleton widthClassName={composerOptionsPickerWidthClassName} />
+    </>
   ) : (
-    <ComposerModelEffortPicker
-      compact={isComposerFooterCompact}
-      provider={selectedProvider}
-      model={selectedModelForPickerWithCustomFallback}
-      lockedProvider={lockedProvider}
-      providers={providerStatuses}
-      modelOptionsByProvider={modelOptionsByProvider}
-      loadingModelProviders={{
-        cursor: cursorModelDiscoveryPending,
-        kilo: kiloModelDiscoveryPending,
-      }}
-      hiddenProviders={settings.hiddenProviders}
-      providerOrder={settings.providerOrder}
-      threadId={threadId}
-      runtimeModel={selectedRuntimeModel}
-      runtimeModels={runtimeModelsByProvider[selectedProvider]}
-      runtimeAgents={dynamicAgents}
-      modelOptions={selectedProviderModelOptions}
-      prompt={prompt}
-      onPromptChange={setPromptFromTraits}
-      onProviderModelChange={onProviderModelSelect}
-      onSelectionCommitted={scheduleComposerFocus}
-      open={isComposerModelEffortPickerOpen}
-      onOpenChange={handleComposerModelEffortPickerOpenChange}
-      shortcutLabel={modelPickerShortcutLabel}
-    />
+    <>
+      <ProviderModelPicker
+        compact={isComposerFooterCompact}
+        provider={selectedProvider}
+        model={selectedModelForPickerWithCustomFallback}
+        lockedProvider={lockedProvider}
+        providers={providerStatuses}
+        modelOptionsByProvider={modelOptionsByProvider}
+        loadingModelProviders={{
+          cursor: cursorModelDiscoveryPending,
+          kilo: kiloModelDiscoveryPending,
+        }}
+        hiddenProviders={settings.hiddenProviders}
+        providerOrder={settings.providerOrder}
+        onProviderModelChange={onProviderModelSelect}
+        onSelectionCommitted={scheduleComposerFocus}
+        open={isModelPickerOpen}
+        onOpenChange={handleModelPickerOpenChange}
+        shortcutLabel={modelPickerShortcutLabel}
+      />
+      <TraitsPicker
+        provider={selectedProvider}
+        threadId={threadId}
+        model={selectedModelForPickerWithCustomFallback}
+        runtimeModel={selectedRuntimeModel}
+        runtimeModels={runtimeModelsByProvider[selectedProvider]}
+        runtimeAgents={dynamicAgents}
+        modelOptions={selectedProviderModelOptions}
+        prompt={prompt}
+        onPromptChange={setPromptFromTraits}
+        open={isTraitsPickerOpen}
+        onOpenChange={handleTraitsPickerOpenChange}
+        onSelectionCommitted={scheduleComposerFocus}
+        shortcutLabel={traitsPickerShortcutLabel}
+      />
+    </>
   );
   const toggleFastMode = useCallback(() => {
     if (!composerTraitSelection.caps.supportsFastMode) {
@@ -8186,7 +8187,7 @@ export default function ChatView({
                         />
                       ) : null}
                       {!isVoiceRecording && !isVoiceTranscribing
-                        ? composerModelEffortPickerControl
+                        ? composerPickerControls
                         : null}
                       {showVoiceNotesControl && (isVoiceRecording || isVoiceTranscribing) ? (
                         <ComposerVoiceRecorderBar

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
@@ -108,7 +108,7 @@ describe("CompactComposerControlsMenu", () => {
 
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
-      expect(text).toContain("Fast Mode");
+      expect(text).toContain("Speed");
       expect(text).toContain("Default");
       expect(text).toContain("Fast");
     });
@@ -122,7 +122,7 @@ describe("CompactComposerControlsMenu", () => {
     await page.getByLabelText("More composer controls").click();
 
     await vi.waitFor(() => {
-      expect(document.body.textContent ?? "").not.toContain("Fast Mode");
+      expect(document.body.textContent ?? "").not.toContain("Speed");
     });
   });
 

--- a/apps/web/src/components/chat/TraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.browser.tsx
@@ -159,7 +159,7 @@ describe("TraitsPicker (Claude)", () => {
 
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
-      expect(text).toContain("Fast Mode");
+      expect(text).toContain("Speed");
       expect(text).toContain("Default");
       expect(text).toContain("Fast");
     });
@@ -172,7 +172,7 @@ describe("TraitsPicker (Claude)", () => {
 
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
-      expect(text).toContain("Context Window");
+      expect(text).toContain("Context");
       expect(text).toContain("200k");
       expect(text).toContain("1M");
     });
@@ -184,7 +184,7 @@ describe("TraitsPicker (Claude)", () => {
     await page.getByRole("button").click();
 
     await vi.waitFor(() => {
-      expect(document.body.textContent ?? "").not.toContain("Fast Mode");
+      expect(document.body.textContent ?? "").not.toContain("Speed");
     });
   });
 
@@ -391,7 +391,7 @@ describe("TraitsPicker (Codex)", () => {
 
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
-      expect(text).toContain("Fast Mode");
+      expect(text).toContain("Speed");
       expect(text).toContain("Default");
       expect(text).toContain("Fast");
     });
@@ -521,7 +521,7 @@ describe("TraitsPicker (Cursor)", () => {
 
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
-      expect(text).toContain("Fast Mode");
+      expect(text).toContain("Speed");
       expect(text).toContain("Default");
       expect(text).toContain("Fast");
       expect(text).not.toMatch(/\bThinking\b/u);

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -11,9 +11,9 @@ import {
   type ThreadId,
 } from "@t3tools/contracts";
 import { applyClaudePromptEffortPrefix } from "@t3tools/shared/model";
-import { memo, useCallback, useState, type ReactNode } from "react";
+import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { IoFlash } from "react-icons/io5";
-import { ChevronDownIcon } from "~/lib/icons";
+import { ChevronDownIcon, SettingsIcon } from "~/lib/icons";
 import { Button } from "../ui/button";
 import {
   Menu,
@@ -289,7 +289,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
         <>
           {hasPriorFastModeSection ? <MenuDivider /> : null}
           <TraitRadioSection
-            label="Fast Mode"
+            label="Speed"
             value={fastModeEnabled ? "on" : "off"}
             options={[
               { value: "off", label: "Default" },
@@ -304,7 +304,7 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
         <>
           <MenuDivider />
           <TraitRadioSection
-            label="Context Window"
+            label="Context"
             value={contextWindow ?? defaultContextWindow ?? ""}
             options={contextWindowOptions.map((option) => ({
               value: option.value,
@@ -352,13 +352,16 @@ export const TraitsPicker = memo(function TraitsPicker({
   modelOptions,
   open,
   onOpenChange,
+  onSelectionCommitted,
   shortcutLabel,
 }: TraitsMenuContentProps & {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  onSelectionCommitted?: () => void;
   shortcutLabel?: string | null;
 }) {
   const [uncontrolledMenuOpen, setUncontrolledMenuOpen] = useState(false);
+  const selectionCommitTimerRef = useRef<number | null>(null);
   const isMenuOpen = open ?? uncontrolledMenuOpen;
   const setMenuOpen = useCallback(
     (nextOpen: boolean) => {
@@ -369,6 +372,27 @@ export const TraitsPicker = memo(function TraitsPicker({
     },
     [onOpenChange, open],
   );
+  const scheduleSelectionCommitted = useCallback(() => {
+    if (selectionCommitTimerRef.current !== null) {
+      window.clearTimeout(selectionCommitTimerRef.current);
+    }
+    selectionCommitTimerRef.current = window.setTimeout(() => {
+      selectionCommitTimerRef.current = null;
+      onSelectionCommitted?.();
+    }, 0);
+  }, [onSelectionCommitted]);
+  useEffect(
+    () => () => {
+      if (selectionCommitTimerRef.current !== null) {
+        window.clearTimeout(selectionCommitTimerRef.current);
+      }
+    },
+    [],
+  );
+  const handleSelectionComplete = useCallback(() => {
+    setMenuOpen(false);
+    scheduleSelectionCommitted();
+  }, [scheduleSelectionCommitted, setMenuOpen]);
   const {
     caps,
     effort,
@@ -428,25 +452,23 @@ export const TraitsPicker = memo(function TraitsPicker({
     <Button
       size="sm"
       variant="chrome"
-      className={
-        isCodexStyle
-          ? `min-w-0 max-w-40 shrink justify-start overflow-hidden whitespace-nowrap px-2 sm:max-w-48 sm:px-3 [&_svg]:mx-0 ${COMPOSER_PICKER_TRIGGER_TEXT_CLASS_NAME}`
-          : `shrink-0 whitespace-nowrap px-2 sm:px-3 ${COMPOSER_PICKER_TRIGGER_TEXT_CLASS_NAME}`
-      }
+      className={`min-w-0 shrink-0 justify-start overflow-hidden whitespace-nowrap px-2 sm:px-2.5 [&_svg]:mx-0 ${COMPOSER_PICKER_TRIGGER_TEXT_CLASS_NAME}`}
+      aria-label="Change effort, context, and speed"
     />
   );
 
   const triggerContent = isCodexStyle ? (
     <span className="flex min-w-0 w-full items-center gap-2 overflow-hidden">
+      <SettingsIcon aria-hidden="true" className="size-3.5 shrink-0 opacity-75" />
       <span className="min-w-0 flex flex-1 items-center gap-1.5 truncate">
         {visiblePrimaryTriggerLabel ? (
           <span className="truncate">{visiblePrimaryTriggerLabel}</span>
-        ) : null}
+        ) : (
+          <span className="truncate">Options</span>
+        )}
         {showsFastBadge ? (
           <>
-            {visiblePrimaryTriggerLabel ? (
-              <span className="shrink-0 text-muted-foreground/45">·</span>
-            ) : null}
+            <span className="shrink-0 text-muted-foreground/45">·</span>
             <span className="inline-flex shrink-0 items-center gap-1">
               <IoFlash aria-hidden="true" className="size-3 text-[hsl(var(--chart-4))]" />
               <span>Fast</span>
@@ -466,13 +488,12 @@ export const TraitsPicker = memo(function TraitsPicker({
     </span>
   ) : (
     <>
+      <SettingsIcon aria-hidden="true" className="size-3.5 opacity-75" />
       <span className="inline-flex items-center gap-1.5">
-        {visiblePrimaryTriggerLabel ? <span>{visiblePrimaryTriggerLabel}</span> : null}
+        <span>{visiblePrimaryTriggerLabel ?? "Options"}</span>
         {showsFastBadge ? (
           <>
-            {visiblePrimaryTriggerLabel ? (
-              <span className="text-muted-foreground/45">·</span>
-            ) : null}
+            <span className="text-muted-foreground/45">·</span>
             <span className="inline-flex items-center gap-1">
               <IoFlash aria-hidden="true" className="size-3 text-[hsl(var(--chart-4))]" />
               <span>Fast</span>
@@ -507,7 +528,7 @@ export const TraitsPicker = memo(function TraitsPicker({
           {!isMenuOpen ? (
             <ComposerPickerTooltipPopup side="top" sideOffset={6}>
               <span className="inline-flex items-center gap-2 px-1 py-0.5">
-                <span>Change reasoning</span>
+                <span>Change effort, context, and speed</span>
                 <ShortcutKbd
                   shortcutLabel={shortcutLabel}
                   className="h-4 min-w-4 px-1 text-[length:var(--app-font-size-ui-2xs,9px)] text-muted-foreground"
@@ -530,7 +551,7 @@ export const TraitsPicker = memo(function TraitsPicker({
           onPromptChange={onPromptChange}
           includeFastMode={includeFastMode}
           modelOptions={modelOptions}
-          onSelectionComplete={() => setMenuOpen(false)}
+          onSelectionComplete={handleSelectionComplete}
         />
       </ComposerPickerMenuPopup>
     </Menu>


### PR DESCRIPTION
## Summary
- Split the empty-thread composer control into a dedicated model picker and a separate options picker.
- Keep started and existing threads on the combined model/options trigger.
- Keep effort, context, and speed controls in the options picker for empty threads.
- Update picker browser expectations for the new labels.

## Verification
- git diff --check

Focused browser tests were not run in this follow-up.