### PR TITLE
[codex] Optimize chat view startup and timeline ordering

### DIFF
--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -559,8 +559,20 @@ export interface ThreadBreadcrumb {
   title: string;
 }
 
+type ThreadBreadcrumbSource = Pick<
+  Thread,
+  | "id"
+  | "title"
+  | "parentThreadId"
+  | "subagentAgentId"
+  | "subagentNickname"
+  | "subagentRole"
+> & {
+  activities?: Thread["activities"];
+};
+
 export function buildThreadBreadcrumbs(
-  threads: ReadonlyArray<Thread>,
+  threads: ReadonlyArray<ThreadBreadcrumbSource>,
   thread: Pick<Thread, "id" | "parentThreadId"> | null | undefined,
 ): ThreadBreadcrumb[] {
   if (!thread?.parentThreadId) {

--- a/apps/web/src/components/ChatView.selectors.test.ts
+++ b/apps/web/src/components/ChatView.selectors.test.ts
@@ -1,0 +1,132 @@
+import { EventId, MessageId, ThreadId, TurnId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import type { AppState } from "../store";
+import type { ChatMessage, Thread, ThreadShell } from "../types";
+import { createThreadLineageSelector } from "./ChatView.selectors";
+
+const rootThreadId = ThreadId.makeUnsafe("thread-root");
+const childThreadId = ThreadId.makeUnsafe("thread-child");
+const unrelatedThreadId = ThreadId.makeUnsafe("thread-unrelated");
+const messageId = MessageId.makeUnsafe("message-1");
+
+const rootShell = {
+  id: rootThreadId,
+  title: "Root thread",
+} as ThreadShell;
+
+const childShell = {
+  id: childThreadId,
+  title: "Child thread",
+  parentThreadId: rootThreadId,
+} as ThreadShell;
+
+const unrelatedShell = {
+  id: unrelatedThreadId,
+  title: "Unrelated thread",
+} as ThreadShell;
+
+const threadIds = [rootThreadId, childThreadId];
+const threadShellById = {
+  [rootThreadId]: rootShell,
+  [childThreadId]: childShell,
+};
+
+const rootActivity = {
+  id: EventId.makeUnsafe("activity-root"),
+  kind: "tool.completed",
+  tone: "tool",
+  summary: "Delegated work",
+  payload: {},
+  turnId: TurnId.makeUnsafe("turn-1"),
+  createdAt: "2026-06-01T00:00:00.000Z",
+} satisfies Thread["activities"][number];
+
+const activityIdsByThreadId = {
+  [rootThreadId]: [rootActivity.id],
+};
+
+const activityByThreadId = {
+  [rootThreadId]: {
+    [rootActivity.id]: rootActivity,
+  },
+};
+
+const message = {
+  id: messageId,
+  role: "assistant",
+  text: "Streaming detail changed",
+  createdAt: "2026-06-01T00:00:01.000Z",
+  streaming: true,
+} satisfies ChatMessage;
+
+function makeState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    threadIds,
+    threadShellById,
+    activityIdsByThreadId,
+    activityByThreadId,
+    messageIdsByThreadId: {},
+    messageByThreadId: {},
+    ...overrides,
+  } as AppState;
+}
+
+describe("createThreadLineageSelector", () => {
+  it("stays stable when only message detail slices change", () => {
+    const selectLineage = createThreadLineageSelector(childThreadId);
+    const before = selectLineage(makeState());
+    const after = selectLineage(
+      makeState({
+        messageIdsByThreadId: {
+          [childThreadId]: [messageId],
+        },
+        messageByThreadId: {
+          [childThreadId]: {
+            [messageId]: message,
+          },
+        },
+      }),
+    );
+
+    expect(after).toBe(before);
+    expect(after.map((thread) => thread.id)).toEqual([rootThreadId, childThreadId]);
+  });
+
+  it("updates when parent activity identity hints change", () => {
+    const selectLineage = createThreadLineageSelector(childThreadId);
+    const before = selectLineage(makeState());
+    const nextActivity = {
+      ...rootActivity,
+      payload: { data: { item: { agents: [{ id: "agent-1", nickname: "Planner" }] } } },
+    };
+    const after = selectLineage(
+      makeState({
+        activityByThreadId: {
+          [rootThreadId]: {
+            [rootActivity.id]: nextActivity,
+          },
+        },
+      }),
+    );
+
+    expect(after).not.toBe(before);
+    expect(after[0]?.activities[0]).toBe(nextActivity);
+  });
+
+  it("stays stable when unrelated thread shells change", () => {
+    const selectLineage = createThreadLineageSelector(childThreadId);
+    const before = selectLineage(makeState());
+    const after = selectLineage(
+      makeState({
+        threadIds: [...threadIds, unrelatedThreadId],
+        threadShellById: {
+          ...threadShellById,
+          [unrelatedThreadId]: unrelatedShell,
+        },
+      }),
+    );
+
+    expect(after).toBe(before);
+  });
+});

--- a/apps/web/src/components/ChatView.selectors.ts
+++ b/apps/web/src/components/ChatView.selectors.ts
@@ -10,7 +10,7 @@ import {
 } from "@t3tools/contracts";
 
 import type { AppState } from "../store";
-import { getThreadFromState } from "../threadDerivation";
+import { collectByIds, getThreadFromState } from "../threadDerivation";
 import type {
   ChatMessage,
   ProposedPlan,
@@ -21,6 +21,8 @@ import type {
   TurnDiffSummary,
 } from "../types";
 import type { WorkLogEntry } from "../session-logic";
+
+const EMPTY_LINEAGE_ACTIVITIES: Thread["activities"] = [];
 
 type ThreadSliceRefs = {
   shell: ThreadShell | undefined;
@@ -36,6 +38,24 @@ type ThreadSliceRefs = {
   turnDiffs: Record<TurnId, TurnDiffSummary> | undefined;
 };
 
+type ThreadLineageSliceRefs = {
+  shell: ThreadShell | undefined;
+  activityIds: readonly string[] | undefined;
+  activities: Record<string, Thread["activities"][number]> | undefined;
+};
+
+export type ThreadLineageEntry = Pick<
+  ThreadShell,
+  | "id"
+  | "title"
+  | "parentThreadId"
+  | "subagentAgentId"
+  | "subagentNickname"
+  | "subagentRole"
+> & {
+  activities: Thread["activities"];
+};
+
 function collectThreadSliceRefs(state: AppState, threadId: ThreadIdType): ThreadSliceRefs {
   return {
     shell: state.threadShellById?.[threadId],
@@ -49,6 +69,17 @@ function collectThreadSliceRefs(state: AppState, threadId: ThreadIdType): Thread
     proposedPlans: state.proposedPlanByThreadId?.[threadId],
     turnDiffIds: state.turnDiffIdsByThreadId?.[threadId],
     turnDiffs: state.turnDiffSummaryByThreadId?.[threadId],
+  };
+}
+
+function collectThreadLineageSliceRefs(
+  state: AppState,
+  threadId: ThreadIdType,
+): ThreadLineageSliceRefs {
+  return {
+    shell: state.threadShellById?.[threadId],
+    activityIds: state.activityIdsByThreadId?.[threadId],
+    activities: state.activityByThreadId?.[threadId],
   };
 }
 
@@ -69,6 +100,18 @@ function threadSliceRefsEqual(left: ThreadSliceRefs | undefined, right: ThreadSl
   );
 }
 
+function threadLineageSliceRefsEqual(
+  left: ThreadLineageSliceRefs | undefined,
+  right: ThreadLineageSliceRefs,
+): boolean {
+  return (
+    left !== undefined &&
+    left.shell === right.shell &&
+    left.activityIds === right.activityIds &&
+    left.activities === right.activities
+  );
+}
+
 function shallowEqualThreadIds(
   left: ReadonlyArray<ThreadIdType>,
   right: ReadonlyArray<ThreadIdType>,
@@ -80,6 +123,13 @@ function shallowEqualThreads(left: ReadonlyArray<Thread>, right: ReadonlyArray<T
   return left.length === right.length && left.every((thread, index) => thread === right[index]);
 }
 
+function shallowEqualThreadLineageEntries(
+  left: ReadonlyArray<ThreadLineageEntry>,
+  right: ReadonlyArray<ThreadLineageEntry>,
+): boolean {
+  return left.length === right.length && left.every((thread, index) => thread === right[index]);
+}
+
 function buildThreadSelectionResult(
   state: AppState,
   selectedThreadIds: ReadonlyArray<ThreadIdType>,
@@ -87,6 +137,35 @@ function buildThreadSelectionResult(
   return selectedThreadIds.flatMap((threadId) => {
     const thread = getThreadFromState(state, threadId);
     return thread ? [thread] : [];
+  });
+}
+
+function buildThreadLineageSelectionResult(
+  state: AppState,
+  selectedThreadIds: ReadonlyArray<ThreadIdType>,
+): ThreadLineageEntry[] {
+  return selectedThreadIds.flatMap((threadId) => {
+    const shell = state.threadShellById?.[threadId];
+    if (!shell) {
+      return [];
+    }
+    return [
+      {
+        id: shell.id,
+        title: shell.title,
+        activities: collectByIds(
+          state.activityIdsByThreadId?.[threadId],
+          state.activityByThreadId?.[threadId],
+          EMPTY_LINEAGE_ACTIVITIES,
+        ),
+        ...(shell.parentThreadId !== undefined ? { parentThreadId: shell.parentThreadId } : {}),
+        ...(shell.subagentAgentId !== undefined ? { subagentAgentId: shell.subagentAgentId } : {}),
+        ...(shell.subagentNickname !== undefined
+          ? { subagentNickname: shell.subagentNickname }
+          : {}),
+        ...(shell.subagentRole !== undefined ? { subagentRole: shell.subagentRole } : {}),
+      },
+    ];
   });
 }
 
@@ -215,19 +294,15 @@ export function createRelevantWorkLogThreadsSelector(input: {
 }
 
 export function createThreadLineageSelector(threadId: ThreadIdType | null) {
-  let previousThreadIds: ReadonlyArray<ThreadIdType> | undefined;
-  let previousThreadShellById: AppState["threadShellById"] | undefined;
   let previousSelectedThreadIds: ThreadIdType[] = [];
-  let previousSliceRefs = new Map<ThreadIdType, ThreadSliceRefs>();
-  let previousResult: Thread[] = [];
+  let previousSliceRefs = new Map<ThreadIdType, ThreadLineageSliceRefs>();
+  let previousResult: ThreadLineageEntry[] = [];
 
-  return (state: AppState): Thread[] => {
+  return (state: AppState): ThreadLineageEntry[] => {
     if (!threadId) {
       if (previousResult.length === 0) {
         return previousResult;
       }
-      previousThreadIds = state.threadIds;
-      previousThreadShellById = state.threadShellById;
       previousSelectedThreadIds = [];
       previousSliceRefs = new Map();
       previousResult = [];
@@ -250,19 +325,21 @@ export function createThreadLineageSelector(threadId: ThreadIdType | null) {
       currentThreadId = thread.parentThreadId ?? null;
     }
 
-    const selectedIdsChanged =
-      previousThreadIds !== threadIds ||
-      previousThreadShellById !== threadShellById ||
-      !shallowEqualThreadIds(previousSelectedThreadIds, selectedThreadIds);
-    const nextSliceRefs = new Map<ThreadIdType, ThreadSliceRefs>();
+    // Breadcrumb labels only need shells plus parent activity identity hints;
+    // avoid subscribing this header path to message/session/diff slices.
+    const selectedIdsChanged = !shallowEqualThreadIds(
+      previousSelectedThreadIds,
+      selectedThreadIds,
+    );
+    const nextSliceRefs = new Map<ThreadIdType, ThreadLineageSliceRefs>();
     let sliceRefsChanged = selectedIdsChanged;
 
     for (const selectedThreadId of selectedThreadIds) {
-      const nextRefs = collectThreadSliceRefs(state, selectedThreadId);
+      const nextRefs = collectThreadLineageSliceRefs(state, selectedThreadId);
       nextSliceRefs.set(selectedThreadId, nextRefs);
       if (
         !sliceRefsChanged &&
-        !threadSliceRefsEqual(previousSliceRefs.get(selectedThreadId), nextRefs)
+        !threadLineageSliceRefsEqual(previousSliceRefs.get(selectedThreadId), nextRefs)
       ) {
         sliceRefsChanged = true;
       }
@@ -272,13 +349,11 @@ export function createThreadLineageSelector(threadId: ThreadIdType | null) {
       return previousResult;
     }
 
-    previousThreadIds = threadIds;
-    previousThreadShellById = threadShellById;
     previousSelectedThreadIds = selectedThreadIds;
     previousSliceRefs = nextSliceRefs;
 
-    const nextResult = buildThreadSelectionResult(state, selectedThreadIds);
-    if (shallowEqualThreads(previousResult, nextResult)) {
+    const nextResult = buildThreadLineageSelectionResult(state, selectedThreadIds);
+    if (shallowEqualThreadLineageEntries(previousResult, nextResult)) {
       return previousResult;
     }
 

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -2388,6 +2388,41 @@ describe("deriveTimelineEntries", () => {
     });
   });
 
+  it("keeps timestamp ties in message, proposed-plan, then work order", () => {
+    const entries = deriveTimelineEntries(
+      [
+        {
+          id: MessageId.makeUnsafe("message-same-time"),
+          role: "assistant",
+          text: "same time",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          streaming: false,
+        },
+      ],
+      [
+        {
+          id: "plan:thread-1:turn:turn-same-time",
+          turnId: TurnId.makeUnsafe("turn-same-time"),
+          planMarkdown: "# Same time",
+          implementedAt: null,
+          implementationThreadId: null,
+          createdAt: "2026-02-23T00:00:01.000Z",
+          updatedAt: "2026-02-23T00:00:01.000Z",
+        },
+      ],
+      [
+        {
+          id: "work-same-time",
+          createdAt: "2026-02-23T00:00:01.000Z",
+          label: "Ran command",
+          tone: "tool",
+        },
+      ],
+    );
+
+    expect(entries.map((entry) => entry.kind)).toEqual(["message", "proposed-plan", "work"]);
+  });
+
   it("hides tagged plan markdown from the assistant row when a proposed plan exists", () => {
     const entries = deriveTimelineEntries(
       [

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -179,6 +179,39 @@ export type TimelineEntry =
       entry: WorkLogEntry;
     };
 
+const orderedActivitiesCache = new WeakMap<
+  ReadonlyArray<OrchestrationThreadActivity>,
+  ReadonlyArray<OrchestrationThreadActivity>
+>();
+
+function isActivityOrderStable(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): boolean {
+  for (let index = 1; index < activities.length; index += 1) {
+    if (compareActivitiesByOrder(activities[index - 1]!, activities[index]!) > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Thread activity arrays are immutable store values and most call sites need the
+// same order; cache it so chat startup does not sort the same array repeatedly.
+function orderedActivities(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): ReadonlyArray<OrchestrationThreadActivity> {
+  const cached = orderedActivitiesCache.get(activities);
+  if (cached) {
+    return cached;
+  }
+
+  const ordered = isActivityOrderStable(activities)
+    ? activities
+    : [...activities].sort(compareActivitiesByOrder);
+  orderedActivitiesCache.set(activities, ordered);
+  return ordered;
+}
+
 function formatDuration(durationMs: number): string {
   if (!Number.isFinite(durationMs) || durationMs < 0) return "0ms";
   if (durationMs < 1_000) return `${Math.max(1, Math.round(durationMs))}ms`;
@@ -307,7 +340,7 @@ export function derivePendingApprovals(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): PendingApproval[] {
   const openByRequestId = new Map<ApprovalRequestId, PendingApproval>();
-  const ordered = [...activities].toSorted(compareActivitiesByOrder);
+  const ordered = orderedActivities(activities);
 
   for (const activity of ordered) {
     const payload =
@@ -413,7 +446,7 @@ export function derivePendingUserInputs(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): PendingUserInput[] {
   const openByRequestId = new Map<ApprovalRequestId, PendingUserInput>();
-  const ordered = [...activities].toSorted(compareActivitiesByOrder);
+  const ordered = orderedActivities(activities);
 
   for (const activity of ordered) {
     const payload =
@@ -506,7 +539,7 @@ export function deriveActiveTaskListState(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
   latestTurnId: TurnId | undefined,
 ): ActiveTaskListState | null {
-  const ordered = [...activities].toSorted(compareActivitiesByOrder);
+  const ordered = orderedActivities(activities);
   const allTaskListActivities = ordered.filter(
     (activity) => activity.kind === "turn.tasks.updated",
   );
@@ -555,7 +588,7 @@ export function deriveActiveBackgroundTasksState(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
   latestTurnId: TurnId | undefined,
 ): ActiveBackgroundTasksState | null {
-  const ordered = [...activities].toSorted(compareActivitiesByOrder);
+  const ordered = orderedActivities(activities);
   const activeTasks = new Map<string, { taskType?: string | undefined }>();
 
   for (const activity of ordered) {
@@ -714,7 +747,7 @@ export function deriveWorkLogEntries(
   options: { visibleTurnIds?: ReadonlySet<TurnId | string> } = {},
 ): WorkLogEntry[] {
   const visibleTurnIds = options.visibleTurnIds;
-  const ordered = [...activities].toSorted(compareActivitiesByOrder);
+  const ordered = orderedActivities(activities);
   const entries = ordered
     .filter((activity) => shouldKeepActivityForWorkLog(activity, latestTurnId, visibleTurnIds))
     .filter((activity) => !shouldOmitRoutedCollabAgentToolActivity(activity))
@@ -1868,6 +1901,59 @@ function compareActivityLifecycleRank(kind: string): number {
   return 1;
 }
 
+function compareTimelineEntries(left: TimelineEntry, right: TimelineEntry): number {
+  return left.createdAt.localeCompare(right.createdAt);
+}
+
+function areTimelineEntriesOrdered(entries: ReadonlyArray<TimelineEntry>): boolean {
+  for (let index = 1; index < entries.length; index += 1) {
+    if (compareTimelineEntries(entries[index - 1]!, entries[index]!) > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function sortedTimelineEntries(entries: TimelineEntry[]): TimelineEntry[] {
+  return areTimelineEntriesOrdered(entries) ? entries : entries.toSorted(compareTimelineEntries);
+}
+
+function mergeTimelineEntries(
+  left: ReadonlyArray<TimelineEntry>,
+  right: ReadonlyArray<TimelineEntry>,
+): TimelineEntry[] {
+  if (left.length === 0) {
+    return [...right];
+  }
+  if (right.length === 0) {
+    return [...left];
+  }
+
+  const merged: TimelineEntry[] = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < left.length && rightIndex < right.length) {
+    const leftEntry = left[leftIndex]!;
+    const rightEntry = right[rightIndex]!;
+    if (compareTimelineEntries(leftEntry, rightEntry) <= 0) {
+      merged.push(leftEntry);
+      leftIndex += 1;
+    } else {
+      merged.push(rightEntry);
+      rightIndex += 1;
+    }
+  }
+  while (leftIndex < left.length) {
+    merged.push(left[leftIndex]!);
+    leftIndex += 1;
+  }
+  while (rightIndex < right.length) {
+    merged.push(right[rightIndex]!);
+    rightIndex += 1;
+  }
+  return merged;
+}
+
 export function deriveTimelineEntries(
   messages: ChatMessage[],
   proposedPlans: ProposedPlan[],
@@ -1910,8 +1996,13 @@ export function deriveTimelineEntries(
     createdAt: entry.createdAt,
     entry,
   }));
-  return [...messageRows, ...proposedPlanRows, ...workRows].toSorted((a, b) =>
-    a.createdAt.localeCompare(b.createdAt),
+
+  return mergeTimelineEntries(
+    mergeTimelineEntries(
+      sortedTimelineEntries(messageRows),
+      sortedTimelineEntries(proposedPlanRows),
+    ),
+    sortedTimelineEntries(workRows),
   );
 }
 

--- a/apps/web/src/storeSelectors.test.ts
+++ b/apps/web/src/storeSelectors.test.ts
@@ -1,17 +1,23 @@
 import { describe, expect, it } from "vitest";
 
-import type { MessageId, ThreadId } from "@t3tools/contracts";
+import type { MessageId, ProjectId, ThreadId } from "@t3tools/contracts";
 
 import type { AppState } from "./store";
-import { createAllThreadsMessagelessSelector, createThreadShellsSelector } from "./storeSelectors";
+import {
+  createAllThreadsMessagelessSelector,
+  createThreadExistsSelector,
+  createThreadProjectIdSelector,
+  createThreadShellsSelector,
+} from "./storeSelectors";
 import type { ThreadShell } from "./types";
 
 const threadIdA = "thread-a" as ThreadId;
 const threadIdB = "thread-b" as ThreadId;
 const messageId = "message-1" as MessageId;
+const projectId = "project-1" as ProjectId;
 
-const shellA = { id: threadIdA, title: "A" } as ThreadShell;
-const shellB = { id: threadIdB, title: "B" } as ThreadShell;
+const shellA = { id: threadIdA, projectId, title: "A" } as ThreadShell;
+const shellB = { id: threadIdB, projectId, title: "B" } as ThreadShell;
 
 interface TestStateSlices {
   threadIds?: readonly ThreadId[];
@@ -94,5 +100,22 @@ describe("createAllThreadsMessagelessSelector", () => {
       messageIdsByThreadId: { [threadIdB]: [messageId] },
     });
     expect(selectMessageless(state)).toBe(false);
+  });
+});
+
+describe("thread shell route selectors", () => {
+  it("resolve existence and project id without reading detail slices", () => {
+    const state = makeState({
+      threadIds: [threadIdA],
+      threadShellById: { [threadIdA]: shellA },
+    });
+    Object.defineProperty(state, "messageIdsByThreadId", {
+      get() {
+        throw new Error("detail messages should not be read");
+      },
+    });
+
+    expect(createThreadExistsSelector(threadIdA)(state)).toBe(true);
+    expect(createThreadProjectIdSelector(threadIdA)(state)).toBe(projectId);
   });
 });

--- a/apps/web/src/storeSelectors.ts
+++ b/apps/web/src/storeSelectors.ts
@@ -134,15 +134,26 @@ export function createAllThreadsMessagelessSelector(): (state: AppState) => bool
 export function createThreadProjectIdSelector(
   threadId: ThreadId | null | undefined,
 ): (state: AppState) => ProjectId | null {
-  const selectThread = createThreadSelector(threadId);
-  return (state) => selectThread(state)?.projectId ?? null;
+  return (state) => {
+    if (!threadId) {
+      return null;
+    }
+    return (
+      state.threadShellById?.[threadId]?.projectId ??
+      state.threads.find((thread) => thread.id === threadId)?.projectId ??
+      null
+    );
+  };
 }
 
 export function createThreadExistsSelector(
   threadId: ThreadId | null | undefined,
 ): (state: AppState) => boolean {
-  const selectThread = createThreadSelector(threadId);
-  return (state) => selectThread(state) !== undefined;
+  return (state) =>
+    threadId
+      ? Boolean(state.threadShellById?.[threadId]) ||
+        state.threads.some((thread) => thread.id === threadId)
+      : false;
 }
 
 export function createSidebarThreadSummarySelector(


### PR DESCRIPTION
## Summary

- Use lightweight thread shell selectors for chat route existence/project checks so the main chat frame can render before full transcript detail hydration.
- Narrow chat lineage selection to the selected shell/activity refs needed for breadcrumbs and subagent labels.
- Avoid repeated activity/timeline sorting by reusing already ordered activity arrays and merging timeline rows with stable tie ordering.

## Root Cause

The sidebar was reading lightweight thread shell data, but the chat route/header path was hydrating full thread details before drawing. That made the main chat view lag behind the sidebar and delayed the chat edge rendering.

## Validation

- `bun run test -- src/session-logic.test.ts src/components/ChatView.selectors.test.ts src/storeSelectors.test.ts src/components/ChatView.logic.test.ts src/lib/subagentPresentation.test.ts`
- Result: 5 files passed, 165 tests passed

Not run per repo instructions unless explicitly requested: `bun fmt`, `bun lint`, `bun typecheck`.