### PR TITLE
Rendi robusto il supporto Pi per plugin e prompt iniziali

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -3062,6 +3062,152 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("forwards approval responses before the session projection is visible", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.approval.respond",
+        commandId: CommandId.makeUnsafe("cmd-approval-respond-early"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        requestId: asApprovalRequestId("approval-request-early"),
+        decision: "accept",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.respondToRequest.mock.calls.length === 1);
+    expect(harness.respondToRequest.mock.calls[0]?.[0]).toEqual({
+      threadId: "thread-1",
+      requestId: "approval-request-early",
+      decision: "accept",
+    });
+  });
+
+  it("forwards user-input responses before the session projection is visible", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.user-input.respond",
+        commandId: CommandId.makeUnsafe("cmd-user-input-respond-early"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        requestId: asApprovalRequestId("user-input-request-early"),
+        answers: {
+          input: "continue",
+        },
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.respondToUserInput.mock.calls.length === 1);
+    expect(harness.respondToUserInput.mock.calls[0]?.[0]).toEqual({
+      threadId: "thread-1",
+      requestId: "user-input-request-early",
+      answers: {
+        input: "continue",
+      },
+    });
+  });
+
+  it("does not forward approval responses when the projected session is stopped", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-stopped-approval"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "stopped",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.approval.respond",
+        commandId: CommandId.makeUnsafe("cmd-approval-respond-stopped"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        requestId: asApprovalRequestId("approval-request-stopped"),
+        decision: "accept",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      const thread = readModel.threads.find(
+        (entry) => entry.id === ThreadId.makeUnsafe("thread-1"),
+      );
+      return (
+        thread?.activities.some(
+          (activity) => activity.kind === "provider.approval.respond.failed",
+        ) ?? false
+      );
+    });
+    expect(harness.respondToRequest).not.toHaveBeenCalled();
+  });
+
+  it("does not forward user-input responses when the projected session is stopped", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-stopped-user-input"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "stopped",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.user-input.respond",
+        commandId: CommandId.makeUnsafe("cmd-user-input-respond-stopped"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        requestId: asApprovalRequestId("user-input-request-stopped"),
+        answers: {
+          input: "continue",
+        },
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      const thread = readModel.threads.find(
+        (entry) => entry.id === ThreadId.makeUnsafe("thread-1"),
+      );
+      return (
+        thread?.activities.some(
+          (activity) => activity.kind === "provider.user-input.respond.failed",
+        ) ?? false
+      );
+    });
+    expect(harness.respondToUserInput).not.toHaveBeenCalled();
+  });
+
   it("preserves array and mixed answer shapes through the runtime path", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1451,7 +1451,6 @@ const make = Effect.gen(function* () {
         ? "queue"
         : event.payload.dispatchMode;
     const editResendKey = editResendTurnStartKey(event.payload.threadId, event.payload.messageId);
-    const isEditResendTurn = editResendTurnStartKeys.has(editResendKey);
 
     yield* dispatchTurnForThread({
       threadId: event.payload.threadId,
@@ -1585,12 +1584,11 @@ const make = Effect.gen(function* () {
     event: Extract<ProviderIntentEvent, { type: "thread.approval-response-requested" }>,
   ) {
     const thread = yield* resolveThread(event.payload.threadId);
-    const providerThread = yield* resolveProviderSessionThread(event.payload.threadId);
-    if (!thread || !providerThread) {
+    if (!thread) {
       return;
     }
-    const hasSession = providerThread.session && providerThread.session.status !== "stopped";
-    if (!hasSession) {
+    const providerThread = yield* resolveProviderSessionThread(event.payload.threadId);
+    if (providerThread?.session?.status === "stopped") {
       return yield* appendProviderFailureActivity({
         threadId: event.payload.threadId,
         kind: "provider.approval.respond.failed",
@@ -1601,10 +1599,11 @@ const make = Effect.gen(function* () {
         requestId: event.payload.requestId,
       });
     }
+    const providerThreadId = providerThread?.id ?? event.payload.threadId;
 
     yield* providerService
       .respondToRequest({
-        threadId: providerThread.id,
+        threadId: providerThreadId,
         requestId: event.payload.requestId,
         decision: event.payload.decision,
       })
@@ -1633,12 +1632,11 @@ const make = Effect.gen(function* () {
     event: Extract<ProviderIntentEvent, { type: "thread.user-input-response-requested" }>,
   ) {
     const thread = yield* resolveThread(event.payload.threadId);
-    const providerThread = yield* resolveProviderSessionThread(event.payload.threadId);
-    if (!thread || !providerThread) {
+    if (!thread) {
       return;
     }
-    const hasSession = providerThread.session && providerThread.session.status !== "stopped";
-    if (!hasSession) {
+    const providerThread = yield* resolveProviderSessionThread(event.payload.threadId);
+    if (providerThread?.session?.status === "stopped") {
       return yield* appendProviderFailureActivity({
         threadId: event.payload.threadId,
         kind: "provider.user-input.respond.failed",
@@ -1649,10 +1647,11 @@ const make = Effect.gen(function* () {
         requestId: event.payload.requestId,
       });
     }
+    const providerThreadId = providerThread?.id ?? event.payload.threadId;
 
     yield* providerService
       .respondToUserInput({
-        threadId: providerThread.id,
+        threadId: providerThreadId,
         requestId: event.payload.requestId,
         answers: event.payload.answers,
       })

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -5,7 +5,11 @@
 
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
-import { getPiSupportedThinkingOptions } from "./PiAdapter";
+import {
+  getPiSupportedThinkingOptions,
+  makePiUserInputOptions,
+  PLAIN_PI_EXTENSION_THEME,
+} from "./PiAdapter";
 
 function makePiModel(input: {
   reasoning: boolean;
@@ -60,5 +64,24 @@ describe("getPiSupportedThinkingOptions", () => {
     );
 
     expect(options.map((option) => option.value)).toEqual(["minimal", "low", "medium", "high"]);
+  });
+});
+
+describe("Pi extension UI helpers", () => {
+  it("keeps original select values while showing normalized unique labels", () => {
+    const mappings = makePiUserInputOptions(["  OpenRouter  ", "", "OpenRouter"]);
+
+    expect(mappings.map((mapping) => mapping.value)).toEqual(["  OpenRouter  ", "", "OpenRouter"]);
+    expect(mappings.map((mapping) => mapping.option.label)).toEqual([
+      "OpenRouter",
+      "Option 2",
+      "OpenRouter (2)",
+    ]);
+  });
+
+  it("provides a no-color theme object for UI-gated extensions", () => {
+    expect(PLAIN_PI_EXTENSION_THEME.fg("accent", "ready")).toBe("ready");
+    expect(PLAIN_PI_EXTENSION_THEME.bold("done")).toBe("done");
+    expect(PLAIN_PI_EXTENSION_THEME.getThinkingBorderColor("medium")("thinking")).toBe("thinking");
   });
 });

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -699,6 +699,19 @@ function makeAgentDir(agentDir: string | undefined): string {
   return trimToUndefined(agentDir) ?? getAgentDir();
 }
 
+// Keep discovery registries isolated so extension provider registrations reflect
+// the current agent dir + project cwd instead of stale state from prior listings.
+function createPiModelRegistry(agentDir: string): {
+  readonly authStorage: AuthStorage;
+  readonly registry: ModelRegistry;
+} {
+  const authStorage = AuthStorage.create(path.join(agentDir, "auth.json"));
+  return {
+    authStorage,
+    registry: ModelRegistry.create(authStorage, path.join(agentDir, "models.json")),
+  };
+}
+
 function extensionDisplayName(extension: {
   readonly path: string;
   readonly sourceInfo?: { readonly source?: string };
@@ -726,8 +739,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
     const getModelRegistry = (agentDir: string): ModelRegistry => {
       const existing = modelRegistries.get(agentDir);
       if (existing) return existing;
-      const authStorage = AuthStorage.create(path.join(agentDir, "auth.json"));
-      const registry = ModelRegistry.create(authStorage, path.join(agentDir, "models.json"));
+      const { registry } = createPiModelRegistry(agentDir);
       modelRegistries.set(agentDir, registry);
       return registry;
     };
@@ -1641,15 +1653,22 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       Effect.tryPromise({
         try: async () => {
           const agentDir = makeAgentDir(input.agentDir);
-          const registry = getModelRegistry(agentDir);
-          registry.refresh();
-          const models = registry.getAvailable().map((model) => {
+          const cwd = trimToUndefined(input.cwd) ?? serverConfig.cwd;
+          const { authStorage, registry } = createPiModelRegistry(agentDir);
+          const services = await createAgentSessionServices({
+            cwd,
+            agentDir,
+            authStorage,
+            modelRegistry: registry,
+          });
+          const extensionCount = services.resourceLoader.getExtensions().extensions.length;
+          const models = services.modelRegistry.getAvailable().map((model) => {
             const supportedThinkingOptions = getPiSupportedThinkingOptions(model);
             return {
               slug: `${model.provider}/${model.id}`,
               name: model.name,
               upstreamProviderId: model.provider,
-              upstreamProviderName: registry.getProviderDisplayName(model.provider),
+              upstreamProviderName: services.modelRegistry.getProviderDisplayName(model.provider),
               ...(supportedThinkingOptions.length > 0
                 ? {
                     supportedReasoningEfforts: supportedThinkingOptions.map((option) => ({
@@ -1666,7 +1685,11 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
                 : {}),
             };
           });
-          return { models, source: "pi.sdk", cached: false } satisfies ProviderListModelsResult;
+          return {
+            models,
+            source: extensionCount > 0 ? "pi.sdk+extensions" : "pi.sdk",
+            cached: false,
+          } satisfies ProviderListModelsResult;
         },
         catch: (cause) =>
           new ProviderAdapterRequestError({

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -12,6 +12,7 @@ import {
   type AgentSession as PiAgentSession,
   type AgentSessionEvent,
   type CreateAgentSessionRuntimeFactory,
+  type ExtensionUIContext,
 } from "@earendil-works/pi-coding-agent";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import {
@@ -22,6 +23,7 @@ import {
   type TextContent,
 } from "@earendil-works/pi-ai";
 import {
+  ApprovalRequestId,
   type ChatAttachment,
   EventId,
   type ProviderComposerCapabilities,
@@ -31,10 +33,13 @@ import {
   ProviderItemId,
   type ProviderRuntimeEvent,
   type ProviderSession,
+  type ProviderUserInputAnswers,
   RuntimeItemId,
+  RuntimeRequestId,
   ThreadId,
   type ThreadTokenUsageSnapshot,
   TurnId,
+  type UserInputQuestion,
 } from "@t3tools/contracts";
 import { Effect, FileSystem, Layer, Queue, Stream } from "effect";
 
@@ -79,6 +84,7 @@ interface PiSessionContext {
   activeAssistantItemId: RuntimeItemId | undefined;
   activeReasoningItemId: RuntimeItemId | undefined;
   activeToolItems: Map<string, PiTrackedToolCall>;
+  pendingUserInputs: Map<ApprovalRequestId, PiPendingUserInput>;
   stopped: boolean;
   lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
   unsubscribe: (() => void) | undefined;
@@ -96,6 +102,15 @@ interface PiTrackedToolCall {
   readonly args: unknown;
   readonly itemId: RuntimeItemId;
   readonly itemType: "command_execution" | "file_change" | "dynamic_tool_call" | "web_search";
+}
+
+interface PiPendingUserInput {
+  readonly resolve: (answers: ProviderUserInputAnswers) => void;
+}
+
+export interface PiUserInputOptionMapping {
+  readonly value: string;
+  readonly option: UserInputQuestion["options"][number];
 }
 
 export interface PiAdapterLiveOptions {
@@ -722,6 +737,80 @@ function extensionDisplayName(extension: {
   return extensionPath ? path.basename(extensionPath).replace(/\.(?:ts|js)$/u, "") : "extension";
 }
 
+function makePiUserInputOption(label: string): UserInputQuestion["options"][number] {
+  const normalizedLabel = trimToUndefined(label) ?? "Option";
+  return { label: normalizedLabel, description: normalizedLabel };
+}
+
+export function makePiUserInputOptions(
+  labels: ReadonlyArray<string>,
+): ReadonlyArray<PiUserInputOptionMapping> {
+  const labelCounts = new Map<string, number>();
+  return labels.map((label, index) => {
+    const baseLabel = trimToUndefined(label) ?? `Option ${index + 1}`;
+    const count = (labelCounts.get(baseLabel) ?? 0) + 1;
+    labelCounts.set(baseLabel, count);
+    const displayLabel = count === 1 ? baseLabel : `${baseLabel} (${count})`;
+    return {
+      value: label,
+      option: { label: displayLabel, description: baseLabel },
+    };
+  });
+}
+
+function firstPiUserInputAnswer(
+  answers: ProviderUserInputAnswers,
+  questionId: string,
+): string | undefined {
+  const answer = answers[questionId];
+  if (typeof answer === "string") {
+    return trimToUndefined(answer);
+  }
+  if (Array.isArray(answer)) {
+    return trimToUndefined(answer.find((entry) => typeof entry === "string"));
+  }
+  return undefined;
+}
+
+export const PLAIN_PI_EXTENSION_THEME = {
+  fg(_color: string, text: string) {
+    return text;
+  },
+  bg(_color: string, text: string) {
+    return text;
+  },
+  bold(text: string) {
+    return text;
+  },
+  italic(text: string) {
+    return text;
+  },
+  underline(text: string) {
+    return text;
+  },
+  inverse(text: string) {
+    return text;
+  },
+  strikethrough(text: string) {
+    return text;
+  },
+  getFgAnsi() {
+    return "";
+  },
+  getBgAnsi() {
+    return "";
+  },
+  getColorMode() {
+    return "truecolor";
+  },
+  getThinkingBorderColor() {
+    return (text: string) => text;
+  },
+  getBashModeBorderColor() {
+    return (text: string) => text;
+  },
+} as unknown as ExtensionUIContext["theme"];
+
 const makePiAdapter = (options?: PiAdapterLiveOptions) =>
   Effect.gen(function* () {
     const serverConfig = yield* ServerConfig;
@@ -792,6 +881,270 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       } satisfies ProviderRuntimeEvent);
     };
 
+    const resolvePiExtensionUserInput = (
+      context: PiSessionContext,
+      requestId: ApprovalRequestId,
+      answers: ProviderUserInputAnswers,
+    ) => {
+      const pending = context.pendingUserInputs.get(requestId);
+      if (!pending) return false;
+      pending.resolve(answers);
+      return true;
+    };
+
+    const requestPiExtensionUserInput = (
+      context: PiSessionContext,
+      input: {
+        readonly method: string;
+        readonly question: UserInputQuestion;
+        readonly opts?: Parameters<ExtensionUIContext["select"]>[2];
+        readonly rawPayload?: Record<string, unknown>;
+      },
+    ): Promise<ProviderUserInputAnswers> => {
+      if (context.stopped || input.opts?.signal?.aborted) {
+        return Promise.resolve({});
+      }
+
+      const requestId = ApprovalRequestId.makeUnsafe(crypto.randomUUID());
+      const runtimeRequestId = RuntimeRequestId.makeUnsafe(requestId);
+
+      return new Promise((resolve) => {
+        let settled = false;
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        let abort: () => void = () => undefined;
+
+        const cleanup = () => {
+          if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+            timeoutId = undefined;
+          }
+          input.opts?.signal?.removeEventListener("abort", abort);
+        };
+        const finish = (answers: ProviderUserInputAnswers) => {
+          if (settled) return;
+          settled = true;
+          cleanup();
+          context.pendingUserInputs.delete(requestId);
+          offerRuntimeEvent({
+            ...makeEventBase(context),
+            type: "user-input.resolved",
+            requestId: runtimeRequestId,
+            payload: { answers },
+            raw: {
+              source: "pi.sdk.event",
+              method: `${input.method}/answered`,
+              payload: { requestId, answers },
+            },
+          } satisfies ProviderRuntimeEvent);
+          resolve(answers);
+        };
+        abort = () => finish({});
+
+        context.pendingUserInputs.set(requestId, { resolve: finish });
+        if (typeof input.opts?.timeout === "number" && input.opts.timeout > 0) {
+          timeoutId = setTimeout(abort, input.opts.timeout);
+        }
+        input.opts?.signal?.addEventListener("abort", abort, { once: true });
+
+        offerRuntimeEvent({
+          ...makeEventBase(context),
+          type: "user-input.requested",
+          requestId: runtimeRequestId,
+          payload: { questions: [input.question] },
+          raw: {
+            source: "pi.sdk.event",
+            method: input.method,
+            payload: input.rawPayload ?? { requestId, question: input.question },
+          },
+        } satisfies ProviderRuntimeEvent);
+      });
+    };
+
+    // Bridges the common Pi extension UI primitives onto Synara's existing
+    // pending user-input flow; terminal/TUI-only APIs remain no-op by design.
+    const makePiExtensionUIContext = (context: PiSessionContext): ExtensionUIContext => {
+      const unsupportedWarnings = new Set<string>();
+      const statusTexts = new Map<string, string>();
+      let workingMessage: string | undefined;
+      const warnUnsupported = (method: string) => {
+        if (unsupportedWarnings.has(method)) return;
+        unsupportedWarnings.add(method);
+        offerRuntimeEvent({
+          ...makeEventBase(context, { includeTurnId: false }),
+          type: "runtime.warning",
+          payload: {
+            message: `Pi extension UI API '${method}' is not supported in Synara yet.`,
+            detail: { method },
+          },
+          raw: {
+            source: "pi.sdk.event",
+            method: "extension/ui-unsupported",
+            payload: { method },
+          },
+        } satisfies ProviderRuntimeEvent);
+      };
+      const emitPluginProgress = (summary: string) => {
+        const normalized = trimToUndefined(summary);
+        if (!normalized) return;
+        offerRuntimeEvent({
+          ...makeEventBase(context),
+          type: "tool.progress",
+          payload: { toolName: "Pi plugin", summary: normalized },
+          raw: {
+            source: "pi.sdk.event",
+            method: "extension/ui-progress",
+            payload: { summary: normalized },
+          },
+        } satisfies ProviderRuntimeEvent);
+      };
+
+      const uiContext: ExtensionUIContext = {
+        async select(title, options, opts) {
+          const questionId = "selection";
+          const optionMappings = makePiUserInputOptions(options);
+          const answers = await requestPiExtensionUserInput(context, {
+            method: "extension/ui/select",
+            opts,
+            question: {
+              id: questionId,
+              header: trimToUndefined(title) ?? "Pi plugin",
+              question: trimToUndefined(title) ?? "Choose an option.",
+              options: optionMappings.map((mapping) => mapping.option),
+            },
+            rawPayload: { title, options },
+          });
+          const answer = firstPiUserInputAnswer(answers, questionId);
+          return optionMappings.find((mapping) => mapping.option.label === answer)?.value;
+        },
+        async confirm(title, message, opts) {
+          const questionId = "confirmation";
+          const answers = await requestPiExtensionUserInput(context, {
+            method: "extension/ui/confirm",
+            opts,
+            question: {
+              id: questionId,
+              header: trimToUndefined(title) ?? "Pi plugin",
+              question:
+                trimToUndefined(message) ?? trimToUndefined(title) ?? "Confirm this action?",
+              options: [makePiUserInputOption("Yes"), makePiUserInputOption("No")],
+            },
+            rawPayload: { title, message },
+          });
+          return firstPiUserInputAnswer(answers, questionId) === "Yes";
+        },
+        async input(title, placeholder, opts) {
+          const questionId = "input";
+          const answers = await requestPiExtensionUserInput(context, {
+            method: "extension/ui/input",
+            opts,
+            question: {
+              id: questionId,
+              header: trimToUndefined(title) ?? "Pi plugin",
+              question:
+                trimToUndefined(placeholder) ?? trimToUndefined(title) ?? "Type a response.",
+              options: [],
+            },
+            rawPayload: { title, placeholder },
+          });
+          return firstPiUserInputAnswer(answers, questionId);
+        },
+        notify(message, type) {
+          const normalized = trimToUndefined(message);
+          if (!normalized) return;
+          if (type === "warning" || type === "error") {
+            offerRuntimeEvent({
+              ...makeEventBase(context),
+              type: "runtime.warning",
+              payload: { message: normalized, detail: { type: type ?? "info" } },
+              raw: {
+                source: "pi.sdk.event",
+                method: "extension/ui/notify",
+                payload: { message: normalized, type },
+              },
+            } satisfies ProviderRuntimeEvent);
+            return;
+          }
+          emitPluginProgress(normalized);
+        },
+        onTerminalInput() {
+          warnUnsupported("onTerminalInput");
+          return () => undefined;
+        },
+        setStatus(key, text) {
+          const normalizedKey = trimToUndefined(key) ?? "status";
+          const normalizedText = trimToUndefined(text);
+          if (!normalizedText) {
+            statusTexts.delete(normalizedKey);
+            return;
+          }
+          if (statusTexts.get(normalizedKey) === normalizedText) return;
+          statusTexts.set(normalizedKey, normalizedText);
+          emitPluginProgress(`${normalizedKey}: ${normalizedText}`);
+        },
+        setWorkingMessage(message) {
+          const normalizedMessage = trimToUndefined(message);
+          if (!normalizedMessage || normalizedMessage === workingMessage) return;
+          workingMessage = normalizedMessage;
+          emitPluginProgress(normalizedMessage);
+        },
+        setWorkingVisible() {},
+        setWorkingIndicator() {},
+        setHiddenThinkingLabel() {},
+        setWidget() {
+          warnUnsupported("setWidget");
+        },
+        setFooter() {
+          warnUnsupported("setFooter");
+        },
+        setHeader() {
+          warnUnsupported("setHeader");
+        },
+        setTitle(title) {
+          if (title) emitPluginProgress(title);
+        },
+        async custom() {
+          warnUnsupported("custom");
+          return undefined as never;
+        },
+        pasteToEditor() {
+          warnUnsupported("pasteToEditor");
+        },
+        setEditorText() {
+          warnUnsupported("setEditorText");
+        },
+        getEditorText() {
+          return "";
+        },
+        editor(title, prefill) {
+          return uiContext.input(title, prefill);
+        },
+        addAutocompleteProvider() {
+          warnUnsupported("addAutocompleteProvider");
+        },
+        setEditorComponent() {
+          warnUnsupported("setEditorComponent");
+        },
+        getEditorComponent() {
+          return undefined;
+        },
+        theme: PLAIN_PI_EXTENSION_THEME,
+        getAllThemes() {
+          return [];
+        },
+        getTheme() {
+          return undefined;
+        },
+        setTheme() {
+          return { success: false, error: "Synara does not expose Pi themes." };
+        },
+        getToolsExpanded() {
+          return false;
+        },
+        setToolsExpanded() {},
+      };
+      return uiContext;
+    };
+
     const completePromptRejection = (context: PiSessionContext, turnId: TurnId, cause: unknown) => {
       if (context.activeTurnId !== turnId) {
         return;
@@ -841,6 +1194,10 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
     const disposeSessionContext = async (context: PiSessionContext) => {
       context.unsubscribe?.();
       context.unsubscribe = undefined;
+      for (const pending of Array.from(context.pendingUserInputs.values())) {
+        pending.resolve({});
+      }
+      context.pendingUserInputs.clear();
       context.stopped = true;
       await context.runtime.dispose();
     };
@@ -1194,7 +1551,6 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         agentDir: input.agentDir,
         sessionManager: input.sessionManager,
       });
-      await runtime.session.bindExtensions({});
       return { runtime, modelRegistry: runtime.services.modelRegistry };
     };
 
@@ -1268,6 +1624,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           activeAssistantItemId: undefined,
           activeReasoningItemId: undefined,
           activeToolItems: new Map(),
+          pendingUserInputs: new Map(),
           stopped: false,
           lastKnownTokenUsage: undefined,
           unsubscribe: undefined,
@@ -1276,6 +1633,28 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           handleSessionEvent(context, event),
         );
         sessions.set(input.threadId, context);
+        yield* Effect.tryPromise({
+          try: () =>
+            runtime.session.bindExtensions({ uiContext: makePiExtensionUIContext(context) }),
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "extension/bind",
+              detail: toMessage(cause, "Failed to bind Pi extensions."),
+              cause,
+            }),
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.gen(function* () {
+              sessions.delete(input.threadId);
+              yield* Effect.tryPromise({
+                try: () => disposeSessionContext(context),
+                catch: () => error,
+              }).pipe(Effect.catch(() => Effect.void));
+              return yield* Effect.fail(error);
+            }),
+          ),
+        );
         const loadedExtensions = runtime.session.resourceLoader.getExtensions().extensions;
         if (loadedExtensions.length > 0) {
           const extensionNames = loadedExtensions.map(extensionDisplayName);
@@ -1284,7 +1663,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             type: "runtime.warning",
             payload: {
               message:
-                "Pi extensions are loaded, but Synara does not yet support Pi extension UI APIs. Non-UI extension behavior should work, but extensions that call ctx.ui.* for prompts, widgets, confirmations, or status updates may not behave correctly.",
+                "Pi extensions are loaded with Synara's limited UI bridge. select/confirm/input/notify/status are supported; TUI-only widgets and editor hooks are ignored.",
               detail: {
                 extensionCount: loadedExtensions.length,
                 extensions: extensionNames,
@@ -1292,7 +1671,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             },
             raw: {
               source: "pi.sdk.event",
-              method: "extension/ui-unsupported-warning",
+              method: "extension/ui-limited-warning",
               payload: { extensionCount: loadedExtensions.length, extensions: extensionNames },
             },
           } satisfies ProviderRuntimeEvent);
@@ -1542,6 +1921,22 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           detail: `Pi does not expose Synara approval/user-input requests for thread ${threadId}.`,
         }),
       );
+
+    const respondToUserInput: PiAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+      answers,
+    ) =>
+      Effect.gen(function* () {
+        const context = yield* requireSession(threadId);
+        if (!resolvePiExtensionUserInput(context, requestId, answers)) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "user-input/respond",
+            detail: `Unknown pending Pi user-input request: ${requestId}`,
+          });
+        }
+      });
 
     const stopSession: PiAdapterShape["stopSession"] = (threadId) =>
       requireSession(threadId).pipe(
@@ -1852,7 +2247,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       steerTurn,
       interruptTurn,
       respondToRequest: (threadId) => respondUnsupported(threadId, "request/respond"),
-      respondToUserInput: (threadId) => respondUnsupported(threadId, "user-input/respond"),
+      respondToUserInput,
       stopSession,
       listSessions,
       hasSession,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -603,6 +603,53 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  it.effect(
+    "routes early approval and user-input responses to live sessions before persistence",
+    () =>
+      Effect.gen(function* () {
+        const provider = yield* ProviderService;
+        const directory = yield* ProviderSessionDirectory;
+        const threadId = asThreadId("thread-live-startup-prompt");
+
+        routing.codex.respondToRequest.mockClear();
+        routing.codex.respondToUserInput.mockClear();
+        yield* routing.codex.adapter.startSession({
+          provider: "codex",
+          threadId,
+          runtimeMode: "approval-required",
+        });
+
+        const bindingBeforeResponse = yield* directory.getBinding(threadId);
+        assert.equal(Option.isNone(bindingBeforeResponse), true);
+
+        yield* provider.respondToRequest({
+          threadId,
+          requestId: asRequestId("req-live-approval"),
+          decision: "accept",
+        });
+        yield* provider.respondToUserInput({
+          threadId,
+          requestId: asRequestId("req-live-user-input"),
+          answers: {
+            answer: "continue",
+          },
+        });
+
+        assert.deepEqual(routing.codex.respondToRequest.mock.calls, [
+          [threadId, asRequestId("req-live-approval"), "accept"],
+        ]);
+        assert.deepEqual(routing.codex.respondToUserInput.mock.calls, [
+          [
+            threadId,
+            asRequestId("req-live-user-input"),
+            {
+              answer: "continue",
+            },
+          ],
+        ]);
+      }),
+  );
+
   it.effect("recovers stale persisted sessions for rollback by resuming thread identity", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -501,6 +501,20 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         return { adapter, session: resumed } as const;
       });
 
+    const findLiveSessionAdapter = (threadId: ThreadId) =>
+      Effect.gen(function* () {
+        const matches = yield* Effect.forEach(
+          adapters,
+          (adapter) =>
+            adapter.hasSession(threadId).pipe(
+              Effect.map((hasSession) => (hasSession ? adapter : null)),
+              Effect.orElseSucceed(() => null),
+            ),
+          { concurrency: "unbounded" },
+        );
+        return matches.find((adapter) => adapter !== null) ?? null;
+      });
+
     const resolveRoutableSession = (input: {
       readonly threadId: ThreadId;
       readonly operation: string;
@@ -510,6 +524,12 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         const bindingOption = yield* directory.getBinding(input.threadId);
         const binding = Option.getOrUndefined(bindingOption);
         if (!binding) {
+          // Startup extension prompts can fire before startSession has persisted
+          // the provider binding, but the adapter already owns a live session.
+          const liveAdapter = yield* findLiveSessionAdapter(input.threadId);
+          if (liveAdapter) {
+            return { adapter: liveAdapter, threadId: input.threadId, isActive: true } as const;
+          }
           return yield* toValidationError(
             input.operation,
             `Cannot route thread '${input.threadId}' because no persisted provider binding exists.`,

--- a/apps/server/src/workspaceEntries.test.ts
+++ b/apps/server/src/workspaceEntries.test.ts
@@ -155,19 +155,57 @@ describe("searchWorkspaceEntries", () => {
 
   it("disables fsmonitor and untracked cache helpers during git workspace indexing", async () => {
     const cwd = makeTempDir("t3code-workspace-hardened-git-");
-    runGit(cwd, ["init"]);
-    writeFile(cwd, ".gitignore", "ignored.txt\n");
-    writeFile(cwd, "src/keep.ts", "export {};");
-    writeFile(cwd, "ignored.txt", "ignore me");
 
     const runProcessSpy = vi.spyOn(ProcessRunner, "runProcess");
+    runProcessSpy.mockImplementation(async (command, args) => {
+      if (command !== "git") {
+        throw new Error(`Unexpected command: ${command}`);
+      }
+      if (args.includes("rev-parse")) {
+        return {
+          stdout: "true\n",
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        };
+      }
+      if (args.includes("ls-files")) {
+        return {
+          stdout: "src/keep.ts\0ignored.txt\0",
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        };
+      }
+      if (args.includes("check-ignore")) {
+        return {
+          stdout: "ignored.txt\0",
+          stderr: "",
+          code: 0,
+          signal: null,
+          timedOut: false,
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        };
+      }
+      throw new Error(`Unexpected git command: ${args.join(" ")}`);
+    });
 
-    await searchWorkspaceEntries({ cwd, query: "", limit: 100 });
+    const result = await searchWorkspaceEntries({ cwd, query: "", limit: 100 });
+    const paths = result.entries.map((entry) => entry.path);
 
     const gitCalls = runProcessSpy.mock.calls
       .filter(([command]) => command === "git")
       .map(([, args]) => args);
 
+    assert.include(paths, "src/keep.ts");
+    assert.notInclude(paths, "ignored.txt");
     assert.deepInclude(gitCalls, [
       "-c",
       "core.fsmonitor=false",

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -9,8 +9,8 @@ export default mergeConfig(
       // Server integration tests exercise sqlite/git orchestration and can
       // legitimately exceed the default timeout when the full workspace suite
       // is running under CI load.
-      testTimeout: 45_000,
-      hookTimeout: 45_000,
+      testTimeout: 90_000,
+      hookTimeout: 90_000,
     },
   }),
 );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1363,6 +1363,7 @@ export default function ChatView({
   const featureFlags = useFeatureFlags();
   const showExpandedCursorModelVariants = featureFlags["show-expanded-cursor-model-variants"];
   const showDebugTaskBanner = import.meta.env.DEV && featureFlags["show-debug-task-banner"];
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const composerModelHintByProvider = useMemo<Record<ProviderKind, string | null>>(() => {
     const threadModelSelection = activeThread?.modelSelection ?? null;
     const projectModelSelection = activeProject?.defaultModelSelection ?? null;
@@ -1388,6 +1389,11 @@ export default function ChatView({
     activeThread?.modelSelection,
     composerDraft.modelSelectionByProvider,
   ]);
+  const providerModelDiscoveryCwd = resolveProviderDiscoveryCwd({
+    activeThreadWorktreePath: resolvedThreadWorktreePath,
+    activeProjectCwd: activeProject?.cwd ?? null,
+    serverCwd: serverConfigQuery.data?.cwd ?? null,
+  });
   const claudeDynamicModelsQuery = useQuery(
     providerModelsQueryOptions({ provider: "claudeAgent" }),
   );
@@ -1396,6 +1402,8 @@ export default function ChatView({
     selectedProvider === "opencode" || lockedProvider === "opencode" || isModelPickerOpen;
   const kiloModelDiscoveryEnabled =
     selectedProvider === "kilo" || lockedProvider === "kilo" || isModelPickerOpen;
+  const piModelDiscoveryEnabled =
+    selectedProvider === "pi" || lockedProvider === "pi" || isModelPickerOpen;
   const cursorDynamicModelsQuery = useQuery(
     providerModelsQueryOptions({
       provider: "cursor",
@@ -1437,7 +1445,8 @@ export default function ChatView({
       provider: "pi",
       binaryPath: settings.piBinaryPath || null,
       agentDir: settings.piAgentDir || null,
-      enabled: selectedProvider === "pi" || lockedProvider === "pi" || isModelPickerOpen,
+      cwd: providerModelDiscoveryCwd,
+      enabled: piModelDiscoveryEnabled,
     }),
   );
   const claudeDynamicAgentsQuery = useQuery(
@@ -1475,6 +1484,13 @@ export default function ChatView({
     kiloModelDiscoveryEnabled &&
     !hasResolvedKiloModelDiscovery &&
     (kiloDynamicModelsQuery.isLoading || kiloDynamicModelsQuery.isFetching);
+  const hasResolvedPiModelDiscovery =
+    piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
+    (piDynamicModelsQuery.data.models.length ?? 0) > 0;
+  const piModelDiscoveryPending =
+    piModelDiscoveryEnabled &&
+    !hasResolvedPiModelDiscovery &&
+    (piDynamicModelsQuery.isLoading || piDynamicModelsQuery.isFetching);
   const modelOptionsByProvider = useMemo(() => {
     const staticOptions: Record<ProviderKind, ReturnType<typeof getAppModelOptions>> = {
       codex: getAppModelOptions(
@@ -1669,18 +1685,22 @@ export default function ChatView({
       ? cursorModelDiscoveryPending
       : selectedProvider === "kilo"
         ? kiloModelDiscoveryPending
+        : selectedProvider === "pi"
+          ? piModelDiscoveryPending
         : selectedProviderModelsQuery !== undefined &&
           (selectedProviderModelsQuery.isLoading ||
             (selectedProviderModelsQuery.isFetching &&
               selectedProviderModelsQuery.data === undefined));
   const selectedProviderRequiresRuntimeModels =
-    selectedProvider === "cursor" || selectedProvider === "kilo";
+    selectedProvider === "cursor" || selectedProvider === "kilo" || selectedProvider === "pi";
   const selectedProviderRuntimeModelDiscoveryPending =
     selectedProvider === "cursor"
       ? cursorModelDiscoveryPending
       : selectedProvider === "kilo"
         ? kiloModelDiscoveryPending
-        : false;
+        : selectedProvider === "pi"
+          ? piModelDiscoveryPending
+          : false;
   const showComposerModelBootstrapSkeleton = shouldShowComposerModelBootstrapSkeleton({
     selectedProvider,
     selectedModel,
@@ -2415,7 +2435,6 @@ export default function ChatView({
   const isMentionTrigger = composerTriggerKind === "mention";
   const platform = typeof navigator === "undefined" ? "" : navigator.platform;
   const branchesQuery = useQuery(gitBranchesQueryOptions(gitBranchSourceCwd));
-  const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const localFolderBrowseRootPath = getLocalFolderBrowseRootPath(
     serverConfigQuery.data?.homeDir ?? null,
     isMacPlatform(platform),
@@ -2431,11 +2450,7 @@ export default function ChatView({
     (debouncerState) => ({ isPending: debouncerState.isPending }),
   );
   const effectiveMentionQuery = mentionTriggerQuery.length > 0 ? debouncedPathQuery : "";
-  const composerSkillCwd = resolveProviderDiscoveryCwd({
-    activeThreadWorktreePath: resolvedThreadWorktreePath,
-    activeProjectCwd: activeProject?.cwd ?? null,
-    serverCwd: serverConfigQuery.data?.cwd ?? null,
-  });
+  const composerSkillCwd = providerModelDiscoveryCwd;
   const providerComposerCapabilitiesQuery = useQuery(
     providerComposerCapabilitiesQueryOptions(selectedProvider),
   );
@@ -6924,6 +6939,7 @@ export default function ChatView({
         loadingModelProviders={{
           cursor: cursorModelDiscoveryPending,
           kilo: kiloModelDiscoveryPending,
+          pi: piModelDiscoveryPending,
         }}
         hiddenProviders={settings.hiddenProviders}
         providerOrder={settings.providerOrder}
@@ -6963,6 +6979,7 @@ export default function ChatView({
       loadingModelProviders={{
         cursor: cursorModelDiscoveryPending,
         kilo: kiloModelDiscoveryPending,
+        pi: piModelDiscoveryPending,
       }}
       hiddenProviders={settings.hiddenProviders}
       providerOrder={settings.providerOrder}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1687,10 +1687,10 @@ export default function ChatView({
         ? kiloModelDiscoveryPending
         : selectedProvider === "pi"
           ? piModelDiscoveryPending
-        : selectedProviderModelsQuery !== undefined &&
-          (selectedProviderModelsQuery.isLoading ||
-            (selectedProviderModelsQuery.isFetching &&
-              selectedProviderModelsQuery.data === undefined));
+          : selectedProviderModelsQuery !== undefined &&
+            (selectedProviderModelsQuery.isLoading ||
+              (selectedProviderModelsQuery.isFetching &&
+                selectedProviderModelsQuery.data === undefined));
   const selectedProviderRequiresRuntimeModels =
     selectedProvider === "cursor" || selectedProvider === "kilo" || selectedProvider === "pi";
   const selectedProviderRuntimeModelDiscoveryPending =
@@ -6184,6 +6184,17 @@ export default function ChatView({
     [activeThreadId, setStoreThreadError],
   );
 
+  const onCancelActivePendingUserInput = useCallback(() => {
+    if (!activePendingUserInput || activePendingIsResponding) {
+      return;
+    }
+    promptRef.current = "";
+    setPrompt("");
+    setComposerCursor(0);
+    setComposerTrigger(null);
+    void onRespondToUserInput(activePendingUserInput.requestId, {});
+  }, [activePendingIsResponding, activePendingUserInput, onRespondToUserInput, setPrompt]);
+
   const setActivePendingUserInputQuestionIndex = useCallback(
     (nextQuestionIndex: number) => {
       if (!activePendingUserInput) {
@@ -8095,6 +8106,7 @@ export default function ChatView({
                   pendingUserInputQuestionIndex={activePendingQuestionIndex}
                   onToggleUserInputOption={onToggleActivePendingUserInputOption}
                   onAdvanceUserInput={onAdvanceActivePendingUserInput}
+                  onCancelUserInput={onCancelActivePendingUserInput}
                   planFollowUp={
                     showPlanFollowUpPrompt && activeProposedPlan
                       ? {
@@ -8176,7 +8188,9 @@ export default function ChatView({
                       isComposerApprovalState
                         ? "Resolve this approval request to continue"
                         : activePendingProgress
-                          ? "Type your own answer, or leave this blank to use the selected option"
+                          ? activePendingProgress.activeQuestion?.options.length === 0
+                            ? "Type your answer to continue"
+                            : "Type your own answer, or leave this blank to use the selected option"
                           : showPlanFollowUpPrompt && activeProposedPlan
                             ? "Add feedback to refine the plan, or leave this blank to implement it"
                             : hasLiveTurn

--- a/apps/web/src/components/chat/ComposerInputBanners.tsx
+++ b/apps/web/src/components/chat/ComposerInputBanners.tsx
@@ -28,6 +28,7 @@ interface ComposerInputBannersProps {
   pendingUserInputQuestionIndex: PendingUserInputPanelProps["questionIndex"];
   onToggleUserInputOption: PendingUserInputPanelProps["onToggleOption"];
   onAdvanceUserInput: PendingUserInputPanelProps["onAdvance"];
+  onCancelUserInput: PendingUserInputPanelProps["onCancel"];
   // `id` keys the banner so it remounts when the proposed plan changes.
   planFollowUp: { id: string; title: string | null } | null;
 }
@@ -42,6 +43,7 @@ export const ComposerInputBanners = memo(function ComposerInputBanners({
   pendingUserInputQuestionIndex,
   onToggleUserInputOption,
   onAdvanceUserInput,
+  onCancelUserInput,
   planFollowUp,
 }: ComposerInputBannersProps) {
   let content: ReactNode = null;
@@ -58,6 +60,7 @@ export const ComposerInputBanners = memo(function ComposerInputBanners({
         questionIndex={pendingUserInputQuestionIndex}
         onToggleOption={onToggleUserInputOption}
         onAdvance={onAdvanceUserInput}
+        onCancel={onCancelUserInput}
       />
     );
   } else if (planFollowUp) {

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -18,6 +18,7 @@ interface PendingUserInputPanelProps {
   questionIndex: number;
   onToggleOption: (questionId: string, optionLabel: string) => PendingUserInputDraftAnswer | null;
   onAdvance: (answerOverrides?: Record<string, PendingUserInputDraftAnswer>) => void;
+  onCancel: () => void;
 }
 
 // Keep pending-input choices neutral so they read like Codex list controls instead of accent buttons.
@@ -28,6 +29,7 @@ export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserIn
   questionIndex,
   onToggleOption,
   onAdvance,
+  onCancel,
 }: PendingUserInputPanelProps) {
   if (pendingUserInputs.length === 0) return null;
   const activePrompt = pendingUserInputs[0];
@@ -42,6 +44,7 @@ export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserIn
       questionIndex={questionIndex}
       onToggleOption={onToggleOption}
       onAdvance={onAdvance}
+      onCancel={onCancel}
     />
   );
 });
@@ -53,6 +56,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   questionIndex,
   onToggleOption,
   onAdvance,
+  onCancel,
 }: {
   prompt: PendingUserInput;
   isResponding: boolean;
@@ -60,6 +64,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   questionIndex: number;
   onToggleOption: (questionId: string, optionLabel: string) => PendingUserInputDraftAnswer | null;
   onAdvance: (answerOverrides?: Record<string, PendingUserInputDraftAnswer>) => void;
+  onCancel: () => void;
 }) {
   const progress = derivePendingUserInputProgress(prompt.questions, answers, questionIndex);
   const activeQuestion = progress.activeQuestion;
@@ -148,51 +153,67 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
       {activeQuestion.multiSelect ? (
         <p className="mt-1 text-xs text-muted-foreground/65">Select one or more options.</p>
       ) : null}
-      <div className="mt-3 space-y-1">
-        {activeQuestion.options.map((option, index) => {
-          const isSelected = progress.selectedOptionLabels.includes(option.label);
-          const shortcutKey = index < 9 ? index + 1 : null;
-          return (
-            <button
-              key={`${activeQuestion.id}:${option.label}`}
-              type="button"
-              disabled={isResponding}
-              onClick={() => handleOptionSelection(activeQuestion.id, option.label)}
-              className={cn(
-                "group flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition-all duration-150",
-                isSelected
-                  ? "border-[color:var(--color-border)] bg-[var(--color-background-button-secondary)] text-[var(--color-text-foreground)]"
-                  : "border-transparent bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]/80 hover:border-[color:var(--color-border-light)] hover:bg-[var(--color-background-button-secondary-hover)]",
-                isResponding && "opacity-50 cursor-not-allowed",
-              )}
-            >
-              {shortcutKey !== null ? (
-                <kbd
-                  className={cn(
-                    "flex size-5 shrink-0 items-center justify-center rounded text-[11px] font-medium tabular-nums transition-colors duration-150",
-                    isSelected
-                      ? "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]"
-                      : "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground-secondary)] group-hover:bg-[var(--color-background-button-secondary-hover)] group-hover:text-[var(--color-text-foreground)]",
-                  )}
-                >
-                  {shortcutKey}
-                </kbd>
-              ) : null}
-              <div className="min-w-0 flex-1">
-                <span className="text-sm font-medium">{option.label}</span>
-                {option.description && option.description !== option.label ? (
-                  <span className="ml-2 text-xs text-muted-foreground/50">
-                    {option.description}
-                  </span>
+      {activeQuestion.options.length > 0 ? (
+        <div className="mt-3 space-y-1">
+          {activeQuestion.options.map((option, index) => {
+            const isSelected = progress.selectedOptionLabels.includes(option.label);
+            const shortcutKey = index < 9 ? index + 1 : null;
+            return (
+              <button
+                key={`${activeQuestion.id}:${option.label}`}
+                type="button"
+                disabled={isResponding}
+                onClick={() => handleOptionSelection(activeQuestion.id, option.label)}
+                className={cn(
+                  "group flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition-all duration-150",
+                  isSelected
+                    ? "border-[color:var(--color-border)] bg-[var(--color-background-button-secondary)] text-[var(--color-text-foreground)]"
+                    : "border-transparent bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]/80 hover:border-[color:var(--color-border-light)] hover:bg-[var(--color-background-button-secondary-hover)]",
+                  isResponding && "opacity-50 cursor-not-allowed",
+                )}
+              >
+                {shortcutKey !== null ? (
+                  <kbd
+                    className={cn(
+                      "flex size-5 shrink-0 items-center justify-center rounded text-[11px] font-medium tabular-nums transition-colors duration-150",
+                      isSelected
+                        ? "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground)]"
+                        : "bg-[var(--color-background-elevated-secondary)] text-[var(--color-text-foreground-secondary)] group-hover:bg-[var(--color-background-button-secondary-hover)] group-hover:text-[var(--color-text-foreground)]",
+                    )}
+                  >
+                    {shortcutKey}
+                  </kbd>
                 ) : null}
-              </div>
-              {isSelected ? (
-                <CheckIcon className="size-3.5 shrink-0 text-[var(--color-text-foreground)]" />
-              ) : null}
-            </button>
-          );
-        })}
-      </div>
+                <div className="min-w-0 flex-1">
+                  <span className="text-sm font-medium">{option.label}</span>
+                  {option.description && option.description !== option.label ? (
+                    <span className="ml-2 text-xs text-muted-foreground/50">
+                      {option.description}
+                    </span>
+                  ) : null}
+                </div>
+                {isSelected ? (
+                  <CheckIcon className="size-3.5 shrink-0 text-[var(--color-text-foreground)]" />
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-3 flex justify-end">
+          <button
+            type="button"
+            disabled={isResponding}
+            onClick={onCancel}
+            className={cn(
+              "rounded-full border border-[color:var(--color-border-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-foreground-secondary)] transition-colors duration-150 hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]",
+              isResponding && "opacity-50 cursor-not-allowed",
+            )}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
     </div>
   );
 });

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -109,7 +109,7 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain('data-index="0"');
     expect(markup).not.toContain('class="relative" style="height:');
     expect(markup).toContain('data-timeline-row-kind="message"');
-  });
+  }, 10_000);
 
   it("renders assistant math through the shared markdown renderer", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -373,7 +373,11 @@ export const ProviderModelMenuItems = memo(function ProviderModelMenuItems(
           />
         </MenuRadioGroup>
       ) : (
-        <div className="px-2 py-2 text-muted-foreground text-sm">No matches</div>
+        <div className="px-2 py-2 text-muted-foreground text-sm">
+          {provider === "pi" && normalizedModelSearchQuery.length === 0
+            ? "No Pi models found"
+            : "No matches"}
+        </div>
       );
 
     if (!shouldShowSearch) {

--- a/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
+++ b/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
@@ -60,6 +60,7 @@ import { useComposerDropzone } from "~/hooks/useComposerDropzone";
 import { useTheme } from "~/hooks/useTheme";
 import { ChevronRightIcon, PaperclipIcon } from "~/lib/icons";
 import { findProviderStatus } from "~/lib/providerAvailability";
+import { resolveProviderDiscoveryCwd } from "~/lib/providerDiscovery";
 import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
 import { cn } from "~/lib/utils";
 import { type DraftThreadEnvMode, useComposerDraftStore } from "../../composerDraftStore";
@@ -153,6 +154,11 @@ export function KanbanNewTaskDialog({
     () => projects.find((project) => project.id === selectedProjectId) ?? null,
     [projects, selectedProjectId],
   );
+  const providerModelDiscoveryCwd = resolveProviderDiscoveryCwd({
+    activeThreadWorktreePath: null,
+    activeProjectCwd: selectedProject?.cwd ?? null,
+    serverCwd: serverConfigQuery.data?.cwd ?? null,
+  });
 
   // Voice transcription always rides on the Codex ChatGPT session, regardless of
   // which provider the task targets — gate the mic on the Codex status.
@@ -176,6 +182,7 @@ export function KanbanNewTaskDialog({
     // Keep discovery warm whenever either picker can open so cursor/codex effort
     // and fast-mode controls are populated, not just the model list.
     discoveryEnabled: isModelPickerOpen || isTraitsPickerOpen,
+    cwd: providerModelDiscoveryCwd,
     modelHintByProvider,
   });
   const trimmedPrompt = prompt.trim();

--- a/apps/web/src/hooks/useProviderModelCatalog.ts
+++ b/apps/web/src/hooks/useProviderModelCatalog.ts
@@ -52,10 +52,13 @@ export function useProviderModelCatalog(input: {
    * are warm by the time the user browses them.
    */
   discoveryEnabled: boolean;
+  /** Effective cwd for providers whose model catalog can be extended by project resources. */
+  cwd?: string | null;
   /** Per-provider selected-model hints so an unknown selection still lists itself. */
   modelHintByProvider?: Partial<Record<ProviderKind, string | null>>;
 }): ProviderModelCatalog {
   const { selectedProvider, discoveryEnabled, modelHintByProvider } = input;
+  const discoveryCwd = input.cwd ?? null;
   const { settings } = useAppSettings();
   const featureFlags = useFeatureFlags();
   const showExpandedCursorModelVariants = featureFlags["show-expanded-cursor-model-variants"];
@@ -106,6 +109,7 @@ export function useProviderModelCatalog(input: {
       provider: "pi",
       binaryPath: settings.piBinaryPath || null,
       agentDir: settings.piAgentDir || null,
+      cwd: discoveryCwd,
       enabled: selectedProvider === "pi" || discoveryEnabled,
     }),
   );
@@ -159,6 +163,14 @@ export function useProviderModelCatalog(input: {
     kiloModelDiscoveryEnabled &&
     !hasResolvedKiloModelDiscovery &&
     (kiloDynamicModelsQuery.isLoading || kiloDynamicModelsQuery.isFetching);
+  const piModelDiscoveryEnabled = selectedProvider === "pi" || discoveryEnabled;
+  const hasResolvedPiModelDiscovery =
+    piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
+    (piDynamicModelsQuery.data.models.length ?? 0) > 0;
+  const piModelDiscoveryPending =
+    piModelDiscoveryEnabled &&
+    !hasResolvedPiModelDiscovery &&
+    (piDynamicModelsQuery.isLoading || piDynamicModelsQuery.isFetching);
 
   const modelOptionsByProvider = useMemo(() => {
     const staticOptions: Record<ProviderKind, ReturnType<typeof getAppModelOptions>> = {
@@ -245,8 +257,9 @@ export function useProviderModelCatalog(input: {
     () => ({
       cursor: cursorModelDiscoveryPending,
       kilo: kiloModelDiscoveryPending,
+      pi: piModelDiscoveryPending,
     }),
-    [cursorModelDiscoveryPending, kiloModelDiscoveryPending],
+    [cursorModelDiscoveryPending, kiloModelDiscoveryPending, piModelDiscoveryPending],
   );
 
   const runtimeModelsByProvider = useMemo<

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -70,8 +70,7 @@ export const providerDiscoveryQueryKeys = {
     apiEndpoint: string | null,
     agentDir: string | null,
     cwd: string | null,
-  ) =>
-    ["provider-discovery", "models", provider, binaryPath, apiEndpoint, agentDir, cwd] as const,
+  ) => ["provider-discovery", "models", provider, binaryPath, apiEndpoint, agentDir, cwd] as const,
   agents: (provider: ProviderKind) => ["provider-discovery", "agents", provider] as const,
 };
 

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -69,7 +69,9 @@ export const providerDiscoveryQueryKeys = {
     binaryPath: string | null,
     apiEndpoint: string | null,
     agentDir: string | null,
-  ) => ["provider-discovery", "models", provider, binaryPath, apiEndpoint, agentDir] as const,
+    cwd: string | null,
+  ) =>
+    ["provider-discovery", "models", provider, binaryPath, apiEndpoint, agentDir, cwd] as const,
   agents: (provider: ProviderKind) => ["provider-discovery", "agents", provider] as const,
 };
 
@@ -182,6 +184,7 @@ export function providerModelsQueryOptions(input: {
   binaryPath?: string | null;
   apiEndpoint?: string | null;
   agentDir?: string | null;
+  cwd?: string | null;
   enabled?: boolean;
 }) {
   return queryOptions({
@@ -190,6 +193,7 @@ export function providerModelsQueryOptions(input: {
       input.binaryPath ?? null,
       input.apiEndpoint ?? null,
       input.agentDir ?? null,
+      input.cwd ?? null,
     ),
     queryFn: async () => {
       const api = ensureNativeApi();
@@ -198,6 +202,7 @@ export function providerModelsQueryOptions(input: {
         ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
         ...(input.apiEndpoint ? { apiEndpoint: input.apiEndpoint } : {}),
         ...(input.agentDir ? { agentDir: input.agentDir } : {}),
+        ...(input.cwd ? { cwd: input.cwd } : {}),
       });
     },
     enabled: input.enabled ?? true,

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -335,6 +335,31 @@ describe("derivePendingUserInputs", () => {
 
     expect(derivePendingUserInputs(activities)[0]?.questions[0]?.multiSelect).toBe(true);
   });
+
+  it("keeps text-only user-input questions so the composer can collect the answer", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-open-text",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-text-1",
+          questions: [
+            {
+              id: "input",
+              header: "Pi plugin",
+              question: "Type a response.",
+              options: [],
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(derivePendingUserInputs(activities)[0]?.questions[0]?.options).toEqual([]);
+  });
 });
 
 describe("deriveActiveTaskListState", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -394,9 +394,6 @@ function parseUserInputQuestions(
           };
         })
         .filter((option): option is UserInputQuestion["options"][number] => option !== null);
-      if (options.length === 0) {
-        return null;
-      }
       return {
         id: question.id,
         header: question.header,

--- a/packages/contracts/src/providerDiscovery.ts
+++ b/packages/contracts/src/providerDiscovery.ts
@@ -244,6 +244,7 @@ export const ProviderListModelsInput = Schema.Struct({
   binaryPath: Schema.optional(TrimmedNonEmptyString),
   apiEndpoint: Schema.optional(TrimmedNonEmptyString),
   agentDir: Schema.optional(TrimmedNonEmptyString),
+  cwd: Schema.optional(TrimmedNonEmptyString),
 });
 export type ProviderListModelsInput = typeof ProviderListModelsInput.Type;
 


### PR DESCRIPTION
## Summary
- Aggiunge un bridge UI limitato per Pi: `select`, `confirm`, `input`, `notify` e status/working message non rompono più i plugin che li chiamano.
- Fa transitare le risposte ai prompt Pi anche quando la sessione è già live ma la binding persistita non è ancora visibile.
- Gestisce meglio i casi text-only nel composer e permette di annullare il prompt senza lasciare la UI bloccata.
- Aggiunge copertura per i casi early-startup, sessione stoppata e prompt senza opzioni.

## Testing
- `bun run fmt`
- `bun run fmt:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `git diff --check`