### PR TITLE
Fix terminal mouse replay after app restart

### DIFF
--- a/apps/server/src/terminal/Layers/Manager.test.ts
+++ b/apps/server/src/terminal/Layers/Manager.test.ts
@@ -478,11 +478,12 @@ describe("TerminalManager", () => {
     expect(process).toBeDefined();
     if (!process) return;
 
-    process.emitData("\u001b[?2004h\u001b[>7u");
+    process.emitData("\u001b[?2004h\u001b[?1002h\u001b[>7u");
     const snapshot = await manager.open(openInput());
 
     expect(snapshot.replayPreamble).toContain("\u001b[?2004h");
     expect(snapshot.replayPreamble).toContain("\u001b[=7;1u");
+    expect(snapshot.replayPreamble ?? "").not.toContain("?1002h");
 
     process.emitData("\u001b[?2004l\u001b[=0;1u");
     const resetSnapshot = await manager.open(openInput());

--- a/apps/server/src/terminal/terminalModeReplay.test.ts
+++ b/apps/server/src/terminal/terminalModeReplay.test.ts
@@ -47,18 +47,29 @@ describe("createTerminalModeReplayTracker", () => {
     });
   });
 
-  it("tracks bracketed paste, focus reporting, mouse tracking, and cursor visibility", () => {
+  it("tracks bracketed paste, focus reporting, and cursor visibility", () => {
     withTracker((tracker) => {
       tracker.feed("\u001b[?2004h\u001b[?1004h\u001b[?1002h\u001b[?25l");
 
       const preamble = tracker.buildPreamble();
       expect(preamble).toContain("\u001b[?2004h");
       expect(preamble).toContain("\u001b[?1004h");
-      expect(preamble).toContain("\u001b[?1002h");
       expect(preamble).toContain("\u001b[?25l");
 
       tracker.feed("\u001b[?2004l");
       expect(tracker.buildPreamble()).not.toContain("?2004");
+    });
+  });
+
+  it("does not replay mouse tracking modes on renderer reattach", () => {
+    withTracker((tracker) => {
+      tracker.feed("\u001b[?9h\u001b[?1000h\u001b[?1002h\u001b[?1003h");
+
+      const preamble = tracker.buildPreamble();
+      expect(preamble).not.toContain("?9h");
+      expect(preamble).not.toContain("?1000h");
+      expect(preamble).not.toContain("?1002h");
+      expect(preamble).not.toContain("?1003h");
     });
   });
 

--- a/apps/server/src/terminal/terminalModeReplay.ts
+++ b/apps/server/src/terminal/terminalModeReplay.ts
@@ -118,22 +118,9 @@ export function createTerminalModeReplayTracker(
       if (!modes.wraparoundMode) parts.push("\u001b[?7l");
       if (internals._core?.coreService?.isCursorHidden === true) parts.push("\u001b[?25l");
 
-      switch (modes.mouseTrackingMode) {
-        case "x10":
-          parts.push("\u001b[?9h");
-          break;
-        case "vt200":
-          parts.push("\u001b[?1000h");
-          break;
-        case "drag":
-          parts.push("\u001b[?1002h");
-          break;
-        case "any":
-          parts.push("\u001b[?1003h");
-          break;
-        case "none":
-          break;
-      }
+      // Do not replay mouse tracking modes. After app restart the TUI that
+      // enabled mouse reporting may be gone, and reasserting it makes ordinary
+      // mouse movement print raw escape sequences into the shell.
 
       if (kittyKeyboardState.flags > 0) {
         parts.push(`\u001b[=${kittyKeyboardState.flags};1u`);


### PR DESCRIPTION
## Summary
- stop replaying terminal mouse tracking modes when a renderer reattaches to an existing PTY
- keep replaying safe modes like bracketed paste, focus reporting, cursor visibility, and kitty keyboard state
- add coverage for the replay helper and manager reattach snapshot

## Root cause
The terminal replay preamble re-enabled mouse reporting modes such as CSI ?1002h after app restart. If the TUI that originally enabled mouse reporting was gone, ordinary mouse movement could be sent to the shell and printed as raw escape sequences.

Fixes #39.

## Verification
- git diff --check
- attempted bun run --filter t3 test apps/server/src/terminal/terminalModeReplay.test.ts apps/server/src/terminal/Layers/Manager.test.ts, but vitest is not installed in this checkout