### PR TITLE
Fix skills settings provider catalog

### DIFF
--- a/apps/server/src/provider/cursorSkillsDiscovery.test.ts
+++ b/apps/server/src/provider/cursorSkillsDiscovery.test.ts
@@ -72,7 +72,7 @@ description: Help globally
     }
   });
 
-  it("keeps the personal scope when the cwd lives under the home dir", async () => {
+  it("keeps the provider scope when the cwd lives under the home dir", async () => {
     const root = mkdtempSync(path.join(os.tmpdir(), "cursor-skills-home-"));
     const homeDir = path.join(root, "home");
     const cwd = path.join(homeDir, "projects", "app");
@@ -95,7 +95,7 @@ description: Help globally
       const skills = await discoverCursorSkills({ cwd, homeDir });
 
       expect(skills).toHaveLength(1);
-      expect(skills[0]).toMatchObject({ name: "global-helper", scope: "personal" });
+      expect(skills[0]).toMatchObject({ name: "global-helper", scope: "cursor" });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/server/src/provider/cursorSkillsDiscovery.ts
+++ b/apps/server/src/provider/cursorSkillsDiscovery.ts
@@ -8,38 +8,22 @@ import * as nodePath from "node:path";
 
 import type { ProviderSkillDescriptor } from "@t3tools/contracts";
 
-import { ancestorsFromDeepest, collectSkillsFromRoots, type SkillRoot } from "./skillsCatalog.ts";
+import { collectSkillsFromRoots, providerNativeSkillRoots } from "./skillsCatalog.ts";
 
 export interface CursorSkillDiscoveryInput {
   readonly cwd: string;
   readonly homeDir: string;
 }
 
-function cursorSkillRoots(input: CursorSkillDiscoveryInput): SkillRoot[] {
-  const homeRoots: SkillRoot[] = [
-    { path: nodePath.join(input.homeDir, ".cursor", "skills-cursor"), scope: "cursor" },
-    { path: nodePath.join(input.homeDir, ".cursor", "skills"), scope: "personal" },
-    { path: nodePath.join(input.homeDir, ".agents", "skills"), scope: "personal" },
-    { path: nodePath.join(input.homeDir, ".claude", "skills"), scope: "personal" },
-    { path: nodePath.join(input.homeDir, ".codex", "skills"), scope: "personal" },
-  ];
-  const homeRootPaths = new Set(homeRoots.map((root) => nodePath.resolve(root.path)));
-
-  const projectRootNames = [".cursor", ".agents", ".claude", ".codex"] as const;
-  // A cwd under the home dir reaches the home skill folders as "project
-  // ancestors"; skip them so each folder is scanned once with its true scope.
-  const projectRoots = ancestorsFromDeepest(input.cwd).flatMap((ancestor) =>
-    projectRootNames
-      .map((rootName) => nodePath.join(ancestor, rootName, "skills"))
-      .filter((rootPath) => !homeRootPaths.has(nodePath.resolve(rootPath)))
-      .map((rootPath) => ({ path: rootPath, scope: "project" })),
-  );
-
-  return [...projectRoots, ...homeRoots];
-}
-
 export async function discoverCursorSkills(
   input: CursorSkillDiscoveryInput,
 ): Promise<ProviderSkillDescriptor[]> {
-  return collectSkillsFromRoots(cursorSkillRoots(input));
+  return collectSkillsFromRoots(
+    providerNativeSkillRoots({
+      cwd: input.cwd,
+      homeDir: input.homeDir,
+      synaraBaseDir: nodePath.join(input.homeDir, ".synara"),
+      provider: "cursor",
+    }),
+  );
 }

--- a/apps/server/src/provider/skillsCatalog.test.ts
+++ b/apps/server/src/provider/skillsCatalog.test.ts
@@ -4,7 +4,7 @@
 // Layer: Server provider tests
 
 import { mkdtempSync, rmSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
 import { access } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -87,6 +87,23 @@ describe("discoverSkillsCatalog", () => {
       "cursor-only",
       "Cursor",
     );
+    await writeSkill(
+      path.join(homeDir, ".gemini", "skills", "gemini-only"),
+      "gemini-only",
+      "Gemini",
+    );
+    await writeSkill(path.join(homeDir, ".grok", "skills", "grok-only"), "grok-only", "Grok");
+    await writeSkill(path.join(homeDir, ".kilo", "skills", "kilo-only"), "kilo-only", "Kilo");
+    await writeSkill(
+      path.join(homeDir, ".config", "opencode", "skills", "opencode-only"),
+      "opencode-only",
+      "OpenCode",
+    );
+    await writeSkill(
+      path.join(homeDir, ".pi", "agent", "skills", "pi-only"),
+      "pi-only",
+      "Pi",
+    );
 
     const skills = await discoverSkillsCatalog({ homeDir, synaraBaseDir });
     const byName = new Map(skills.map((skill) => [skill.name, skill]));
@@ -95,11 +112,51 @@ describe("discoverSkillsCatalog", () => {
     expect(byName.get("codex-only")?.scope).toBe("codex");
     expect(byName.get("claude-only")?.scope).toBe("claude");
     expect(byName.get("cursor-only")?.scope).toBe("cursor");
+    expect(byName.get("gemini-only")?.scope).toBe("gemini");
+    expect(byName.get("grok-only")?.scope).toBe("grok");
+    expect(byName.get("kilo-only")?.scope).toBe("kilo");
+    expect(byName.get("opencode-only")?.scope).toBe("opencode");
+    expect(byName.get("pi-only")?.scope).toBe("pi");
+  });
+
+  it("follows symlinked skill directories from provider homes", async () => {
+    const realSkillDir = path.join(root, "linked-skills", "check-code");
+    await writeSkill(realSkillDir, "check-code", "Linked Claude skill");
+    await mkdir(path.join(homeDir, ".claude", "skills"), { recursive: true });
+    await symlink(realSkillDir, path.join(homeDir, ".claude", "skills", "check-code"), "dir");
+
+    const skills = await discoverSkillsCatalog({
+      homeDir,
+      synaraBaseDir,
+      includeDuplicateOrigins: true,
+    });
+
+    const linkedSkill = skills.find((skill) => skill.name === "check-code");
+    expect(linkedSkill?.scope).toBe("claude");
+    expect(linkedSkill?.path).toContain(path.join(".claude", "skills", "check-code", "SKILL.md"));
+  });
+
+  it("can include duplicate skill names from different origins for settings", async () => {
+    await writeSkill(path.join(homeDir, ".codex", "skills", "reviewer"), "reviewer", "Codex");
+    await writeSkill(path.join(homeDir, ".claude", "skills", "reviewer"), "reviewer", "Claude");
+
+    const defaultCatalog = await discoverSkillsCatalog({ homeDir, synaraBaseDir });
+    expect(defaultCatalog.filter((skill) => skill.name === "reviewer")).toHaveLength(1);
+    expect(defaultCatalog.find((skill) => skill.name === "reviewer")?.scope).toBe("codex");
+
+    const settingsCatalog = await discoverSkillsCatalog({
+      homeDir,
+      synaraBaseDir,
+      includeDuplicateOrigins: true,
+    });
+    expect(settingsCatalog.filter((skill) => skill.name === "reviewer")).toHaveLength(2);
+    expect(settingsCatalog.map((skill) => skill.scope).sort()).toEqual(["claude", "codex"]);
   });
 
   it("prefers the provider-native copy and falls back to Synara for that provider", async () => {
     await writeSkill(path.join(synaraBaseDir, "skills", "shared"), "shared", "Synara copy");
     await writeSkill(path.join(homeDir, ".codex", "skills", "shared"), "shared", "Codex copy");
+    await writeSkill(path.join(homeDir, ".gemini", "skills", "shared"), "shared", "Gemini copy");
     await writeSkill(path.join(synaraBaseDir, "skills", "only-synara"), "only-synara", "Fallback");
 
     const codexView = await discoverSkillsCatalog({ homeDir, synaraBaseDir, provider: "codex" });
@@ -116,6 +173,70 @@ describe("discoverSkillsCatalog", () => {
     });
     const claudeShared = claudeView.find((skill) => skill.name === "shared");
     expect(claudeShared?.scope).toBe("synara");
+
+    const geminiView = await discoverSkillsCatalog({
+      homeDir,
+      synaraBaseDir,
+      provider: "gemini",
+    });
+    const geminiShared = geminiView.find((skill) => skill.name === "shared");
+    expect(geminiShared?.scope).toBe("gemini");
+  });
+
+  it("uses documented provider alias roots before Synara fallbacks", async () => {
+    await writeSkill(path.join(synaraBaseDir, "skills", "shared"), "shared", "Synara copy");
+    await writeSkill(path.join(homeDir, ".agents", "skills", "shared"), "shared", "Agents alias");
+    await writeSkill(path.join(homeDir, ".gemini", "skills", "shared"), "shared", "Gemini copy");
+
+    const geminiView = await discoverSkillsCatalog({
+      homeDir,
+      synaraBaseDir,
+      provider: "gemini",
+    });
+
+    expect(geminiView.find((skill) => skill.name === "shared")?.scope).toBe("agents");
+  });
+
+  it("uses provider-native roots before shared aliases for Grok and Pi", async () => {
+    await writeSkill(path.join(synaraBaseDir, "skills", "shared"), "shared", "Synara copy");
+    await writeSkill(path.join(homeDir, ".agents", "skills", "shared"), "shared", "Agents alias");
+    await writeSkill(path.join(homeDir, ".grok", "skills", "shared"), "shared", "Grok copy");
+    await writeSkill(path.join(homeDir, ".pi", "agent", "skills", "shared"), "shared", "Pi copy");
+
+    const grokView = await discoverSkillsCatalog({
+      homeDir,
+      synaraBaseDir,
+      provider: "grok",
+    });
+    const piView = await discoverSkillsCatalog({
+      homeDir,
+      synaraBaseDir,
+      provider: "pi",
+    });
+
+    expect(grokView.find((skill) => skill.name === "shared")?.scope).toBe("grok");
+    expect(piView.find((skill) => skill.name === "shared")?.scope).toBe("pi");
+  });
+
+  it("discovers Pi direct markdown skills from Pi roots", async () => {
+    const piRoot = path.join(homeDir, ".pi", "agent", "skills");
+    await mkdir(piRoot, { recursive: true });
+    await writeFile(
+      path.join(piRoot, "direct-review.md"),
+      `---
+name: direct-review
+description: Direct Pi markdown skill
+---
+
+# Direct Review
+`,
+    );
+
+    const skills = await discoverSkillsCatalog({ homeDir, synaraBaseDir });
+
+    const directSkill = skills.find((skill) => skill.name === "direct-review");
+    expect(directSkill?.scope).toBe("pi");
+    expect(directSkill?.path).toContain(path.join(".pi", "agent", "skills", "direct-review.md"));
   });
 
   it("serves cached results within the TTL and rescans on forceReload", async () => {

--- a/apps/server/src/provider/skillsCatalog.ts
+++ b/apps/server/src/provider/skillsCatalog.ts
@@ -18,6 +18,7 @@ type FrontmatterValue = string | boolean;
 export interface SkillRoot {
   readonly path: string;
   readonly scope: string;
+  readonly includeMarkdownFiles?: boolean;
 }
 
 // ── Frontmatter parsing ──────────────────────────────────────────────
@@ -119,10 +120,51 @@ async function readdirOrEmpty(path: string): Promise<import("node:fs").Dirent[]>
   }
 }
 
+async function isWalkableSkillDirectory(
+  parentPath: string,
+  dirent: import("node:fs").Dirent,
+): Promise<boolean> {
+  if (dirent.isDirectory()) {
+    return true;
+  }
+  if (!dirent.isSymbolicLink()) {
+    return false;
+  }
+  try {
+    return (await fs.stat(nodePath.join(parentPath, dirent.name))).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 // Skills may be nested one namespace deep, e.g. `.cursor/skills/skills-sh/find-skills`.
 // Subdirectories are visited concurrently but results are flattened in sorted name
-// order so name-dedup always picks the same winner across runs.
-export async function collectSkillMarkdownPaths(rootPath: string): Promise<string[]> {
+// order so name-dedup always picks the same winner across runs. Provider skill
+// folders may be symlinked, so directory checks intentionally follow symlinks.
+async function isReadableMarkdownFile(
+  parentPath: string,
+  dirent: import("node:fs").Dirent,
+): Promise<boolean> {
+  if (!dirent.name.toLowerCase().endsWith(".md") || dirent.name.toLowerCase() === "skill.md") {
+    return false;
+  }
+  if (dirent.isFile()) {
+    return true;
+  }
+  if (!dirent.isSymbolicLink()) {
+    return false;
+  }
+  try {
+    return (await fs.stat(nodePath.join(parentPath, dirent.name))).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export async function collectSkillMarkdownPaths(
+  rootPath: string,
+  options?: { readonly includeMarkdownFiles?: boolean },
+): Promise<string[]> {
   async function visit(dir: string, depth: number): Promise<string[]> {
     const skillPath = nodePath.join(dir, "SKILL.md");
     try {
@@ -139,14 +181,35 @@ export async function collectSkillMarkdownPaths(rootPath: string): Promise<strin
     }
 
     const dirents = await readdirOrEmpty(dir);
-    const subdirNames = dirents
-      .filter((dirent) => dirent.isDirectory())
-      .map((dirent) => dirent.name)
+    const directMarkdownFiles =
+      depth === 0 && options?.includeMarkdownFiles
+        ? (
+            await Promise.all(
+              dirents.map(async (dirent) => ({
+                name: dirent.name,
+                isMarkdownFile: await isReadableMarkdownFile(dir, dirent),
+              })),
+            )
+          )
+            .filter((entry) => entry.isMarkdownFile)
+            .map((entry) => nodePath.join(dir, entry.name))
+            .sort()
+        : [];
+    const subdirNames = (
+      await Promise.all(
+        dirents.map(async (dirent) => ({
+          name: dirent.name,
+          isDirectory: await isWalkableSkillDirectory(dir, dirent),
+        })),
+      )
+    )
+      .filter((entry) => entry.isDirectory)
+      .map((entry) => entry.name)
       .sort();
     const nested = await Promise.all(
       subdirNames.map((name) => visit(nodePath.join(dir, name), depth + 1)),
     );
-    return nested.flat();
+    return [...directMarkdownFiles, ...nested.flat()];
   }
 
   return visit(rootPath, 0);
@@ -164,7 +227,11 @@ export async function readSkillDescriptor(input: {
   }
 
   const frontmatter = parseSkillFrontmatter(raw);
-  const fallbackName = nodePath.basename(nodePath.dirname(input.skillPath));
+  const skillFilename = nodePath.basename(input.skillPath);
+  const fallbackName =
+    skillFilename.toLowerCase() === "skill.md"
+      ? nodePath.basename(nodePath.dirname(input.skillPath))
+      : nodePath.basename(input.skillPath, nodePath.extname(input.skillPath));
   const name = readStringField(frontmatter, ["name"]) ?? fallbackName;
   const description = readStringField(frontmatter, ["description"]);
   const displayName = readStringField(frontmatter, ["display-name", "displayName", "title"]);
@@ -197,28 +264,35 @@ export function skillNameKey(name: string): string {
   return name.trim().toLowerCase();
 }
 
-// Scans all roots concurrently, then dedupes by name in root order so earlier
-// roots keep precedence. Within a root, SKILL.md path order is preserved.
-export async function collectSkillsFromRoots(
+async function collectSkillDescriptorsFromRoots(
   roots: ReadonlyArray<SkillRoot>,
 ): Promise<ProviderSkillDescriptor[]> {
   const skillsPerRoot = await Promise.all(
     roots.map(async (root) => {
-      const skillPaths = await collectSkillMarkdownPaths(root.path);
+      const skillPaths = await collectSkillMarkdownPaths(
+        root.path,
+        root.includeMarkdownFiles ? { includeMarkdownFiles: true } : undefined,
+      );
       const descriptors = await Promise.all(
         skillPaths.map((skillPath) => readSkillDescriptor({ skillPath, scope: root.scope })),
       );
       return descriptors.filter((skill) => skill !== null);
     }),
   );
+  return skillsPerRoot.flat();
+}
 
+// Scans all roots concurrently, then dedupes by name in root order so earlier
+// roots keep precedence. Within a root, SKILL.md path order is preserved.
+export async function collectSkillsFromRoots(
+  roots: ReadonlyArray<SkillRoot>,
+): Promise<ProviderSkillDescriptor[]> {
+  const allSkills = await collectSkillDescriptorsFromRoots(roots);
   const byName = new Map<string, ProviderSkillDescriptor>();
-  for (const rootSkills of skillsPerRoot) {
-    for (const skill of rootSkills) {
-      const key = skillNameKey(skill.name);
-      if (!byName.has(key)) {
-        byName.set(key, skill);
-      }
+  for (const skill of allSkills) {
+    const key = skillNameKey(skill.name);
+    if (!byName.has(key)) {
+      byName.set(key, skill);
     }
   }
   return [...byName.values()];
@@ -234,11 +308,29 @@ export interface SkillsCatalogDiscoveryInput {
   readonly synaraBaseDir: string;
   /** Provider whose native copies should win when the same skill exists in several roots. */
   readonly provider?: ProviderKind | null;
+  /** Settings needs every origin; composer/provider pickers keep one winner by name. */
+  readonly includeDuplicateOrigins?: boolean;
   /** Bypass the short-lived discovery cache. */
   readonly forceReload?: boolean;
 }
 
-const HOME_ORIGIN_ORDER = ["synara", "codex", "claude", "cursor", "agents"] as const;
+export interface SkillsCatalogRootInput extends SkillsCatalogDiscoveryInput {
+  /** Native provider scans can opt out; the catalog itself always includes Synara. */
+  readonly includeSynaraRoot?: boolean;
+}
+
+const HOME_ORIGIN_ORDER = [
+  "synara",
+  "codex",
+  "claude",
+  "cursor",
+  "gemini",
+  "grok",
+  "kilo",
+  "opencode",
+  "pi",
+  "agents",
+] as const;
 export type SkillsCatalogOrigin = (typeof HOME_ORIGIN_ORDER)[number] | "project";
 
 // Composer skill pickers refetch aggressively (per keystroke, per provider); a
@@ -252,9 +344,13 @@ interface SkillsCatalogCacheEntry {
 }
 
 const skillsCatalogCache = new Map<string, SkillsCatalogCacheEntry>();
+const skillsCatalogInflight = new Map<string, Promise<ReadonlyArray<ProviderSkillDescriptor>>>();
+const ensuredSynaraSkillsDirs = new Set<string>();
 
 export function clearSkillsCatalogCacheForTests(): void {
   skillsCatalogCache.clear();
+  skillsCatalogInflight.clear();
+  ensuredSynaraSkillsDirs.clear();
 }
 
 export function synaraSkillsDir(synaraBaseDir: string): string {
@@ -264,76 +360,117 @@ export function synaraSkillsDir(synaraBaseDir: string): string {
 // Creates the portable skills folder on first use so users have a drop-in target.
 export async function ensureSynaraSkillsDir(synaraBaseDir: string): Promise<string> {
   const dir = synaraSkillsDir(synaraBaseDir);
+  if (ensuredSynaraSkillsDirs.has(dir)) {
+    return dir;
+  }
   try {
     await fs.mkdir(dir, { recursive: true });
+    ensuredSynaraSkillsDirs.add(dir);
   } catch {
     // Discovery still works without the folder; reads simply return nothing.
   }
   return dir;
 }
 
-function homeRootsForOrigin(
-  origin: (typeof HOME_ORIGIN_ORDER)[number],
-  input: SkillsCatalogDiscoveryInput,
-): string[] {
-  switch (origin) {
-    case "synara":
-      return [synaraSkillsDir(input.synaraBaseDir)];
-    case "codex":
-      return [nodePath.join(input.homeDir, ".codex", "skills")];
-    case "claude":
-      return [nodePath.join(input.homeDir, ".claude", "skills")];
-    case "cursor":
-      return [
-        nodePath.join(input.homeDir, ".cursor", "skills-cursor"),
-        nodePath.join(input.homeDir, ".cursor", "skills"),
-      ];
-    case "agents":
-      return [nodePath.join(input.homeDir, ".agents", "skills")];
-  }
+type SkillsHomeOrigin = (typeof HOME_ORIGIN_ORDER)[number];
+
+interface SkillOriginRootSpec {
+  readonly homeRoots: (input: SkillsCatalogDiscoveryInput) => string[];
+  readonly projectRootNames: readonly string[];
 }
 
-function projectRootNamesForOrigin(origin: (typeof HOME_ORIGIN_ORDER)[number]): string[] {
-  switch (origin) {
-    case "synara":
-      return [".synara"];
-    case "codex":
-      return [".codex"];
-    case "claude":
-      return [".claude"];
-    case "cursor":
-      return [".cursor"];
-    case "agents":
-      return [".agents"];
-  }
+const SKILL_ORIGIN_ROOTS = {
+  synara: {
+    homeRoots: (input) => [synaraSkillsDir(input.synaraBaseDir)],
+    projectRootNames: [".synara"],
+  },
+  codex: {
+    // Keep Synara's existing Codex-local root. Official Codex discovery uses
+    // `.agents/skills`, which is represented separately by the shared origin.
+    homeRoots: (input) => [nodePath.join(input.homeDir, ".codex", "skills")],
+    projectRootNames: [".codex"],
+  },
+  claude: {
+    homeRoots: (input) => [nodePath.join(input.homeDir, ".claude", "skills")],
+    projectRootNames: [".claude"],
+  },
+  cursor: {
+    homeRoots: (input) => [
+      nodePath.join(input.homeDir, ".cursor", "skills-cursor"),
+      nodePath.join(input.homeDir, ".cursor", "skills"),
+    ],
+    projectRootNames: [".cursor"],
+  },
+  gemini: {
+    homeRoots: (input) => [nodePath.join(input.homeDir, ".gemini", "skills")],
+    projectRootNames: [".gemini"],
+  },
+  grok: {
+    homeRoots: (input) => [nodePath.join(input.homeDir, ".grok", "skills")],
+    projectRootNames: [".grok"],
+  },
+  kilo: {
+    homeRoots: (input) => [nodePath.join(input.homeDir, ".kilo", "skills")],
+    projectRootNames: [".kilo"],
+  },
+  opencode: {
+    homeRoots: (input) => [nodePath.join(input.homeDir, ".config", "opencode", "skills")],
+    projectRootNames: [".opencode"],
+  },
+  pi: {
+    homeRoots: (input) => [nodePath.join(input.homeDir, ".pi", "agent", "skills")],
+    projectRootNames: [".pi"],
+  },
+  agents: {
+    homeRoots: (input) => [nodePath.join(input.homeDir, ".agents", "skills")],
+    projectRootNames: [".agents"],
+  },
+} as const satisfies Record<SkillsHomeOrigin, SkillOriginRootSpec>;
+
+const PROVIDER_SKILL_ORIGIN_PREFERENCES = {
+  codex: ["codex", "agents"],
+  claudeAgent: ["claude"],
+  cursor: ["cursor", "agents", "claude", "codex"],
+  gemini: ["agents", "gemini"],
+  grok: ["grok", "claude", "agents"],
+  kilo: ["kilo", "agents", "claude"],
+  opencode: ["opencode", "claude", "agents"],
+  pi: ["pi", "agents"],
+} as const satisfies Partial<Record<ProviderKind, readonly SkillsHomeOrigin[]>>;
+
+function homeRootsForOrigin(origin: SkillsHomeOrigin, input: SkillsCatalogDiscoveryInput): string[] {
+  return SKILL_ORIGIN_ROOTS[origin].homeRoots(input);
+}
+
+function projectRootNamesForOrigin(origin: SkillsHomeOrigin): readonly string[] {
+  return SKILL_ORIGIN_ROOTS[origin].projectRootNames;
 }
 
 // Native copies first so an agent keeps using its own skill, then Synara as the
 // portable fallback, then the remaining provider homes for cross-provider reuse.
 function preferredOriginsForProvider(
   provider: ProviderKind | null | undefined,
-): ReadonlyArray<(typeof HOME_ORIGIN_ORDER)[number]> {
-  switch (provider) {
-    case "codex":
-      return ["codex"];
-    case "claudeAgent":
-      return ["claude"];
-    case "cursor":
-      return ["cursor", "agents"];
-    default:
-      return [];
-  }
+): ReadonlyArray<SkillsHomeOrigin> {
+  return provider ? (PROVIDER_SKILL_ORIGIN_PREFERENCES[provider] ?? []) : [];
 }
 
 function orderedOriginsForProvider(
   provider: ProviderKind | null | undefined,
-): Array<(typeof HOME_ORIGIN_ORDER)[number]> {
+  includeSynaraRoot = true,
+  includeRemainingOrigins = true,
+): SkillsHomeOrigin[] {
   const preferred = preferredOriginsForProvider(provider);
   const ordered = [...preferred];
-  if (!ordered.includes("synara")) {
+  if (includeSynaraRoot && !ordered.includes("synara")) {
     ordered.push("synara");
   }
+  if (!includeRemainingOrigins) {
+    return ordered.filter((origin) => includeSynaraRoot || origin !== "synara");
+  }
   for (const origin of HOME_ORIGIN_ORDER) {
+    if (!includeSynaraRoot && origin === "synara") {
+      continue;
+    }
     if (!ordered.includes(origin)) {
       ordered.push(origin);
     }
@@ -341,11 +478,16 @@ function orderedOriginsForProvider(
   return ordered;
 }
 
-export function skillsCatalogRoots(input: SkillsCatalogDiscoveryInput): SkillRoot[] {
-  const orderedOrigins = orderedOriginsForProvider(input.provider);
-
+function rootsForOrderedOrigins(
+  input: SkillsCatalogRootInput,
+  orderedOrigins: ReadonlyArray<SkillsHomeOrigin>,
+): SkillRoot[] {
   const homeRoots = orderedOrigins.flatMap((origin) =>
-    homeRootsForOrigin(origin, input).map((path) => ({ path, scope: origin })),
+    homeRootsForOrigin(origin, input).map((path) => ({
+      path,
+      scope: origin,
+      ...(origin === "pi" ? { includeMarkdownFiles: true } : {}),
+    })),
   );
   const homeRootPaths = new Set(homeRoots.map((root) => nodePath.resolve(root.path)));
 
@@ -368,13 +510,28 @@ export function skillsCatalogRoots(input: SkillsCatalogDiscoveryInput): SkillRoo
           if (homeRootPaths.has(nodePath.resolve(rootPath))) {
             continue;
           }
-          projectRoots.push({ path: rootPath, scope: "project" });
+          projectRoots.push({
+            path: rootPath,
+            scope: "project",
+            ...(origin === "pi" ? { includeMarkdownFiles: true } : {}),
+          });
         }
       }
     }
   }
 
   return [...projectRoots, ...homeRoots];
+}
+
+export function skillsCatalogRoots(input: SkillsCatalogRootInput): SkillRoot[] {
+  return rootsForOrderedOrigins(
+    input,
+    orderedOriginsForProvider(input.provider, input.includeSynaraRoot !== false),
+  );
+}
+
+export function providerNativeSkillRoots(input: SkillsCatalogRootInput): SkillRoot[] {
+  return rootsForOrderedOrigins(input, orderedOriginsForProvider(input.provider, false, false));
 }
 
 export async function discoverSkillsCatalog(
@@ -385,6 +542,7 @@ export async function discoverSkillsCatalog(
     input.provider ?? "",
     input.homeDir,
     input.synaraBaseDir,
+    input.includeDuplicateOrigins ? "all-origins" : "deduped",
   ].join("\u0000");
 
   if (!input.forceReload) {
@@ -394,19 +552,35 @@ export async function discoverSkillsCatalog(
     }
   }
 
-  await ensureSynaraSkillsDir(input.synaraBaseDir);
-  const skills = await collectSkillsFromRoots(skillsCatalogRoots(input));
-
-  skillsCatalogCache.delete(cacheKey);
-  skillsCatalogCache.set(cacheKey, { at: Date.now(), skills });
-  while (skillsCatalogCache.size > SKILLS_CATALOG_CACHE_MAX_ENTRIES) {
-    const oldestKey = skillsCatalogCache.keys().next().value;
-    if (oldestKey === undefined) {
-      break;
-    }
-    skillsCatalogCache.delete(oldestKey);
+  const inflight = skillsCatalogInflight.get(cacheKey);
+  if (inflight) {
+    return [...(await inflight)];
   }
-  return skills;
+
+  const scan = (async () => {
+    await ensureSynaraSkillsDir(input.synaraBaseDir);
+    const skills = input.includeDuplicateOrigins
+      ? await collectSkillDescriptorsFromRoots(skillsCatalogRoots(input))
+      : await collectSkillsFromRoots(skillsCatalogRoots(input));
+
+    skillsCatalogCache.delete(cacheKey);
+    skillsCatalogCache.set(cacheKey, { at: Date.now(), skills });
+    while (skillsCatalogCache.size > SKILLS_CATALOG_CACHE_MAX_ENTRIES) {
+      const oldestKey = skillsCatalogCache.keys().next().value;
+      if (oldestKey === undefined) {
+        break;
+      }
+      skillsCatalogCache.delete(oldestKey);
+    }
+    return skills;
+  })();
+
+  skillsCatalogInflight.set(cacheKey, scan);
+  try {
+    return [...(await scan)];
+  } finally {
+    skillsCatalogInflight.delete(cacheKey);
+  }
 }
 
 // Provider-native discovery results win on name conflicts; catalog entries fill the gaps.

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -1079,6 +1079,7 @@ export const makeWsRpcLayer = () =>
                 cwd: input.cwd ?? null,
                 homeDir: config.homeDir,
                 synaraBaseDir: config.baseDir,
+                includeDuplicateOrigins: true,
               }),
             ).pipe(
               Effect.map((skills) => ({

--- a/apps/web/src/components/settings/SettingsPanelPrimitives.tsx
+++ b/apps/web/src/components/settings/SettingsPanelPrimitives.tsx
@@ -61,7 +61,7 @@ export function SettingsRow({
   children,
   onClick,
 }: {
-  title: string;
+  title: ReactNode;
   description: string;
   status?: ReactNode;
   resetAction?: ReactNode;

--- a/apps/web/src/components/settings/SkillsSettingsPanel.tsx
+++ b/apps/web/src/components/settings/SkillsSettingsPanel.tsx
@@ -31,11 +31,12 @@ function SkillProviderStack({ providers }: { providers: ReadonlyArray<ProviderKi
   }
 
   const label = providers.map(providerDisplayName).join(", ");
+  const stackLabel = `Provider ${providers.length === 1 ? "copy" : "copies"}: ${label}`;
   return (
     <span
       className="inline-flex shrink-0 items-center -space-x-1"
-      aria-label={`Available from ${label}`}
-      title={label}
+      aria-label={stackLabel}
+      title={stackLabel}
     >
       {providers.map((provider) => (
         <span

--- a/apps/web/src/components/settings/SkillsSettingsPanel.tsx
+++ b/apps/web/src/components/settings/SkillsSettingsPanel.tsx
@@ -4,53 +4,49 @@
 // a skill comes from, and lets the user enable/disable each one. Disabled skills are
 // hidden from the composer skill picker on every provider.
 
-import type { ProviderKind, ProviderSkillDescriptor, ServerSettings } from "@t3tools/contracts";
-import { PROVIDER_DISPLAY_NAMES } from "@t3tools/contracts";
+import type { ProviderKind, ServerSettings } from "@t3tools/contracts";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 import { ProviderIcon } from "~/components/ProviderIcon";
 import { SettingsRow, SettingsSection } from "~/components/settings/SettingsPanelPrimitives";
 import { Switch } from "~/components/ui/switch";
+import { SkillCubeIcon } from "~/lib/icons";
 import { ensureNativeApi } from "~/nativeApi";
 import {
   providerDiscoveryQueryKeys,
   skillsCatalogQueryOptions,
 } from "~/lib/providerDiscoveryReactQuery";
 import { serverQueryKeys, serverSettingsQueryOptions } from "~/lib/serverReactQuery";
+import {
+  buildSettingsSkillGroups,
+  buildSettingsSkillSections,
+  providerDisplayName,
+  settingsSkillNameKey,
+} from "./skillsSettingsModel";
 
-interface SkillOriginInfo {
-  readonly label: string;
-  readonly provider: ProviderKind | null;
-}
-
-function skillOriginInfo(scope: string | undefined): SkillOriginInfo {
-  switch (scope) {
-    case "synara":
-      return { label: "Synara", provider: null };
-    case "codex":
-      return { label: PROVIDER_DISPLAY_NAMES.codex, provider: "codex" };
-    case "claude":
-      return { label: PROVIDER_DISPLAY_NAMES.claudeAgent, provider: "claudeAgent" };
-    case "cursor":
-      return { label: PROVIDER_DISPLAY_NAMES.cursor, provider: "cursor" };
-    case "agents":
-      return { label: "Shared (.agents)", provider: null };
-    case "project":
-      return { label: "Project", provider: null };
-    default:
-      return { label: scope ?? "Personal", provider: null };
+function SkillProviderStack({ providers }: { providers: ReadonlyArray<ProviderKind> }) {
+  if (providers.length === 0) {
+    return null;
   }
-}
 
-const ORIGIN_SECTION_ORDER = ["synara", "codex", "claude", "cursor", "agents", "project"] as const;
-
-function skillNameKey(name: string): string {
-  return name.trim().toLowerCase();
-}
-
-function skillDisplayName(skill: ProviderSkillDescriptor): string {
-  return skill.interface?.displayName ?? skill.name;
+  const label = providers.map(providerDisplayName).join(", ");
+  return (
+    <span
+      className="inline-flex shrink-0 items-center -space-x-1"
+      aria-label={`Available from ${label}`}
+      title={label}
+    >
+      {providers.map((provider) => (
+        <span
+          key={provider}
+          className="inline-flex size-4 items-center justify-center rounded-full border border-background bg-background"
+        >
+          <ProviderIcon provider={provider} className="size-3" />
+        </span>
+      ))}
+    </span>
+  );
 }
 
 export function SkillsSettingsPanel() {
@@ -60,31 +56,18 @@ export function SkillsSettingsPanel() {
 
   const disabledSkillNames = useMemo(
     () =>
-      new Set((serverSettingsQuery.data?.skills.disabled ?? []).map((name) => skillNameKey(name))),
+      new Set(
+        (serverSettingsQuery.data?.skills.disabled ?? []).map((name) => settingsSkillNameKey(name)),
+      ),
     [serverSettingsQuery.data?.skills.disabled],
   );
 
-  const skillsByOrigin = useMemo(() => {
-    const groups = new Map<string, ProviderSkillDescriptor[]>();
-    for (const skill of catalogQuery.data?.skills ?? []) {
-      const origin = skill.scope ?? "personal";
-      const group = groups.get(origin) ?? [];
-      group.push(skill);
-      groups.set(origin, group);
-    }
-    for (const group of groups.values()) {
-      group.sort((left, right) => skillDisplayName(left).localeCompare(skillDisplayName(right)));
-    }
-    const orderedOrigins = [
-      ...ORIGIN_SECTION_ORDER.filter((origin) => groups.has(origin)),
-      ...[...groups.keys()].filter(
-        (origin) => !(ORIGIN_SECTION_ORDER as readonly string[]).includes(origin),
-      ),
-    ];
-    return orderedOrigins.map((origin) => ({
-      origin,
-      skills: groups.get(origin) ?? [],
-    }));
+  const skillGroups = useMemo(
+    () => buildSettingsSkillGroups(catalogQuery.data?.skills ?? []),
+    [catalogQuery.data?.skills],
+  );
+  const skillSections = useMemo(() => {
+    return buildSettingsSkillSections(catalogQuery.data?.skills ?? []);
   }, [catalogQuery.data?.skills]);
 
   const setSkillEnabled = (skillName: string, enabled: boolean) => {
@@ -92,8 +75,8 @@ export function SkillsSettingsPanel() {
     // build on each other instead of clobbering the previous patch.
     const latestSettings = queryClient.getQueryData<ServerSettings>(serverQueryKeys.settings());
     const currentDisabled = latestSettings?.skills.disabled ?? [...disabledSkillNames];
-    const key = skillNameKey(skillName);
-    const next = new Set(currentDisabled.map((name) => skillNameKey(name)));
+    const key = settingsSkillNameKey(skillName);
+    const next = new Set(currentDisabled.map((name) => settingsSkillNameKey(name)));
     if (enabled) {
       next.delete(key);
     } else {
@@ -119,10 +102,8 @@ export function SkillsSettingsPanel() {
       });
   };
 
-  const totalSkills = catalogQuery.data?.skills.length ?? 0;
-  const enabledSkills = (catalogQuery.data?.skills ?? []).filter(
-    (skill) => !disabledSkillNames.has(skillNameKey(skill.name)),
-  ).length;
+  const totalSkills = skillGroups.length;
+  const enabledSkills = skillGroups.filter((group) => !disabledSkillNames.has(group.key)).length;
   const synaraSkillsDir = catalogQuery.data?.synaraSkillsDir;
 
   return (
@@ -159,41 +140,54 @@ export function SkillsSettingsPanel() {
         <SettingsSection title="Skills">
           <SettingsRow
             title="No skills found"
-            description="Add a skill folder containing a SKILL.md to the Synara skills folder above, or install skills for Codex, Claude, or Cursor."
+            description="Add a skill folder containing a SKILL.md to the Synara skills folder above, or install skills for any supported provider."
           />
         </SettingsSection>
       ) : null}
 
-      {skillsByOrigin.map(({ origin, skills }) => {
-        const originInfo = skillOriginInfo(origin);
+      {skillSections.map((section) => {
         return (
-          <SettingsSection key={origin} title={`From ${originInfo.label}`}>
-            {skills.map((skill) => {
-              const enabled = !disabledSkillNames.has(skillNameKey(skill.name));
+          <SettingsSection key={section.key} title={section.title}>
+            {section.groups.map((group) => {
+              const enabled = !disabledSkillNames.has(group.key);
               return (
                 <SettingsRow
-                  key={skill.path}
-                  title={skillDisplayName(skill)}
-                  description={
-                    skill.interface?.shortDescription ?? skill.description ?? "No description."
-                  }
-                  status={
-                    <span className="flex min-w-0 items-center gap-1.5">
-                      <ProviderIcon
-                        provider={originInfo.provider}
-                        className="size-3 shrink-0"
-                        fallback={null}
+                  key={group.key}
+                  title={
+                    <span className="inline-flex min-w-0 items-center gap-1.5">
+                      <SkillCubeIcon
+                        aria-hidden="true"
+                        className="size-3.5 shrink-0 text-muted-foreground"
                       />
-                      <code className="truncate text-[11px] text-muted-foreground">
-                        {skill.path}
-                      </code>
+                      <span className="truncate">{group.displayName}</span>
+                    </span>
+                  }
+                  description={group.description}
+                  status={
+                    <span className="flex min-w-0 flex-col gap-1">
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <SkillProviderStack providers={group.providers} />
+                        <span className="truncate text-[11px] text-muted-foreground">
+                          {group.sources.map((source) => source.originInfo.label).join(" · ")}
+                        </span>
+                      </span>
+                      {group.sources.map((source) => (
+                        <code
+                          key={source.skill.path}
+                          className="truncate text-[11px] text-muted-foreground"
+                        >
+                          {source.skill.path}
+                        </code>
+                      ))}
                     </span>
                   }
                   control={
                     <Switch
                       checked={enabled}
-                      onCheckedChange={(checked) => setSkillEnabled(skill.name, Boolean(checked))}
-                      aria-label={`Enable the ${skillDisplayName(skill)} skill`}
+                      onCheckedChange={(checked) =>
+                        setSkillEnabled(group.primarySkill.name, Boolean(checked))
+                      }
+                      aria-label={`Enable the ${group.displayName} skill`}
                     />
                   }
                 />

--- a/apps/web/src/components/settings/skillsSettingsModel.test.ts
+++ b/apps/web/src/components/settings/skillsSettingsModel.test.ts
@@ -59,7 +59,7 @@ describe("buildSettingsSkillGroups", () => {
     expect(cursorOnly?.providers).toEqual(["cursor"]);
   });
 
-  it("shows shared alias skills as available to providers that read .agents", () => {
+  it("does not show provider icons for shared alias-only skills", () => {
     const groups = buildSettingsSkillGroups([
       skill({
         name: "portable-review",
@@ -69,16 +69,8 @@ describe("buildSettingsSkillGroups", () => {
       }),
     ]);
 
-    expect(groups[0]?.providers).toEqual([
-      "codex",
-      "cursor",
-      "gemini",
-      "grok",
-      "kilo",
-      "opencode",
-      "pi",
-    ]);
-    expect(groups[0]?.section).toBe("shared");
+    expect(groups[0]?.providers).toEqual([]);
+    expect(groups[0]?.section).toBe("agents");
   });
 });
 

--- a/apps/web/src/components/settings/skillsSettingsModel.test.ts
+++ b/apps/web/src/components/settings/skillsSettingsModel.test.ts
@@ -1,0 +1,108 @@
+// FILE: skillsSettingsModel.test.ts
+// Purpose: Locks down Settings -> Skills grouping for duplicate provider skill copies.
+// Layer: Web settings logic tests
+
+import type { ProviderSkillDescriptor } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import { buildSettingsSkillGroups, buildSettingsSkillSections } from "./skillsSettingsModel";
+
+function skill(partial: Partial<ProviderSkillDescriptor>): ProviderSkillDescriptor {
+  return {
+    name: "example",
+    enabled: true,
+    path: "/tmp/example/SKILL.md",
+    ...partial,
+  };
+}
+
+describe("buildSettingsSkillGroups", () => {
+  it("renders duplicate provider copies as one shared skill group", () => {
+    const groups = buildSettingsSkillGroups([
+      skill({
+        name: "check-code",
+        description: "Codex copy",
+        path: "/Users/test/.codex/skills/check-code/SKILL.md",
+        scope: "codex",
+      }),
+      skill({
+        name: "check-code",
+        description: "Claude copy",
+        path: "/Users/test/.claude/skills/check-code/SKILL.md",
+        scope: "claude",
+      }),
+      skill({
+        name: "check-code",
+        description: "Gemini copy",
+        path: "/Users/test/.gemini/skills/check-code/SKILL.md",
+        scope: "gemini",
+      }),
+      skill({
+        name: "cursor-only",
+        path: "/Users/test/.cursor/skills/cursor-only/SKILL.md",
+        scope: "cursor",
+      }),
+    ]);
+
+    const shared = groups.find((group) => group.key === "check-code");
+    expect(shared?.section).toBe("shared");
+    expect(shared?.providers).toEqual(["codex", "claudeAgent", "gemini"]);
+    expect(shared?.sources.map((source) => source.origin)).toEqual(["codex", "claude", "gemini"]);
+    expect(shared?.sources.map((source) => source.skill.path)).toEqual([
+      "/Users/test/.codex/skills/check-code/SKILL.md",
+      "/Users/test/.claude/skills/check-code/SKILL.md",
+      "/Users/test/.gemini/skills/check-code/SKILL.md",
+    ]);
+
+    const cursorOnly = groups.find((group) => group.key === "cursor-only");
+    expect(cursorOnly?.section).toBe("cursor");
+    expect(cursorOnly?.providers).toEqual(["cursor"]);
+  });
+
+  it("shows shared alias skills as available to providers that read .agents", () => {
+    const groups = buildSettingsSkillGroups([
+      skill({
+        name: "portable-review",
+        description: "Shared standard copy",
+        path: "/Users/test/.agents/skills/portable-review/SKILL.md",
+        scope: "agents",
+      }),
+    ]);
+
+    expect(groups[0]?.providers).toEqual([
+      "codex",
+      "cursor",
+      "gemini",
+      "grok",
+      "kilo",
+      "opencode",
+      "pi",
+    ]);
+    expect(groups[0]?.section).toBe("shared");
+  });
+});
+
+describe("buildSettingsSkillSections", () => {
+  it("places shared skill groups before provider-only sections", () => {
+    const sections = buildSettingsSkillSections([
+      skill({
+        name: "logic-consolidator",
+        path: "/Users/test/.codex/skills/logic-consolidator/SKILL.md",
+        scope: "codex",
+      }),
+      skill({
+        name: "logic-consolidator",
+        path: "/Users/test/.claude/skills/logic-consolidator/SKILL.md",
+        scope: "claude",
+      }),
+      skill({
+        name: "cursor-only",
+        path: "/Users/test/.cursor/skills/cursor-only/SKILL.md",
+        scope: "cursor",
+      }),
+    ]);
+
+    expect(sections.map((section) => section.title)).toEqual(["Shared skills", "From Cursor"]);
+    expect(sections[0]?.groups.map((group) => group.key)).toEqual(["logic-consolidator"]);
+  });
+});

--- a/apps/web/src/components/settings/skillsSettingsModel.ts
+++ b/apps/web/src/components/settings/skillsSettingsModel.ts
@@ -89,16 +89,8 @@ export function skillOriginInfo(scope: string | undefined): SkillOriginInfo {
 }
 
 export function providersForSkillOrigin(origin: string): ProviderKind[] {
-  switch (origin) {
-    case "synara":
-      return [...PROVIDER_STACK_ORDER];
-    case "agents":
-      return sortProviderStack(["codex", "cursor", "gemini", "grok", "kilo", "opencode", "pi"]);
-    default: {
-      const provider = skillOriginInfo(origin).provider;
-      return provider ? [provider] : [];
-    }
-  }
+  const provider = skillOriginInfo(origin).provider;
+  return provider ? [provider] : [];
 }
 
 export function settingsSkillNameKey(name: string): string {
@@ -174,9 +166,7 @@ export function buildSettingsSkillGroups(
           .filter((provider, index, all) => all.indexOf(provider) === index),
       );
       const section =
-        sources.length > 1 || providers.length > 1
-          ? SHARED_SKILLS_SECTION
-          : sources[0]?.origin ?? PERSONAL_ORIGIN;
+        sources.length > 1 ? SHARED_SKILLS_SECTION : sources[0]?.origin ?? PERSONAL_ORIGIN;
       const description =
         primarySkill.interface?.shortDescription ?? primarySkill.description ?? "No description.";
       return {

--- a/apps/web/src/components/settings/skillsSettingsModel.ts
+++ b/apps/web/src/components/settings/skillsSettingsModel.ts
@@ -1,0 +1,211 @@
+// FILE: skillsSettingsModel.ts
+// Purpose: Groups duplicate skill copies for Settings -> Skills so shared names render once.
+// Layer: Settings UI logic
+// Exports: origin metadata, canonical skill grouping, and section ordering helpers.
+
+import type { ProviderKind, ProviderSkillDescriptor } from "@t3tools/contracts";
+import { PROVIDER_DISPLAY_NAMES } from "@t3tools/contracts";
+
+export interface SkillOriginInfo {
+  readonly label: string;
+  readonly provider: ProviderKind | null;
+}
+
+export interface SettingsSkillSource {
+  readonly skill: ProviderSkillDescriptor;
+  readonly origin: string;
+  readonly originInfo: SkillOriginInfo;
+}
+
+export interface SettingsSkillGroup {
+  readonly key: string;
+  readonly displayName: string;
+  readonly description: string;
+  readonly primarySkill: ProviderSkillDescriptor;
+  readonly providers: ReadonlyArray<ProviderKind>;
+  readonly sources: ReadonlyArray<SettingsSkillSource>;
+  readonly section: string;
+}
+
+export interface SettingsSkillSection {
+  readonly key: string;
+  readonly title: string;
+  readonly groups: ReadonlyArray<SettingsSkillGroup>;
+}
+
+const SHARED_SKILLS_SECTION = "shared";
+const PERSONAL_ORIGIN = "personal";
+export const ORIGIN_SECTION_ORDER = [
+  "synara",
+  "codex",
+  "claude",
+  "cursor",
+  "gemini",
+  "grok",
+  "kilo",
+  "opencode",
+  "pi",
+  "agents",
+  "project",
+] as const;
+export const PROVIDER_STACK_ORDER: readonly ProviderKind[] = [
+  "codex",
+  "claudeAgent",
+  "cursor",
+  "gemini",
+  "grok",
+  "kilo",
+  "opencode",
+  "pi",
+] as const;
+
+export function skillOriginInfo(scope: string | undefined): SkillOriginInfo {
+  switch (scope) {
+    case "synara":
+      return { label: "Synara", provider: null };
+    case "codex":
+      return { label: PROVIDER_DISPLAY_NAMES.codex, provider: "codex" };
+    case "claude":
+      return { label: PROVIDER_DISPLAY_NAMES.claudeAgent, provider: "claudeAgent" };
+    case "cursor":
+      return { label: PROVIDER_DISPLAY_NAMES.cursor, provider: "cursor" };
+    case "gemini":
+      return { label: PROVIDER_DISPLAY_NAMES.gemini, provider: "gemini" };
+    case "grok":
+      return { label: PROVIDER_DISPLAY_NAMES.grok, provider: "grok" };
+    case "kilo":
+      return { label: PROVIDER_DISPLAY_NAMES.kilo, provider: "kilo" };
+    case "opencode":
+      return { label: PROVIDER_DISPLAY_NAMES.opencode, provider: "opencode" };
+    case "pi":
+      return { label: PROVIDER_DISPLAY_NAMES.pi, provider: "pi" };
+    case "agents":
+      return { label: "Shared (.agents)", provider: null };
+    case "project":
+      return { label: "Project", provider: null };
+    default:
+      return { label: scope ?? "Personal", provider: null };
+  }
+}
+
+export function providersForSkillOrigin(origin: string): ProviderKind[] {
+  switch (origin) {
+    case "synara":
+      return [...PROVIDER_STACK_ORDER];
+    case "agents":
+      return sortProviderStack(["codex", "cursor", "gemini", "grok", "kilo", "opencode", "pi"]);
+    default: {
+      const provider = skillOriginInfo(origin).provider;
+      return provider ? [provider] : [];
+    }
+  }
+}
+
+export function settingsSkillNameKey(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+export function skillDisplayName(skill: ProviderSkillDescriptor): string {
+  return skill.interface?.displayName ?? skill.name;
+}
+
+export function providerDisplayName(provider: ProviderKind): string {
+  return PROVIDER_DISPLAY_NAMES[provider];
+}
+
+export function sortProviderStack(providers: ReadonlyArray<ProviderKind>): ProviderKind[] {
+  return [...providers].sort(
+    (left, right) => PROVIDER_STACK_ORDER.indexOf(left) - PROVIDER_STACK_ORDER.indexOf(right),
+  );
+}
+
+function originRank(origin: string): number {
+  const index = (ORIGIN_SECTION_ORDER as readonly string[]).indexOf(origin);
+  return index >= 0 ? index : ORIGIN_SECTION_ORDER.length;
+}
+
+function sourceSortKey(source: SettingsSkillSource): string {
+  return `${originRank(source.origin).toString().padStart(2, "0")}\u0000${source.skill.path}`;
+}
+
+function sectionTitle(section: string): string {
+  if (section === SHARED_SKILLS_SECTION) {
+    return "Shared skills";
+  }
+  return `From ${skillOriginInfo(section).label}`;
+}
+
+function sectionRank(section: string): number {
+  if (section === SHARED_SKILLS_SECTION) {
+    return -1;
+  }
+  return originRank(section);
+}
+
+// Creates one canonical row per normalized skill name. Duplicate provider copies
+// stay visible as sources instead of letting the first origin hide the rest.
+export function buildSettingsSkillGroups(
+  skills: ReadonlyArray<ProviderSkillDescriptor>,
+): SettingsSkillGroup[] {
+  const groups = new Map<string, SettingsSkillSource[]>();
+  for (const skill of skills) {
+    const key = settingsSkillNameKey(skill.name);
+    const origin = skill.scope ?? PERSONAL_ORIGIN;
+    const source: SettingsSkillSource = {
+      skill,
+      origin,
+      originInfo: skillOriginInfo(origin),
+    };
+    groups.set(key, [...(groups.get(key) ?? []), source]);
+  }
+
+  return [...groups.entries()]
+    .map(([key, unsortedSources]) => {
+      const sources = [...unsortedSources].sort((left, right) =>
+        sourceSortKey(left).localeCompare(sourceSortKey(right)),
+      );
+      const primarySkill = sources[0]?.skill;
+      if (!primarySkill) {
+        return null;
+      }
+      const providers = sortProviderStack(
+        sources
+          .flatMap((source) => providersForSkillOrigin(source.origin))
+          .filter((provider, index, all) => all.indexOf(provider) === index),
+      );
+      const section =
+        sources.length > 1 || providers.length > 1
+          ? SHARED_SKILLS_SECTION
+          : sources[0]?.origin ?? PERSONAL_ORIGIN;
+      const description =
+        primarySkill.interface?.shortDescription ?? primarySkill.description ?? "No description.";
+      return {
+        key,
+        displayName: skillDisplayName(primarySkill),
+        description,
+        primarySkill,
+        providers,
+        sources,
+        section,
+      } satisfies SettingsSkillGroup;
+    })
+    .filter((group): group is SettingsSkillGroup => group !== null)
+    .sort((left, right) => left.displayName.localeCompare(right.displayName));
+}
+
+export function buildSettingsSkillSections(
+  skills: ReadonlyArray<ProviderSkillDescriptor>,
+): SettingsSkillSection[] {
+  const sections = new Map<string, SettingsSkillGroup[]>();
+  for (const group of buildSettingsSkillGroups(skills)) {
+    sections.set(group.section, [...(sections.get(group.section) ?? []), group]);
+  }
+
+  return [...sections.entries()]
+    .map(([key, groups]) => ({
+      key,
+      title: sectionTitle(key),
+      groups,
+    }))
+    .sort((left, right) => sectionRank(left.key) - sectionRank(right.key));
+}

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -8,7 +8,7 @@ function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
   return (
     <SwitchPrimitive.Root
       className={cn(
-        "inline-flex h-[calc(var(--thumb-size)+2px)] w-[calc(var(--thumb-size)*2-2px)] shrink-0 cursor-pointer items-center rounded-full p-px outline-none transition-[background-color,box-shadow] duration-200 [--thumb-size:--spacing(5)] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background data-checked:bg-primary data-unchecked:bg-input data-disabled:cursor-not-allowed data-disabled:opacity-64 sm:[--thumb-size:--spacing(4)]",
+        "inline-flex h-[calc(var(--thumb-size)+2px)] w-[calc(var(--thumb-size)*2-2px)] shrink-0 cursor-pointer items-center rounded-full border border-[color:var(--color-border-light)] p-px outline-none transition-[background-color,box-shadow,border-color] duration-200 [--thumb-size:--spacing(5)] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background data-checked:bg-primary data-unchecked:bg-input data-disabled:cursor-not-allowed data-disabled:opacity-64 sm:[--thumb-size:--spacing(4)]",
         className,
       )}
       data-slot="switch"

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -112,8 +112,8 @@ export function providerSkillsQueryOptions(input: {
 }
 
 // Unified cross-provider skills catalog (settings page); not filtered by toggles.
-// No placeholderData: the settings panel relies on `isLoading` to distinguish the
-// initial scan from a genuinely empty catalog.
+// Keep prior data during refetches so Settings does not flicker back to "Scanning..."
+// while the server refreshes filesystem discovery in the background.
 export function skillsCatalogQueryOptions(input?: { cwd?: string | null; enabled?: boolean }) {
   const cwd = input?.cwd ?? null;
   return queryOptions({
@@ -124,6 +124,7 @@ export function skillsCatalogQueryOptions(input?: { cwd?: string | null; enabled
     },
     enabled: input?.enabled ?? true,
     staleTime: 30_000,
+    placeholderData: (previous) => previous,
   });
 }
 

--- a/apps/web/src/settingsNavigation.ts
+++ b/apps/web/src/settingsNavigation.ts
@@ -122,7 +122,7 @@ export const SETTINGS_NAV_ITEMS: readonly SettingsNavItem[] = [
     group: "synara",
     label: "Skills",
     description: "Every skill found across providers, with toggles to control availability.",
-    icon: "sparkle",
+    icon: "building-blocks",
     eyebrow: "Agent skills",
   },
   {


### PR DESCRIPTION
## Summary
- unify Settings skill discovery across provider roots, including symlinked skill dirs and duplicate origins
- group duplicate skill copies into one Settings row while showing only provider icons for actual provider-native copies
- add Grok/Gemini/Kilo/OpenCode/Pi skill roots and Pi direct markdown skill support
- keep Settings loading smoother and add the skills nav/input icon updates

## Verification
- git diff --check
- bun run test src/provider/skillsCatalog.test.ts src/provider/cursorSkillsDiscovery.test.ts
- bun run test src/components/settings/skillsSettingsModel.test.ts
- Playwright visual smoke check for Settings > Skills desktop/mobile
- Toggle smoke check: 62/62 -> 61/62 -> 62/62

Note: did not run full bun fmt/lint/typecheck because repo instructions require explicit request for those heavyweight checks.