### PR TITLE
[codex] Add Cmd+L composer focus shortcut

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -27,6 +27,7 @@ See the full schema for more details: [`packages/contracts/src/keybindings.ts`](
   { "key": "mod+shift+o", "command": "chat.new", "when": "!terminalFocus" },
   { "key": "mod+shift+n", "command": "chat.newLocal", "when": "!terminalFocus" },
   { "key": "mod+shift+t", "command": "chat.newTerminal", "when": "!terminalFocus" },
+  { "key": "cmd+l", "command": "composer.focus.toggle", "when": "!terminalFocus" },
   { "key": "mod+o", "command": "editor.openFavorite" }
 ]
 ```
@@ -54,6 +55,7 @@ Invalid rules are ignored. Invalid config files are ignored. Warnings are logged
 - `chat.new`: create a new chat thread preserving the active thread's branch/worktree state
 - `chat.newLocal`: create a new chat thread for the active project in a new environment (local/worktree determined by app settings (default `local`))
 - `chat.newTerminal`: create a new terminal-first thread preserving the active thread's branch/worktree state
+- `composer.focus.toggle`: focus or blur the chat prompt composer
 - `editor.openFavorite`: open current project/worktree in the last-used editor
 - `script.{id}.run`: run a project script by id (for example `script.test.run`)
 

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -84,6 +84,8 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+2", command: "terminal.workspace.chat", when: "terminalWorkspaceOpen" },
   { key: "mod+shift+b", command: "browser.toggle", when: "!terminalFocus" },
   { key: "mod+d", command: "diff.toggle", when: "!terminalFocus" },
+  // Cmd-only instead of mod so Ctrl+L remains available to shells on non-macOS.
+  { key: "cmd+l", command: "composer.focus.toggle", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+shift+e", command: "traitsPicker.toggle", when: "!terminalFocus" },
   { key: "mod+shift+u", command: "settings.usage", when: "!terminalFocus" },

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1101,6 +1101,17 @@ function dispatchConfiguredShortcut(
   );
 }
 
+function dispatchComposerFocusToggleShortcut(): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "l",
+    metaKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+  return event;
+}
+
 // The composer model/effort shortcuts both drop into the same combined picker,
 // rendered as a Base UI menu popup. Provider and effort detail live in lazily
 // mounted submenus, so the reliable signal that the surface opened is the popup
@@ -2031,6 +2042,42 @@ describe("ChatView timeline estimator parity (full app)", () => {
         { timeout: 8_000, interval: 16 },
       );
     } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("toggles composer focus with Cmd+L", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-composer-focus-shortcut" as MessageId,
+        targetText: "composer focus shortcut",
+      }),
+    });
+    const focusTarget = document.createElement("button");
+    focusTarget.type = "button";
+    focusTarget.textContent = "Focus sink";
+    document.body.appendChild(focusTarget);
+
+    try {
+      await waitForServerConfigToApply();
+      const composerEditor = await waitForComposerEditor();
+      focusTarget.focus();
+      expect(document.activeElement).toBe(focusTarget);
+
+      const focusEvent = dispatchComposerFocusToggleShortcut();
+      expect(focusEvent.defaultPrevented).toBe(true);
+      await vi.waitFor(() => {
+        expect(document.activeElement).toBe(composerEditor);
+      });
+
+      const blurEvent = dispatchComposerFocusToggleShortcut();
+      expect(blurEvent.defaultPrevented).toBe(true);
+      await vi.waitFor(() => {
+        expect(document.activeElement).not.toBe(composerEditor);
+      });
+    } finally {
+      focusTarget.remove();
       await mounted.cleanup();
     }
   });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3108,6 +3108,15 @@ export default function ChatView({
     pendingComposerFocusRef.current = false;
     editor.focusAtEnd();
   }, [secondaryChromeReady]);
+  const toggleComposerFocus = useCallback(() => {
+    const editor = composerEditorRef.current;
+    if (secondaryChromeReady && editor?.isFocused()) {
+      pendingComposerFocusRef.current = false;
+      editor.blur();
+      return;
+    }
+    focusComposer();
+  }, [focusComposer, secondaryChromeReady]);
   const scheduleComposerFocus = useCallback(() => {
     pendingComposerFocusRef.current = true;
     window.requestAnimationFrame(() => {
@@ -4916,6 +4925,14 @@ export default function ChatView({
       });
       if (!command) return;
 
+      if (command === "composer.focus.toggle") {
+        if (isComposerApprovalState || isVoiceRecording || isVoiceTranscribing) return;
+        event.preventDefault();
+        event.stopPropagation();
+        toggleComposerFocus();
+        return;
+      }
+
       if (command === "modelPicker.toggle") {
         if (!composerPickerShortcutActive) return;
         event.preventDefault();
@@ -5094,6 +5111,7 @@ export default function ChatView({
     setTerminalWorkspaceTab,
     surfaceMode,
     scheduleComposerFocus,
+    toggleComposerFocus,
     toggleTerminalVisibility,
   ]);
 

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -484,9 +484,11 @@ function collectTerminalContextIds(node: LexicalNode): string[] {
 }
 
 export interface ComposerPromptEditorHandle {
+  blur: () => void;
   focus: () => void;
   focusAt: (cursor: number) => void;
   focusAtEnd: () => void;
+  isFocused: () => boolean;
   readSnapshot: () => {
     value: string;
     cursor: number;
@@ -930,6 +932,18 @@ function ComposerPromptEditorInner({
     [editor],
   );
 
+  const blurEditor = useCallback(() => {
+    editor.getRootElement()?.blur();
+  }, [editor]);
+
+  // Keep global shortcuts decoupled from Lexical's root element details.
+  const isEditorFocused = useCallback(() => {
+    const rootElement = editor.getRootElement();
+    return Boolean(
+      rootElement && typeof document !== "undefined" && document.activeElement === rootElement,
+    );
+  }, [editor]);
+
   const readSnapshot = useCallback((): {
     value: string;
     cursor: number;
@@ -967,6 +981,7 @@ function ComposerPromptEditorInner({
   useImperativeHandle(
     editorRef,
     () => ({
+      blur: blurEditor,
       focus: () => {
         focusAt(snapshotRef.current.cursor);
       },
@@ -979,9 +994,10 @@ function ComposerPromptEditorInner({
           ),
         );
       },
+      isFocused: isEditorFocused,
       readSnapshot,
     }),
-    [focusAt, readSnapshot],
+    [blurEditor, focusAt, isEditorFocused, readSnapshot],
   );
 
   const handleEditorChange = useCallback((editorState: EditorState) => {

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -159,6 +159,11 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   {
+    shortcut: modShortcut("l", { metaKey: true, modKey: false }),
+    command: "composer.focus.toggle",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
     shortcut: modShortcut("u", { shiftKey: true }),
     command: "settings.usage",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
@@ -481,6 +486,33 @@ describe("settings shortcuts", () => {
   });
 });
 
+describe("composer focus shortcuts", () => {
+  it("toggles composer focus with Cmd+L outside terminal focus", () => {
+    assert.equal(
+      resolveShortcutCommand(event({ key: "l", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "composer.focus.toggle",
+    );
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "l", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: true },
+      }),
+    );
+  });
+
+  it("does not treat Ctrl+L as the composer focus shortcut on non-macOS", () => {
+    assert.isNull(
+      resolveShortcutCommand(event({ key: "l", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+        context: { terminalFocus: false },
+      }),
+    );
+  });
+});
+
 describe("recent view shortcuts", () => {
   it("resolves Ctrl+Tab outside terminal focus", () => {
     assert.strictEqual(
@@ -743,6 +775,10 @@ describe("shortcutLabelForCommand", () => {
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "traitsPicker.toggle", "MacIntel"),
       "⇧⌘E",
+    );
+    assert.strictEqual(
+      shortcutLabelForCommand(DEFAULT_BINDINGS, "composer.focus.toggle", "MacIntel"),
+      "⌘L",
     );
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "terminal.workspace.terminal", "MacIntel"),
@@ -1174,6 +1210,20 @@ describe("resolveShortcutCommand", () => {
         context: { terminalFocus: false },
       }),
       "traitsPicker.toggle",
+    );
+  });
+
+  it("falls back to the composer focus default when runtime config is missing it", () => {
+    const legacyBindings = DEFAULT_BINDINGS.filter(
+      (binding) => binding.command !== "composer.focus.toggle",
+    );
+
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "l", metaKey: true }), legacyBindings, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+      "composer.focus.toggle",
     );
   });
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -137,6 +137,12 @@ export const DEFAULT_SHORTCUT_FALLBACKS: ResolvedKeybindingsConfig = [
     shortcut: commandShortcut("e", { shiftKey: true }),
     whenAst: whenNotTerminalFocus,
   },
+  // Cmd-only instead of mod so Ctrl+L remains available to shells on non-macOS.
+  {
+    command: "composer.focus.toggle",
+    shortcut: commandShortcut("l", { metaKey: true, modKey: false }),
+    whenAst: whenNotTerminalFocus,
+  },
   {
     command: "settings.usage",
     shortcut: commandShortcut("u", { shiftKey: true }),

--- a/apps/web/src/shortcutsSheet.test.ts
+++ b/apps/web/src/shortcutsSheet.test.ts
@@ -48,6 +48,11 @@ describe("buildShortcutSheetSections", () => {
         (entry) => entry.id === "thread.jump.1" && entry.shortcutLabel === "⌘1",
       ),
     ).toBe(true);
+    expect(
+      sections[0]?.entries.some(
+        (entry) => entry.id === "composer.focus.toggle" && entry.shortcutLabel === "⌘L",
+      ),
+    ).toBe(true);
     expect(sections[1]?.title).toBe("In workspace mode");
     expect(sections[2]?.entries[0]?.shortcutLabel).toBe("⌘R");
   });

--- a/apps/web/src/shortcutsSheet.ts
+++ b/apps/web/src/shortcutsSheet.ts
@@ -126,6 +126,11 @@ const AVAILABLE_NOW_DEFINITIONS: readonly ShortcutDefinition[] = [
     description: "Open the composer reasoning and trait controls.",
   },
   {
+    command: "composer.focus.toggle",
+    label: "Focus composer",
+    description: "Focus or blur the chat prompt composer.",
+  },
+  {
     command: "terminal.toggle",
     label: "Toggle terminal",
     description: "Show or hide the terminal surface for the active thread.",

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -101,6 +101,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedTraitsPickerToggle.command, "traitsPicker.toggle");
 
+    const parsedComposerFocusToggle = yield* decode(KeybindingRule, {
+      key: "cmd+l",
+      command: "composer.focus.toggle",
+    });
+    assert.strictEqual(parsedComposerFocusToggle.command, "composer.focus.toggle");
+
     const parsedNewChat = yield* decode(KeybindingRule, {
       key: "mod+alt+n",
       command: "chat.newChat",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -26,6 +26,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "terminal.workspace.chat",
   "browser.toggle",
   "diff.toggle",
+  "composer.focus.toggle",
   "modelPicker.toggle",
   "traitsPicker.toggle",
   "settings.usage",


### PR DESCRIPTION
## Summary

Adds the `composer.focus.toggle` keybinding for SYN-111 so Cmd+L focuses the chat prompt composer, and pressing Cmd+L again blurs it.

## Details

- Adds the command to the shared keybinding schema and server/web default bindings.
- Keeps the default as literal `cmd+l` instead of `mod+l`, so non-macOS Ctrl+L remains available for terminal workflows.
- Extends the composer editor handle with focus-state and blur helpers.
- Wires ChatView to handle the shortcut only in the focused chat pane and outside terminal focus.
- Adds shortcut sheet/docs coverage and focused unit/browser tests.

## Validation

- `bun run --cwd packages/contracts test src/keybindings.test.ts`
- `bun run --cwd apps/server test src/keybindings.test.ts`
- `bun run --cwd apps/web test src/keybindings.test.ts src/shortcutsSheet.test.ts`
- `bun run --cwd apps/web test:browser src/components/ChatView.browser.tsx -t "toggles composer focus with Cmd\\+L"`
- `git diff --cached --check`

Note: the working tree also contains unrelated PDF/local-preview changes that were intentionally left unstaged and are not part of this PR.