### PR TITLE
[codex] Fix transcript turn collapse and tail jitter

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1734,13 +1734,34 @@ export default function ChatView({
   );
   const phase = derivePhase(activeThread?.session ?? null);
   const isConnecting = isLocalConnecting || phase === "connecting";
+  // User messages intentionally have no turn id; assistant messages are the stable
+  // bridge for deciding which historical work can fold into visible replies.
+  const workLogVisibleTurnIds = useMemo(() => {
+    const turnIds = new Set<TurnId>();
+    for (const message of activeThread?.messages ?? []) {
+      if (message.turnId) {
+        turnIds.add(message.turnId);
+      }
+    }
+    if (activeLatestTurn?.turnId) {
+      turnIds.add(activeLatestTurn.turnId);
+    }
+    return turnIds;
+  }, [activeLatestTurn?.turnId, activeThread?.messages]);
   const rawWorkLogEntries = useMemo(
-    () => deriveWorkLogEntries(threadActivities, activeLatestTurn?.turnId ?? undefined),
-    [activeLatestTurn?.turnId, threadActivities],
+    () =>
+      deriveWorkLogEntries(threadActivities, activeLatestTurn?.turnId ?? undefined, {
+        visibleTurnIds: workLogVisibleTurnIds,
+      }),
+    [activeLatestTurn?.turnId, threadActivities, workLogVisibleTurnIds],
   );
   const activeTurnHasFileChangeWork = useMemo(
-    () => rawWorkLogEntries.some(isProviderFileEditWorkLogEntry),
-    [rawWorkLogEntries],
+    () =>
+      rawWorkLogEntries.some(
+        (entry) =>
+          entry.turnId === activeLatestTurn?.turnId && isProviderFileEditWorkLogEntry(entry),
+      ),
+    [activeLatestTurn?.turnId, rawWorkLogEntries],
   );
   const hasWorkLogSubagents = useMemo(
     () => rawWorkLogEntries.some((entry) => (entry.subagents?.length ?? 0) > 0),
@@ -4160,7 +4181,7 @@ export default function ChatView({
   const onMessagesWheelBase = useCallback(() => {
     clearTranscriptAutoFollow();
   }, [clearTranscriptAutoFollow]);
-  useEffect(() => {
+  useLayoutEffect(() => {
     const shouldFollowPendingTurn =
       activeThread?.id !== undefined && autoFollowThreadIdRef.current === activeThread.id;
     if (!isAtEndRef.current && !shouldFollowPendingTurn) {
@@ -4174,7 +4195,13 @@ export default function ChatView({
     return () => {
       window.cancelAnimationFrame(frameId);
     };
-  }, [activeThread?.id, scrollToEnd, transcriptMessageCount, transcriptTailKey]);
+  }, [
+    activeThread?.id,
+    activeTurnInProgress,
+    scrollToEnd,
+    transcriptMessageCount,
+    transcriptTailKey,
+  ]);
   const {
     pendingTranscriptSelectionAction,
     commitTranscriptAssistantSelection,

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -549,6 +549,7 @@ function workLogEntryContentEqual(a: WorkLogEntry, b: WorkLogEntry): boolean {
   return (
     a.id === b.id &&
     a.createdAt === b.createdAt &&
+    a.turnId === b.turnId &&
     a.label === b.label &&
     a.detail === b.detail &&
     a.toolTitle === b.toolTitle &&

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1483,7 +1483,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         initialScrollAtEnd
         maintainScrollAtEnd={followLiveOutput}
         maintainScrollAtEndThreshold={0.1}
-        maintainVisibleContentPosition
+        {...(!followLiveOutput ? { maintainVisibleContentPosition: true } : {})}
         onClickCapture={onMessagesClickCapture}
         onMouseUp={onMessagesMouseUp}
         onPointerCancel={onMessagesPointerCancel}

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -804,6 +804,28 @@ describe("deriveWorkLogEntries", () => {
     expect(entries.map((entry) => entry.id)).toEqual(["turn-2"]);
   });
 
+  it("keeps work for every visible transcript turn when requested", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({ id: "turn-1", turnId: "turn-1", summary: "First tool", kind: "tool.started" }),
+      makeActivity({
+        id: "turn-2",
+        turnId: "turn-2",
+        summary: "Second tool complete",
+        kind: "tool.completed",
+      }),
+      makeActivity({ id: "turn-3", turnId: "turn-3", summary: "Hidden tool", kind: "tool.started" }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, TurnId.makeUnsafe("turn-2"), {
+      visibleTurnIds: new Set([TurnId.makeUnsafe("turn-1"), TurnId.makeUnsafe("turn-2")]),
+    });
+
+    expect(entries.map((entry) => [entry.id, entry.turnId])).toEqual([
+      ["turn-1", TurnId.makeUnsafe("turn-1")],
+      ["turn-2", TurnId.makeUnsafe("turn-2")],
+    ]);
+  });
+
   it("omits checkpoint captured info entries", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -55,6 +55,7 @@ export const PROVIDER_OPTIONS: Array<{
 export interface WorkLogEntry {
   id: string;
   createdAt: string;
+  turnId?: TurnId | null;
   label: string;
   detail?: string;
   command?: string;
@@ -710,15 +711,12 @@ export function hasActionableProposedPlan(
 export function deriveWorkLogEntries(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
   latestTurnId: TurnId | undefined,
+  options: { visibleTurnIds?: ReadonlySet<TurnId | string> } = {},
 ): WorkLogEntry[] {
+  const visibleTurnIds = options.visibleTurnIds;
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
   const entries = ordered
-    .filter((activity) =>
-      latestTurnId
-        ? activity.turnId === latestTurnId ||
-          (activity.kind === "context-compaction" && activity.turnId === null)
-        : true,
-    )
+    .filter((activity) => shouldKeepActivityForWorkLog(activity, latestTurnId, visibleTurnIds))
     .filter((activity) => !shouldOmitRoutedCollabAgentToolActivity(activity))
     .filter((activity) => activity.kind !== "task.started" && activity.kind !== "task.completed")
     .filter((activity) => !isQuietTurnLifecycleActivity(activity))
@@ -740,6 +738,23 @@ export function deriveWorkLogEntries(
       ...entry
     }) => entry,
   );
+}
+
+function shouldKeepActivityForWorkLog(
+  activity: OrchestrationThreadActivity,
+  latestTurnId: TurnId | undefined,
+  visibleTurnIds: ReadonlySet<TurnId | string> | undefined,
+): boolean {
+  // Thread-level compaction progress has no provider turn id but should stay visible.
+  if (activity.kind === "context-compaction" && activity.turnId === null) {
+    return true;
+  }
+
+  if (visibleTurnIds) {
+    return activity.turnId !== null && visibleTurnIds.has(activity.turnId);
+  }
+
+  return latestTurnId ? activity.turnId === latestTurnId : true;
 }
 
 function isQuietTurnLifecycleActivity(activity: OrchestrationThreadActivity): boolean {
@@ -799,6 +814,7 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   const entry: DerivedWorkLogEntry = {
     id: activity.id,
     createdAt: activity.createdAt,
+    ...(activity.turnId !== null ? { turnId: activity.turnId } : {}),
     label: activity.summary,
     tone: activity.tone === "approval" ? "info" : activity.tone,
     activityKind: activity.kind,
@@ -1036,9 +1052,11 @@ function mergeDerivedWorkLogEntries(
   const collapseKey = next.collapseKey ?? previous.collapseKey;
   const toolName = next.toolName ?? previous.toolName;
   const toolCallId = next.toolCallId ?? previous.toolCallId;
+  const turnId = next.turnId ?? previous.turnId;
   return {
     ...previous,
     ...next,
+    ...(turnId !== undefined ? { turnId } : {}),
     ...(detail ? { detail } : {}),
     ...(command ? { command } : {}),
     ...(rawCommand ? { rawCommand } : {}),


### PR DESCRIPTION
## Summary
- preserve provider turn ids on derived work-log entries and derive work for all visible assistant turns
- keep active-turn file-change affordances scoped to the current turn
- reduce live-output tail jitter by disabling visible-position anchoring while following live output and snapping in layout timing
- add coverage for visible-turn work-log retention

## Validation
- bun run test src/session-logic.test.ts src/components/chat/MessagesTimeline.logic.test.ts
- bun run test src/components/chat/MessagesTimeline.test.tsx src/components/chat/ChatTranscriptPane.test.tsx
- git diff --check

Note: per repo instructions, I did not run bun fmt, bun lint, or bun typecheck.