### PR TITLE
Align composer plan steps width

### DIFF
--- a/apps/web/src/components/chat/ComposerColumnFrame.test.tsx
+++ b/apps/web/src/components/chat/ComposerColumnFrame.test.tsx
@@ -52,7 +52,7 @@ describe("ComposerStackedHeaderFrame", () => {
     );
 
     expect(markup).toContain('class="pointer-events-none w-full"');
-    expect(markup).toContain('class="pointer-events-auto mx-auto -mb-px w-11/12 min-w-0"');
+    expect(markup).toContain('class="pointer-events-auto mx-auto -mb-px w-full min-w-0"');
     expect(markup).toContain('data-testid="content"');
   });
 });

--- a/apps/web/src/components/chat/ComposerColumnFrame.tsx
+++ b/apps/web/src/components/chat/ComposerColumnFrame.tsx
@@ -1,5 +1,5 @@
 // FILE: ComposerColumnFrame.tsx
-// Purpose: Shared composer column wrapper and the 11/12 stacked-activity rail that must
+// Purpose: Shared composer column wrapper and the stacked-activity rail that must
 // live inside it (queued follow-ups, active plan/task activity). Keeps stacked panels
 // aligned with the composer input instead of the full gutter viewport.
 // Layer: Chat composer layout
@@ -26,7 +26,7 @@ function useComposerColumnFrameContext(componentName: string) {
   const insideComposerColumnFrame = useContext(ComposerColumnFrameContext);
   if (import.meta.env.DEV && !insideComposerColumnFrame) {
     console.warn(
-      `${componentName} must render inside ComposerColumnFrame so stacked activity stays at 11/12 of the composer input width.`,
+      `${componentName} must render inside ComposerColumnFrame so stacked activity stays aligned to the composer input width.`,
     );
   }
   return insideComposerColumnFrame;
@@ -56,7 +56,7 @@ interface ComposerStackedHeaderFrameProps extends HTMLAttributes<HTMLDivElement>
   passthroughSideMargins?: boolean;
 }
 
-/** 11/12-width rail for panels stacked flush above the composer input. */
+/** Full-width rail for panels stacked flush above the composer input. */
 export const ComposerStackedHeaderFrame = memo(function ComposerStackedHeaderFrame({
   children,
   className,

--- a/apps/web/src/components/chat/composerPickerStyles.ts
+++ b/apps/web/src/components/chat/composerPickerStyles.ts
@@ -108,13 +108,13 @@ export const COMPOSER_COLUMN_FRAME_CLASS_NAME = CHAT_COLUMN_FRAME_CLASS_NAME;
 
 /**
  * Frame for rows stacked above the composer (queued steer/queue rows, active task
- * list). Keeps stacked activity on the same 11/12-width rail as queued rows so
- * the composer input can remain a distinct, fully rounded surface underneath.
+ * list). Keeps stacked activity on the same width as the composer input so wide
+ * screens do not make plan/task rows drift wider than the field they belong to.
  *
  * Prefer ComposerStackedPanel inside ComposerColumnFrame instead of using this
  * token directly so chrome and attached-radius behavior stay centralized.
  */
-export const COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME = "mx-auto -mb-px w-11/12 min-w-0";
+export const COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME = "mx-auto -mb-px w-full min-w-0";
 
 /** Opaque base behind the composer shell: the composer overlaps the scrolling
  *  transcript (`-mt-5`), so without a solid backing the frosted surface would let

--- a/apps/web/src/components/chat/composerStackedHeaderFrame.test.ts
+++ b/apps/web/src/components/chat/composerStackedHeaderFrame.test.ts
@@ -8,13 +8,13 @@ import { describe, expect, it } from "vitest";
 import { COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME } from "./composerPickerStyles";
 
 describe("COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME", () => {
-  it("keeps the stacked rail narrower than the composer column", () => {
+  it("keeps the stacked rail aligned to the composer column", () => {
     const classes = COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME.split(/\s+/);
 
     expect(classes).toContain("mx-auto");
     expect(classes).toContain("-mb-px");
-    expect(classes).toContain("w-11/12");
+    expect(classes).toContain("w-full");
     expect(classes).toContain("min-w-0");
-    expect(classes).not.toContain("w-full");
+    expect(classes).not.toContain("w-11/12");
   });
 });


### PR DESCRIPTION
## Summary
- align composer-stacked plan/task rows to the same width as the composer input column
- update the shared stacked-frame contract and tests from fractional width to full composer width
- refresh developer warning/comment text to describe the alignment behavior

## Root cause
The active plan/task strip used a separate fractional-width rail, w-11/12, instead of the same width contract as the composer input. On wide layouts this made the stacked plan UI drift out of alignment with the input it belongs to.

Fixes #150.

## Verification
- git diff --check
- attempted bun run --filter @t3tools/web test apps/web/src/components/chat/composerStackedHeaderFrame.test.ts apps/web/src/components/chat/ComposerColumnFrame.test.tsx, but vitest is not installed in this checkout