### PR TITLE
Fix duplicate plan mode icon and stale plan sidebar

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -713,6 +713,7 @@ function createSnapshotWithSettledPlanAwaitingFollowUp(): OrchestrationReadModel
         ? {
             ...thread,
             interactionMode: "plan",
+            hasActionableProposedPlan: true,
             proposedPlans: [
               {
                 id: "plan-awaiting-follow-up",
@@ -3330,6 +3331,37 @@ describe("ChatView timeline estimator parity (full app)", () => {
           "plan",
         );
       });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("distinguishes plan mode from the plan details sidebar button", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotWithSettledPlanAwaitingFollowUp(),
+    });
+
+    try {
+      await waitForServerConfigToApply();
+      const footer = await waitForElement(
+        () => document.querySelector<HTMLElement>('[data-chat-composer-footer="true"]'),
+        "Unable to find composer footer.",
+      );
+
+      await vi.waitFor(() => {
+        const buttonLabels = Array.from(footer.querySelectorAll("button"))
+          .map((button) => button.textContent?.trim() ?? "")
+          .filter(Boolean);
+
+        expect(buttonLabels.filter((label) => label === "Plan")).toHaveLength(1);
+        expect(buttonLabels).toContain("Plan details");
+        expect(document.querySelector('button[title="Show plan sidebar"]')).toBeNull();
+      });
+      await expect
+        .element(page.getByTitle("Plan mode — click to return to normal build mode"))
+        .toBeInTheDocument();
+      await expect.element(page.getByLabelText("Show plan details sidebar")).toBeInTheDocument();
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -175,6 +175,7 @@ import {
   findSidebarProposedPlan,
   findLatestProposedPlan,
   deriveWorkLogEntries,
+  buildSourceProposedPlanReference,
   hasActionableProposedPlan,
   hasLiveTurnTailWork,
   isProviderFileEditWorkLogEntry,
@@ -231,6 +232,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   ComposerSendArrowIcon,
+  LayoutSidebarIcon,
   RefreshCwIcon,
   XIcon,
 } from "~/lib/icons";
@@ -1904,7 +1906,10 @@ export default function ChatView({
       sidebarPlanSourceThreadProposedPlans,
     ],
   );
-  const planSidebarLabel = sidebarProposedPlan || interactionMode === "plan" ? "Plan" : "Tasks";
+  const planSidebarLabel = sidebarProposedPlan ? "Plan details" : "Tasks";
+  const planSidebarToggleLabel = planSidebarOpen ? `Hide ${planSidebarLabel}` : planSidebarLabel;
+  const planSidebarToggleTitle =
+    `${planSidebarOpen ? "Hide" : "Show"} ${planSidebarLabel.toLowerCase()} sidebar`;
   const [activeTaskListCardHeight, setActiveTaskListCardHeight] = useState(0);
   const activeTaskListCardRef = useRef<HTMLDivElement | null>(null);
   const previousActiveTaskListCardHeightRef = useRef(0);
@@ -3969,12 +3974,34 @@ export default function ChatView({
       if (isLocalDraftThread) {
         setDraftThreadContext(threadId, { interactionMode: mode });
       }
+      if (serverThread) {
+        const api = readNativeApi();
+        if (api) {
+          void api.orchestration
+            .dispatchCommand({
+              type: "thread.interaction-mode.set",
+              commandId: newCommandId(),
+              threadId,
+              interactionMode: mode,
+              createdAt: new Date().toISOString(),
+            })
+            .catch((error) => {
+              toastManager.add({
+                type: "error",
+                title: "Could not update plan mode",
+                description:
+                  error instanceof Error ? error.message : "An unexpected error occurred.",
+              });
+            });
+        }
+      }
       scheduleComposerFocus();
     },
     [
       interactionMode,
       isLocalDraftThread,
       scheduleComposerFocus,
+      serverThread,
       setComposerDraftInteractionMode,
       setDraftThreadContext,
       threadId,
@@ -5537,7 +5564,9 @@ export default function ChatView({
       assistantSelectionCount: composerAssistantSelectionsForSend.length,
       terminalContexts: composerTerminalContextsForSend,
     });
-    if (showPlanFollowUpPrompt && activeProposedPlan) {
+    // Queued chat turns already captured their intended mode; only live composer
+    // submissions should be interpreted as plan refinement/implementation.
+    if (queuedChatTurn === null && showPlanFollowUpPrompt && activeProposedPlan) {
       const followUp = resolvePlanFollowUpSubmission({
         draftText: trimmed,
         planMarkdown: activeProposedPlan.planMarkdown,
@@ -6387,6 +6416,13 @@ export default function ChatView({
       const providerOptionsForPlanDispatch =
         queuedTurn?.providerOptionsForDispatch ?? providerOptionsForDispatch;
       const modelSelectionForPlanDispatch = queuedTurn?.modelSelection ?? selectedModelSelection;
+      const sourceProposedPlan =
+        nextInteractionMode === "default"
+          ? buildSourceProposedPlanReference({
+              threadId: activeThread.id,
+              proposedPlan: activeProposedPlan,
+            })
+          : undefined;
       rememberCustomBinaryPathForDispatch({
         threadId: threadIdForSend,
         provider: modelSelectionForPlanDispatch.provider,
@@ -6412,14 +6448,7 @@ export default function ChatView({
         dispatchMode,
         runtimeMode: queuedTurn?.runtimeMode ?? runtimeMode,
         interactionMode: nextInteractionMode,
-        ...(nextInteractionMode === "default" && activeProposedPlan
-          ? {
-              sourceProposedPlan: {
-                threadId: activeThread.id,
-                planId: activeProposedPlan.id,
-              },
-            }
-          : {}),
+        ...(sourceProposedPlan ? { sourceProposedPlan } : {}),
         createdAt: messageCreatedAt,
       });
       // Optimistically open the plan sidebar when implementing (not refining).
@@ -6657,6 +6686,10 @@ export default function ChatView({
     });
     const nextThreadTitle = truncateTitle(buildPlanImplementationThreadTitle(planMarkdown));
     const nextThreadModelSelection: ModelSelection = selectedModelSelection;
+    const sourceProposedPlan = buildSourceProposedPlanReference({
+      threadId: activeThread.id,
+      proposedPlan: activeProposedPlan,
+    });
 
     sendInFlightRef.current = true;
     beginLocalDispatch();
@@ -6706,6 +6739,7 @@ export default function ChatView({
           dispatchMode: "queue",
           runtimeMode,
           interactionMode: "default",
+          ...(sourceProposedPlan ? { sourceProposedPlan } : {}),
           createdAt,
         });
       })
@@ -8229,15 +8263,12 @@ export default function ChatView({
                               size="sm"
                               type="button"
                               onClick={togglePlanSidebar}
-                              title={
-                                planSidebarOpen
-                                  ? `Hide ${planSidebarLabel.toLowerCase()} sidebar`
-                                  : `Show ${planSidebarLabel.toLowerCase()} sidebar`
-                              }
+                              title={planSidebarToggleTitle}
+                              aria-label={planSidebarToggleTitle}
                             >
-                              <GoTasklist className="size-3.5" />
+                              <LayoutSidebarIcon className="size-3.5" />
                               <span className="sr-only sm:not-sr-only">
-                                {planSidebarOpen ? `Hide ${planSidebarLabel}` : planSidebarLabel}
+                                {planSidebarToggleLabel}
                               </span>
                             </Button>
                           ) : null}

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -8,6 +8,7 @@ import {
 import { describe, expect, it } from "vitest";
 
 import {
+  buildSourceProposedPlanReference,
   deriveActiveBackgroundTasksState,
   deriveActiveWorkStartedAt,
   deriveActiveTaskListState,
@@ -609,6 +610,29 @@ describe("hasActionableProposedPlan", () => {
   });
 });
 
+describe("buildSourceProposedPlanReference", () => {
+  it("returns source plan metadata for implementation turns", () => {
+    expect(
+      buildSourceProposedPlanReference({
+        threadId: ThreadId.makeUnsafe("thread-source"),
+        proposedPlan: { id: "plan-source" },
+      }),
+    ).toEqual({
+      threadId: ThreadId.makeUnsafe("thread-source"),
+      planId: "plan-source",
+    });
+  });
+
+  it("omits source plan metadata when no plan is active", () => {
+    expect(
+      buildSourceProposedPlanReference({
+        threadId: ThreadId.makeUnsafe("thread-source"),
+        proposedPlan: null,
+      }),
+    ).toBeUndefined();
+  });
+});
+
 describe("findSidebarProposedPlan", () => {
   it("prefers the running turn source proposed plan when available on the same thread", () => {
     expect(
@@ -703,6 +727,38 @@ describe("findSidebarProposedPlan", () => {
         threadId: ThreadId.makeUnsafe("thread-1"),
       })?.planMarkdown,
     ).toBe("# Latest");
+  });
+
+  it("hides implemented proposed plans once the implementation turn is settled", () => {
+    expect(
+      findSidebarProposedPlan({
+        threads: [
+          {
+            id: ThreadId.makeUnsafe("thread-1"),
+            proposedPlans: [
+              {
+                id: "plan-implemented",
+                turnId: TurnId.makeUnsafe("turn-plan"),
+                planMarkdown: "# Implemented",
+                implementedAt: "2026-02-23T00:00:05.000Z",
+                implementationThreadId: ThreadId.makeUnsafe("thread-1"),
+                createdAt: "2026-02-23T00:00:01.000Z",
+                updatedAt: "2026-02-23T00:00:05.000Z",
+              },
+            ],
+          },
+        ],
+        latestTurn: {
+          turnId: TurnId.makeUnsafe("turn-implementation"),
+          sourceProposedPlan: {
+            threadId: ThreadId.makeUnsafe("thread-1"),
+            planId: "plan-implemented",
+          },
+        },
+        latestTurnSettled: true,
+        threadId: ThreadId.makeUnsafe("thread-1"),
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -699,13 +699,29 @@ export function findSidebarProposedPlan(input: {
     }
   }
 
-  return findLatestProposedPlan(activeThreadPlans, input.latestTurn?.turnId ?? null);
+  return findLatestProposedPlan(
+    activeThreadPlans.filter((plan) => plan.implementedAt === null),
+    input.latestTurn?.turnId ?? null,
+  );
 }
 
 export function hasActionableProposedPlan(
   proposedPlan: LatestProposedPlanState | Pick<ProposedPlan, "implementedAt"> | null,
 ): boolean {
   return proposedPlan !== null && proposedPlan.implementedAt === null;
+}
+
+export function buildSourceProposedPlanReference(input: {
+  threadId: ThreadId;
+  proposedPlan: Pick<ProposedPlan, "id"> | null | undefined;
+}): OrchestrationLatestTurn["sourceProposedPlan"] | undefined {
+  if (!input.proposedPlan) {
+    return undefined;
+  }
+  return {
+    threadId: input.threadId,
+    planId: input.proposedPlan.id,
+  };
 }
 
 export function deriveWorkLogEntries(


### PR DESCRIPTION
## Summary
- Separate plan interaction mode from the plan details sidebar so the footer shows one `Plan` mode chip and one `Plan details` control.
- Hide implemented plans once the implementation turn settles, and keep the source plan link when starting implementation in a new thread.
- Add coverage for the shared source-plan helper and the sidebar visibility rules.

## Testing
- `bun run test src/session-logic.test.ts`
- `bun run test:browser src/components/ChatView.browser.tsx -t "distinguishes plan mode from the plan details sidebar button"`
- `git diff --check`