### PR TITLE
Portable skills across providers (SYN-76)

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -717,9 +717,33 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
   private readonly modelCache = new Map<string, ProviderListModelsResult>();
 
   private runPromise: (effect: Effect.Effect<unknown, never>) => Promise<unknown>;
-  constructor(services?: ServiceMap.ServiceMap<never>) {
+  private readonly synaraSkillsDir: string | undefined;
+  constructor(
+    services?: ServiceMap.ServiceMap<never>,
+    options?: { readonly synaraSkillsDir?: string },
+  ) {
     super();
     this.runPromise = services ? Effect.runPromiseWith(services) : Effect.runPromise;
+    this.synaraSkillsDir = options?.synaraSkillsDir;
+  }
+
+  // Registers `~/.synara/skills` as a codex skill root so portable skills are
+  // first-class: skills/list returns them and turn/start `skill` items inject
+  // their instructions. Verified live: skill items with paths outside known
+  // roots are silently ignored by codex app-server, so this call is required.
+  private async registerSynaraSkillsRoot(context: CodexSessionContext): Promise<void> {
+    if (!this.synaraSkillsDir) {
+      return;
+    }
+    try {
+      await this.sendRequest(context, "skills/extraRoots/set", {
+        extraRoots: [this.synaraSkillsDir],
+      });
+    } catch (error) {
+      // Older codex builds (< extra-roots support) keep working; Synara-only
+      // skills simply stay invisible to codex on those versions.
+      console.log("codex skills/extraRoots/set unavailable", error);
+    }
   }
 
   async startSession(input: CodexAppServerStartSessionInput): Promise<ProviderSession> {
@@ -791,6 +815,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       await this.sendRequest(context, "initialize", buildCodexInitializeParams());
 
       this.writeMessage(context, { method: "initialized" });
+      await this.registerSynaraSkillsRoot(context);
       try {
         const modelListResponse = await this.sendRequest(context, "model/list", {});
         console.log("codex model/list response", modelListResponse);
@@ -1407,6 +1432,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
       await this.sendRequest(context, "initialize", buildCodexInitializeParams());
       this.writeMessage(context, { method: "initialized" });
+      await this.registerSynaraSkillsRoot(context);
       try {
         const accountReadResponse = await this.sendRequest(context, "account/read", {});
         context.account = readCodexAccountSnapshot(accountReadResponse);
@@ -1997,6 +2023,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     try {
       await this.sendRequest(context, "initialize", buildCodexInitializeParams());
       this.writeMessage(context, { method: "initialized" });
+      await this.registerSynaraSkillsRoot(context);
       try {
         const accountReadResponse = await this.sendRequest(context, "account/read", {});
         context.account = readCodexAccountSnapshot(accountReadResponse);

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -41,6 +41,7 @@ import {
 import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import { ProviderAdapterRequestError, ProviderServiceError } from "../../provider/Errors.ts";
+import { buildInlineSkillInstructions } from "../../provider/skillPromptInjection.ts";
 import {
   TextGeneration,
   type BranchNameGenerationInput,
@@ -933,10 +934,35 @@ const make = Effect.gen(function* () {
         : priorTranscriptBootstrapText
           ? `<thread_context>\n${priorTranscriptBootstrapText}\n</thread_context>\n\n<latest_user_message>\n${boundaryMessageText}\n</latest_user_message>`
           : boundaryMessageText;
+    // Portable skills fallback: providers that cannot load the referenced skill
+    // file natively get the skill instructions inlined into the prompt.
+    const skillInlineText =
+      input.skills !== undefined && input.skills.length > 0
+        ? yield* Effect.tryPromise(() =>
+            buildInlineSkillInstructions({
+              provider: selectedProvider as ProviderKind,
+              skills: input.skills ?? [],
+              maxChars: Math.max(
+                0,
+                PROVIDER_SEND_TURN_MAX_INPUT_CHARS - providerInput.length - 1_000,
+              ),
+            }),
+          ).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("failed to inline portable skill instructions", {
+                threadId: input.threadId,
+                error,
+              }).pipe(Effect.as("")),
+            ),
+          )
+        : "";
+    const providerInputWithSkills = skillInlineText
+      ? `${providerInput}\n\n${skillInlineText}`
+      : providerInput;
     const normalizedInput = toNonEmptyProviderInput(
       normalizeSkillMentionTextForProvider({
         provider: selectedProvider as ProviderKind,
-        messageText: providerInput,
+        messageText: providerInputWithSkills,
         ...(input.skills !== undefined ? { skills: input.skills } : {}),
       }),
     );
@@ -1057,10 +1083,13 @@ const make = Effect.gen(function* () {
             const retryProviderInput = retryBootstrapText
               ? `<thread_context>\n${retryBootstrapText}\n</thread_context>\n\n<latest_user_message>\n${boundaryMessageText}\n</latest_user_message>`
               : boundaryMessageText;
+            const retryProviderInputWithSkills = skillInlineText
+              ? `${retryProviderInput}\n\n${skillInlineText}`
+              : retryProviderInput;
             const retryNormalizedInput = toNonEmptyProviderInput(
               normalizeSkillMentionTextForProvider({
                 provider: selectedProvider as ProviderKind,
-                messageText: retryProviderInput,
+                messageText: retryProviderInputWithSkills,
                 ...(input.skills !== undefined ? { skills: input.skills } : {}),
               }),
             );

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -53,6 +53,7 @@ import {
 import { isNonFatalCodexErrorMessage } from "../../codexErrorClassification.ts";
 import { ServerConfig } from "../../config.ts";
 import { extractProposedPlanMarkdown } from "../planMode.ts";
+import { synaraSkillsDir } from "../skillsCatalog.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 
 const PROVIDER = "codex" as const;
@@ -1556,7 +1557,12 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
           return options.manager;
         }
         const services = yield* Effect.services<never>();
-        return options?.makeManager?.(services) ?? new CodexAppServerManager(services);
+        return (
+          options?.makeManager?.(services) ??
+          new CodexAppServerManager(services, {
+            synaraSkillsDir: synaraSkillsDir(serverConfig.baseDir),
+          })
+        );
       }),
       (manager) =>
         Effect.sync(() => {

--- a/apps/server/src/provider/Layers/ProviderDiscoveryService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderDiscoveryService.test.ts
@@ -1,0 +1,193 @@
+// FILE: ProviderDiscoveryService.test.ts
+// Purpose: Verifies the discovery service merges provider-native skills with the
+//          unified Synara catalog, filters user-disabled skills, and reports
+//          skill discovery as supported for every provider.
+// Layer: Server provider tests
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type {
+  ProviderComposerCapabilities,
+  ProviderKind,
+  ProviderListSkillsResult,
+} from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { deriveServerPaths, ServerConfig, type ServerConfigShape } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import type { ProviderAdapterError } from "../Errors.ts";
+import { ProviderAdapterRequestError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
+import { ProviderDiscoveryService } from "../Services/ProviderDiscoveryService.ts";
+import { clearSkillsCatalogCacheForTests } from "../skillsCatalog.ts";
+import { ProviderDiscoveryServiceLive } from "./ProviderDiscoveryService.ts";
+
+let root: string;
+let homeDir: string;
+let baseDir: string;
+let cwd: string;
+
+async function writeSkill(skillDir: string, name: string): Promise<void> {
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(
+    path.join(skillDir, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${name} description\n---\n\n# ${name}\n`,
+  );
+}
+
+const makeConfigLayer = () =>
+  Layer.effect(
+    ServerConfig,
+    Effect.gen(function* () {
+      const derived = yield* deriveServerPaths(baseDir, undefined);
+      return {
+        mode: "web",
+        port: 0,
+        host: undefined,
+        cwd,
+        homeDir,
+        baseDir,
+        ...derived,
+        staticDir: undefined,
+        devUrl: undefined,
+        noBrowser: true,
+        authToken: undefined,
+        autoBootstrapProjectFromCwd: false,
+        logProviderEvents: false,
+        logWebSocketEvents: false,
+      } satisfies ServerConfigShape;
+    }),
+  );
+
+const makeRegistryLayer = (adapter: Partial<ProviderAdapterShape<ProviderAdapterError>>) =>
+  Layer.succeed(ProviderAdapterRegistry, {
+    getByProvider: () => Effect.succeed(adapter as ProviderAdapterShape<ProviderAdapterError>),
+    listProviders: () => Effect.succeed([]),
+  });
+
+const runListSkills = (input: {
+  adapter: Partial<ProviderAdapterShape<ProviderAdapterError>>;
+  disabled?: string[];
+  provider: ProviderKind;
+}) => {
+  const baseLayer = Layer.mergeAll(
+    makeConfigLayer(),
+    ServerSettingsService.layerTest({ skills: { disabled: input.disabled ?? [] } }),
+    makeRegistryLayer(input.adapter),
+  ).pipe(Layer.provideMerge(NodeServices.layer));
+  const testLayer = ProviderDiscoveryServiceLive.pipe(Layer.provideMerge(baseLayer));
+  const program = Effect.gen(function* () {
+    const discovery = yield* ProviderDiscoveryService;
+    return yield* discovery.listSkills({ provider: input.provider, cwd });
+  }).pipe(Effect.provide(testLayer));
+  return Effect.runPromise(
+    program as unknown as Effect.Effect<ProviderListSkillsResult, never, never>,
+  );
+};
+
+beforeEach(async () => {
+  clearSkillsCatalogCacheForTests();
+  root = mkdtempSync(path.join(os.tmpdir(), "discovery-service-"));
+  homeDir = path.join(root, "home");
+  baseDir = path.join(homeDir, ".synara");
+  cwd = path.join(root, "repo");
+  await mkdir(cwd, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("ProviderDiscoveryService.listSkills", () => {
+  it("serves the unified catalog for providers without native skill discovery", async () => {
+    await writeSkill(path.join(baseDir, "skills", "portable"), "portable");
+
+    const result = await runListSkills({ adapter: {}, provider: "gemini" });
+
+    expect(result.skills.map((skill) => skill.name)).toEqual(["portable"]);
+  });
+
+  it("prefers provider-native entries and appends catalog-only skills", async () => {
+    await writeSkill(path.join(baseDir, "skills", "shared"), "shared");
+    await writeSkill(path.join(baseDir, "skills", "portable"), "portable");
+
+    const nativeShared = {
+      name: "shared",
+      path: path.join(homeDir, ".codex", "skills", "shared", "SKILL.md"),
+      enabled: true,
+      scope: "user",
+    };
+    const result = await runListSkills({
+      adapter: {
+        listSkills: () =>
+          Effect.succeed({ skills: [nativeShared], source: "codex-app-server", cached: false }),
+      },
+      provider: "codex",
+    });
+
+    const shared = result.skills.find((skill) => skill.name === "shared");
+    expect(shared?.path).toBe(nativeShared.path);
+    expect(result.skills.some((skill) => skill.name === "portable")).toBe(true);
+  });
+
+  it("filters user-disabled skills from merged results", async () => {
+    await writeSkill(path.join(baseDir, "skills", "portable"), "portable");
+    await writeSkill(path.join(baseDir, "skills", "muted"), "muted");
+
+    const result = await runListSkills({
+      adapter: {},
+      disabled: ["Muted"],
+      provider: "opencode",
+    });
+
+    expect(result.skills.map((skill) => skill.name)).toEqual(["portable"]);
+  });
+
+  it("falls back to the catalog when native discovery fails", async () => {
+    await writeSkill(path.join(baseDir, "skills", "portable"), "portable");
+
+    const result = await runListSkills({
+      adapter: {
+        listSkills: () =>
+          Effect.fail(
+            new ProviderAdapterRequestError({
+              provider: "codex",
+              method: "skills/list",
+              detail: "codex binary missing",
+            }),
+          ),
+      },
+      provider: "codex",
+    });
+
+    expect(result.skills.map((skill) => skill.name)).toEqual(["portable"]);
+  });
+});
+
+describe("ProviderDiscoveryService.getComposerCapabilities", () => {
+  it("reports skill discovery as supported even when the adapter declines it", async () => {
+    const baseLayer = Layer.mergeAll(
+      makeConfigLayer(),
+      ServerSettingsService.layerTest(),
+      makeRegistryLayer({}),
+    ).pipe(Layer.provideMerge(NodeServices.layer));
+    const testLayer = ProviderDiscoveryServiceLive.pipe(Layer.provideMerge(baseLayer));
+
+    const program = Effect.gen(function* () {
+      const discovery = yield* ProviderDiscoveryService;
+      return yield* discovery.getComposerCapabilities({ provider: "grok" });
+    }).pipe(Effect.provide(testLayer));
+    const capabilities = await Effect.runPromise(
+      program as unknown as Effect.Effect<ProviderComposerCapabilities, never, never>,
+    );
+
+    expect(capabilities.supportsSkillDiscovery).toBe(true);
+    expect(capabilities.supportsSkillMentions).toBe(true);
+  });
+});

--- a/apps/server/src/provider/Layers/ProviderDiscoveryService.ts
+++ b/apps/server/src/provider/Layers/ProviderDiscoveryService.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_SERVER_SETTINGS,
   type ProviderComposerCapabilities,
   ProviderGetComposerCapabilitiesInput,
   ProviderListAgentsInput,
@@ -6,16 +7,25 @@ import {
   ProviderListModelsInput,
   ProviderListPluginsInput,
   ProviderListSkillsInput,
+  type ProviderListSkillsResult,
   ProviderReadPluginInput,
+  type ProviderSkillDescriptor,
 } from "@t3tools/contracts";
 import { Effect, Layer, Schema, SchemaIssue } from "effect";
 
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
 import { ProviderValidationError } from "../Errors.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import {
   ProviderDiscoveryService,
   type ProviderDiscoveryServiceShape,
 } from "../Services/ProviderDiscoveryService.ts";
+import {
+  discoverSkillsCatalog,
+  filterDisabledSkills,
+  mergeSkillsIntoCatalog,
+} from "../skillsCatalog.ts";
 
 const decodeInputOrValidationError = <S extends Schema.Top>(input: {
   readonly operation: string;
@@ -49,6 +59,8 @@ const disabledCapabilitiesForProvider = (
 
 const make = Effect.gen(function* () {
   const registry = yield* ProviderAdapterRegistry;
+  const serverConfig = yield* ServerConfig;
+  const serverSettings = yield* ServerSettingsService;
 
   const getComposerCapabilities: ProviderDiscoveryServiceShape["getComposerCapabilities"] = (
     input,
@@ -60,10 +72,16 @@ const make = Effect.gen(function* () {
         payload: input,
       });
       const adapter = yield* registry.getByProvider(parsed.provider);
-      if (adapter.getComposerCapabilities) {
-        return yield* adapter.getComposerCapabilities();
-      }
-      return disabledCapabilitiesForProvider(parsed.provider);
+      const capabilities = adapter.getComposerCapabilities
+        ? yield* adapter.getComposerCapabilities()
+        : disabledCapabilitiesForProvider(parsed.provider);
+      // The unified Synara skills catalog backs skill discovery for every
+      // provider, including ones without native skill support.
+      return {
+        ...capabilities,
+        supportsSkillMentions: true,
+        supportsSkillDiscovery: true,
+      };
     });
 
   const listSkills: ProviderDiscoveryServiceShape["listSkills"] = (input) =>
@@ -74,14 +92,46 @@ const make = Effect.gen(function* () {
         payload: input,
       });
       const adapter = yield* registry.getByProvider(parsed.provider);
-      if (!adapter.listSkills) {
-        return {
-          skills: [],
-          source: "unsupported",
-          cached: false,
-        };
-      }
-      return yield* adapter.listSkills(parsed);
+      const nativeResult: ProviderListSkillsResult | null = adapter.listSkills
+        ? yield* adapter
+            .listSkills(parsed)
+            .pipe(
+              Effect.catch((error) =>
+                Effect.logWarning(
+                  "provider-native skill discovery failed; serving the Synara skills catalog only",
+                  { provider: parsed.provider, error },
+                ).pipe(Effect.as(null)),
+              ),
+            )
+        : null;
+      const catalogSkills = yield* Effect.tryPromise(() =>
+        discoverSkillsCatalog({
+          cwd: parsed.cwd,
+          homeDir: serverConfig.homeDir,
+          synaraBaseDir: serverConfig.baseDir,
+          provider: parsed.provider,
+          ...(parsed.forceReload !== undefined ? { forceReload: parsed.forceReload } : {}),
+        }),
+      ).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("synara skills catalog discovery failed", {
+            provider: parsed.provider,
+            cause,
+          }).pipe(Effect.as([] as ProviderSkillDescriptor[])),
+        ),
+      );
+      const merged = mergeSkillsIntoCatalog({
+        native: nativeResult?.skills ?? [],
+        catalog: catalogSkills,
+      });
+      const settings = yield* serverSettings.getSettings.pipe(
+        Effect.orElseSucceed(() => DEFAULT_SERVER_SETTINGS),
+      );
+      return {
+        skills: filterDisabledSkills(merged, settings.skills.disabled),
+        source: nativeResult?.source ? `${nativeResult.source}+synara.catalog` : "synara.catalog",
+        cached: nativeResult?.cached ?? false,
+      } satisfies ProviderListSkillsResult;
     });
 
   const listCommands: ProviderDiscoveryServiceShape["listCommands"] = (input) =>

--- a/apps/server/src/provider/cursorSkillsDiscovery.test.ts
+++ b/apps/server/src/provider/cursorSkillsDiscovery.test.ts
@@ -1,7 +1,8 @@
 // FILE: cursorSkillsDiscovery.test.ts
 // Purpose: Verifies Cursor filesystem skill discovery without starting Cursor ACP.
 // Layer: Server provider tests
-// Exports: Vitest cases for cursorSkillsDiscovery.
+// Exports: Vitest cases for cursorSkillsDiscovery (frontmatter parsing is covered
+// in skillsCatalog.test.ts where the parser now lives).
 
 import { mkdtempSync, rmSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
@@ -10,26 +11,7 @@ import * as path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { discoverCursorSkills, parseSkillFrontmatter } from "./cursorSkillsDiscovery.ts";
-
-describe("parseSkillFrontmatter", () => {
-  it("parses scalar Agent Skill metadata", () => {
-    expect(
-      parseSkillFrontmatter(`---
-name: check-code
-description: "Review recent code changes"
-disable-model-invocation: true
----
-
-# Check Code
-`),
-    ).toEqual({
-      name: "check-code",
-      description: "Review recent code changes",
-      "disable-model-invocation": true,
-    });
-  });
-});
+import { discoverCursorSkills } from "./cursorSkillsDiscovery.ts";
 
 describe("discoverCursorSkills", () => {
   it("discovers project, nested, and user Cursor skill folders", async () => {
@@ -85,6 +67,35 @@ description: Help globally
         enabled: true,
         scope: "project",
       });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the personal scope when the cwd lives under the home dir", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "cursor-skills-home-"));
+    const homeDir = path.join(root, "home");
+    const cwd = path.join(homeDir, "projects", "app");
+    const userSkill = path.join(homeDir, ".cursor", "skills", "global-helper");
+
+    try {
+      await mkdir(userSkill, { recursive: true });
+      await mkdir(cwd, { recursive: true });
+      await writeFile(
+        path.join(userSkill, "SKILL.md"),
+        `---
+name: global-helper
+description: Help globally
+---
+
+# Global Helper
+`,
+      );
+
+      const skills = await discoverCursorSkills({ cwd, homeDir });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0]).toMatchObject({ name: "global-helper", scope: "personal" });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/server/src/provider/cursorSkillsDiscovery.ts
+++ b/apps/server/src/provider/cursorSkillsDiscovery.ts
@@ -1,230 +1,45 @@
 // FILE: cursorSkillsDiscovery.ts
-// Purpose: Finds Cursor-compatible Agent Skill folders from project and user skill roots.
+// Purpose: Finds Cursor-compatible Agent Skill folders from project and user skill roots,
+//          mirroring the roots cursor-agent scans natively.
 // Layer: Server provider discovery helper
-// Exports: discoverCursorSkills plus frontmatter parsing helpers for tests.
+// Exports: discoverCursorSkills (generic primitives live in skillsCatalog.ts).
 
-import * as fs from "node:fs/promises";
 import * as nodePath from "node:path";
 
 import type { ProviderSkillDescriptor } from "@t3tools/contracts";
 
-type FrontmatterValue = string | boolean;
+import { ancestorsFromDeepest, collectSkillsFromRoots, type SkillRoot } from "./skillsCatalog.ts";
 
 export interface CursorSkillDiscoveryInput {
   readonly cwd: string;
   readonly homeDir: string;
 }
 
-interface SkillRoot {
-  readonly path: string;
-  readonly scope: string;
-}
-
-function stripYamlQuotes(value: string): string {
-  const trimmed = value.trim();
-  if (
-    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
-    (trimmed.startsWith("'") && trimmed.endsWith("'"))
-  ) {
-    return trimmed.slice(1, -1).trim();
-  }
-  return trimmed;
-}
-
-function parseYamlScalar(value: string): FrontmatterValue {
-  const unquoted = stripYamlQuotes(value);
-  const normalized = unquoted.toLowerCase();
-  if (normalized === "true") return true;
-  if (normalized === "false") return false;
-  return unquoted;
-}
-
-// Parses the small scalar frontmatter subset used by Agent Skills without pulling in YAML.
-export function parseSkillFrontmatter(markdown: string): Record<string, FrontmatterValue> {
-  const normalized = markdown.replace(/\r\n/g, "\n");
-  const match = /^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/.exec(normalized);
-  if (!match) {
-    return {};
-  }
-
-  const record: Record<string, FrontmatterValue> = {};
-  for (const line of (match[1] ?? "").split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
-    const separatorIndex = trimmed.indexOf(":");
-    if (separatorIndex <= 0) {
-      continue;
-    }
-    const key = trimmed.slice(0, separatorIndex).trim();
-    const value = trimmed.slice(separatorIndex + 1).trim();
-    if (!key || !value) {
-      continue;
-    }
-    record[key] = parseYamlScalar(value);
-  }
-  return record;
-}
-
-function readStringField(
-  frontmatter: Record<string, FrontmatterValue>,
-  keys: ReadonlyArray<string>,
-): string | undefined {
-  for (const key of keys) {
-    const value = frontmatter[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      return value.trim();
-    }
-  }
-  return undefined;
-}
-
-function readBooleanField(
-  frontmatter: Record<string, FrontmatterValue>,
-  keys: ReadonlyArray<string>,
-): boolean | undefined {
-  for (const key of keys) {
-    const value = frontmatter[key];
-    if (typeof value === "boolean") {
-      return value;
-    }
-  }
-  return undefined;
-}
-
-function ancestorsFromDeepest(cwd: string): string[] {
-  const resolved = nodePath.resolve(cwd);
-  const ancestors: string[] = [];
-  let current = resolved;
-  while (true) {
-    ancestors.push(current);
-    const parent = nodePath.dirname(current);
-    if (parent === current) {
-      return ancestors;
-    }
-    current = parent;
-  }
-}
-
 function cursorSkillRoots(input: CursorSkillDiscoveryInput): SkillRoot[] {
-  const projectRootNames = [".cursor", ".agents", ".claude", ".codex"] as const;
-  const projectRoots = ancestorsFromDeepest(input.cwd).flatMap((ancestor) =>
-    projectRootNames.map((rootName) => ({
-      path: nodePath.join(ancestor, rootName, "skills"),
-      scope: "project",
-    })),
-  );
-
-  return [
-    ...projectRoots,
+  const homeRoots: SkillRoot[] = [
     { path: nodePath.join(input.homeDir, ".cursor", "skills-cursor"), scope: "cursor" },
     { path: nodePath.join(input.homeDir, ".cursor", "skills"), scope: "personal" },
     { path: nodePath.join(input.homeDir, ".agents", "skills"), scope: "personal" },
     { path: nodePath.join(input.homeDir, ".claude", "skills"), scope: "personal" },
     { path: nodePath.join(input.homeDir, ".codex", "skills"), scope: "personal" },
   ];
-}
+  const homeRootPaths = new Set(homeRoots.map((root) => nodePath.resolve(root.path)));
 
-async function readdirOrEmpty(path: string): Promise<import("node:fs").Dirent[]> {
-  try {
-    return await fs.readdir(path, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-}
+  const projectRootNames = [".cursor", ".agents", ".claude", ".codex"] as const;
+  // A cwd under the home dir reaches the home skill folders as "project
+  // ancestors"; skip them so each folder is scanned once with its true scope.
+  const projectRoots = ancestorsFromDeepest(input.cwd).flatMap((ancestor) =>
+    projectRootNames
+      .map((rootName) => nodePath.join(ancestor, rootName, "skills"))
+      .filter((rootPath) => !homeRootPaths.has(nodePath.resolve(rootPath)))
+      .map((rootPath) => ({ path: rootPath, scope: "project" })),
+  );
 
-// Cursor skills may be nested one namespace deep, e.g. `.cursor/skills/skills-sh/find-skills`.
-async function collectSkillMarkdownPaths(rootPath: string): Promise<string[]> {
-  const skillPaths: string[] = [];
-
-  async function visit(dir: string, depth: number): Promise<void> {
-    const skillPath = nodePath.join(dir, "SKILL.md");
-    try {
-      const stat = await fs.stat(skillPath);
-      if (stat.isFile()) {
-        skillPaths.push(skillPath);
-        return;
-      }
-    } catch {
-      // Keep walking; this directory may be a namespace rather than a skill.
-    }
-
-    if (depth >= 2) {
-      return;
-    }
-
-    const dirents = await readdirOrEmpty(dir);
-    await Promise.all(
-      dirents
-        .filter((dirent) => dirent.isDirectory())
-        .map((dirent) => visit(nodePath.join(dir, dirent.name), depth + 1)),
-    );
-  }
-
-  await visit(rootPath, 0);
-  return skillPaths;
-}
-
-async function readSkillDescriptor(input: {
-  readonly skillPath: string;
-  readonly scope: string;
-}): Promise<ProviderSkillDescriptor | null> {
-  let raw: string;
-  try {
-    raw = await fs.readFile(input.skillPath, "utf8");
-  } catch {
-    return null;
-  }
-
-  const frontmatter = parseSkillFrontmatter(raw);
-  const fallbackName = nodePath.basename(nodePath.dirname(input.skillPath));
-  const name = readStringField(frontmatter, ["name"]) ?? fallbackName;
-  const description = readStringField(frontmatter, ["description"]);
-  const displayName = readStringField(frontmatter, ["display-name", "displayName", "title"]);
-  const shortDescription = readStringField(frontmatter, [
-    "short-description",
-    "shortDescription",
-    "summary",
-  ]);
-  const disabled =
-    readBooleanField(frontmatter, ["disable-model-invocation", "disableModelInvocation"]) === true;
-
-  return {
-    name,
-    ...(description ? { description } : {}),
-    path: input.skillPath,
-    enabled: !disabled,
-    scope: input.scope,
-    ...(displayName || shortDescription
-      ? {
-          interface: {
-            ...(displayName ? { displayName } : {}),
-            ...(shortDescription ? { shortDescription } : {}),
-          },
-        }
-      : {}),
-  };
+  return [...projectRoots, ...homeRoots];
 }
 
 export async function discoverCursorSkills(
   input: CursorSkillDiscoveryInput,
 ): Promise<ProviderSkillDescriptor[]> {
-  const byName = new Map<string, ProviderSkillDescriptor>();
-
-  for (const root of cursorSkillRoots(input)) {
-    const skillPaths = await collectSkillMarkdownPaths(root.path);
-    for (const skillPath of skillPaths) {
-      const skill = await readSkillDescriptor({ skillPath, scope: root.scope });
-      if (!skill) {
-        continue;
-      }
-      const key = skill.name.toLowerCase();
-      if (!byName.has(key)) {
-        byName.set(key, skill);
-      }
-    }
-  }
-
-  return [...byName.values()];
+  return collectSkillsFromRoots(cursorSkillRoots(input));
 }

--- a/apps/server/src/provider/runtimeLayer.ts
+++ b/apps/server/src/provider/runtimeLayer.ts
@@ -1,8 +1,9 @@
-import { Effect, FileSystem, Layer } from "effect";
+import { Effect, FileSystem, Layer, Path } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { ServerConfig } from "../config";
+import { ServerSettingsLive } from "../serverSettings";
 import { AnalyticsService } from "../telemetry/Services/AnalyticsService";
 import { ProviderUnsupportedError } from "./Errors";
 import { makeClaudeAdapterLive } from "./Layers/ClaudeAdapter";
@@ -29,6 +30,7 @@ export function makeServerProviderLayer(): Layer.Layer<
   | SqlClient.SqlClient
   | ServerConfig
   | FileSystem.FileSystem
+  | Path.Path
   | AnalyticsService
   | ChildProcessSpawner.ChildProcessSpawner
 > {
@@ -87,6 +89,9 @@ export function makeServerProviderLayer(): Layer.Layer<
     ).pipe(Layer.provide(adapterRegistryLayer), Layer.provide(providerSessionDirectoryLayer));
     const providerDiscoveryLayer = ProviderDiscoveryServiceLive.pipe(
       Layer.provide(adapterRegistryLayer),
+      // Skill toggles live in server settings; the shared ServerSettingsLive
+      // layer is memoized so this reuses the instance built at the top level.
+      Layer.provide(ServerSettingsLive),
     );
     return Layer.mergeAll(
       providerServiceLayer,

--- a/apps/server/src/provider/skillPromptInjection.test.ts
+++ b/apps/server/src/provider/skillPromptInjection.test.ts
@@ -1,0 +1,114 @@
+// FILE: skillPromptInjection.test.ts
+// Purpose: Verifies which providers receive inlined portable skill instructions
+//          and that the inline text respects the turn character budget.
+// Layer: Server provider tests
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildInlineSkillInstructions,
+  shouldInlineSkillForProvider,
+} from "./skillPromptInjection.ts";
+
+const synaraSkillPath = "/Users/me/.synara/skills/reviewer/SKILL.md";
+const codexSkillPath = "/Users/me/.codex/skills/reviewer/SKILL.md";
+const claudeSkillPath = "/Users/me/.claude/skills/reviewer/SKILL.md";
+const cursorSkillPath = "/Users/me/.cursor/skills/reviewer/SKILL.md";
+const piSkillPath = "/Users/me/.pi/agent/skills/reviewer/SKILL.md";
+
+describe("shouldInlineSkillForProvider", () => {
+  it("skips codex-native and synara roots for codex but inlines foreign provider roots", () => {
+    // Codex loads .codex roots natively and ~/.synara/skills via the extra
+    // skill root registered at session start.
+    expect(shouldInlineSkillForProvider("codex", synaraSkillPath)).toBe(false);
+    expect(shouldInlineSkillForProvider("codex", codexSkillPath)).toBe(false);
+    expect(shouldInlineSkillForProvider("codex", claudeSkillPath)).toBe(true);
+    expect(shouldInlineSkillForProvider("codex", cursorSkillPath)).toBe(true);
+  });
+
+  it("inlines only Synara-owned paths for cursor", () => {
+    expect(shouldInlineSkillForProvider("cursor", synaraSkillPath)).toBe(true);
+    expect(shouldInlineSkillForProvider("cursor", cursorSkillPath)).toBe(false);
+    expect(shouldInlineSkillForProvider("cursor", codexSkillPath)).toBe(false);
+  });
+
+  it("inlines everything except .claude paths for claudeAgent", () => {
+    expect(shouldInlineSkillForProvider("claudeAgent", claudeSkillPath)).toBe(false);
+    expect(shouldInlineSkillForProvider("claudeAgent", synaraSkillPath)).toBe(true);
+    expect(shouldInlineSkillForProvider("claudeAgent", codexSkillPath)).toBe(true);
+  });
+
+  it("inlines cross-provider paths for pi but not pi-native skills", () => {
+    expect(shouldInlineSkillForProvider("pi", synaraSkillPath)).toBe(true);
+    expect(shouldInlineSkillForProvider("pi", claudeSkillPath)).toBe(true);
+    expect(shouldInlineSkillForProvider("pi", piSkillPath)).toBe(false);
+  });
+
+  it("always inlines for providers without native skill support", () => {
+    for (const provider of ["gemini", "grok", "kilo", "opencode"] as const) {
+      expect(shouldInlineSkillForProvider(provider, synaraSkillPath)).toBe(true);
+      expect(shouldInlineSkillForProvider(provider, claudeSkillPath)).toBe(true);
+    }
+  });
+});
+
+describe("buildInlineSkillInstructions", () => {
+  it("inlines skill content for non-native providers and skips unreadable paths", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "skill-inline-"));
+    const skillDir = path.join(root, ".synara", "skills", "reviewer");
+    try {
+      await mkdir(skillDir, { recursive: true });
+      const skillPath = path.join(skillDir, "SKILL.md");
+      await writeFile(skillPath, "# Reviewer\n\nAlways review carefully.");
+
+      const text = await buildInlineSkillInstructions({
+        provider: "gemini",
+        skills: [
+          { name: "reviewer", path: skillPath },
+          { name: "missing", path: path.join(root, ".synara", "skills", "missing", "SKILL.md") },
+        ],
+        maxChars: 10_000,
+      });
+
+      expect(text).toContain('<skill name="reviewer"');
+      expect(text).toContain("Always review carefully.");
+      expect(text).not.toContain("missing");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty text when nothing fits in the budget", async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "skill-inline-budget-"));
+    const skillDir = path.join(root, ".synara", "skills", "reviewer");
+    try {
+      await mkdir(skillDir, { recursive: true });
+      const skillPath = path.join(skillDir, "SKILL.md");
+      await writeFile(skillPath, "content".repeat(100));
+
+      const text = await buildInlineSkillInstructions({
+        provider: "gemini",
+        skills: [{ name: "reviewer", path: skillPath }],
+        maxChars: 50,
+      });
+
+      expect(text).toBe("");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not inline synara-rooted skills for codex (covered by the extra skill root)", async () => {
+    const text = await buildInlineSkillInstructions({
+      provider: "codex",
+      skills: [{ name: "reviewer", path: synaraSkillPath }],
+      maxChars: 10_000,
+    });
+    expect(text).toBe("");
+  });
+});

--- a/apps/server/src/provider/skillPromptInjection.ts
+++ b/apps/server/src/provider/skillPromptInjection.ts
@@ -1,0 +1,95 @@
+// FILE: skillPromptInjection.ts
+// Purpose: Inlines portable skill instructions into the outgoing prompt for providers
+//          that cannot natively load the referenced skill files. This is the fallback
+//          that makes Synara catalog skills usable on every provider.
+// Layer: Server provider helper
+// Exports: shouldInlineSkillForProvider, buildInlineSkillInstructions
+
+import * as fs from "node:fs/promises";
+import * as nodePath from "node:path";
+
+import type { ProviderKind, ProviderSkillReference } from "@t3tools/contracts";
+
+// Per-skill cap keeps a single oversized SKILL.md from eating the turn budget.
+const MAX_INLINE_SKILL_CONTENT_CHARS = 24_000;
+
+const INLINE_SKILLS_HEADER =
+  "The user invoked the following agent skill(s) for this request. Follow each " +
+  "skill's instructions. File paths referenced inside a skill are relative to its " +
+  '"dir" attribute.';
+
+const CROSS_PROVIDER_SKILL_DIR_NAMES = [
+  ".synara",
+  ".codex",
+  ".cursor",
+  ".claude",
+  ".agents",
+] as const;
+
+function pathSegments(path: string): Set<string> {
+  return new Set(nodePath.normalize(path).split(/[\\/]+/));
+}
+
+export function shouldInlineSkillForProvider(provider: ProviderKind, skillPath: string): boolean {
+  const segments = pathSegments(skillPath);
+  switch (provider) {
+    case "codex":
+      // Codex injects structured skill items only from roots it knows: its own
+      // folders plus `~/.synara/skills`, which Synara registers at session start
+      // via skills/extraRoots/set. Skills resolved from other providers' folders
+      // must be inlined.
+      return [".claude", ".cursor", ".agents"].some((dir) => segments.has(dir));
+    case "cursor":
+      // cursor-agent natively scans .cursor/.agents/.claude/.codex skill roots;
+      // only Synara-owned paths need inlining.
+      return segments.has(".synara");
+    case "claudeAgent":
+      // Claude Code only loads skills from .claude/skills folders.
+      return !segments.has(".claude");
+    case "pi":
+      // Pi loads its own skill set; anything resolved from a cross-provider
+      // folder is portable and must be inlined.
+      return CROSS_PROVIDER_SKILL_DIR_NAMES.some((dir) => segments.has(dir));
+    default:
+      // gemini/grok/kilo/opencode have no native skill support.
+      return true;
+  }
+}
+
+export async function buildInlineSkillInstructions(input: {
+  readonly provider: ProviderKind;
+  readonly skills: ReadonlyArray<ProviderSkillReference>;
+  readonly maxChars: number;
+}): Promise<string> {
+  const inlineSkills = input.skills.filter((skill) =>
+    shouldInlineSkillForProvider(input.provider, skill.path),
+  );
+  if (inlineSkills.length === 0 || input.maxChars <= 0) {
+    return "";
+  }
+
+  let text = "";
+  for (const skill of inlineSkills) {
+    let content: string;
+    try {
+      content = await fs.readFile(skill.path, "utf8");
+    } catch {
+      continue;
+    }
+    let trimmed = content.trim();
+    if (trimmed.length > MAX_INLINE_SKILL_CONTENT_CHARS) {
+      trimmed = `${trimmed.slice(0, MAX_INLINE_SKILL_CONTENT_CHARS)}\n[skill content truncated]`;
+    }
+    const block = `<skill name=${JSON.stringify(skill.name)} dir=${JSON.stringify(
+      nodePath.dirname(skill.path),
+    )}>\n${trimmed}\n</skill>`;
+    const candidate =
+      text.length === 0 ? `${INLINE_SKILLS_HEADER}\n\n${block}` : `${text}\n\n${block}`;
+    if (candidate.length > input.maxChars) {
+      // Keep whatever already fits instead of overflowing the provider turn budget.
+      break;
+    }
+    text = candidate;
+  }
+  return text;
+}

--- a/apps/server/src/provider/skillsCatalog.test.ts
+++ b/apps/server/src/provider/skillsCatalog.test.ts
@@ -1,0 +1,209 @@
+// FILE: skillsCatalog.test.ts
+// Purpose: Verifies the unified cross-provider skills catalog discovery, dedup
+//          precedence, merge with provider-native results, and toggle filtering.
+// Layer: Server provider tests
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { access } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { ProviderSkillDescriptor } from "@t3tools/contracts";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearSkillsCatalogCacheForTests,
+  discoverSkillsCatalog,
+  filterDisabledSkills,
+  mergeSkillsIntoCatalog,
+  parseSkillFrontmatter,
+} from "./skillsCatalog.ts";
+
+let root: string;
+let homeDir: string;
+let synaraBaseDir: string;
+
+async function writeSkill(skillDir: string, name: string, description: string): Promise<void> {
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(
+    path.join(skillDir, "SKILL.md"),
+    `---
+name: ${name}
+description: ${description}
+---
+
+# ${name}
+`,
+  );
+}
+
+beforeEach(() => {
+  clearSkillsCatalogCacheForTests();
+  root = mkdtempSync(path.join(os.tmpdir(), "synara-skills-catalog-"));
+  homeDir = path.join(root, "home");
+  synaraBaseDir = path.join(homeDir, ".synara");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("parseSkillFrontmatter", () => {
+  it("parses scalar Agent Skill metadata", () => {
+    expect(
+      parseSkillFrontmatter(`---
+name: check-code
+description: "Review recent code changes"
+disable-model-invocation: true
+---
+
+# Check Code
+`),
+    ).toEqual({
+      name: "check-code",
+      description: "Review recent code changes",
+      "disable-model-invocation": true,
+    });
+  });
+});
+
+describe("discoverSkillsCatalog", () => {
+  it("creates the Synara skills folder on first discovery", async () => {
+    await discoverSkillsCatalog({ homeDir, synaraBaseDir });
+    await expect(access(path.join(synaraBaseDir, "skills"))).resolves.toBeUndefined();
+  });
+
+  it("aggregates skills from synara and provider home folders with origin scopes", async () => {
+    await writeSkill(path.join(synaraBaseDir, "skills", "portable"), "portable", "Synara skill");
+    await writeSkill(path.join(homeDir, ".codex", "skills", "codex-only"), "codex-only", "Codex");
+    await writeSkill(
+      path.join(homeDir, ".claude", "skills", "claude-only"),
+      "claude-only",
+      "Claude",
+    );
+    await writeSkill(
+      path.join(homeDir, ".cursor", "skills", "cursor-only"),
+      "cursor-only",
+      "Cursor",
+    );
+
+    const skills = await discoverSkillsCatalog({ homeDir, synaraBaseDir });
+    const byName = new Map(skills.map((skill) => [skill.name, skill]));
+
+    expect(byName.get("portable")?.scope).toBe("synara");
+    expect(byName.get("codex-only")?.scope).toBe("codex");
+    expect(byName.get("claude-only")?.scope).toBe("claude");
+    expect(byName.get("cursor-only")?.scope).toBe("cursor");
+  });
+
+  it("prefers the provider-native copy and falls back to Synara for that provider", async () => {
+    await writeSkill(path.join(synaraBaseDir, "skills", "shared"), "shared", "Synara copy");
+    await writeSkill(path.join(homeDir, ".codex", "skills", "shared"), "shared", "Codex copy");
+    await writeSkill(path.join(synaraBaseDir, "skills", "only-synara"), "only-synara", "Fallback");
+
+    const codexView = await discoverSkillsCatalog({ homeDir, synaraBaseDir, provider: "codex" });
+    const codexShared = codexView.find((skill) => skill.name === "shared");
+    expect(codexShared?.scope).toBe("codex");
+    expect(codexShared?.path).toContain(path.join(".codex", "skills"));
+    expect(codexView.some((skill) => skill.name === "only-synara")).toBe(true);
+
+    // A provider without its own copy resolves the Synara fallback.
+    const claudeView = await discoverSkillsCatalog({
+      homeDir,
+      synaraBaseDir,
+      provider: "claudeAgent",
+    });
+    const claudeShared = claudeView.find((skill) => skill.name === "shared");
+    expect(claudeShared?.scope).toBe("synara");
+  });
+
+  it("serves cached results within the TTL and rescans on forceReload", async () => {
+    await writeSkill(path.join(synaraBaseDir, "skills", "first"), "first", "First skill");
+
+    const initial = await discoverSkillsCatalog({ homeDir, synaraBaseDir });
+    expect(initial.map((skill) => skill.name)).toEqual(["first"]);
+
+    // A skill added after the first scan is invisible to the cached entry...
+    await writeSkill(path.join(synaraBaseDir, "skills", "second"), "second", "Second skill");
+    const cached = await discoverSkillsCatalog({ homeDir, synaraBaseDir });
+    expect(cached.map((skill) => skill.name)).toEqual(["first"]);
+
+    // ...but forceReload bypasses the cache and refreshes it.
+    const reloaded = await discoverSkillsCatalog({ homeDir, synaraBaseDir, forceReload: true });
+    expect(reloaded.map((skill) => skill.name).sort()).toEqual(["first", "second"]);
+  });
+
+  it("includes project-level .synara skills when a cwd is provided", async () => {
+    const cwd = path.join(root, "repo", "packages", "web");
+    await mkdir(cwd, { recursive: true });
+    await writeSkill(
+      path.join(root, "repo", ".synara", "skills", "repo-skill"),
+      "repo-skill",
+      "Project skill",
+    );
+
+    const skills = await discoverSkillsCatalog({ cwd, homeDir, synaraBaseDir });
+    expect(skills.find((skill) => skill.name === "repo-skill")?.scope).toBe("project");
+  });
+
+  it("keeps home origins when the cwd lives under the home dir", async () => {
+    // The home dir is an ancestor of the cwd here, so home skill folders are
+    // reachable as "project" roots too; they must keep their true origin.
+    const cwd = path.join(homeDir, "projects", "app");
+    await mkdir(cwd, { recursive: true });
+    await writeSkill(path.join(homeDir, ".codex", "skills", "from-codex"), "from-codex", "Codex");
+    await writeSkill(path.join(synaraBaseDir, "skills", "portable"), "portable", "Synara");
+
+    const skills = await discoverSkillsCatalog({ cwd, homeDir, synaraBaseDir });
+
+    const names = skills.map((skill) => skill.name);
+    expect(names.filter((name) => name === "from-codex")).toHaveLength(1);
+    expect(skills.find((skill) => skill.name === "from-codex")?.scope).toBe("codex");
+    expect(skills.find((skill) => skill.name === "portable")?.scope).toBe("synara");
+  });
+
+  it("dedupes same-named skills within a root deterministically", async () => {
+    await writeSkill(path.join(synaraBaseDir, "skills", "zeta"), "twin", "Copy in zeta");
+    await writeSkill(path.join(synaraBaseDir, "skills", "alpha"), "twin", "Copy in alpha");
+
+    const skills = await discoverSkillsCatalog({ homeDir, synaraBaseDir });
+    const twins = skills.filter((skill) => skill.name === "twin");
+    expect(twins).toHaveLength(1);
+    expect(twins[0]?.path).toContain(path.join("skills", "alpha"));
+  });
+});
+
+describe("mergeSkillsIntoCatalog", () => {
+  const descriptor = (name: string, scope: string): ProviderSkillDescriptor => ({
+    name,
+    path: `/tmp/${scope}/${name}/SKILL.md`,
+    enabled: true,
+    scope,
+  });
+
+  it("keeps provider-native entries and appends catalog-only entries", () => {
+    const merged = mergeSkillsIntoCatalog({
+      native: [descriptor("shared", "codex-native")],
+      catalog: [descriptor("Shared", "synara"), descriptor("extra", "synara")],
+    });
+    expect(merged).toHaveLength(2);
+    expect(merged.find((skill) => skill.name.toLowerCase() === "shared")?.scope).toBe(
+      "codex-native",
+    );
+    expect(merged.some((skill) => skill.name === "extra")).toBe(true);
+  });
+});
+
+describe("filterDisabledSkills", () => {
+  it("filters disabled skills case-insensitively", () => {
+    const skills: ProviderSkillDescriptor[] = [
+      { name: "Reviewer", path: "/tmp/a/SKILL.md", enabled: true },
+      { name: "writer", path: "/tmp/b/SKILL.md", enabled: true },
+    ];
+    expect(filterDisabledSkills(skills, ["reviewer"]).map((skill) => skill.name)).toEqual([
+      "writer",
+    ]);
+    expect(filterDisabledSkills(skills, [])).toHaveLength(2);
+  });
+});

--- a/apps/server/src/provider/skillsCatalog.ts
+++ b/apps/server/src/provider/skillsCatalog.ts
@@ -1,0 +1,436 @@
+// FILE: skillsCatalog.ts
+// Purpose: Generic Agent Skill discovery primitives (frontmatter parsing, SKILL.md
+//          walking) plus the unified cross-provider skills catalog backing Synara
+//          portable skills. Aggregates `~/.synara/skills` with every provider-native
+//          skills folder, deduping by name with provider-native copies winning for
+//          the active provider.
+// Layer: Server provider discovery helper
+// Exports: parseSkillFrontmatter, collectSkillsFromRoots, discoverSkillsCatalog,
+//          mergeSkillsIntoCatalog, filterDisabledSkills, ensureSynaraSkillsDir
+
+import * as fs from "node:fs/promises";
+import * as nodePath from "node:path";
+
+import type { ProviderKind, ProviderSkillDescriptor } from "@t3tools/contracts";
+
+type FrontmatterValue = string | boolean;
+
+export interface SkillRoot {
+  readonly path: string;
+  readonly scope: string;
+}
+
+// ── Frontmatter parsing ──────────────────────────────────────────────
+
+function stripYamlQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function parseYamlScalar(value: string): FrontmatterValue {
+  const unquoted = stripYamlQuotes(value);
+  const normalized = unquoted.toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  return unquoted;
+}
+
+// Parses the small scalar frontmatter subset used by Agent Skills without pulling in YAML.
+export function parseSkillFrontmatter(markdown: string): Record<string, FrontmatterValue> {
+  const normalized = markdown.replace(/\r\n/g, "\n");
+  const match = /^---\s*\n([\s\S]*?)\n---\s*(?:\n|$)/.exec(normalized);
+  if (!match) {
+    return {};
+  }
+
+  const record: Record<string, FrontmatterValue> = {};
+  for (const line of (match[1] ?? "").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const separatorIndex = trimmed.indexOf(":");
+    if (separatorIndex <= 0) {
+      continue;
+    }
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const value = trimmed.slice(separatorIndex + 1).trim();
+    if (!key || !value) {
+      continue;
+    }
+    record[key] = parseYamlScalar(value);
+  }
+  return record;
+}
+
+function readStringField(
+  frontmatter: Record<string, FrontmatterValue>,
+  keys: ReadonlyArray<string>,
+): string | undefined {
+  for (const key of keys) {
+    const value = frontmatter[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readBooleanField(
+  frontmatter: Record<string, FrontmatterValue>,
+  keys: ReadonlyArray<string>,
+): boolean | undefined {
+  for (const key of keys) {
+    const value = frontmatter[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+// ── Filesystem walking ───────────────────────────────────────────────
+
+export function ancestorsFromDeepest(cwd: string): string[] {
+  const resolved = nodePath.resolve(cwd);
+  const ancestors: string[] = [];
+  let current = resolved;
+  while (true) {
+    ancestors.push(current);
+    const parent = nodePath.dirname(current);
+    if (parent === current) {
+      return ancestors;
+    }
+    current = parent;
+  }
+}
+
+async function readdirOrEmpty(path: string): Promise<import("node:fs").Dirent[]> {
+  try {
+    return await fs.readdir(path, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+// Skills may be nested one namespace deep, e.g. `.cursor/skills/skills-sh/find-skills`.
+// Subdirectories are visited concurrently but results are flattened in sorted name
+// order so name-dedup always picks the same winner across runs.
+export async function collectSkillMarkdownPaths(rootPath: string): Promise<string[]> {
+  async function visit(dir: string, depth: number): Promise<string[]> {
+    const skillPath = nodePath.join(dir, "SKILL.md");
+    try {
+      const stat = await fs.stat(skillPath);
+      if (stat.isFile()) {
+        return [skillPath];
+      }
+    } catch {
+      // Keep walking; this directory may be a namespace rather than a skill.
+    }
+
+    if (depth >= 2) {
+      return [];
+    }
+
+    const dirents = await readdirOrEmpty(dir);
+    const subdirNames = dirents
+      .filter((dirent) => dirent.isDirectory())
+      .map((dirent) => dirent.name)
+      .sort();
+    const nested = await Promise.all(
+      subdirNames.map((name) => visit(nodePath.join(dir, name), depth + 1)),
+    );
+    return nested.flat();
+  }
+
+  return visit(rootPath, 0);
+}
+
+export async function readSkillDescriptor(input: {
+  readonly skillPath: string;
+  readonly scope: string;
+}): Promise<ProviderSkillDescriptor | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(input.skillPath, "utf8");
+  } catch {
+    return null;
+  }
+
+  const frontmatter = parseSkillFrontmatter(raw);
+  const fallbackName = nodePath.basename(nodePath.dirname(input.skillPath));
+  const name = readStringField(frontmatter, ["name"]) ?? fallbackName;
+  const description = readStringField(frontmatter, ["description"]);
+  const displayName = readStringField(frontmatter, ["display-name", "displayName", "title"]);
+  const shortDescription = readStringField(frontmatter, [
+    "short-description",
+    "shortDescription",
+    "summary",
+  ]);
+  const disabled =
+    readBooleanField(frontmatter, ["disable-model-invocation", "disableModelInvocation"]) === true;
+
+  return {
+    name,
+    ...(description ? { description } : {}),
+    path: input.skillPath,
+    enabled: !disabled,
+    scope: input.scope,
+    ...(displayName || shortDescription
+      ? {
+          interface: {
+            ...(displayName ? { displayName } : {}),
+            ...(shortDescription ? { shortDescription } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+export function skillNameKey(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+// Scans all roots concurrently, then dedupes by name in root order so earlier
+// roots keep precedence. Within a root, SKILL.md path order is preserved.
+export async function collectSkillsFromRoots(
+  roots: ReadonlyArray<SkillRoot>,
+): Promise<ProviderSkillDescriptor[]> {
+  const skillsPerRoot = await Promise.all(
+    roots.map(async (root) => {
+      const skillPaths = await collectSkillMarkdownPaths(root.path);
+      const descriptors = await Promise.all(
+        skillPaths.map((skillPath) => readSkillDescriptor({ skillPath, scope: root.scope })),
+      );
+      return descriptors.filter((skill) => skill !== null);
+    }),
+  );
+
+  const byName = new Map<string, ProviderSkillDescriptor>();
+  for (const rootSkills of skillsPerRoot) {
+    for (const skill of rootSkills) {
+      const key = skillNameKey(skill.name);
+      if (!byName.has(key)) {
+        byName.set(key, skill);
+      }
+    }
+  }
+  return [...byName.values()];
+}
+
+// ── Unified cross-provider catalog ───────────────────────────────────
+
+export interface SkillsCatalogDiscoveryInput {
+  /** Optional workspace cwd; when present, project-level skill folders are included. */
+  readonly cwd?: string | null;
+  readonly homeDir: string;
+  /** Synara base dir (usually `~/.synara`); skills live in `{base}/skills`. */
+  readonly synaraBaseDir: string;
+  /** Provider whose native copies should win when the same skill exists in several roots. */
+  readonly provider?: ProviderKind | null;
+  /** Bypass the short-lived discovery cache. */
+  readonly forceReload?: boolean;
+}
+
+const HOME_ORIGIN_ORDER = ["synara", "codex", "claude", "cursor", "agents"] as const;
+export type SkillsCatalogOrigin = (typeof HOME_ORIGIN_ORDER)[number] | "project";
+
+// Composer skill pickers refetch aggressively (per keystroke, per provider); a
+// short TTL absorbs that burst while still picking up new skill files quickly.
+const SKILLS_CATALOG_CACHE_TTL_MS = 15_000;
+const SKILLS_CATALOG_CACHE_MAX_ENTRIES = 64;
+
+interface SkillsCatalogCacheEntry {
+  readonly at: number;
+  readonly skills: ReadonlyArray<ProviderSkillDescriptor>;
+}
+
+const skillsCatalogCache = new Map<string, SkillsCatalogCacheEntry>();
+
+export function clearSkillsCatalogCacheForTests(): void {
+  skillsCatalogCache.clear();
+}
+
+export function synaraSkillsDir(synaraBaseDir: string): string {
+  return nodePath.join(synaraBaseDir, "skills");
+}
+
+// Creates the portable skills folder on first use so users have a drop-in target.
+export async function ensureSynaraSkillsDir(synaraBaseDir: string): Promise<string> {
+  const dir = synaraSkillsDir(synaraBaseDir);
+  try {
+    await fs.mkdir(dir, { recursive: true });
+  } catch {
+    // Discovery still works without the folder; reads simply return nothing.
+  }
+  return dir;
+}
+
+function homeRootsForOrigin(
+  origin: (typeof HOME_ORIGIN_ORDER)[number],
+  input: SkillsCatalogDiscoveryInput,
+): string[] {
+  switch (origin) {
+    case "synara":
+      return [synaraSkillsDir(input.synaraBaseDir)];
+    case "codex":
+      return [nodePath.join(input.homeDir, ".codex", "skills")];
+    case "claude":
+      return [nodePath.join(input.homeDir, ".claude", "skills")];
+    case "cursor":
+      return [
+        nodePath.join(input.homeDir, ".cursor", "skills-cursor"),
+        nodePath.join(input.homeDir, ".cursor", "skills"),
+      ];
+    case "agents":
+      return [nodePath.join(input.homeDir, ".agents", "skills")];
+  }
+}
+
+function projectRootNamesForOrigin(origin: (typeof HOME_ORIGIN_ORDER)[number]): string[] {
+  switch (origin) {
+    case "synara":
+      return [".synara"];
+    case "codex":
+      return [".codex"];
+    case "claude":
+      return [".claude"];
+    case "cursor":
+      return [".cursor"];
+    case "agents":
+      return [".agents"];
+  }
+}
+
+// Native copies first so an agent keeps using its own skill, then Synara as the
+// portable fallback, then the remaining provider homes for cross-provider reuse.
+function preferredOriginsForProvider(
+  provider: ProviderKind | null | undefined,
+): ReadonlyArray<(typeof HOME_ORIGIN_ORDER)[number]> {
+  switch (provider) {
+    case "codex":
+      return ["codex"];
+    case "claudeAgent":
+      return ["claude"];
+    case "cursor":
+      return ["cursor", "agents"];
+    default:
+      return [];
+  }
+}
+
+function orderedOriginsForProvider(
+  provider: ProviderKind | null | undefined,
+): Array<(typeof HOME_ORIGIN_ORDER)[number]> {
+  const preferred = preferredOriginsForProvider(provider);
+  const ordered = [...preferred];
+  if (!ordered.includes("synara")) {
+    ordered.push("synara");
+  }
+  for (const origin of HOME_ORIGIN_ORDER) {
+    if (!ordered.includes(origin)) {
+      ordered.push(origin);
+    }
+  }
+  return ordered;
+}
+
+export function skillsCatalogRoots(input: SkillsCatalogDiscoveryInput): SkillRoot[] {
+  const orderedOrigins = orderedOriginsForProvider(input.provider);
+
+  const homeRoots = orderedOrigins.flatMap((origin) =>
+    homeRootsForOrigin(origin, input).map((path) => ({ path, scope: origin })),
+  );
+  const homeRootPaths = new Set(homeRoots.map((root) => nodePath.resolve(root.path)));
+
+  const projectRoots: SkillRoot[] = [];
+  const cwd = input.cwd?.trim();
+  if (cwd) {
+    for (const ancestor of ancestorsFromDeepest(cwd)) {
+      const seenRootNames = new Set<string>();
+      for (const origin of orderedOrigins) {
+        for (const rootName of projectRootNamesForOrigin(origin)) {
+          if (seenRootNames.has(rootName)) {
+            continue;
+          }
+          seenRootNames.add(rootName);
+          const rootPath = nodePath.join(ancestor, rootName, "skills");
+          // A cwd under the home dir reaches the home skill folders as
+          // "project ancestors"; skip them here so each folder is scanned once
+          // and keeps its true origin scope. Precedence is unchanged because
+          // project and home roots share the same origin ordering.
+          if (homeRootPaths.has(nodePath.resolve(rootPath))) {
+            continue;
+          }
+          projectRoots.push({ path: rootPath, scope: "project" });
+        }
+      }
+    }
+  }
+
+  return [...projectRoots, ...homeRoots];
+}
+
+export async function discoverSkillsCatalog(
+  input: SkillsCatalogDiscoveryInput,
+): Promise<ProviderSkillDescriptor[]> {
+  const cacheKey = [
+    input.cwd?.trim() ?? "",
+    input.provider ?? "",
+    input.homeDir,
+    input.synaraBaseDir,
+  ].join("\u0000");
+
+  if (!input.forceReload) {
+    const entry = skillsCatalogCache.get(cacheKey);
+    if (entry && Date.now() - entry.at <= SKILLS_CATALOG_CACHE_TTL_MS) {
+      return [...entry.skills];
+    }
+  }
+
+  await ensureSynaraSkillsDir(input.synaraBaseDir);
+  const skills = await collectSkillsFromRoots(skillsCatalogRoots(input));
+
+  skillsCatalogCache.delete(cacheKey);
+  skillsCatalogCache.set(cacheKey, { at: Date.now(), skills });
+  while (skillsCatalogCache.size > SKILLS_CATALOG_CACHE_MAX_ENTRIES) {
+    const oldestKey = skillsCatalogCache.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    skillsCatalogCache.delete(oldestKey);
+  }
+  return skills;
+}
+
+// Provider-native discovery results win on name conflicts; catalog entries fill the gaps.
+export function mergeSkillsIntoCatalog(input: {
+  readonly native: ReadonlyArray<ProviderSkillDescriptor>;
+  readonly catalog: ReadonlyArray<ProviderSkillDescriptor>;
+}): ProviderSkillDescriptor[] {
+  const byName = new Map<string, ProviderSkillDescriptor>();
+  for (const skill of [...input.native, ...input.catalog]) {
+    const key = skillNameKey(skill.name);
+    if (!byName.has(key)) {
+      byName.set(key, skill);
+    }
+  }
+  return [...byName.values()];
+}
+
+export function filterDisabledSkills(
+  skills: ReadonlyArray<ProviderSkillDescriptor>,
+  disabledNames: ReadonlyArray<string>,
+): ProviderSkillDescriptor[] {
+  if (disabledNames.length === 0) {
+    return [...skills];
+  }
+  const disabled = new Set(disabledNames.map((name) => skillNameKey(name)));
+  return skills.filter((skill) => !disabled.has(skillNameKey(skill.name)));
+}

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -41,6 +41,7 @@ import { makeImportThreadHandler } from "./orchestration/importThreadRoute";
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ProviderDiscoveryService } from "./provider/Services/ProviderDiscoveryService";
+import { discoverSkillsCatalog, synaraSkillsDir } from "./provider/skillsCatalog";
 import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
 import { ProviderHealth } from "./provider/Services/ProviderHealth";
 import { ProviderService } from "./provider/Services/ProviderService";
@@ -1071,6 +1072,22 @@ export const makeWsRpcLayer = () =>
           rpcEffect(providerDiscoveryService.listCommands(input), "Failed to list commands"),
         [WS_METHODS.providerListSkills]: (input) =>
           rpcEffect(providerDiscoveryService.listSkills(input), "Failed to list skills"),
+        [WS_METHODS.providerListSkillsCatalog]: (input) =>
+          rpcEffect(
+            Effect.tryPromise(() =>
+              discoverSkillsCatalog({
+                cwd: input.cwd ?? null,
+                homeDir: config.homeDir,
+                synaraBaseDir: config.baseDir,
+              }),
+            ).pipe(
+              Effect.map((skills) => ({
+                skills,
+                synaraSkillsDir: synaraSkillsDir(config.baseDir),
+              })),
+            ),
+            "Failed to list the skills catalog",
+          ),
         [WS_METHODS.providerListPlugins]: (input) =>
           rpcEffect(providerDiscoveryService.listPlugins(input), "Failed to list plugins"),
         [WS_METHODS.providerReadPlugin]: (input) =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2480,10 +2480,6 @@ export default function ChatView({
     composerCommandPicker === null &&
     isMentionTrigger &&
     isLocalFolderMentionQuery(mentionTriggerQuery);
-  const skillTriggerQuery =
-    composerTrigger?.kind === "skill" || composerTrigger?.kind === "slash-command"
-      ? composerTrigger.query
-      : "";
   const isSkillTrigger = composerTriggerKind === "skill";
   const [debouncedPathQuery, composerPathQueryDebouncer] = useDebouncedValue(
     mentionTriggerQuery,
@@ -2541,7 +2537,6 @@ export default function ChatView({
       cwd: composerSkillCwd,
       threadId,
       agentDir: selectedProvider === "pi" ? settings.piAgentDir || null : null,
-      query: skillTriggerQuery,
       enabled:
         (isSkillTrigger || composerTriggerKind === "slash-command" || selectedProvider === "pi") &&
         canDiscoverProviderSkills &&

--- a/apps/web/src/components/PluginLibrary.tsx
+++ b/apps/web/src/components/PluginLibrary.tsx
@@ -493,7 +493,6 @@ export function PluginLibrary() {
       provider: selectedProvider,
       cwd: discoveryCwd,
       threadId: providerThreadId,
-      query: selectedTab === "skills" ? deferredSkillSearch : "",
       enabled: selectedTab === "skills" && canListSkills && discoveryCwd !== null,
     }),
   );

--- a/apps/web/src/components/settings/SkillsSettingsPanel.tsx
+++ b/apps/web/src/components/settings/SkillsSettingsPanel.tsx
@@ -1,0 +1,207 @@
+// FILE: SkillsSettingsPanel.tsx
+// Purpose: Settings → Skills panel. Lists every skill from the unified cross-provider
+// catalog (~/.synara/skills plus each provider's skills folder), shows which provider
+// a skill comes from, and lets the user enable/disable each one. Disabled skills are
+// hidden from the composer skill picker on every provider.
+
+import type { ProviderKind, ProviderSkillDescriptor, ServerSettings } from "@t3tools/contracts";
+import { PROVIDER_DISPLAY_NAMES } from "@t3tools/contracts";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { ProviderIcon } from "~/components/ProviderIcon";
+import { SettingsRow, SettingsSection } from "~/components/settings/SettingsPanelPrimitives";
+import { Switch } from "~/components/ui/switch";
+import { ensureNativeApi } from "~/nativeApi";
+import {
+  providerDiscoveryQueryKeys,
+  skillsCatalogQueryOptions,
+} from "~/lib/providerDiscoveryReactQuery";
+import { serverQueryKeys, serverSettingsQueryOptions } from "~/lib/serverReactQuery";
+
+interface SkillOriginInfo {
+  readonly label: string;
+  readonly provider: ProviderKind | null;
+}
+
+function skillOriginInfo(scope: string | undefined): SkillOriginInfo {
+  switch (scope) {
+    case "synara":
+      return { label: "Synara", provider: null };
+    case "codex":
+      return { label: PROVIDER_DISPLAY_NAMES.codex, provider: "codex" };
+    case "claude":
+      return { label: PROVIDER_DISPLAY_NAMES.claudeAgent, provider: "claudeAgent" };
+    case "cursor":
+      return { label: PROVIDER_DISPLAY_NAMES.cursor, provider: "cursor" };
+    case "agents":
+      return { label: "Shared (.agents)", provider: null };
+    case "project":
+      return { label: "Project", provider: null };
+    default:
+      return { label: scope ?? "Personal", provider: null };
+  }
+}
+
+const ORIGIN_SECTION_ORDER = ["synara", "codex", "claude", "cursor", "agents", "project"] as const;
+
+function skillNameKey(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function skillDisplayName(skill: ProviderSkillDescriptor): string {
+  return skill.interface?.displayName ?? skill.name;
+}
+
+export function SkillsSettingsPanel() {
+  const queryClient = useQueryClient();
+  const catalogQuery = useQuery(skillsCatalogQueryOptions());
+  const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
+
+  const disabledSkillNames = useMemo(
+    () =>
+      new Set((serverSettingsQuery.data?.skills.disabled ?? []).map((name) => skillNameKey(name))),
+    [serverSettingsQuery.data?.skills.disabled],
+  );
+
+  const skillsByOrigin = useMemo(() => {
+    const groups = new Map<string, ProviderSkillDescriptor[]>();
+    for (const skill of catalogQuery.data?.skills ?? []) {
+      const origin = skill.scope ?? "personal";
+      const group = groups.get(origin) ?? [];
+      group.push(skill);
+      groups.set(origin, group);
+    }
+    for (const group of groups.values()) {
+      group.sort((left, right) => skillDisplayName(left).localeCompare(skillDisplayName(right)));
+    }
+    const orderedOrigins = [
+      ...ORIGIN_SECTION_ORDER.filter((origin) => groups.has(origin)),
+      ...[...groups.keys()].filter(
+        (origin) => !(ORIGIN_SECTION_ORDER as readonly string[]).includes(origin),
+      ),
+    ];
+    return orderedOrigins.map((origin) => ({
+      origin,
+      skills: groups.get(origin) ?? [],
+    }));
+  }, [catalogQuery.data?.skills]);
+
+  const setSkillEnabled = (skillName: string, enabled: boolean) => {
+    // Read through the query cache (not the render closure) so rapid toggles
+    // build on each other instead of clobbering the previous patch.
+    const latestSettings = queryClient.getQueryData<ServerSettings>(serverQueryKeys.settings());
+    const currentDisabled = latestSettings?.skills.disabled ?? [...disabledSkillNames];
+    const key = skillNameKey(skillName);
+    const next = new Set(currentDisabled.map((name) => skillNameKey(name)));
+    if (enabled) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    const disabled = [...next].sort();
+    if (latestSettings) {
+      // Optimistic flip; a failed patch invalidates back to the server state.
+      queryClient.setQueryData(serverQueryKeys.settings(), {
+        ...latestSettings,
+        skills: { disabled },
+      });
+    }
+    void ensureNativeApi()
+      .server.updateSettings({ skills: { disabled } })
+      .then((nextSettings) => {
+        queryClient.setQueryData(serverQueryKeys.settings(), nextSettings);
+        // Composer skill pickers are served filtered by these toggles.
+        void queryClient.invalidateQueries({ queryKey: providerDiscoveryQueryKeys.all });
+      })
+      .catch(() => {
+        void queryClient.invalidateQueries({ queryKey: serverQueryKeys.settings() });
+      });
+  };
+
+  const totalSkills = catalogQuery.data?.skills.length ?? 0;
+  const enabledSkills = (catalogQuery.data?.skills ?? []).filter(
+    (skill) => !disabledSkillNames.has(skillNameKey(skill.name)),
+  ).length;
+  const synaraSkillsDir = catalogQuery.data?.synaraSkillsDir;
+
+  return (
+    <div className="space-y-8">
+      <SettingsSection title="Portable skills">
+        <SettingsRow
+          title="Synara skills folder"
+          description="Skills placed here are available on every provider. When a provider already ships its own copy of a skill, that copy is used; otherwise Synara's copy is the fallback."
+          status={
+            synaraSkillsDir ? (
+              <code className="break-all text-[11px] text-muted-foreground">{synaraSkillsDir}</code>
+            ) : null
+          }
+          control={
+            <span className="text-xs font-medium text-muted-foreground">
+              {catalogQuery.isLoading
+                ? "Scanning…"
+                : `${enabledSkills} of ${totalSkills} skill${totalSkills === 1 ? "" : "s"} enabled`}
+            </span>
+          }
+        />
+      </SettingsSection>
+
+      {catalogQuery.isError ? (
+        <SettingsSection title="Skills">
+          <SettingsRow
+            title="Skill discovery failed"
+            description="Synara could not scan the skill folders. Retry after checking that the server is running."
+          />
+        </SettingsSection>
+      ) : null}
+
+      {!catalogQuery.isLoading && !catalogQuery.isError && totalSkills === 0 ? (
+        <SettingsSection title="Skills">
+          <SettingsRow
+            title="No skills found"
+            description="Add a skill folder containing a SKILL.md to the Synara skills folder above, or install skills for Codex, Claude, or Cursor."
+          />
+        </SettingsSection>
+      ) : null}
+
+      {skillsByOrigin.map(({ origin, skills }) => {
+        const originInfo = skillOriginInfo(origin);
+        return (
+          <SettingsSection key={origin} title={`From ${originInfo.label}`}>
+            {skills.map((skill) => {
+              const enabled = !disabledSkillNames.has(skillNameKey(skill.name));
+              return (
+                <SettingsRow
+                  key={skill.path}
+                  title={skillDisplayName(skill)}
+                  description={
+                    skill.interface?.shortDescription ?? skill.description ?? "No description."
+                  }
+                  status={
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <ProviderIcon
+                        provider={originInfo.provider}
+                        className="size-3 shrink-0"
+                        fallback={null}
+                      />
+                      <code className="truncate text-[11px] text-muted-foreground">
+                        {skill.path}
+                      </code>
+                    </span>
+                  }
+                  control={
+                    <Switch
+                      checked={enabled}
+                      onCheckedChange={(checked) => setSkillEnabled(skill.name, Boolean(checked))}
+                      aria-label={`Enable the ${skillDisplayName(skill)} skill`}
+                    />
+                  }
+                />
+              );
+            })}
+          </SettingsSection>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -7,6 +7,7 @@ import type {
   ProviderListPluginsResult,
   ProviderListSkillsResult,
   ProviderReadPluginResult,
+  ProviderSkillsCatalogResult,
 } from "@t3tools/contracts";
 import { queryOptions } from "@tanstack/react-query";
 import { ensureNativeApi } from "~/nativeApi";
@@ -54,8 +55,11 @@ export const providerDiscoveryQueryKeys = {
     agentDir: string | null,
     connectionKey: string | null,
   ) => ["provider-discovery", "commands", provider, cwd, agentDir, connectionKey] as const,
-  skills: (provider: ProviderKind, cwd: string | null, query: string, agentDir: string | null) =>
-    ["provider-discovery", "skills", provider, cwd, query, agentDir] as const,
+  // The skill list is query-independent (filtering is client-side), so the key
+  // deliberately excludes the typed filter to avoid a refetch per keystroke.
+  skills: (provider: ProviderKind, cwd: string | null, agentDir: string | null) =>
+    ["provider-discovery", "skills", provider, cwd, agentDir] as const,
+  skillsCatalog: (cwd: string | null) => ["provider-discovery", "skills-catalog", cwd] as const,
   plugins: (provider: ProviderKind, cwd: string | null) =>
     ["provider-discovery", "plugins", provider, cwd] as const,
   plugin: (provider: ProviderKind, marketplacePath: string, pluginName: string) =>
@@ -85,16 +89,10 @@ export function providerSkillsQueryOptions(input: {
   cwd: string | null;
   threadId?: string | null;
   agentDir?: string | null;
-  query: string;
   enabled?: boolean;
 }) {
   return queryOptions({
-    queryKey: providerDiscoveryQueryKeys.skills(
-      input.provider,
-      input.cwd,
-      input.query,
-      input.agentDir ?? null,
-    ),
+    queryKey: providerDiscoveryQueryKeys.skills(input.provider, input.cwd, input.agentDir ?? null),
     queryFn: async () => {
       const api = ensureNativeApi();
       if (!input.cwd) {
@@ -110,6 +108,22 @@ export function providerSkillsQueryOptions(input: {
     enabled: (input.enabled ?? true) && input.cwd !== null,
     staleTime: 30_000,
     placeholderData: (previous) => previous ?? EMPTY_SKILLS_RESULT,
+  });
+}
+
+// Unified cross-provider skills catalog (settings page); not filtered by toggles.
+// No placeholderData: the settings panel relies on `isLoading` to distinguish the
+// initial scan from a genuinely empty catalog.
+export function skillsCatalogQueryOptions(input?: { cwd?: string | null; enabled?: boolean }) {
+  const cwd = input?.cwd ?? null;
+  return queryOptions({
+    queryKey: providerDiscoveryQueryKeys.skillsCatalog(cwd),
+    queryFn: async (): Promise<ProviderSkillsCatalogResult> => {
+      const api = ensureNativeApi();
+      return api.provider.listSkillsCatalog(cwd ? { cwd } : {});
+    },
+    enabled: input?.enabled ?? true,
+    staleTime: 30_000,
   });
 }
 

--- a/apps/web/src/providerUpdates.test.ts
+++ b/apps/web/src/providerUpdates.test.ts
@@ -66,6 +66,7 @@ function serverSettings(overrides: Partial<ServerSettings["providers"]> = {}): S
       pi: { ...provider, binaryPath: "pi", agentDir: "" },
       ...overrides,
     },
+    skills: { disabled: [] },
   };
 }
 

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -86,6 +86,7 @@ import {
   SettingsSelectPopup,
 } from "../components/settings/SettingsPanelPrimitives";
 import { ProviderUsageSettingsPanel } from "../components/settings/ProviderUsageSettingsPanel";
+import { SkillsSettingsPanel } from "../components/settings/SkillsSettingsPanel";
 import {
   CHAT_CONTENT_CARD_CLASS_NAME,
   CHAT_MAIN_VIEWPORT_SHELL_CLASS_NAME,
@@ -3117,6 +3118,8 @@ function SettingsRouteView() {
         return renderModelsPanel();
       case "providers":
         return renderProvidersPanel();
+      case "skills":
+        return <SkillsSettingsPanel />;
       case "usage":
         return <ProviderUsageSettingsPanel />;
       case "advanced":

--- a/apps/web/src/settingsNavigation.ts
+++ b/apps/web/src/settingsNavigation.ts
@@ -12,6 +12,7 @@ export const SETTINGS_SECTION_IDS = [
   "archived",
   "models",
   "providers",
+  "skills",
   "usage",
   "advanced",
 ] as const;
@@ -115,6 +116,14 @@ export const SETTINGS_NAV_ITEMS: readonly SettingsNavItem[] = [
     description: "Choose visible providers, review CLI installs, and update provider tools.",
     icon: "puzzle",
     eyebrow: "Picker visibility",
+  },
+  {
+    id: "skills",
+    group: "synara",
+    label: "Skills",
+    description: "Every skill found across providers, with toggles to control availability.",
+    icon: "sparkle",
+    eyebrow: "Agent skills",
   },
   {
     id: "usage",

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -311,6 +311,7 @@ describe("wsNativeApi", () => {
           },
           pi: { enabled: true, binaryPath: "pi", agentDir: "", customModels: [] },
         },
+        skills: { disabled: [] },
       },
     } as const;
     emitPush(WS_CHANNELS.serverSettingsUpdated, payload);

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -631,6 +631,7 @@ export function createWsNativeApi(): NativeApi {
       compactThread: (input) => transport.request(WS_METHODS.providerCompactThread, input),
       listCommands: (input) => transport.request(WS_METHODS.providerListCommands, input),
       listSkills: (input) => transport.request(WS_METHODS.providerListSkills, input),
+      listSkillsCatalog: (input) => transport.request(WS_METHODS.providerListSkillsCatalog, input),
       listPlugins: (input) => transport.request(WS_METHODS.providerListPlugins, input),
       readPlugin: (input) => transport.request(WS_METHODS.providerReadPlugin, input),
       listModels: (input) => transport.request(WS_METHODS.providerListModels, input),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -136,6 +136,8 @@ import type {
   ProviderListPluginsResult,
   ProviderListSkillsInput,
   ProviderListSkillsResult,
+  ProviderSkillsCatalogInput,
+  ProviderSkillsCatalogResult,
   ProviderReadPluginInput,
   ProviderReadPluginResult,
 } from "./providerDiscovery";
@@ -475,6 +477,7 @@ export interface NativeApi {
     compactThread: (input: ProviderCompactThreadInput) => Promise<void>;
     listCommands: (input: ProviderListCommandsInput) => Promise<ProviderListCommandsResult>;
     listSkills: (input: ProviderListSkillsInput) => Promise<ProviderListSkillsResult>;
+    listSkillsCatalog: (input: ProviderSkillsCatalogInput) => Promise<ProviderSkillsCatalogResult>;
     listPlugins: (input: ProviderListPluginsInput) => Promise<ProviderListPluginsResult>;
     readPlugin: (input: ProviderReadPluginInput) => Promise<ProviderReadPluginResult>;
     listModels: (input: ProviderListModelsInput) => Promise<ProviderListModelsResult>;

--- a/packages/contracts/src/providerDiscovery.ts
+++ b/packages/contracts/src/providerDiscovery.ts
@@ -81,6 +81,19 @@ export const ProviderListSkillsResult = Schema.Struct({
 });
 export type ProviderListSkillsResult = typeof ProviderListSkillsResult.Type;
 
+// Unified cross-provider skills catalog (Synara portable skills). Descriptors use
+// `scope` to carry the origin label ("synara", "codex", "claude", "cursor", ...).
+export const ProviderSkillsCatalogInput = Schema.Struct({
+  cwd: Schema.optional(TrimmedNonEmptyString),
+});
+export type ProviderSkillsCatalogInput = typeof ProviderSkillsCatalogInput.Type;
+
+export const ProviderSkillsCatalogResult = Schema.Struct({
+  skills: Schema.Array(ProviderSkillDescriptor),
+  synaraSkillsDir: Schema.optional(TrimmedNonEmptyString),
+});
+export type ProviderSkillsCatalogResult = typeof ProviderSkillsCatalogResult.Type;
+
 export const ProviderNativeCommandDescriptor = Schema.Struct({
   name: TrimmedNonEmptyString,
   description: Schema.optional(TrimmedNonEmptyString),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -68,6 +68,8 @@ import {
   ProviderListPluginsResult,
   ProviderListSkillsInput,
   ProviderListSkillsResult,
+  ProviderSkillsCatalogInput,
+  ProviderSkillsCatalogResult,
   ProviderReadPluginInput,
   ProviderReadPluginResult,
 } from "./providerDiscovery";
@@ -639,6 +641,12 @@ export const WsProviderListSkillsRpc = Rpc.make(WS_METHODS.providerListSkills, {
   error: WsRpcError,
 });
 
+export const WsProviderListSkillsCatalogRpc = Rpc.make(WS_METHODS.providerListSkillsCatalog, {
+  payload: ProviderSkillsCatalogInput,
+  success: ProviderSkillsCatalogResult,
+  error: WsRpcError,
+});
+
 export const WsProviderListPluginsRpc = Rpc.make(WS_METHODS.providerListPlugins, {
   payload: ProviderListPluginsInput,
   success: ProviderListPluginsResult,
@@ -741,6 +749,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsProviderCompactThreadRpc,
   WsProviderListCommandsRpc,
   WsProviderListSkillsRpc,
+  WsProviderListSkillsCatalogRpc,
   WsProviderListPluginsRpc,
   WsProviderReadPluginRpc,
   WsProviderListModelsRpc,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -73,6 +73,17 @@ export const PiServerProviderSettings = Schema.Struct({
 });
 export type PiServerProviderSettings = typeof PiServerProviderSettings.Type;
 
+const DisabledSkillNames = Schema.Array(Schema.String.check(Schema.isMaxLength(256))).pipe(
+  Schema.withDecodingDefault(() => []),
+);
+
+// User-level skill toggles. Skills are keyed by lowercased name because the
+// unified catalog dedupes provider copies of the same skill by name.
+export const SkillsServerSettings = Schema.Struct({
+  disabled: DisabledSkillNames,
+});
+export type SkillsServerSettings = typeof SkillsServerSettings.Type;
+
 export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   defaultThreadEnvMode: ThreadEnvironmentMode.pipe(Schema.withDecodingDefault(() => "local")),
@@ -93,6 +104,7 @@ export const ServerSettings = Schema.Struct({
     opencode: OpenCodeServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
     pi: PiServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
   }).pipe(Schema.withDecodingDefault(() => ({}))),
+  skills: SkillsServerSettings.pipe(Schema.withDecodingDefault(() => ({}))),
 });
 export type ServerSettings = typeof ServerSettings.Type;
 
@@ -159,6 +171,11 @@ export const ServerSettingsPatch = Schema.Struct({
           agentDir: Schema.optionalKey(StringSetting),
         }),
       ),
+    }),
+  ),
+  skills: Schema.optionalKey(
+    Schema.Struct({
+      disabled: Schema.optionalKey(Schema.Array(Schema.String.check(Schema.isMaxLength(256)))),
     }),
   ),
 });

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -89,6 +89,7 @@ import {
   ProviderListAgentsInput,
   ProviderReadPluginInput,
   ProviderListSkillsInput,
+  ProviderSkillsCatalogInput,
 } from "./providerDiscovery";
 import { ProviderCompactThreadInput } from "./provider";
 
@@ -179,6 +180,7 @@ export const WS_METHODS = {
   providerCompactThread: "provider.compactThread",
   providerListCommands: "provider.listCommands",
   providerListSkills: "provider.listSkills",
+  providerListSkillsCatalog: "provider.listSkillsCatalog",
   providerListPlugins: "provider.listPlugins",
   providerReadPlugin: "provider.readPlugin",
   providerListModels: "provider.listModels",
@@ -300,6 +302,7 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.providerCompactThread, ProviderCompactThreadInput),
   tagRequestBody(WS_METHODS.providerListCommands, ProviderListCommandsInput),
   tagRequestBody(WS_METHODS.providerListSkills, ProviderListSkillsInput),
+  tagRequestBody(WS_METHODS.providerListSkillsCatalog, ProviderSkillsCatalogInput),
   tagRequestBody(WS_METHODS.providerListPlugins, ProviderListPluginsInput),
   tagRequestBody(WS_METHODS.providerReadPlugin, ProviderReadPluginInput),
   tagRequestBody(WS_METHODS.providerListModels, ProviderListModelsInput),

--- a/scripts/lib/desktop-stage-dependency-overrides.ts
+++ b/scripts/lib/desktop-stage-dependency-overrides.ts
@@ -3,6 +3,10 @@
 // Layer: Release/build script support
 
 export const DESKTOP_STAGE_DEPENDENCY_OVERRIDES = {
+  // 1.2.9 declares a dependency on @pierre/theming@0.0.1 which is not published
+  // to npm (404), breaking fresh staged installs. Pin the last installable
+  // version until upstream ships a fixed release.
+  "@pierre/diffs": "1.2.8",
   "@pierre/theme": "1.0.3",
   diff: "8.0.3",
   "hast-util-to-html": "9.0.5",


### PR DESCRIPTION
## What Changed

- New unified skills catalog (`apps/server/src/provider/skillsCatalog.ts`): aggregates `~/.synara/skills` plus every provider skill folder (`.codex`, `.claude`, `.cursor`/`skills-cursor`, `.agents`, and project-level variants), deduped by name with deterministic ordering. Precedence: project > active provider's native copy > Synara fallback > other providers.
- Skills are usable on **all 8 providers**:
  - Codex: Synara's skills folder is registered as a native skill root via `skills/extraRoots/set` at every app-server handshake (verified live against codex-cli 0.139 — skill items with unregistered paths are silently ignored).
  - Providers that can't load a skill natively (Gemini, Grok, Kilo, OpenCode, and foreign-root skills on Codex/Claude/Cursor/Pi) get the `SKILL.md` content inlined into the prompt within the turn character budget (`skillPromptInjection.ts`).
- New **Settings → Skills** section: lists every discovered skill grouped by origin provider, with a per-skill enable toggle persisted in server settings (`skills.disabled`). Disabled skills are filtered out of the composer skill picker on every provider, server-side.
- New `provider.listSkillsCatalog` WS RPC + contracts (`ProviderSkillsCatalogInput/Result`, `SkillsServerSettings` + patch schema).
- Performance: parallel root scanning (~4ms → ~1ms median on a 75-skill synthetic tree), 15s LRU+TTL server cache, and the skill query key no longer includes the typed filter (results are query-independent), removing a request + fs scan per keystroke.

## Why

Skills were siloed per provider: Codex-only via app-server, Cursor via its own fs scan, nothing for Claude/Gemini/Grok/Kilo/OpenCode. This makes one drop-in folder (`~/.synara/skills`) work everywhere without duplicating skills across provider folders, while still preferring a provider's own copy when it exists (SYN-76). The toggles keep large skill collections from flooding the composer picker.

## UI Changes

New "Skills" section in Settings (Synara group): origin-grouped list with provider icon, path, description, and an enable switch per skill; header card shows the Synara skills folder path and enabled count. Verified end-to-end on an isolated dev instance (catalog rendering, toggle persistence to `settings.json`, picker filtering).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
