### PR TITLE
Fix stale Codex auth overlay

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -513,6 +513,35 @@ describe("buildCodexProcessEnv", () => {
     }
   });
 
+  it("repairs stale auth.json files in Synara's Codex home overlay", () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "t3-codex-env-"));
+    const runtimeHome = mkdtempSync(path.join(os.tmpdir(), "t3-runtime-home-"));
+    try {
+      const sourceAuthPath = path.join(tempDir, "auth.json");
+      writeFileSync(path.join(tempDir, "config.toml"), 'model = "gpt-5.5"', "utf8");
+      writeFileSync(sourceAuthPath, '{"tokens":{"access_token":"fresh"}}', "utf8");
+
+      const overlayHome = path.join(runtimeHome, "codex-home-overlay");
+      const overlayAuthPath = path.join(overlayHome, "auth.json");
+      mkdirSync(overlayHome, { recursive: true });
+      writeFileSync(overlayAuthPath, '{"tokens":{"access_token":"stale"}}', "utf8");
+
+      const env = buildCodexProcessEnv({
+        env: { SYNARA_HOME: runtimeHome },
+        homePath: tempDir,
+        platform: "darwin",
+      });
+
+      expect(env.CODEX_HOME).toBe(overlayHome);
+      expect(lstatSync(overlayAuthPath).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(overlayAuthPath)).toBe(sourceAuthPath);
+      expect(readFileSync(overlayAuthPath, "utf8")).toContain("fresh");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+      rmSync(runtimeHome, { recursive: true, force: true });
+    }
+  });
+
   it("preserves real generated image directories in Synara's Codex home overlay", () => {
     const tempDir = mkdtempSync(path.join(os.tmpdir(), "t3-codex-env-"));
     const runtimeHome = mkdtempSync(path.join(os.tmpdir(), "t3-runtime-home-"));

--- a/apps/server/src/codexProcessEnv.ts
+++ b/apps/server/src/codexProcessEnv.ts
@@ -33,6 +33,7 @@ import {
 const CODEX_PROCESS_SHELL_ENV_NAMES = ["PATH", "SSH_AUTH_SOCK"] as const;
 const NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS = "NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS";
 const DPCODE_BROWSER_PLUGIN_CONFIG_HEADER = '[plugins."dpcode-browser@local"]';
+const CODEX_OVERLAY_SHARED_STATE_FILES = new Set(["auth.json"]);
 
 export function resolveCodexBrowserUsePipePath(
   input: {
@@ -118,10 +119,11 @@ function ensureCodexOverlaySymlink(input: {
 
     if (
       targetStat.isSymbolicLink() ||
-      /^.+\.sqlite(?:-(?:wal|shm|journal))?$/.test(input.entryName)
+      /^.+\.sqlite(?:-(?:wal|shm|journal))?$/.test(input.entryName) ||
+      CODEX_OVERLAY_SHARED_STATE_FILES.has(input.entryName)
     ) {
-      // SQLite files must stay generation-matched; mixed DB/WAL/SHM/journal files
-      // make Codex fail during initialize. Other real overlay data is preserved.
+      // SQLite files must stay generation-matched, and auth must mirror the
+      // user's real Codex home so external `codex login` changes are visible.
       rmSync(input.targetPath, { recursive: true, force: true });
     } else {
       return;


### PR DESCRIPTION
## Summary
- repair stale `auth.json` files in Synara's Codex home overlay
- keep overlay auth pointed at the real Codex home so external `codex login` changes are visible
- add regression coverage for stale overlay auth

## Tests
- `bun run test src/codexAppServerManager.test.ts src/provider/Layers/ProviderHealth.test.ts`