### PR TITLE
Add Codex-like chat workspace folders

### DIFF
--- a/apps/server/src/config.test.ts
+++ b/apps/server/src/config.test.ts
@@ -1,0 +1,48 @@
+// FILE: config.test.ts
+// Purpose: Verifies pure server configuration path derivation helpers.
+
+import { describe, expect, it } from "vitest";
+
+import { resolveDefaultChatWorkspaceRoot } from "./config";
+
+describe("resolveDefaultChatWorkspaceRoot", () => {
+  it("places the managed chat workspace under Documents/Synara on macOS and Linux", () => {
+    expect(
+      resolveDefaultChatWorkspaceRoot({
+        homeDir: "/Users/tester",
+        platform: "darwin",
+      }),
+    ).toBe("/Users/tester/Documents/Synara");
+    expect(
+      resolveDefaultChatWorkspaceRoot({
+        homeDir: "/home/tester",
+        platform: "linux",
+      }),
+    ).toBe("/home/tester/Documents/Synara");
+  });
+
+  it("uses Windows separators when deriving the managed chat workspace on Windows", () => {
+    expect(
+      resolveDefaultChatWorkspaceRoot({
+        homeDir: "C:\\Users\\tester",
+        platform: "win32",
+      }),
+    ).toBe("C:\\Users\\tester\\Documents\\Synara");
+  });
+
+  it("defaults to the current process platform when no platform is supplied", () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "win32",
+    });
+
+    try {
+      expect(resolveDefaultChatWorkspaceRoot({ homeDir: "C:\\Users\\tester" })).toBe(
+        "C:\\Users\\tester\\Documents\\Synara",
+      );
+    } finally {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor!);
+    }
+  });
+});

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -8,6 +8,8 @@
  */
 import { Effect, FileSystem, Layer, Path, ServiceMap } from "effect";
 import OS from "node:os";
+import pathPosix from "node:path/posix";
+import pathWin32 from "node:path/win32";
 
 export const DEFAULT_PORT = 3773;
 
@@ -43,6 +45,7 @@ export interface ServerConfigShape extends ServerDerivedPaths {
   readonly host: string | undefined;
   readonly cwd: string;
   readonly homeDir: string;
+  readonly chatWorkspaceRoot: string;
   readonly baseDir: string;
   readonly staticDir: string | undefined;
   readonly devUrl: URL | undefined;
@@ -83,6 +86,16 @@ export const deriveServerPaths = Effect.fn(function* (
   };
 });
 
+export function resolveDefaultChatWorkspaceRoot(input: {
+  readonly homeDir: string;
+  readonly platform?: NodeJS.Platform;
+}): string {
+  const homeDir = input.homeDir.trim();
+  const platform = input.platform ?? process.platform;
+  const pathApi = platform === "win32" ? pathWin32 : pathPosix;
+  return pathApi.join(homeDir, "Documents", "Synara");
+}
+
 /**
  * ServerConfig - Service tag for server runtime configuration.
  */
@@ -109,6 +122,7 @@ export class ServerConfig extends ServiceMap.Service<ServerConfig, ServerConfigS
         return {
           cwd,
           homeDir: OS.homedir(),
+          chatWorkspaceRoot: resolveDefaultChatWorkspaceRoot({ homeDir: OS.homedir() }),
           baseDir,
           ...derivedPaths,
           mode: "web",

--- a/apps/server/src/effectServer.ts
+++ b/apps/server/src/effectServer.ts
@@ -128,6 +128,7 @@ export const createEffectServer = Effect.fn(function* () {
     payload: {
       cwd: config.cwd,
       homeDir: config.homeDir,
+      chatWorkspaceRoot: config.chatWorkspaceRoot,
       projectName: config.cwd.split(/[\\/]/).filter(Boolean).at(-1) ?? config.cwd,
     },
   });

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -11,7 +11,11 @@ import { EDITOR_ICON_ROUTE_PATH } from "@t3tools/shared/editorIcons";
 import { clearEditorIconInFlightCache } from "./editorAppIcons";
 import { createHttpRequestHandler, isLegacyTokenAuthorized } from "./http";
 import type { ServerAuthShape } from "./auth/Services/ServerAuth";
-import { deriveServerPaths, type ServerConfigShape } from "./config";
+import {
+  deriveServerPaths,
+  resolveDefaultChatWorkspaceRoot,
+  type ServerConfigShape,
+} from "./config";
 import type { ProjectFaviconResolverShape } from "./project/Services/ProjectFaviconResolver";
 import type { ServerReadiness } from "./server/readiness";
 
@@ -57,6 +61,7 @@ async function makeConfig(overrides: Partial<ServerConfigShape> = {}): Promise<S
     host: undefined,
     cwd: baseDir,
     homeDir: os.homedir(),
+    chatWorkspaceRoot: resolveDefaultChatWorkspaceRoot({ homeDir: os.homedir() }),
     baseDir,
     ...derivedPaths,
     staticDir: undefined,

--- a/apps/server/src/localImageRoute.test.ts
+++ b/apps/server/src/localImageRoute.test.ts
@@ -13,7 +13,11 @@ import { HttpRouter } from "effect/unstable/http";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ServerAuth, type ServerAuthShape } from "./auth/Services/ServerAuth";
-import { ServerConfig, type ServerConfigShape } from "./config";
+import {
+  resolveDefaultChatWorkspaceRoot,
+  ServerConfig,
+  type ServerConfigShape,
+} from "./config";
 import { attachmentsEffectRouteLayer, localImageEffectRouteLayer } from "./http";
 
 const tempDirs: string[] = [];
@@ -38,6 +42,7 @@ function makeServerConfig(overrides: Partial<ServerConfigShape> = {}): ServerCon
     host: undefined,
     cwd: baseDir,
     homeDir: os.homedir(),
+    chatWorkspaceRoot: resolveDefaultChatWorkspaceRoot({ homeDir: os.homedir() }),
     baseDir,
     keybindingsConfigPath: path.join(baseDir, "keybindings.json"),
     serverRuntimeStatePath: path.join(baseDir, "runtime.json"),

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -13,6 +13,7 @@ import { NetService } from "@t3tools/shared/Net";
 import {
   DEFAULT_PORT,
   deriveServerPaths,
+  resolveDefaultChatWorkspaceRoot,
   resolveStaticDir,
   ServerConfig,
   type RuntimeMode,
@@ -168,11 +169,12 @@ const ServerConfigLive = (input: CliInput) =>
       const devUrl = Option.getOrElse(input.devUrl, () => env.devUrl);
       const configuredHome =
         Option.getOrUndefined(input.t3Home) ?? env.synaraHome ?? env.t3Home ?? env.dpcodeHome;
+      const userHomeDir = OS.homedir();
       const baseDir = yield* resolveBaseDir(configuredHome);
       // Import legacy state before runtime paths are derived under ~/.synara.
       yield* migrateLegacyHomeIfNeeded({
         baseDir,
-        homeDir: OS.homedir(),
+        homeDir: userHomeDir,
         devUrl,
       }).pipe(
         Effect.mapError(
@@ -212,7 +214,8 @@ const ServerConfigLive = (input: CliInput) =>
         mode,
         port,
         cwd: cliConfig.cwd,
-        homeDir: OS.homedir(),
+        homeDir: userHomeDir,
+        chatWorkspaceRoot: resolveDefaultChatWorkspaceRoot({ homeDir: userHomeDir }),
         host,
         baseDir,
         ...derivedPaths,

--- a/apps/server/src/orchestration/dispatchCommandNormalization.ts
+++ b/apps/server/src/orchestration/dispatchCommandNormalization.ts
@@ -37,7 +37,13 @@ export function makeDispatchCommandNormalizer<E>(options: DispatchCommandNormali
     if (input.command.type === "project.meta.update" && input.command.workspaceRoot !== undefined) {
       return {
         ...input.command,
-        workspaceRoot: yield* options.canonicalizeProjectWorkspaceRoot(input.command.workspaceRoot),
+        workspaceRoot: yield* options.canonicalizeProjectWorkspaceRoot(
+          input.command.workspaceRoot,
+          {
+            createIfMissing: input.command.createWorkspaceRootIfMissing === true,
+          },
+        ),
+        createWorkspaceRootIfMissing: input.command.createWorkspaceRootIfMissing === true,
       } satisfies OrchestrationCommand;
     }
 

--- a/apps/server/src/provider/Layers/ProviderDiscoveryService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderDiscoveryService.test.ts
@@ -18,7 +18,12 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, Layer } from "effect";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { deriveServerPaths, ServerConfig, type ServerConfigShape } from "../../config.ts";
+import {
+  deriveServerPaths,
+  resolveDefaultChatWorkspaceRoot,
+  ServerConfig,
+  type ServerConfigShape,
+} from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import type { ProviderAdapterError } from "../Errors.ts";
 import { ProviderAdapterRequestError } from "../Errors.ts";
@@ -52,6 +57,7 @@ const makeConfigLayer = () =>
         host: undefined,
         cwd,
         homeDir,
+        chatWorkspaceRoot: resolveDefaultChatWorkspaceRoot({ homeDir }),
         baseDir,
         ...derived,
         staticDir: undefined,

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -481,6 +481,7 @@ export const makeWsRpcLayer = () =>
         return {
           cwd: config.cwd,
           homeDir: config.homeDir,
+          chatWorkspaceRoot: config.chatWorkspaceRoot,
           worktreesDir: config.worktreesDir,
           keybindingsConfigPath: config.keybindingsConfigPath,
           keybindings: keybindingsConfig.keybindings,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1162,8 +1162,12 @@ export default function ChatView({
     useMemo(() => createProjectSelector(activeProjectId), [activeProjectId]),
   );
   const homeDir = useWorkspaceStore((state) => state.homeDir);
+  const chatWorkspaceRoot = useWorkspaceStore((state) => state.chatWorkspaceRoot);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
-  const isHomeChatContainer = isHomeChatContainerProject(activeProject, homeDir);
+  const isHomeChatContainer = isHomeChatContainerProject(activeProject, {
+    homeDir,
+    chatWorkspaceRoot,
+  });
   const activeProjectDisplayName = isHomeChatContainer
     ? activeProject?.folderName
     : activeProject?.name;
@@ -2314,7 +2318,9 @@ export default function ChatView({
   const isCenteredEmptyLanding =
     timelineEntries.length === 0 && !activeThread?.parentThreadId && !isEditorRail;
   const isEmptyChatLanding =
-    isCenteredEmptyLanding && Boolean(homeDir) && activeProject?.cwd === homeDir;
+    isCenteredEmptyLanding &&
+    Boolean(homeDir) &&
+    isHomeChatContainerProject(activeProject, { homeDir, chatWorkspaceRoot });
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
   const turnDiffSummaryByAssistantMessageId = useMemo(() => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1212,6 +1212,7 @@ export default function Sidebar() {
   const deleteWorkspace = useWorkspaceStore((store) => store.deleteWorkspace);
   const reorderWorkspace = useWorkspaceStore((store) => store.reorderWorkspace);
   const homeDir = useWorkspaceStore((store) => store.homeDir);
+  const chatWorkspaceRoot = useWorkspaceStore((store) => store.chatWorkspaceRoot);
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
   const isOnSettings = useLocation({
@@ -2156,8 +2157,8 @@ export default function Sidebar() {
     if (!homeDir) {
       return;
     }
-    prewarmHomeChatProject(homeDir);
-  }, [homeDir]);
+    prewarmHomeChatProject({ homeDir, chatWorkspaceRoot });
+  }, [chatWorkspaceRoot, homeDir]);
 
   // Opens a fresh home-chat draft directly on the draft thread route so the first send
   // does not need a second route swap from "/" to "/$threadId".
@@ -3775,8 +3776,11 @@ export default function Sidebar() {
     [appSettings.sidebarProjectSortOrder, projects, sidebarThreads],
   );
   const chatProjects = useMemo(
-    () => sortedProjects.filter((project) => isHomeChatContainerProject(project, homeDir)),
-    [homeDir, sortedProjects],
+    () =>
+      sortedProjects.filter((project) =>
+        isHomeChatContainerProject(project, { homeDir, chatWorkspaceRoot }),
+      ),
+    [chatWorkspaceRoot, homeDir, sortedProjects],
   );
   const visibleChatThreadRows = useMemo(() => {
     if (!chatSectionExpanded) {
@@ -3826,9 +3830,11 @@ export default function Sidebar() {
   const standardProjectsBase = useMemo(
     () =>
       sortedProjects.filter(
-        (project) => project.kind === "project" && !isHomeChatContainerProject(project, homeDir),
+        (project) =>
+          project.kind === "project" &&
+          !isHomeChatContainerProject(project, { homeDir, chatWorkspaceRoot }),
       ),
-    [homeDir, sortedProjects],
+    [chatWorkspaceRoot, homeDir, sortedProjects],
   );
   const pinnedProjectIds = useMemo(
     () =>

--- a/apps/web/src/components/WorkspaceView.tsx
+++ b/apps/web/src/components/WorkspaceView.tsx
@@ -49,7 +49,7 @@ export default function WorkspaceView({ workspaceId }: { workspaceId: string }) 
   const ensureWorkspacePage = useWorkspaceStore((state) => state.ensureWorkspacePage);
   const renameWorkspace = useWorkspaceStore((state) => state.renameWorkspace);
   const setWorkspaceLayoutPreset = useWorkspaceStore((state) => state.setWorkspaceLayoutPreset);
-  const setWorkspaceHomeDir = useWorkspaceStore((state) => state.setHomeDir);
+  const setServerWorkspacePaths = useWorkspaceStore((state) => state.setServerWorkspacePaths);
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const threadId = useMemo(() => workspaceThreadId(workspaceId), [workspaceId]);
   const terminal = useTerminalSurfaceController(threadId);
@@ -84,16 +84,29 @@ export default function WorkspaceView({ workspaceId }: { workspaceId: string }) 
   }, [ensureWorkspacePage, workspaceId]);
 
   useEffect(
-    () => onServerWelcome((payload) => setWorkspaceHomeDir(payload.homeDir)),
-    [setWorkspaceHomeDir],
+    () =>
+      onServerWelcome((payload) =>
+        setServerWorkspacePaths({
+          homeDir: payload.homeDir,
+          chatWorkspaceRoot: payload.chatWorkspaceRoot,
+        }),
+      ),
+    [setServerWorkspacePaths],
   );
 
   useEffect(() => {
     if (!serverConfigQuery.data?.homeDir) {
       return;
     }
-    setWorkspaceHomeDir(serverConfigQuery.data.homeDir);
-  }, [serverConfigQuery.data?.homeDir, setWorkspaceHomeDir]);
+    setServerWorkspacePaths({
+      homeDir: serverConfigQuery.data.homeDir,
+      chatWorkspaceRoot: serverConfigQuery.data.chatWorkspaceRoot,
+    });
+  }, [
+    serverConfigQuery.data?.chatWorkspaceRoot,
+    serverConfigQuery.data?.homeDir,
+    setServerWorkspacePaths,
+  ]);
 
   useEffect(() => {
     if (!workspace) {

--- a/apps/web/src/components/kanban/useKanbanBoard.ts
+++ b/apps/web/src/components/kanban/useKanbanBoard.ts
@@ -39,6 +39,7 @@ export function useKanbanBoard(): KanbanBoard {
   const allProjects = useStore((state) => state.projects);
   const threadsHydrated = useStore((state) => state.threadsHydrated);
   const homeDir = useWorkspaceStore((state) => state.homeDir);
+  const chatWorkspaceRoot = useWorkspaceStore((state) => state.chatWorkspaceRoot);
   const { settings } = useAppSettings();
   const projectSortOrder = settings.sidebarProjectSortOrder;
 
@@ -48,10 +49,10 @@ export function useKanbanBoard(): KanbanBoard {
   // findCanonicalHomeProject — so they never surface as extra empty boards.
   const { projects, projectIdAliases } = useMemo(() => {
     const chatContainers = allProjects.filter((project) =>
-      isHomeChatContainerProject(project, homeDir),
+      isHomeChatContainerProject(project, { homeDir, chatWorkspaceRoot }),
     );
     const otherProjects = allProjects.filter(
-      (project) => !isHomeChatContainerProject(project, homeDir),
+      (project) => !isHomeChatContainerProject(project, { homeDir, chatWorkspaceRoot }),
     );
     const canonicalContainer =
       chatContainers.find((project) => project.kind === "chat") ?? chatContainers[0] ?? null;
@@ -70,7 +71,7 @@ export function useKanbanBoard(): KanbanBoard {
       ],
       projectIdAliases: aliases,
     };
-  }, [allProjects, homeDir, projectSortOrder, threads]);
+  }, [allProjects, chatWorkspaceRoot, homeDir, projectSortOrder, threads]);
   const draftsByThreadId = useComposerDraftStore((state) => state.draftsByThreadId);
   const draftThreadsByThreadId = useComposerDraftStore((state) => state.draftThreadsByThreadId);
   const draftOrderByProjectId = useKanbanUiStore((state) => state.draftOrderByProjectId);

--- a/apps/web/src/hooks/useHandleNewChat.ts
+++ b/apps/web/src/hooks/useHandleNewChat.ts
@@ -7,6 +7,7 @@ import { useHandleNewThread } from "./useHandleNewThread";
 
 export function useHandleNewChat() {
   const homeDir = useWorkspaceStore((state) => state.homeDir);
+  const chatWorkspaceRoot = useWorkspaceStore((state) => state.chatWorkspaceRoot);
   const { handleNewThread } = useHandleNewThread();
 
   const handleNewChat = useCallback(
@@ -18,7 +19,7 @@ export function useHandleNewChat() {
         };
       }
 
-      const projectId = await ensureHomeChatProject(homeDir);
+      const projectId = await ensureHomeChatProject({ homeDir, chatWorkspaceRoot });
       if (!projectId) {
         return {
           ok: false,
@@ -44,7 +45,7 @@ export function useHandleNewChat() {
         };
       }
     },
-    [handleNewThread, homeDir],
+    [chatWorkspaceRoot, handleNewThread, homeDir],
   );
 
   return { handleNewChat };

--- a/apps/web/src/lib/chatProjects.test.ts
+++ b/apps/web/src/lib/chatProjects.test.ts
@@ -1,0 +1,59 @@
+// FILE: chatProjects.test.ts
+// Purpose: Verifies home chat-container project recognition across new and legacy roots.
+
+import { describe, expect, it } from "vitest";
+
+import { isHomeChatContainerProject } from "./chatProjects";
+
+describe("isHomeChatContainerProject", () => {
+  it("matches the managed Documents/Synara general-chat workspace", () => {
+    expect(
+      isHomeChatContainerProject(
+        {
+          cwd: "/Users/tester/Documents/Synara",
+          kind: "chat",
+          name: "Home",
+          remoteName: "Home",
+        },
+        {
+          homeDir: "/Users/tester",
+          chatWorkspaceRoot: "/Users/tester/Documents/Synara",
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps recognizing the legacy home-directory chat container during migration", () => {
+    expect(
+      isHomeChatContainerProject(
+        {
+          cwd: "/Users/tester",
+          kind: "chat",
+          name: "Home",
+          remoteName: "Home",
+        },
+        {
+          homeDir: "/Users/tester",
+          chatWorkspaceRoot: "/Users/tester/Documents/Synara",
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not classify ordinary projects under Documents/Synara as home chat containers", () => {
+    expect(
+      isHomeChatContainerProject(
+        {
+          cwd: "/Users/tester/Documents/Synara",
+          kind: "project",
+          name: "Synara",
+          remoteName: "Synara",
+        },
+        {
+          homeDir: "/Users/tester",
+          chatWorkspaceRoot: "/Users/tester/Documents/Synara",
+        },
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/chatProjects.ts
+++ b/apps/web/src/lib/chatProjects.ts
@@ -3,79 +3,136 @@
 // Layer: Web orchestration helper
 
 import { type ProjectId } from "@t3tools/contracts";
+import { workspaceRootsEqual } from "@t3tools/shared/threadWorkspace";
 import type { Project } from "../types";
 import { readNativeApi } from "../nativeApi";
 import { useStore } from "../store";
 import { getThreadFromState } from "../threadDerivation";
+import {
+  resolveServerChatWorkspaceRoot,
+  type ServerWorkspacePaths,
+} from "./serverWorkspacePaths";
 import { newCommandId, newProjectId } from "./utils";
 
-const pendingHomeChatCreationByHomeDir = new Map<string, Promise<ProjectId | null>>();
-const pendingHomeChatFixupByHomeDir = new Map<string, Promise<void>>();
+const pendingHomeChatCreationByWorkspaceRoot = new Map<string, Promise<ProjectId | null>>();
+const pendingHomeChatFixupByWorkspaceRoot = new Map<string, Promise<void>>();
+
+function matchesHomeChatWorkspaceRoot(
+  project: Pick<Project, "cwd">,
+  input: ServerWorkspacePaths,
+): boolean {
+  const workspaceRoot = resolveServerChatWorkspaceRoot(input);
+  const homeDir = input.homeDir?.trim() ?? "";
+  if (!workspaceRoot || !homeDir) {
+    return false;
+  }
+  return (
+    workspaceRootsEqual(project.cwd, workspaceRoot) ||
+    workspaceRootsEqual(project.cwd, homeDir)
+  );
+}
+
+function hasThreadsForProject(projectId: ProjectId): boolean {
+  const state = useStore.getState();
+  return (state.threadIds ?? [])
+    .map((threadId) => getThreadFromState(state, threadId))
+    .some((thread) => thread?.projectId === projectId);
+}
+
+function scoreHomeChatProject(project: Project, input: ServerWorkspacePaths): number {
+  const workspaceRoot = resolveServerChatWorkspaceRoot(input);
+  let score = 0;
+  if (hasThreadsForProject(project.id)) score += 8;
+  if (project.kind === "chat") score += 4;
+  if (workspaceRoot && workspaceRootsEqual(project.cwd, workspaceRoot)) score += 2;
+  if (project.remoteName === "Home" || project.name === "Home") score += 1;
+  return score;
+}
 
 export function findHomeChatContainerProject<
   T extends Pick<Project, "cwd" | "kind" | "name" | "remoteName">,
->(projects: readonly T[], homeDir: string | null | undefined): T | null {
-  if (!homeDir) {
+>(projects: readonly T[], paths: ServerWorkspacePaths): T | null {
+  if (!paths.homeDir) {
     return null;
   }
-  return projects.find((project) => isHomeChatContainerProject(project, homeDir)) ?? null;
+  return projects.find((project) => isHomeChatContainerProject(project, paths)) ?? null;
 }
 
-function findCanonicalHomeProject(homeDir: string): {
+function findCanonicalHomeProject(input: ServerWorkspacePaths): {
   canonicalProjectId: ProjectId | null;
   duplicateProjectIds: ProjectId[];
   needsKindFixup: boolean;
+  needsWorkspaceRootFixup: boolean;
 } {
   const state = useStore.getState();
   const homeProjects = state.projects.filter((project) =>
-    isHomeChatContainerProject(project, homeDir),
+    isHomeChatContainerProject(project, input),
   );
+  const workspaceRoot = resolveServerChatWorkspaceRoot(input);
   const canonicalProject =
-    homeProjects.find((project) => project.kind === "chat") ?? homeProjects[0];
+    [...homeProjects].sort(
+      (left, right) =>
+        scoreHomeChatProject(right, input) - scoreHomeChatProject(left, input),
+    )[0] ?? null;
   if (!canonicalProject) {
     return {
       canonicalProjectId: null,
       duplicateProjectIds: [],
       needsKindFixup: false,
+      needsWorkspaceRootFixup: false,
     };
   }
 
   const duplicateProjectIds = homeProjects
     .filter((project) => project.id !== canonicalProject.id)
     .flatMap((project) => {
-      const hasThreads = (state.threadIds ?? [])
-        .map((threadId) => getThreadFromState(state, threadId))
-        .some((thread) => thread?.projectId === project.id);
-      return hasThreads ? [] : [project.id];
+      return hasThreadsForProject(project.id) ? [] : [project.id];
     });
 
   return {
     canonicalProjectId: canonicalProject.id,
     duplicateProjectIds,
     needsKindFixup: canonicalProject.kind !== "chat",
+    needsWorkspaceRootFixup: Boolean(
+      workspaceRoot && !workspaceRootsEqual(canonicalProject.cwd, workspaceRoot),
+    ),
   };
 }
 
-async function fixupHomeChatProject(homeDir: string): Promise<void> {
+async function fixupHomeChatProject(input: ServerWorkspacePaths): Promise<void> {
   const api = readNativeApi();
   if (!api) {
     return;
   }
 
-  const { canonicalProjectId, duplicateProjectIds, needsKindFixup } =
-    findCanonicalHomeProject(homeDir);
+  const { canonicalProjectId, duplicateProjectIds, needsKindFixup, needsWorkspaceRootFixup } =
+    findCanonicalHomeProject(input);
   if (!canonicalProjectId) {
     return;
   }
 
-  if (needsKindFixup) {
+  const targetWorkspaceRoot = needsWorkspaceRootFixup ? resolveServerChatWorkspaceRoot(input) : null;
+  if (needsWorkspaceRootFixup && !targetWorkspaceRoot) {
+    return;
+  }
+
+  if (needsKindFixup || needsWorkspaceRootFixup) {
+    const workspaceRootPatch:
+      | { readonly workspaceRoot: string; readonly createWorkspaceRootIfMissing: true }
+      | Record<string, never> =
+      needsWorkspaceRootFixup && targetWorkspaceRoot
+        ? {
+            workspaceRoot: targetWorkspaceRoot,
+            createWorkspaceRootIfMissing: true,
+          }
+        : {};
     await api.orchestration.dispatchCommand({
       type: "project.meta.update",
       commandId: newCommandId(),
       projectId: canonicalProjectId,
       kind: "chat",
-      title: "Home",
-      workspaceRoot: homeDir,
+      ...(needsKindFixup ? { title: "Home" } : {}),
+      ...workspaceRootPatch,
     });
   }
 
@@ -88,29 +145,38 @@ async function fixupHomeChatProject(homeDir: string): Promise<void> {
   }
 }
 
-function scheduleHomeChatFixup(homeDir: string): void {
-  if (pendingHomeChatFixupByHomeDir.has(homeDir)) {
+function scheduleHomeChatFixup(input: ServerWorkspacePaths): void {
+  const workspaceRoot = resolveServerChatWorkspaceRoot(input);
+  if (!workspaceRoot) {
     return;
   }
-  const promise = fixupHomeChatProject(homeDir).finally(() => {
-    pendingHomeChatFixupByHomeDir.delete(homeDir);
+  if (pendingHomeChatFixupByWorkspaceRoot.has(workspaceRoot)) {
+    return;
+  }
+  const promise = fixupHomeChatProject(input).finally(() => {
+    pendingHomeChatFixupByWorkspaceRoot.delete(workspaceRoot);
   });
-  pendingHomeChatFixupByHomeDir.set(homeDir, promise);
+  pendingHomeChatFixupByWorkspaceRoot.set(workspaceRoot, promise);
 }
 
-export async function ensureHomeChatProject(homeDir: string): Promise<ProjectId | null> {
+export async function ensureHomeChatProject(paths: ServerWorkspacePaths): Promise<ProjectId | null> {
   const api = readNativeApi();
   if (!api) {
     return null;
   }
 
-  const { canonicalProjectId } = findCanonicalHomeProject(homeDir);
+  const workspaceRoot = resolveServerChatWorkspaceRoot(paths);
+  if (!workspaceRoot || !paths.homeDir) {
+    return null;
+  }
+
+  const { canonicalProjectId } = findCanonicalHomeProject(paths);
   if (canonicalProjectId) {
-    scheduleHomeChatFixup(homeDir);
+    scheduleHomeChatFixup(paths);
     return canonicalProjectId;
   }
 
-  const pendingCreation = pendingHomeChatCreationByHomeDir.get(homeDir);
+  const pendingCreation = pendingHomeChatCreationByWorkspaceRoot.get(workspaceRoot);
   if (pendingCreation) {
     return pendingCreation;
   }
@@ -123,31 +189,32 @@ export async function ensureHomeChatProject(homeDir: string): Promise<ProjectId 
       projectId,
       kind: "chat",
       title: "Home",
-      workspaceRoot: homeDir,
+      workspaceRoot,
+      createWorkspaceRootIfMissing: true,
       createdAt: new Date().toISOString(),
     });
     return projectId;
   })().finally(() => {
-    pendingHomeChatCreationByHomeDir.delete(homeDir);
+    pendingHomeChatCreationByWorkspaceRoot.delete(workspaceRoot);
   });
 
-  pendingHomeChatCreationByHomeDir.set(homeDir, creationPromise);
+  pendingHomeChatCreationByWorkspaceRoot.set(workspaceRoot, creationPromise);
   return creationPromise;
 }
 
-export function prewarmHomeChatProject(homeDir: string): void {
-  void ensureHomeChatProject(homeDir);
+export function prewarmHomeChatProject(paths: ServerWorkspacePaths): void {
+  void ensureHomeChatProject(paths);
 }
 
 export function isHomeChatContainerProject(
   project: Pick<Project, "cwd" | "kind" | "name" | "remoteName"> | null | undefined,
-  homeDir: string | null | undefined,
+  paths: ServerWorkspacePaths,
 ): boolean {
-  if (!project || !homeDir) {
+  if (!project || !paths.homeDir) {
     return false;
   }
   return (
-    project.cwd === homeDir &&
+    matchesHomeChatWorkspaceRoot(project, paths) &&
     (project.kind === "chat" || project.remoteName === "Home" || project.name === "Home")
   );
 }

--- a/apps/web/src/lib/serverWorkspacePaths.ts
+++ b/apps/web/src/lib/serverWorkspacePaths.ts
@@ -1,0 +1,28 @@
+// FILE: serverWorkspacePaths.ts
+// Purpose: Normalize server-provided home and general-chat workspace paths.
+// Layer: Web domain helper
+// Exports: ServerWorkspacePaths plus normalization and fallback helpers.
+
+export interface ServerWorkspacePaths {
+  readonly homeDir: string | null | undefined;
+  readonly chatWorkspaceRoot?: string | null | undefined;
+}
+
+export interface NormalizedServerWorkspacePaths {
+  readonly homeDir: string | null;
+  readonly chatWorkspaceRoot: string | null;
+}
+
+export function normalizeServerWorkspacePaths(
+  paths: ServerWorkspacePaths,
+): NormalizedServerWorkspacePaths {
+  return {
+    homeDir: paths.homeDir?.trim() || null,
+    chatWorkspaceRoot: paths.chatWorkspaceRoot?.trim() || null,
+  };
+}
+
+export function resolveServerChatWorkspaceRoot(paths: ServerWorkspacePaths): string | null {
+  const normalized = normalizeServerWorkspacePaths(paths);
+  return normalized.chatWorkspaceRoot || normalized.homeDir;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -761,7 +761,7 @@ function EventRouter() {
   const removeOrphanedTerminalStates = useTerminalStateStore(
     (store) => store.removeOrphanedTerminalStates,
   );
-  const setWorkspaceHomeDir = useWorkspaceStore((store) => store.setHomeDir);
+  const setServerWorkspacePaths = useWorkspaceStore((store) => store.setServerWorkspacePaths);
   const workspacePages = useWorkspaceStore((store) => store.workspacePages);
   const serverThreads = useStore((store) => store.threads);
   const queryClient = useQueryClient();
@@ -1235,7 +1235,10 @@ function EventRouter() {
       .catch(() => undefined);
     const unsubWelcome = onServerWelcome((payload) => {
       void (async () => {
-        setWorkspaceHomeDir(payload.homeDir);
+        setServerWorkspacePaths({
+          homeDir: payload.homeDir,
+          chatWorkspaceRoot: payload.chatWorkspaceRoot,
+        });
         await ensureScopedSubscriptions();
         if (disposed) {
           return;
@@ -1402,7 +1405,7 @@ function EventRouter() {
     queryClient,
     removeOrphanedTerminalStates,
     setProjectExpanded,
-    setWorkspaceHomeDir,
+    setServerWorkspacePaths,
     syncServerShellSnapshot,
     syncServerThreadDetailHotPath,
   ]);

--- a/apps/web/src/workspaceStore.test.ts
+++ b/apps/web/src/workspaceStore.test.ts
@@ -53,4 +53,54 @@ describe("workspaceStore", () => {
 
     expect(useWorkspaceStore.getState().homeDir).toBeNull();
   });
+
+  it("keeps chat workspace root while server config is still loading", async () => {
+    installMemoryLocalStorage();
+    vi.resetModules();
+
+    const { useWorkspaceStore } = await import("./workspaceStore");
+
+    useWorkspaceStore.getState().setChatWorkspaceRoot("/Users/tester/Documents/Synara");
+    useWorkspaceStore.getState().setChatWorkspaceRoot(undefined);
+
+    expect(useWorkspaceStore.getState().chatWorkspaceRoot).toBe(
+      "/Users/tester/Documents/Synara",
+    );
+  });
+
+  it("updates home and chat workspace roots together from server paths", async () => {
+    installMemoryLocalStorage();
+    vi.resetModules();
+
+    const { useWorkspaceStore } = await import("./workspaceStore");
+
+    useWorkspaceStore.getState().setServerWorkspacePaths({
+      homeDir: "/Users/tester",
+      chatWorkspaceRoot: "/Users/tester/Documents/Synara",
+    });
+
+    expect(useWorkspaceStore.getState().homeDir).toBe("/Users/tester");
+    expect(useWorkspaceStore.getState().chatWorkspaceRoot).toBe(
+      "/Users/tester/Documents/Synara",
+    );
+  });
+
+  it("persists the chat workspace root with the home directory", async () => {
+    installMemoryLocalStorage();
+    vi.resetModules();
+
+    let workspaceModule = await import("./workspaceStore");
+    workspaceModule.useWorkspaceStore.getState().setServerWorkspacePaths({
+      homeDir: "/Users/tester",
+      chatWorkspaceRoot: "/Users/tester/Documents/Synara",
+    });
+
+    vi.resetModules();
+    workspaceModule = await import("./workspaceStore");
+
+    expect(workspaceModule.useWorkspaceStore.getState().homeDir).toBe("/Users/tester");
+    expect(workspaceModule.useWorkspaceStore.getState().chatWorkspaceRoot).toBe(
+      "/Users/tester/Documents/Synara",
+    );
+  });
 });

--- a/apps/web/src/workspaceStore.ts
+++ b/apps/web/src/workspaceStore.ts
@@ -10,6 +10,10 @@ import {
   getWorkspaceLayoutPreset,
   type WorkspaceLayoutPresetId,
 } from "./workspaceTerminalLayoutPresets";
+import {
+  normalizeServerWorkspacePaths,
+  type ServerWorkspacePaths,
+} from "./lib/serverWorkspacePaths";
 
 interface WorkspacePage {
   id: string;
@@ -21,8 +25,11 @@ interface WorkspacePage {
 
 interface WorkspaceStoreState {
   homeDir: string | null;
+  chatWorkspaceRoot: string | null;
   workspacePages: WorkspacePage[];
   setHomeDir: (homeDir: string | null | undefined) => void;
+  setChatWorkspaceRoot: (chatWorkspaceRoot: string | null | undefined) => void;
+  setServerWorkspacePaths: (paths: ServerWorkspacePaths) => void;
   ensureWorkspacePage: (workspaceId: string) => void;
   createWorkspace: () => string;
   renameWorkspace: (workspaceId: string, title: string) => void;
@@ -134,6 +141,7 @@ export const useWorkspaceStore = create<WorkspaceStoreState>()(
   persist(
     (set) => ({
       homeDir: null,
+      chatWorkspaceRoot: null,
       workspacePages: [createWorkspacePage([])],
       setHomeDir: (homeDir) =>
         set((state) => {
@@ -146,6 +154,36 @@ export const useWorkspaceStore = create<WorkspaceStoreState>()(
             return state;
           }
           return { homeDir: normalizedHomeDir };
+        }),
+      setChatWorkspaceRoot: (chatWorkspaceRoot) =>
+        set((state) => {
+          // `undefined` means server config has not arrived yet; keep the last known value.
+          if (chatWorkspaceRoot === undefined) {
+            return state;
+          }
+          const normalizedChatWorkspaceRoot = chatWorkspaceRoot?.trim() ?? null;
+          if (state.chatWorkspaceRoot === normalizedChatWorkspaceRoot) {
+            return state;
+          }
+          return { chatWorkspaceRoot: normalizedChatWorkspaceRoot };
+        }),
+      setServerWorkspacePaths: (paths) =>
+        set((state) => {
+          const normalizedPaths = normalizeServerWorkspacePaths(paths);
+          const next: Partial<WorkspaceStoreState> = {};
+          if (paths.homeDir !== undefined) {
+            const normalizedHomeDir = normalizedPaths.homeDir;
+            if (state.homeDir !== normalizedHomeDir) {
+              next.homeDir = normalizedHomeDir;
+            }
+          }
+          if (paths.chatWorkspaceRoot !== undefined) {
+            const normalizedChatWorkspaceRoot = normalizedPaths.chatWorkspaceRoot;
+            if (state.chatWorkspaceRoot !== normalizedChatWorkspaceRoot) {
+              next.chatWorkspaceRoot = normalizedChatWorkspaceRoot;
+            }
+          }
+          return Object.keys(next).length > 0 ? next : state;
         }),
       ensureWorkspacePage: (workspaceId) =>
         set((state) => {
@@ -241,6 +279,7 @@ export const useWorkspaceStore = create<WorkspaceStoreState>()(
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         homeDir: state.homeDir,
+        chatWorkspaceRoot: state.chatWorkspaceRoot,
         workspacePages: state.workspacePages,
       }),
       merge: (persistedState, currentState) => {
@@ -249,6 +288,7 @@ export const useWorkspaceStore = create<WorkspaceStoreState>()(
         return {
           ...currentState,
           homeDir: candidate.homeDir?.trim() ?? null,
+          chatWorkspaceRoot: candidate.chatWorkspaceRoot?.trim() ?? null,
           workspacePages,
         };
       },

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -753,6 +753,9 @@ const ProjectMetaUpdateCommand = Schema.Struct({
   kind: Schema.optional(ProjectKind),
   title: Schema.optional(TrimmedNonEmptyString),
   workspaceRoot: Schema.optional(TrimmedNonEmptyString),
+  createWorkspaceRootIfMissing: Schema.optional(Schema.Boolean).pipe(
+    Schema.withDecodingDefault(() => false),
+  ),
   defaultModelSelection: Schema.optional(Schema.NullOr(ModelSelection)),
   scripts: Schema.optional(Schema.Array(ProjectScript)),
   isPinned: Schema.optional(Schema.Boolean),

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -86,6 +86,7 @@ const ServerProviderStatuses = Schema.Array(ServerProviderStatus);
 export const ServerConfig = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   homeDir: Schema.optional(TrimmedNonEmptyString),
+  chatWorkspaceRoot: Schema.optional(TrimmedNonEmptyString),
   worktreesDir: TrimmedNonEmptyString,
   keybindingsConfigPath: TrimmedNonEmptyString,
   keybindings: ResolvedKeybindingsConfig,
@@ -309,6 +310,7 @@ export type ServerSettingsUpdatedPayload = typeof ServerSettingsUpdatedPayload.T
 export const ServerLifecycleWelcomePayload = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   homeDir: Schema.optional(TrimmedNonEmptyString),
+  chatWorkspaceRoot: Schema.optional(TrimmedNonEmptyString),
   projectName: TrimmedNonEmptyString,
   bootstrapProjectId: Schema.optional(ProjectId),
   bootstrapThreadId: Schema.optional(ThreadId),

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -335,6 +335,7 @@ export type WsPushSequence = typeof WsPushSequence.Type;
 export const WsWelcomePayload = Schema.Struct({
   cwd: TrimmedNonEmptyString,
   homeDir: Schema.optional(TrimmedNonEmptyString),
+  chatWorkspaceRoot: Schema.optional(TrimmedNonEmptyString),
   projectName: TrimmedNonEmptyString,
   bootstrapProjectId: Schema.optional(ProjectId),
   bootstrapThreadId: Schema.optional(ThreadId),


### PR DESCRIPTION
## Summary
- Add a dedicated general-chat workspace root under `Documents/Synara` by default, with platform-safe resolution on macOS, Linux, and Windows.
- Plumb `chatWorkspaceRoot` through server config, welcome payloads, and websocket state so the client can keep chat placement consistent.
- Refactor the hidden Home chat project logic to use the new root, create missing folders when needed, and persist the path in workspace state.
- Add focused tests for config resolution, workspace-store persistence, and chat project matching.

## Testing
- Unit tests added and run for server config, chat project matching, and workspace-store persistence.
- Existing focused checks passed locally, including the related workspace-store and chat-project tests.