### PR TITLE
Fix editor mode production feedback

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -1119,6 +1119,7 @@ export default function DiffPanel({
             resolvedTheme={resolvedTheme}
             diffRenderMode={diffRenderMode}
             diffWordWrap={diffWordWrap}
+            workspaceRoot={activeCwd ?? null}
             collapsedFiles={collapsedFiles}
             onToggleFileCollapsed={toggleFileCollapsed}
             chatActions={diffFileChatActions}

--- a/apps/web/src/components/DiffPanelFileList.tsx
+++ b/apps/web/src/components/DiffPanelFileList.tsx
@@ -4,11 +4,13 @@
 // Layer: Diff panel UI
 
 import type { FileDiffMetadata } from "@pierre/diffs/react";
+import { isSupportedLocalImagePath } from "@t3tools/shared/localImage";
 import { memo, useCallback, type MouseEvent as ReactMouseEvent } from "react";
 import { ChevronDownIcon, CopyIcon, EllipsisIcon, MessageCircleIcon } from "~/lib/icons";
 
 import { buildFileDiffRenderKey, resolveFileDiffPath } from "~/lib/diffRendering";
 import { FileDiffCard, FileDiffSurface } from "./chat/FileDiffView";
+import { LocalImagePreview } from "./LocalImagePreview";
 import { PanelStateMessage } from "./chat/PanelStateMessage";
 import { ComposerPickerMenuPopup } from "./chat/ComposerPickerMenuPopup";
 import { IconButton } from "./ui/icon-button";
@@ -100,6 +102,7 @@ const DiffPanelFileRow = memo(function DiffPanelFileRow(props: {
   resolvedTheme: "light" | "dark";
   diffRenderMode: DiffRenderMode;
   diffWordWrap: boolean;
+  workspaceRoot: string | null;
   isCollapsed: boolean;
   onToggleFileCollapsed: (fileKey: string) => void;
   chatActions?: DiffFileChatActions | undefined;
@@ -107,6 +110,8 @@ const DiffPanelFileRow = memo(function DiffPanelFileRow(props: {
   const filePath = resolveFileDiffPath(props.fileDiff);
   const fileKey = buildFileDiffRenderKey(props.fileDiff);
   const { chatActions, isCollapsed } = props;
+  const shouldPreviewImage =
+    !isCollapsed && props.workspaceRoot !== null && isSupportedLocalImagePath(filePath);
   const renderHeaderMetadata = useCallback(
     () => (
       <span style={{ display: "inline-flex", alignItems: "center", gap: "2px" }}>
@@ -155,6 +160,15 @@ const DiffPanelFileRow = memo(function DiffPanelFileRow(props: {
         collapsed={props.isCollapsed}
         renderHeaderMetadata={renderHeaderMetadata}
       />
+      {shouldPreviewImage ? (
+        <LocalImagePreview
+          src={filePath}
+          cwd={props.workspaceRoot}
+          alt={`Preview of ${filePath}`}
+          className="diff-render-file__image-preview"
+          imageClassName="max-h-[320px]"
+        />
+      ) : null}
     </div>
   );
 });
@@ -180,6 +194,7 @@ export const DiffPanelFileList = memo(
     resolvedTheme: "light" | "dark";
     diffRenderMode: DiffRenderMode;
     diffWordWrap: boolean;
+    workspaceRoot: string | null;
     collapsedFiles: ReadonlySet<string>;
     onToggleFileCollapsed: (fileKey: string) => void;
     chatActions?: DiffFileChatActions | undefined;
@@ -206,6 +221,7 @@ export const DiffPanelFileList = memo(
               resolvedTheme={props.resolvedTheme}
               diffRenderMode={props.diffRenderMode}
               diffWordWrap={props.diffWordWrap}
+              workspaceRoot={props.workspaceRoot}
               isCollapsed={props.collapsedFiles.has(fileKey)}
               onToggleFileCollapsed={props.onToggleFileCollapsed}
               chatActions={props.chatActions}
@@ -221,6 +237,7 @@ export const DiffPanelFileList = memo(
       previous.resolvedTheme === next.resolvedTheme &&
       previous.diffRenderMode === next.diffRenderMode &&
       previous.diffWordWrap === next.diffWordWrap &&
+      previous.workspaceRoot === next.workspaceRoot &&
       areCollapsedSetsEqual(previous.collapsedFiles, next.collapsedFiles) &&
       previous.onToggleFileCollapsed === next.onToggleFileCollapsed &&
       previous.chatActions === next.chatActions

--- a/apps/web/src/components/DiffPanelPatchViewport.tsx
+++ b/apps/web/src/components/DiffPanelPatchViewport.tsx
@@ -20,6 +20,7 @@ export const DiffPanelPatchViewport = memo(
     resolvedTheme: "light" | "dark";
     diffRenderMode: DiffRenderMode;
     diffWordWrap: boolean;
+    workspaceRoot: string | null;
     collapsedFiles: ReadonlySet<string>;
     onToggleFileCollapsed: (fileKey: string) => void;
     chatActions?: DiffFileChatActions | undefined;
@@ -78,6 +79,7 @@ export const DiffPanelPatchViewport = memo(
             resolvedTheme={props.resolvedTheme}
             diffRenderMode={props.diffRenderMode}
             diffWordWrap={props.diffWordWrap}
+            workspaceRoot={props.workspaceRoot}
             collapsedFiles={props.collapsedFiles}
             onToggleFileCollapsed={props.onToggleFileCollapsed}
             chatActions={props.chatActions}
@@ -111,6 +113,7 @@ export const DiffPanelPatchViewport = memo(
       previous.resolvedTheme === next.resolvedTheme &&
       previous.diffRenderMode === next.diffRenderMode &&
       previous.diffWordWrap === next.diffWordWrap &&
+      previous.workspaceRoot === next.workspaceRoot &&
       previous.collapsedFiles === next.collapsedFiles &&
       previous.onToggleFileCollapsed === next.onToggleFileCollapsed &&
       previous.chatActions === next.chatActions &&

--- a/apps/web/src/components/EditorWorkspaceView.test.tsx
+++ b/apps/web/src/components/EditorWorkspaceView.test.tsx
@@ -4,6 +4,7 @@
 // Depends on: EditorWorkspaceView and React server rendering.
 
 import type { FileDiffMetadata } from "@pierre/diffs/react";
+import { ProjectId } from "@t3tools/contracts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
@@ -13,6 +14,11 @@ import { SidebarProvider } from "./ui/sidebar";
 
 vi.mock("../hooks/useTheme", () => ({
   useTheme: () => ({ resolvedTheme: "dark" }),
+}));
+
+vi.mock("~/hooks/useDesktopTopBarGutter", () => ({
+  useDesktopTopBarTrafficLightGutterClassName: () => "traffic-light-gutter",
+  useDesktopTopBarWindowControlsGutterClassName: () => "windows-caption-gutter",
 }));
 
 function createFileDiff(path: string, additions: number, deletions: number): FileDiffMetadata {
@@ -30,6 +36,64 @@ function createFileDiff(path: string, additions: number, deletions: number): Fil
 }
 
 describe("EditorWorkspaceView", () => {
+  it("renders a project switcher arrow beside the project title", () => {
+    const markup = renderToStaticMarkup(
+      <EditorWorkspaceView
+        workspaceRoot="/Users/tester/project"
+        projectName="project"
+        currentProjectId={ProjectId.makeUnsafe("project-current")}
+        projectOptions={[
+          {
+            id: ProjectId.makeUnsafe("project-current"),
+            name: "project",
+            folderName: "project",
+            localName: null,
+            cwd: "/Users/tester/project",
+          },
+        ]}
+        selectedFilePath={null}
+        expandedDirectories={new Set()}
+        centerMode="diff"
+        diffFiles={[]}
+        selectedDiffFilePath={null}
+        diffPanel={<div>Diff panel</div>}
+        chatPanel={<div>Chat panel</div>}
+        onSelectFile={vi.fn()}
+        onSelectDiffFile={vi.fn()}
+        onToggleDirectory={vi.fn()}
+        onCenterModeChange={vi.fn()}
+        onExitEditorView={vi.fn()}
+        onSelectProject={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('aria-label="Switch project"');
+    expect(markup).toContain("project");
+  });
+
+  it("reserves a top-bar gutter for Windows caption controls", () => {
+    const markup = renderToStaticMarkup(
+      <EditorWorkspaceView
+        workspaceRoot="/Users/tester/project"
+        projectName="project"
+        selectedFilePath={null}
+        expandedDirectories={new Set()}
+        centerMode="diff"
+        diffFiles={[]}
+        selectedDiffFilePath={null}
+        diffPanel={<div>Diff panel</div>}
+        chatPanel={<div>Chat panel</div>}
+        onSelectFile={vi.fn()}
+        onSelectDiffFile={vi.fn()}
+        onToggleDirectory={vi.fn()}
+        onCenterModeChange={vi.fn()}
+        onExitEditorView={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("windows-caption-gutter");
+  });
+
   it("renders diff options beside the changed-file line totals", () => {
     const markup = renderToStaticMarkup(
       <SidebarProvider>
@@ -130,6 +194,64 @@ describe("EditorWorkspaceView", () => {
     const diffWrapperIndex = markup.indexOf("Diff panel body");
     const hiddenIndex = markup.lastIndexOf("hidden", diffWrapperIndex);
     expect(hiddenIndex).toBeGreaterThan(-1);
+  });
+
+  it("renders image files through the local image preview instead of text preview", () => {
+    const queryClient = new QueryClient();
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <EditorWorkspaceView
+          workspaceRoot="/Users/tester/project"
+          projectName="project"
+          selectedFilePath="assets/screenshot.png"
+          expandedDirectories={new Set()}
+          centerMode="file"
+          diffFiles={[]}
+          selectedDiffFilePath={null}
+          diffPanel={<div>Diff panel</div>}
+          chatPanel={<div>Chat panel</div>}
+          onSelectFile={vi.fn()}
+          onSelectDiffFile={vi.fn()}
+          onToggleDirectory={vi.fn()}
+          onCenterModeChange={vi.fn()}
+          onExitEditorView={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain("local-image-preview");
+    expect(markup).toContain(
+      "/api/local-image?path=assets%2Fscreenshot.png&amp;cwd=%2FUsers%2Ftester%2Fproject",
+    );
+    expect(markup).not.toContain("editor-file-viewer__plain");
+    expect(markup).not.toContain("editor-file-viewer__highlight");
+  });
+
+  it("shows a Markdown preview toggle for Markdown files", () => {
+    const queryClient = new QueryClient();
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <EditorWorkspaceView
+          workspaceRoot="/Users/tester/project"
+          projectName="project"
+          selectedFilePath="README.md"
+          expandedDirectories={new Set()}
+          centerMode="file"
+          diffFiles={[]}
+          selectedDiffFilePath={null}
+          diffPanel={<div>Diff panel</div>}
+          chatPanel={<div>Chat panel</div>}
+          onSelectFile={vi.fn()}
+          onSelectDiffFile={vi.fn()}
+          onToggleDirectory={vi.fn()}
+          onCenterModeChange={vi.fn()}
+          onExitEditorView={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain('aria-label="Show Markdown preview"');
+    expect(markup).toContain('aria-pressed="false"');
   });
 
   it("shows pointer cursor on activity buttons that switch files and diff", () => {

--- a/apps/web/src/components/EditorWorkspaceView.tsx
+++ b/apps/web/src/components/EditorWorkspaceView.tsx
@@ -2,8 +2,9 @@
 // Purpose: Read-only editor-style thread surface with file explorer, file/diff preview, and chat.
 // Layer: Chat route presentation
 
-import type { ProjectFileSystemEntry } from "@t3tools/contracts";
+import type { ProjectFileSystemEntry, ProjectId } from "@t3tools/contracts";
 import type { FileDiffMetadata } from "@pierre/diffs/react";
+import { isSupportedLocalImagePath } from "@t3tools/shared/localImage";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Component,
@@ -25,9 +26,22 @@ import {
   useState,
 } from "react";
 
-import { ChangesIcon, ChatBubbleIcon, DiffIcon, PanelRightCloseIcon } from "~/lib/icons";
+import {
+  ChangesIcon,
+  ChatBubbleIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  DiffIcon,
+  EyeIcon,
+  FileIcon,
+  FolderIcon,
+  PanelRightCloseIcon,
+} from "~/lib/icons";
 import { basenameOfPath } from "~/file-icons";
-import { useDesktopTopBarTrafficLightGutterClassName } from "~/hooks/useDesktopTopBarGutter";
+import {
+  useDesktopTopBarTrafficLightGutterClassName,
+  useDesktopTopBarWindowControlsGutterClassName,
+} from "~/hooks/useDesktopTopBarGutter";
 import {
   buildFileDiffRenderKey,
   resolveDiffThemeName,
@@ -60,9 +74,11 @@ import {
 import { readNativeApi } from "~/nativeApi";
 import { cn } from "~/lib/utils";
 import { useTheme } from "~/hooks/useTheme";
+import ChatMarkdown from "./ChatMarkdown";
 import { Skeleton } from "./ui/skeleton";
 import {
   ChatHeaderButton,
+  ChatHeaderIconButton,
   CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME,
   CHAT_SURFACE_HEADER_HEIGHT_CLASS,
 } from "./chat/chatHeaderControls";
@@ -73,7 +89,9 @@ import { DiffStat } from "./chat/DiffStatLabel";
 import { PanelStateMessage } from "./chat/PanelStateMessage";
 import { TranscriptSelectionAction } from "./chat/TranscriptSelectionAction";
 import { useCodeSelectionAction } from "./chat/useCodeSelectionAction";
+import { LocalImagePreview } from "./LocalImagePreview";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu";
 
 type EditorCenterMode = "file" | "diff";
 
@@ -102,10 +120,13 @@ const EDITOR_CHAT_PANE_DEFAULT_WIDTH = 384;
 const EDITOR_CHAT_PANE_MIN_WIDTH = 320;
 const EDITOR_CHAT_PANE_MAX_WIDTH = 600;
 const EDITOR_CHAT_PANE_KEYBOARD_STEP = 24;
+const EDITOR_MARKDOWN_PREVIEW_EXTENSIONS = new Set([".markdown", ".md", ".mdx"]);
 
 interface EditorWorkspaceViewProps {
   workspaceRoot: string | null;
   projectName: string | null;
+  currentProjectId?: ProjectId | null;
+  projectOptions?: readonly EditorProjectOption[];
   selectedFilePath: string | null;
   expandedDirectories: ReadonlySet<string>;
   centerMode: EditorCenterMode;
@@ -122,6 +143,17 @@ interface EditorWorkspaceViewProps {
   onExitEditorView: () => void;
   onReferenceInChat?: (reference: ChatFileReference) => void;
   onAskWhyInChat?: (reference: ChatFileReference) => void;
+  onSelectProject?: (projectId: ProjectId) => void;
+}
+
+interface EditorProjectOption {
+  id: ProjectId;
+  name: string;
+  folderName: string;
+  localName: string | null;
+  cwd: string;
+  createdAt?: string | undefined;
+  updatedAt?: string | undefined;
 }
 
 // Marks the drag payload so the chat composer can accept it as a reference.
@@ -254,6 +286,137 @@ interface EditorChatPaneResizeState {
   restoreBodyUserSelect: string;
   onPointerMove: (event: PointerEvent) => void;
   onPointerEnd: (event: PointerEvent) => void;
+}
+
+function fileNameFromPath(path: string): string {
+  return path.split("/").filter(Boolean).at(-1) ?? path;
+}
+
+function parentDirectoryFromPath(path: string): string | null {
+  const normalized = path.replace(/\\/g, "/");
+  const separatorIndex = normalized.lastIndexOf("/");
+  if (separatorIndex <= 0) {
+    return null;
+  }
+  return normalized.slice(0, separatorIndex);
+}
+
+function joinWorkspaceRelativeDirectory(workspaceRoot: string, relativeDirectory: string): string {
+  const separator = workspaceRoot.includes("\\") ? "\\" : "/";
+  const normalizedRoot = workspaceRoot.replace(/[\\/]+$/, "");
+  const normalizedRelativeDirectory = relativeDirectory.split("/").join(separator);
+  return `${normalizedRoot}${separator}${normalizedRelativeDirectory}`;
+}
+
+function markdownPreviewCwd(workspaceRoot: string | null, filePath: string): string | undefined {
+  if (!workspaceRoot) {
+    return undefined;
+  }
+  const parentDirectory = parentDirectoryFromPath(filePath);
+  if (!parentDirectory) {
+    return workspaceRoot;
+  }
+  return joinWorkspaceRelativeDirectory(workspaceRoot, parentDirectory);
+}
+
+function editorProjectLabel(project: EditorProjectOption): {
+  primary: string;
+  secondary: string | null;
+} {
+  const folderName = basenameOfPath(project.cwd) ?? project.folderName ?? project.name;
+  const primary = project.localName?.trim() || folderName || project.name;
+  const secondary =
+    project.localName?.trim() && project.localName.trim() !== folderName ? folderName : null;
+  return { primary, secondary };
+}
+
+function compareEditorProjects(left: EditorProjectOption, right: EditorProjectOption): number {
+  const leftTime = Date.parse(left.updatedAt ?? left.createdAt ?? "") || 0;
+  const rightTime = Date.parse(right.updatedAt ?? right.createdAt ?? "") || 0;
+  if (leftTime !== rightTime) {
+    return rightTime - leftTime;
+  }
+  return editorProjectLabel(left).primary.localeCompare(editorProjectLabel(right).primary);
+}
+
+function EditorProjectSwitcher(props: {
+  workspaceRoot: string | null;
+  projectName: string | null;
+  currentProjectId: ProjectId | null | undefined;
+  projectOptions: readonly EditorProjectOption[];
+  onSelectProject: ((projectId: ProjectId) => void) | undefined;
+}) {
+  const {
+    currentProjectId,
+    onSelectProject,
+    projectName,
+    projectOptions,
+    workspaceRoot,
+  } = props;
+  const [open, setOpen] = useState(false);
+  const sortedProjects = useMemo(
+    () =>
+      projectOptions
+        .filter((project) => project.cwd.trim().length > 0)
+        .slice()
+        .sort(compareEditorProjects),
+    [projectOptions],
+  );
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-1.5">
+      <div className="flex min-w-0 items-baseline gap-2">
+        <span className="truncate text-[13px] font-medium text-foreground">
+          {projectName ?? "Workspace"}
+        </span>
+        <span className="hidden truncate text-[11px] text-muted-foreground/70 sm:inline">
+          {workspaceRoot ?? "No workspace"}
+        </span>
+      </div>
+      <Menu open={open} onOpenChange={setOpen}>
+        <MenuTrigger
+          render={
+            <ChatHeaderIconButton
+              type="button"
+              tone="plain"
+              label="Switch project"
+              title="Switch project"
+              className="size-6"
+            >
+              <ChevronDownIcon className="size-3.5" />
+            </ChatHeaderIconButton>
+          }
+        />
+        <MenuPopup align="start" side="bottom" sideOffset={8} className="w-64 min-w-64">
+          <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">
+            Recent projects
+          </div>
+          {sortedProjects.length === 0 ? (
+            <div className="px-2 py-1.5 text-muted-foreground text-sm">No recent projects</div>
+          ) : (
+            sortedProjects.map((project) => {
+              const label = editorProjectLabel(project);
+              const isSelected = project.id === currentProjectId;
+              return (
+                <MenuItem
+                  key={project.id}
+                  className="h-9 cursor-pointer gap-2 px-2 text-sm transition-colors hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]"
+                  onClick={() => {
+                    onSelectProject?.(project.id);
+                    setOpen(false);
+                  }}
+                >
+                  <FolderIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
+                  <span className="min-w-0 flex-1 truncate">{label.primary}</span>
+                  {isSelected ? <CheckIcon className="size-3.5 shrink-0" /> : null}
+                </MenuItem>
+              );
+            })
+          )}
+        </MenuPopup>
+      </Menu>
+    </div>
+  );
 }
 
 function shouldShowExplorerEntry(entry: ProjectFileSystemEntry): boolean {
@@ -856,6 +1019,12 @@ const FileContentsView = memo(function FileContentsView(props: {
   );
 });
 
+function isMarkdownPreviewablePath(filePath: string): boolean {
+  const dot = filePath.lastIndexOf(".");
+  if (dot < 0) return false;
+  return EDITOR_MARKDOWN_PREVIEW_EXTENSIONS.has(filePath.slice(dot).toLowerCase());
+}
+
 // Mimics indented code lines so the placeholder reads as a file body
 // instead of a generic spinner block.
 const FILE_PREVIEW_SKELETON_LINES = [
@@ -904,15 +1073,27 @@ function FilePreview(props: {
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
   const contentsRef = useRef<HTMLDivElement>(null);
   const { onAskWhyInChat, onReferenceInChat, selectedFilePath } = props;
+  const selectedFileIsImage =
+    selectedFilePath !== null && isSupportedLocalImagePath(selectedFilePath);
+  const selectedFileIsMarkdown =
+    selectedFilePath !== null && isMarkdownPreviewablePath(selectedFilePath);
+  const [markdownPreviewEnabled, setMarkdownPreviewEnabled] = useState(false);
   const fileQuery = useQuery(
     projectReadFileQueryOptions({
       cwd: props.workspaceRoot,
       relativePath: props.selectedFilePath,
-      enabled: props.workspaceRoot !== null && props.selectedFilePath !== null,
+      enabled:
+        props.workspaceRoot !== null &&
+        props.selectedFilePath !== null &&
+        !selectedFileIsImage,
     }),
   );
+  useEffect(() => {
+    setMarkdownPreviewEnabled(false);
+  }, [selectedFilePath]);
 
   const fileContents = fileQuery.data?.contents ?? "";
+  const showMarkdownPreview = selectedFileIsMarkdown && markdownPreviewEnabled;
   const lineCount = useMemo(
     () => (fileContents.length === 0 ? 0 : fileContents.split("\n").length),
     [fileContents],
@@ -997,8 +1178,37 @@ function FilePreview(props: {
         {fileQuery.data?.truncated ? (
           <span className="shrink-0 text-[10px] text-muted-foreground/70">Shown partially</span>
         ) : null}
+        {selectedFileIsMarkdown ? (
+          <ChatHeaderIconButton
+            type="button"
+            label={showMarkdownPreview ? "Show Markdown source" : "Show Markdown preview"}
+            title={showMarkdownPreview ? "Show Markdown source" : "Show Markdown preview"}
+            aria-pressed={showMarkdownPreview}
+            tone="plain"
+            onClick={() => setMarkdownPreviewEnabled((previous) => !previous)}
+          >
+            {showMarkdownPreview ? (
+              <FileIcon className="size-3.5" aria-hidden="true" />
+            ) : (
+              <EyeIcon className="size-3.5" aria-hidden="true" />
+            )}
+          </ChatHeaderIconButton>
+        ) : null}
       </div>
-      {fileQuery.isLoading ? (
+      {selectedFileIsImage ? (
+        <div
+          className="editor-file-viewer min-h-0 flex-1 overflow-auto"
+          onContextMenu={handleContentsContextMenu}
+        >
+          <LocalImagePreview
+            src={props.selectedFilePath}
+            cwd={props.workspaceRoot}
+            alt={fileNameFromPath(props.selectedFilePath)}
+            className="min-h-full"
+            imageClassName="max-h-[calc(100vh-13rem)]"
+          />
+        </div>
+      ) : fileQuery.isLoading ? (
         <FilePreviewLoadingState />
       ) : fileQuery.error ? (
         <PanelStateMessage density="compact" fill="flex" className="items-start justify-start p-3">
@@ -1009,17 +1219,35 @@ function FilePreview(props: {
       ) : (
         <div
           ref={contentsRef}
-          className="editor-file-viewer min-h-0 flex-1 overflow-auto"
+          className={cn(
+            "editor-file-viewer min-h-0 flex-1 overflow-auto",
+            showMarkdownPreview && "editor-file-viewer--markdown-preview",
+          )}
           onContextMenu={handleContentsContextMenu}
-          onMouseUp={previewSelectionAction.onContainerMouseUp}
+          onMouseUp={
+            showMarkdownPreview ? undefined : previewSelectionAction.onContainerMouseUp
+          }
         >
-          <FileContentsView
-            path={props.selectedFilePath}
-            contents={fileContents}
-            themeName={diffThemeName}
-          />
-          {lineCount > 0 ? <span className="sr-only">{lineCount} lines</span> : null}
-          {previewSelectionAction.pendingAction ? (
+          {showMarkdownPreview ? (
+            <div className="editor-markdown-preview">
+              <ChatMarkdown
+                text={fileContents}
+                cwd={markdownPreviewCwd(props.workspaceRoot, props.selectedFilePath)}
+                isStreaming={false}
+                className="editor-markdown-preview__body text-sm leading-relaxed"
+              />
+            </div>
+          ) : (
+            <FileContentsView
+              path={props.selectedFilePath}
+              contents={fileContents}
+              themeName={diffThemeName}
+            />
+          )}
+          {!showMarkdownPreview && lineCount > 0 ? (
+            <span className="sr-only">{lineCount} lines</span>
+          ) : null}
+          {!showMarkdownPreview && previewSelectionAction.pendingAction ? (
             <TranscriptSelectionAction
               left={previewSelectionAction.pendingAction.left}
               top={previewSelectionAction.pendingAction.top}
@@ -1124,6 +1352,8 @@ export function EditorWorkspaceView(props: EditorWorkspaceViewProps) {
   const [chatPaneVisible, setChatPaneVisible] = useState(() =>
     readStoredEditorVisibility(EDITOR_CHAT_PANE_VISIBLE_STORAGE_KEY),
   );
+  const desktopTopBarWindowControlsGutterClassName =
+    useDesktopTopBarWindowControlsGutterClassName();
   const { centerMode, onCenterModeChange } = props;
   const handleActivityBarSelectMode = useCallback(
     (mode: EditorCenterMode) => {
@@ -1267,15 +1497,17 @@ export function EditorWorkspaceView(props: EditorWorkspaceViewProps) {
           "flex shrink-0 items-center gap-2 px-2 sm:px-3",
           CHAT_SURFACE_HEADER_HEIGHT_CLASS,
           CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME,
+          desktopTopBarWindowControlsGutterClassName,
         )}
       >
         <div className={cn("flex min-w-0 flex-1 items-center gap-2", trafficLightGutterClassName)}>
-          <span className="truncate text-[13px] font-medium text-foreground">
-            {props.projectName ?? "Workspace"}
-          </span>
-          <span className="hidden truncate text-[11px] text-muted-foreground/70 sm:inline">
-            {props.workspaceRoot ?? "No workspace"}
-          </span>
+          <EditorProjectSwitcher
+            workspaceRoot={props.workspaceRoot}
+            projectName={props.projectName}
+            currentProjectId={props.currentProjectId}
+            projectOptions={props.projectOptions ?? []}
+            onSelectProject={props.onSelectProject}
+          />
         </div>
         <ChatHeaderButton
           type="button"

--- a/apps/web/src/components/LocalImagePreview.tsx
+++ b/apps/web/src/components/LocalImagePreview.tsx
@@ -1,0 +1,86 @@
+// FILE: LocalImagePreview.tsx
+// Purpose: Shared local-image preview surface for editor file and diff views.
+// Layer: Web UI primitive
+
+import { useEffect, useMemo, useState } from "react";
+
+import { DownloadIcon, Loader2Icon, TriangleAlertIcon } from "~/lib/icons";
+import { buildLocalImageUrl, localImageFileName } from "~/lib/localImageUrls";
+import { cn } from "~/lib/utils";
+
+type LocalImagePreviewStatus = "loading" | "ready" | "error";
+
+export function LocalImagePreview(props: {
+  src: string;
+  cwd: string | null | undefined;
+  alt: string;
+  className?: string;
+  imageClassName?: string;
+}) {
+  const { src, cwd } = props;
+  const previewUrl = useMemo(() => buildLocalImageUrl({ src, cwd: cwd ?? undefined }), [cwd, src]);
+  const downloadUrl = useMemo(
+    () => buildLocalImageUrl({ src, cwd: cwd ?? undefined, download: true }),
+    [cwd, src],
+  );
+  const fileName = useMemo(() => localImageFileName(src), [src]);
+  const [status, setStatus] = useState<LocalImagePreviewStatus>("loading");
+
+  useEffect(() => {
+    setStatus("loading");
+  }, [previewUrl]);
+
+  if (status === "error") {
+    return (
+      <div className={cn("local-image-preview local-image-preview--error", props.className)}>
+        <span className="local-image-preview__error-icon" aria-hidden="true">
+          <TriangleAlertIcon className="size-4" />
+        </span>
+        <span className="local-image-preview__error-body">
+          <span className="local-image-preview__error-title">Couldn’t open this image</span>
+          <span className="local-image-preview__error-subtitle">
+            The file may have moved or be unavailable.
+          </span>
+        </span>
+        <a
+          href={downloadUrl}
+          download={fileName || ""}
+          className="local-image-preview__action"
+          aria-label="Download image"
+        >
+          <DownloadIcon className="size-3.5" aria-hidden="true" />
+          <span>Download</span>
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("local-image-preview", props.className)} data-status={status}>
+      {status === "loading" ? (
+        <span className="local-image-preview__skeleton" aria-hidden="true">
+          <Loader2Icon className="size-4 animate-spin opacity-60" />
+        </span>
+      ) : null}
+      <img
+        src={previewUrl}
+        alt={props.alt}
+        loading="lazy"
+        decoding="async"
+        draggable={false}
+        onLoad={() => setStatus("ready")}
+        onError={() => setStatus("error")}
+        className={cn("local-image-preview__img", props.imageClassName)}
+      />
+      <a
+        href={downloadUrl}
+        download={fileName || ""}
+        className="local-image-preview__download"
+        aria-label="Download image"
+        title="Download"
+      >
+        <DownloadIcon className="size-3.5" aria-hidden="true" />
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useDesktopTopBarGutter.test.ts
+++ b/apps/web/src/hooks/useDesktopTopBarGutter.test.ts
@@ -1,11 +1,14 @@
 // FILE: useDesktopTopBarGutter.test.ts
-// Purpose: Covers the pure top-bar traffic-light gutter decision helper.
+// Purpose: Covers pure desktop top-bar gutter decision helpers.
 // Layer: Hook unit tests
-// Depends on: shouldReserveDesktopTopBarTrafficLightGutter and Vitest assertions.
+// Depends on: useDesktopTopBarGutter pure helpers and Vitest assertions.
 
 import { describe, expect, it } from "vitest";
 
-import { shouldReserveDesktopTopBarTrafficLightGutter } from "./useDesktopTopBarGutter";
+import {
+  shouldReserveDesktopTopBarTrafficLightGutter,
+  shouldReserveDesktopTopBarWindowControlsGutter,
+} from "./useDesktopTopBarGutter";
 
 describe("shouldReserveDesktopTopBarTrafficLightGutter", () => {
   it("never reserves a gutter in the browser build", () => {
@@ -63,5 +66,34 @@ describe("shouldReserveDesktopTopBarTrafficLightGutter", () => {
         }),
       ).toBe(true);
     }
+  });
+});
+
+describe("shouldReserveDesktopTopBarWindowControlsGutter", () => {
+  it("never reserves a gutter outside Electron", () => {
+    expect(
+      shouldReserveDesktopTopBarWindowControlsGutter({
+        isElectron: false,
+        isWindowsDesktop: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("never reserves a gutter for non-Windows desktop windows", () => {
+    expect(
+      shouldReserveDesktopTopBarWindowControlsGutter({
+        isElectron: true,
+        isWindowsDesktop: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("reserves a gutter for Windows Electron caption controls", () => {
+    expect(
+      shouldReserveDesktopTopBarWindowControlsGutter({
+        isElectron: true,
+        isWindowsDesktop: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1062,6 +1062,160 @@ label:has(> select#reasoning-effort) select {
   user-select: none;
 }
 
+.editor-file-viewer--markdown-preview {
+  background: color-mix(in srgb, var(--background) 96%, var(--card));
+}
+
+.editor-markdown-preview {
+  min-height: 100%;
+  padding: 1rem;
+}
+
+.editor-markdown-preview__body {
+  max-width: 880px;
+  margin: 0 auto;
+  padding-bottom: 3rem;
+}
+
+.editor-markdown-preview__body > :first-child {
+  margin-top: 0;
+}
+
+/* Local image preview used by editor file and diff views. */
+.local-image-preview {
+  position: relative;
+  display: flex;
+  min-height: 180px;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background:
+    linear-gradient(45deg, color-mix(in srgb, var(--foreground) 4%, transparent) 25%, transparent 25%),
+    linear-gradient(-45deg, color-mix(in srgb, var(--foreground) 4%, transparent) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, color-mix(in srgb, var(--foreground) 4%, transparent) 75%),
+    linear-gradient(-45deg, transparent 75%, color-mix(in srgb, var(--foreground) 4%, transparent) 75%),
+    color-mix(in srgb, var(--background) 96%, var(--foreground));
+  background-position:
+    0 0,
+    0 8px,
+    8px -8px,
+    -8px 0;
+  background-size: 16px 16px;
+}
+
+.local-image-preview__img {
+  display: block;
+  max-width: 100%;
+  object-fit: contain;
+  border-radius: 0.35rem;
+  box-shadow: 0 1px 16px -10px color-mix(in srgb, var(--foreground) 45%, transparent);
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.local-image-preview[data-status="loading"] .local-image-preview__img {
+  opacity: 0;
+}
+
+.local-image-preview__skeleton {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted-foreground);
+}
+
+.local-image-preview__download,
+.local-image-preview__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  background: color-mix(in srgb, var(--background) 88%, transparent);
+  color: var(--foreground);
+  text-decoration: none;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.local-image-preview__download {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 0.45rem;
+  opacity: 0;
+}
+
+.local-image-preview[data-status="ready"]:hover .local-image-preview__download,
+.local-image-preview[data-status="ready"]:focus-within .local-image-preview__download {
+  opacity: 1;
+}
+
+.local-image-preview__download:hover,
+.local-image-preview__download:focus-visible,
+.local-image-preview__action:hover,
+.local-image-preview__action:focus-visible {
+  border-color: color-mix(in srgb, var(--border) 45%, var(--foreground));
+  background: color-mix(in srgb, var(--background) 72%, var(--foreground));
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+.local-image-preview--error {
+  min-height: 0;
+  justify-content: flex-start;
+  gap: 0.6rem;
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  background: color-mix(in srgb, var(--muted) 35%, transparent);
+}
+
+.local-image-preview__error-icon {
+  display: inline-flex;
+  width: 1.7rem;
+  height: 1.7rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.45rem;
+  background: color-mix(in srgb, var(--destructive) 18%, transparent);
+  color: var(--destructive);
+}
+
+.local-image-preview__error-body {
+  display: inline-flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 0.05rem;
+}
+
+.local-image-preview__error-title {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--foreground);
+}
+
+.local-image-preview__error-subtitle {
+  font-size: 0.72rem;
+  color: var(--muted-foreground);
+}
+
+.local-image-preview__action {
+  flex: 0 0 auto;
+  border-radius: 0.45rem;
+  padding: 0.32rem 0.55rem;
+  font-size: 0.74rem;
+  font-weight: 500;
+}
+
 /* Generated image preview/download card rendered inline from markdown ![alt](file.png) */
 .chat-generated-image {
   position: relative;
@@ -1323,6 +1477,11 @@ diffs-container {
 .diff-render-file [data-diffs-header],
 .diff-render-file [data-file-info] {
   cursor: pointer;
+}
+
+.diff-render-file__image-preview {
+  min-height: 150px;
+  border-top: 1px solid var(--border);
 }
 
 /* Composer surface follows Codex's renderer token path: light uses

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -98,6 +98,26 @@ describe("file diff identity helpers", () => {
     if (reparsed?.kind !== "files") return;
     expect(reparsed.files.map((file) => buildFileDiffRenderKey(file))).toEqual(keys);
   });
+
+  it("keeps binary image diffs as renderable file rows", () => {
+    const patch = [
+      "diff --git a/assets/screenshot.png b/assets/screenshot.png",
+      "index 1111111..2222222 100644",
+      "Binary files a/assets/screenshot.png and b/assets/screenshot.png differ",
+      "",
+    ].join("\n");
+
+    const renderable = getRenderablePatch(patch, "git-pane:binary-image");
+    expect(renderable?.kind).toBe("files");
+    if (renderable?.kind !== "files") return;
+
+    expect(renderable.files).toHaveLength(1);
+    const [file] = renderable.files;
+    expect(file).toBeDefined();
+    if (!file) return;
+    expect(resolveFileDiffPath(file)).toBe("assets/screenshot.png");
+    expect(file.hunks).toEqual([]);
+  });
 });
 
 describe("splitRepoRelativePath", () => {

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -50,6 +50,7 @@ import {
   stripDiffSearchParams,
 } from "../diffRouteSearch";
 import { useHandleNewChat } from "../hooks/useHandleNewChat";
+import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { resolveActiveSplitView, isSplitRoute } from "../splitViewRoute";
 import { canSubdividePane, collectLeaves, findLeafPaneById } from "../splitView.logic";
 import {
@@ -98,6 +99,7 @@ import {
 } from "../lib/panelResize";
 import { getSidechatCreator } from "../lib/sidechatCreatorRegistry";
 import { toastManager } from "../components/ui/toast";
+import { useAppSettings } from "../appSettings";
 import { useStore } from "../store";
 import {
   createAllThreadsSelector,
@@ -106,6 +108,7 @@ import {
   createThreadExistsSelector,
   createThreadProjectIdSelector,
 } from "../storeSelectors";
+import { sortThreadsForSidebar } from "../components/Sidebar.logic";
 import { Button } from "../components/ui/button";
 import {
   Dialog,
@@ -1399,6 +1402,9 @@ function SingleChatSurface(props: {
   const activeProject = useStore(
     useMemo(() => createProjectSelector(props.projectId), [props.projectId]),
   );
+  const projects = useStore((store) => store.projects);
+  const { settings: appSettings } = useAppSettings();
+  const { handleNewThread } = useHandleNewThread();
   const queryClient = useQueryClient();
   const lastAppliedRoutePanelSearchKeyRef = useRef<string | null>(null);
   const [editorExpandedDirectories, setEditorExpandedDirectories] = useState<ReadonlySet<string>>(
@@ -1720,6 +1726,62 @@ function SingleChatSurface(props: {
   // selector, which re-emits on every streaming token of any thread and would
   // otherwise re-render the entire chat surface + right dock + active pane.
   const threadSummaries = useStore(useMemo(() => createSidebarThreadSummariesSelector(), []));
+  const editorProjectOptions = useMemo(
+    () => projects.filter((project) => project.kind === "project"),
+    [projects],
+  );
+  const openEditorProject = useCallback(
+    async (projectId: ProjectId) => {
+      const latestThread = sortThreadsForSidebar(
+        threadSummaries.filter((thread) => thread.projectId === projectId),
+        appSettings.sidebarThreadSortOrder,
+      )[0];
+
+      if (latestThread) {
+        await navigate({
+          to: "/$threadId",
+          params: { threadId: latestThread.id },
+          search: (previous) => ({
+            ...stripEditorViewSearchParams(stripDiffSearchParams(previous)),
+            view: "editor",
+          }),
+        });
+        return;
+      }
+
+      await handleNewThread(
+        projectId,
+        {
+          envMode: appSettings.defaultThreadEnvMode,
+        },
+        {
+          search: (previous) => ({
+            ...stripEditorViewSearchParams(stripDiffSearchParams(previous)),
+            view: "editor",
+          }),
+        },
+      );
+    },
+    [
+      appSettings.defaultThreadEnvMode,
+      appSettings.sidebarThreadSortOrder,
+      handleNewThread,
+      navigate,
+      threadSummaries,
+    ],
+  );
+  const handleSelectEditorProject = useCallback(
+    (projectId: ProjectId) => {
+      void openEditorProject(projectId).catch((error: unknown) => {
+        toastManager.add({
+          type: "error",
+          title: "Unable to open project",
+          description: error instanceof Error ? error.message : "The project could not be opened.",
+        });
+      });
+    },
+    [openEditorProject],
+  );
   const paneLabelOverrides = useMemo(() => {
     const hasSidechatPane = dockState.panes.some((pane) => pane.kind === "sidechat");
     if (!hasSidechatPane) {
@@ -1958,6 +2020,8 @@ function SingleChatSurface(props: {
         <EditorWorkspaceView
           workspaceRoot={activeProject?.cwd ?? null}
           projectName={activeProject?.name ?? null}
+          currentProjectId={activeProject?.id ?? null}
+          projectOptions={editorProjectOptions}
           selectedFilePath={selectedEditorFilePath}
           expandedDirectories={editorExpandedDirectories}
           centerMode={editorCenterMode}
@@ -1972,6 +2036,7 @@ function SingleChatSurface(props: {
           onExitEditorView={handleCloseEditorView}
           onReferenceInChat={handleEditorReferenceInChat}
           onAskWhyInChat={handleEditorAskWhyInChat}
+          onSelectProject={handleSelectEditorProject}
           diffPanel={
             <LazyDiffPanel
               mode="sidebar"


### PR DESCRIPTION
## Summary

Fixes the production feedback from the new Editor mode rollout:

- render supported local images in the Editor file viewer and diff sidebar instead of trying to read them as text
- add a Markdown preview/source toggle for Markdown files
- reserve Windows caption-control space in the Editor top bar so native window buttons do not overlap app controls
- add a compact current-project switcher beside the project title/path, with recent projects only and tuned hover/active states

## Impact

Editor mode now handles image and Markdown files more predictably, the top bar stays usable on Windows, and switching between recent projects is available without leaving the Editor surface.

## Validation

- `bun run test src/components/EditorWorkspaceView.test.tsx src/lib/diffRendering.test.ts src/hooks/useDesktopTopBarGutter.test.ts`
- `git diff --check`
