### PR TITLE
Limit live turn file changes to the active turn

### DIFF
--- a/apps/server/src/checkpointing/Diffs.test.ts
+++ b/apps/server/src/checkpointing/Diffs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseTurnDiffFilesFromUnifiedDiff } from "./Diffs.ts";
+import { parseCheckpointFilesFromUnifiedDiff, parseTurnDiffFilesFromUnifiedDiff } from "./Diffs.ts";
 
 describe("parseTurnDiffFilesFromUnifiedDiff", () => {
   it("returns empty list for empty diff", () => {
@@ -88,6 +88,24 @@ describe("parseTurnDiffFilesFromUnifiedDiff", () => {
 
     expect(parseTurnDiffFilesFromUnifiedDiff(diff)).toEqual([
       { path: "CLAUDE.md", additions: 2, deletions: 3 },
+    ]);
+  });
+
+  it("maps parsed file summaries into checkpoint files", () => {
+    const diff = [
+      "diff --git a/src/app.ts b/src/app.ts",
+      "index 1111111..2222222 100644",
+      "--- a/src/app.ts",
+      "+++ b/src/app.ts",
+      "@@ -1 +1,2 @@",
+      "-old",
+      "+new",
+      "+extra",
+      "",
+    ].join("\n");
+
+    expect(parseCheckpointFilesFromUnifiedDiff(diff)).toEqual([
+      { path: "src/app.ts", kind: "modified", additions: 2, deletions: 1 },
     ]);
   });
 });

--- a/apps/server/src/checkpointing/Diffs.ts
+++ b/apps/server/src/checkpointing/Diffs.ts
@@ -1,3 +1,9 @@
+// FILE: Diffs.ts
+// Purpose: Parses unified diffs into turn/checkpoint file summaries.
+// Layer: Server checkpointing helper
+// Exports: turn diff file parsers used by checkpoint capture and provider live-diff ingestion
+
+import type { OrchestrationCheckpointFile } from "@t3tools/contracts";
 import { parsePatchFiles } from "@pierre/diffs";
 
 export interface TurnDiffFileSummary {
@@ -32,4 +38,13 @@ export function parseTurnDiffFilesFromUnifiedDiff(
   return Array.from(filesByPath.values()).toSorted((left, right) =>
     left.path.localeCompare(right.path),
   );
+}
+
+export function parseCheckpointFilesFromUnifiedDiff(diff: string): OrchestrationCheckpointFile[] {
+  return parseTurnDiffFilesFromUnifiedDiff(diff).map((file) => ({
+    path: file.path,
+    kind: "modified",
+    additions: file.additions,
+    deletions: file.deletions,
+  }));
 }

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -13,7 +13,7 @@ import {
 import { Cause, Effect, Layer, Option, Stream } from "effect";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
-import { parseTurnDiffFilesFromUnifiedDiff } from "../../checkpointing/Diffs.ts";
+import { parseCheckpointFilesFromUnifiedDiff } from "../../checkpointing/Diffs.ts";
 import {
   checkpointRefForThreadMessageStart,
   checkpointRefForThreadTurn,
@@ -347,14 +347,7 @@ const make = Effect.gen(function* () {
             ignoreWhitespace: false,
           })
           .pipe(
-            Effect.map((diff) =>
-              parseTurnDiffFilesFromUnifiedDiff(diff).map((file) => ({
-                path: file.path,
-                kind: "modified" as const,
-                additions: file.additions,
-                deletions: file.deletions,
-              })),
-            ),
+            Effect.map((diff) => parseCheckpointFilesFromUnifiedDiff(diff)),
             Effect.tapError((error) =>
               appendCaptureFailureActivity({
                 threadId: input.threadId,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -78,7 +78,11 @@ function createProviderServiceHarness() {
     respondToUserInput: () => unsupported(),
     stopSession: () => unsupported(),
     listSessions: () => Effect.succeed([...runtimeSessions]),
-    getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
+    getCapabilities: (provider) =>
+      Effect.succeed({
+        sessionModelSwitch: "in-session",
+        supportsLiveTurnDiffPatch: provider === "codex",
+      }),
     rollbackConversation: () => unsupported(),
     compactThread: () => unsupported(),
     streamEvents: Stream.fromPubSub(runtimeEventPubSub),
@@ -3122,7 +3126,17 @@ describe("ProviderRuntimeIngestion", () => {
       turnId: asTurnId("turn-p1"),
       itemId: asItemId("item-p1-assistant"),
       payload: {
-        unifiedDiff: "diff --git a/file.txt b/file.txt\n+hello\n",
+        unifiedDiff: [
+          "diff --git a/file.txt b/file.txt",
+          "index 1111111..2222222 100644",
+          "--- a/file.txt",
+          "+++ b/file.txt",
+          "@@ -1 +1,2 @@",
+          "-hello",
+          "+hello updated",
+          "+again",
+          "",
+        ].join("\n"),
       },
     });
 
@@ -3183,6 +3197,133 @@ describe("ProviderRuntimeIngestion", () => {
     expect(checkpoint?.status).toBe("missing");
     expect(checkpoint?.assistantMessageId).toBeNull();
     expect(checkpoint?.checkpointRef).toBe("provider-diff:evt-turn-diff-updated");
+    expect(checkpoint?.files).toEqual([
+      { path: "file.txt", kind: "modified", additions: 2, deletions: 1 },
+    ]);
+  });
+
+  it("updates live provider diff placeholders for the same turn", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "turn.diff.updated",
+      eventId: asEventId("evt-turn-diff-first"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-live"),
+      payload: {
+        unifiedDiff: [
+          "diff --git a/file.txt b/file.txt",
+          "index 1111111..2222222 100644",
+          "--- a/file.txt",
+          "+++ b/file.txt",
+          "@@ -1 +1 @@",
+          "-old",
+          "+new",
+          "",
+        ].join("\n"),
+      },
+    });
+
+    await waitForThread(harness.engine, (entry) =>
+      entry.checkpoints.some(
+        (checkpoint: ProviderRuntimeTestCheckpoint) =>
+          checkpoint.turnId === "turn-live" && checkpoint.files.length === 1,
+      ),
+    );
+
+    harness.emit({
+      type: "turn.diff.updated",
+      eventId: asEventId("evt-turn-diff-second"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-live"),
+      payload: {
+        unifiedDiff: [
+          "diff --git a/file.txt b/file.txt",
+          "index 1111111..2222222 100644",
+          "--- a/file.txt",
+          "+++ b/file.txt",
+          "@@ -1 +1,2 @@",
+          "-old",
+          "+new",
+          "+second",
+          "diff --git a/src/next.ts b/src/next.ts",
+          "new file mode 100644",
+          "index 0000000..3333333",
+          "--- /dev/null",
+          "+++ b/src/next.ts",
+          "@@ -0,0 +1 @@",
+          "+export const next = true;",
+          "",
+        ].join("\n"),
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.checkpoints.some(
+        (checkpoint: ProviderRuntimeTestCheckpoint) =>
+          checkpoint.turnId === "turn-live" && checkpoint.files.length === 2,
+      ),
+    );
+
+    const checkpoints = thread.checkpoints.filter(
+      (checkpoint: ProviderRuntimeTestCheckpoint) => checkpoint.turnId === "turn-live",
+    );
+    expect(checkpoints).toHaveLength(1);
+    expect(checkpoints[0]).toMatchObject({
+      checkpointTurnCount: 1,
+      checkpointRef: "provider-diff:evt-turn-diff-first",
+      status: "missing",
+      files: [
+        { path: "file.txt", kind: "modified", additions: 2, deletions: 1 },
+        { path: "src/next.ts", kind: "modified", additions: 1, deletions: 0 },
+      ],
+    });
+  });
+
+  it("does not parse live diff files for providers without patch capability", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "turn.diff.updated",
+      eventId: asEventId("evt-claude-diff-placeholder"),
+      provider: "claudeAgent",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-claude"),
+      payload: {
+        unifiedDiff: [
+          "diff --git a/file.txt b/file.txt",
+          "index 1111111..2222222 100644",
+          "--- a/file.txt",
+          "+++ b/file.txt",
+          "@@ -1 +1 @@",
+          "-old",
+          "+new",
+          "",
+        ].join("\n"),
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.checkpoints.some(
+        (checkpoint: ProviderRuntimeTestCheckpoint) => checkpoint.turnId === "turn-claude",
+      ),
+    );
+
+    const checkpoint = thread.checkpoints.find(
+      (entry: ProviderRuntimeTestCheckpoint) => entry.turnId === "turn-claude",
+    );
+    expect(checkpoint).toMatchObject({
+      checkpointRef: "provider-diff:evt-claude-diff-placeholder",
+      status: "missing",
+      files: [],
+    });
   });
 
   it("projects context window updates into normalized thread activities", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -29,6 +29,7 @@ import {
   generatedImagePathFromRuntimeEvent,
   isGeneratedImageOnlyMarkdown,
 } from "../../codexGeneratedImages.ts";
+import { parseCheckpointFilesFromUnifiedDiff } from "../../checkpointing/Diffs.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
 import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/ProjectionTurns.ts";
@@ -84,6 +85,19 @@ type RuntimeIngestionInput =
     };
 
 type ActivityPayload = OrchestrationThreadActivity["payload"];
+type ProviderDiffPlaceholder = {
+  readonly checkpointRef: CheckpointRef;
+  readonly checkpointTurnCount: number;
+  readonly files: ReturnType<typeof parseCheckpointFilesFromUnifiedDiff>;
+};
+
+function parseProviderTurnDiffFiles(unifiedDiff: string) {
+  try {
+    return parseCheckpointFilesFromUnifiedDiff(unifiedDiff);
+  } catch {
+    return null;
+  }
+}
 
 function toActivityPayload(payload: unknown): ActivityPayload {
   return payload as ActivityPayload;
@@ -1146,6 +1160,7 @@ const make = Effect.gen(function* () {
     timeToLive: BUFFERED_PROPOSED_PLAN_BY_ID_TTL,
     lookup: () => Effect.succeed({ text: "", createdAt: "" }),
   });
+  const providerDiffPlaceholdersRef = yield* Ref.make(new Map<string, ProviderDiffPlaceholder>());
 
   const getThreadDetail = Effect.fnUntraced(function* (
     threadId: ThreadId,
@@ -1185,6 +1200,22 @@ const make = Effect.gen(function* () {
     }
     return isGitRepository(workspaceCwd);
   });
+
+  const supportsLiveTurnDiffPatch = Effect.fnUntraced(function* (
+    provider: ProviderRuntimeEvent["provider"],
+  ) {
+    const capabilities = yield* providerService
+      .getCapabilities(provider)
+      .pipe(Effect.catch(() => Effect.succeed(null)));
+    return capabilities?.supportsLiveTurnDiffPatch === true;
+  });
+
+  const clearProviderDiffPlaceholder = (threadId: ThreadId, turnId: TurnId) =>
+    Ref.update(providerDiffPlaceholdersRef, (placeholders) => {
+      const next = new Map(placeholders);
+      next.delete(providerTurnKey(threadId, turnId));
+      return next;
+    });
 
   const rememberAssistantMessageId = (threadId: ThreadId, turnId: TurnId, messageId: MessageId) =>
     Cache.getOption(turnMessageIdsByTurnKey, providerTurnKey(threadId, turnId)).pipe(
@@ -2188,6 +2219,7 @@ const make = Effect.gen(function* () {
             turnId: finalizedTurnId,
             updatedAt: now,
           });
+          yield* clearProviderDiffPlaceholder(thread.id, finalizedTurnId);
         }
       }
 
@@ -2202,6 +2234,7 @@ const make = Effect.gen(function* () {
             commandTag: "assistant-complete-session-exit",
             finalDeltaCommandTag: "assistant-delta-session-exit",
           });
+          yield* clearProviderDiffPlaceholder(thread.id, exitedTurnId);
         }
         yield* clearTurnStateForSession(thread.id);
       }
@@ -2219,6 +2252,7 @@ const make = Effect.gen(function* () {
             commandTag: "assistant-complete-runtime-error",
             finalDeltaCommandTag: "assistant-delta-runtime-error",
           });
+          yield* clearProviderDiffPlaceholder(thread.id, erroredTurnId);
         }
 
         const shouldApplyRuntimeError = !STRICT_PROVIDER_LIFECYCLE_GUARD
@@ -2256,17 +2290,41 @@ const make = Effect.gen(function* () {
       if (event.type === "turn.diff.updated") {
         const turnId = toTurnId(event.turnId);
         if (turnId && (yield* isGitRepoForThread(thread.id))) {
-          // Skip if a checkpoint already exists for this turn. A real
-          // (non-placeholder) capture from CheckpointReactor should not
-          // be clobbered, and dispatching a duplicate placeholder for the
-          // same turnId would produce an unstable checkpointTurnCount.
-          if (thread.checkpoints.some((c) => c.turnId === turnId)) {
-            // Already tracked; no-op.
+          const existingCheckpoint = thread.checkpoints.find((c) => c.turnId === turnId);
+          const placeholderKey = providerTurnKey(thread.id, turnId);
+          const trackedPlaceholder = (yield* Ref.get(providerDiffPlaceholdersRef)).get(
+            placeholderKey,
+          );
+          const existingProviderPlaceholder =
+            existingCheckpoint?.checkpointRef.startsWith("provider-diff:") === true
+              ? {
+                  checkpointRef: existingCheckpoint.checkpointRef,
+                  checkpointTurnCount: existingCheckpoint.checkpointTurnCount,
+                  files: existingCheckpoint.files,
+                }
+              : null;
+          // Only provider-diff placeholders are live-updated. A real checkpoint from
+          // CheckpointReactor is the terminal turn diff and must stay authoritative.
+          if (existingCheckpoint && !existingProviderPlaceholder) {
+            yield* clearProviderDiffPlaceholder(thread.id, turnId);
           } else {
+            const canParseLiveDiffPatch = yield* supportsLiveTurnDiffPatch(event.provider);
+            const livePlaceholder = trackedPlaceholder ?? existingProviderPlaceholder;
             const maxTurnCount = thread.checkpoints.reduce(
               (max, c) => Math.max(max, c.checkpointTurnCount),
               0,
             );
+            const files =
+              (canParseLiveDiffPatch
+                ? parseProviderTurnDiffFiles(event.payload.unifiedDiff)
+                : null) ??
+              trackedPlaceholder?.files ??
+              existingCheckpoint?.files ??
+              [];
+            const checkpointRef =
+              livePlaceholder?.checkpointRef ??
+              CheckpointRef.makeUnsafe(`provider-diff:${event.eventId}`);
+            const checkpointTurnCount = livePlaceholder?.checkpointTurnCount ?? maxTurnCount + 1;
             // Leave assistantMessageId undefined on the placeholder: the real
             // capture performed by CheckpointReactor will resolve the actual
             // assistant MessageId once the message is finalized. Emitting a
@@ -2278,13 +2336,24 @@ const make = Effect.gen(function* () {
               threadId: thread.id,
               turnId,
               completedAt: now,
-              checkpointRef: CheckpointRef.makeUnsafe(`provider-diff:${event.eventId}`),
+              checkpointRef,
               status: "missing",
-              files: [],
+              files,
               assistantMessageId: undefined,
-              checkpointTurnCount: maxTurnCount + 1,
+              checkpointTurnCount,
               createdAt: now,
             });
+            if (canParseLiveDiffPatch) {
+              yield* Ref.update(providerDiffPlaceholdersRef, (placeholders) => {
+                const next = new Map(placeholders);
+                next.set(placeholderKey, {
+                  checkpointRef,
+                  checkpointTurnCount,
+                  files,
+                });
+                return next;
+              });
+            }
           }
         }
       }

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3868,6 +3868,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         supportsPluginMentions: false,
         supportsPluginDiscovery: false,
         supportsRuntimeModelList: true,
+        supportsLiveTurnDiffPatch: false,
       },
       startSession,
       sendTurn,

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -2012,6 +2012,7 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
         supportsPluginDiscovery: true,
         supportsRuntimeModelList: true,
         supportsTurnSteering: true,
+        supportsLiveTurnDiffPatch: true,
       },
       startSession,
       sendTurn,

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -55,6 +55,8 @@ export interface ProviderAdapterCapabilities {
   readonly supportsPluginDiscovery?: boolean;
   readonly supportsRuntimeModelList?: boolean;
   readonly supportsTurnSteering?: boolean;
+  /** True when `turn.diff.updated.payload.unifiedDiff` contains a parseable live patch. */
+  readonly supportsLiveTurnDiffPatch?: boolean;
 }
 
 export interface ProviderThreadTurnSnapshot {

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,4 +1,4 @@
-import { ThreadId, type ModelSlug } from "@t3tools/contracts";
+import { ThreadId, TurnId, type ModelSlug } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -12,6 +12,7 @@ import {
   hasServerAcknowledgedLocalDispatch,
   isVoiceAuthExpiredMessage,
   resolveActiveThreadTitle,
+  resolveActiveTurnLiveDiffState,
   resolveCommittedProviderModel,
   resolveDefaultEnvironmentPanelOpen,
   resolveEnvironmentPanelVisible,
@@ -265,6 +266,58 @@ describe("environment panel visibility", () => {
         environmentPanelOpen: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveActiveTurnLiveDiffState", () => {
+  it("uses only the diff summary for the active turn", () => {
+    const activeTurnId = TurnId.makeUnsafe("turn-active");
+
+    expect(
+      resolveActiveTurnLiveDiffState({
+        latestTurnId: activeTurnId,
+        turnDiffSummaries: [
+          {
+            turnId: TurnId.makeUnsafe("turn-previous"),
+            completedAt: "2026-06-13T10:00:00.000Z",
+            files: [{ path: "old.ts", additions: 100, deletions: 50 }],
+          },
+          {
+            turnId: activeTurnId,
+            completedAt: "2026-06-13T10:01:00.000Z",
+            files: [
+              { path: "src/a.ts", additions: 2, deletions: 1 },
+              { path: "src/b.ts", additions: 3, deletions: 0 },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({
+      turnId: activeTurnId,
+      fileCount: 2,
+      additions: 5,
+      deletions: 1,
+    });
+  });
+
+  it("returns zero totals before the active turn has a diff summary", () => {
+    expect(
+      resolveActiveTurnLiveDiffState({
+        latestTurnId: TurnId.makeUnsafe("turn-active"),
+        turnDiffSummaries: [
+          {
+            turnId: TurnId.makeUnsafe("turn-previous"),
+            completedAt: "2026-06-13T10:00:00.000Z",
+            files: [{ path: "old.ts", additions: 100, deletions: 50 }],
+          },
+        ],
+      }),
+    ).toEqual({
+      turnId: null,
+      fileCount: 0,
+      additions: 0,
+      deletions: 0,
+    });
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -19,6 +19,7 @@ import {
   type SessionPhase,
   type Thread,
   type ThreadPrimarySurface,
+  type TurnDiffSummary,
 } from "../types";
 import { type DraftThreadState } from "../composerDraftStore";
 import { Schema } from "effect";
@@ -99,6 +100,27 @@ export function resolveEnvironmentPanelVisible(input: {
   environmentPanelOpen: boolean;
 }): boolean {
   return input.environmentEnabled && input.environmentPanelOpen;
+}
+
+export function resolveActiveTurnLiveDiffState(input: {
+  latestTurnId: string | null | undefined;
+  turnDiffSummaries: ReadonlyArray<TurnDiffSummary>;
+}): {
+  turnId: TurnDiffSummary["turnId"] | null;
+  fileCount: number;
+  additions: number;
+  deletions: number;
+} {
+  const summary = input.latestTurnId
+    ? (input.turnDiffSummaries.find((entry) => entry.turnId === input.latestTurnId) ?? null)
+    : null;
+  const files = summary?.files ?? [];
+  return {
+    turnId: summary?.turnId ?? null,
+    fileCount: files.length,
+    additions: files.reduce((total, file) => total + (file.additions ?? 0), 0),
+    deletions: files.reduce((total, file) => total + (file.deletions ?? 0), 0),
+  };
 }
 
 export function buildLocalDraftThread(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -128,6 +128,7 @@ import {
   buildThreadBreadcrumbs,
   enrichSubagentWorkEntries,
   resolveActiveThreadTitle,
+  resolveActiveTurnLiveDiffState,
   resolveCommittedProviderModel,
   resolveDefaultEnvironmentPanelOpen,
   resolveEnvironmentPanelVisible,
@@ -178,7 +179,6 @@ import {
   buildSourceProposedPlanReference,
   hasActionableProposedPlan,
   hasLiveTurnTailWork,
-  isProviderFileEditWorkLogEntry,
   isLatestTurnSettled,
   type ActiveTaskListState,
 } from "../session-logic";
@@ -1156,8 +1156,8 @@ export default function ChatView({
   const latestTurnSettled = latestTurnSettledByProvider && !hasLiveTurnTail;
   // `latestTurnSettled` is also false when there is NO started turn (a brand-new
   // chat), because `isLatestTurnSettled` treats a non-existent turn as unsettled.
-  // Gate "live turn" UI on an actually-started turn so the working-tree diff strip
-  // doesn't leak onto a fresh chat just because the repo happens to be dirty.
+  // Gate live-turn UI on an actually-started turn so composer chrome cannot
+  // appear on a fresh chat just because the repo already has local edits.
   const latestTurnLive = Boolean(activeLatestTurn?.startedAt) && !latestTurnSettled;
   const activeProjectId = activeThread?.projectId ?? draftThread?.projectId ?? null;
   const activeProject = useStore(
@@ -1780,14 +1780,6 @@ export default function ChatView({
         visibleTurnIds: workLogVisibleTurnIds,
       }),
     [activeLatestTurn?.turnId, threadActivities, workLogVisibleTurnIds],
-  );
-  const activeTurnHasFileChangeWork = useMemo(
-    () =>
-      rawWorkLogEntries.some(
-        (entry) =>
-          entry.turnId === activeLatestTurn?.turnId && isProviderFileEditWorkLogEntry(entry),
-      ),
-    [activeLatestTurn?.turnId, rawWorkLogEntries],
   );
   const hasWorkLogSubagents = useMemo(
     () => rawWorkLogEntries.some((entry) => (entry.subagents?.length ?? 0) > 0),
@@ -2872,6 +2864,16 @@ export default function ChatView({
     isGitRepo,
     refetchInterval: repoDiffBadgeRefreshIntervalMs,
   });
+  // The composer live strip is turn-scoped; repoDiffTotals can include unrelated
+  // local edits that existed before the active agent turn started.
+  const activeTurnLiveDiffState = useMemo(
+    () =>
+      resolveActiveTurnLiveDiffState({
+        latestTurnId: activeLatestTurn?.turnId ?? null,
+        turnDiffSummaries,
+      }),
+    [activeLatestTurn?.turnId, turnDiffSummaries],
+  );
   const splitTerminalShortcutLabel = useMemo(
     () =>
       shortcutLabelForCommand(keybindings, "terminal.splitRight") ??
@@ -7772,6 +7774,13 @@ export default function ChatView({
     },
     [diffEnvironmentPending, navigate, onOpenTurnDiffPanel, threadId],
   );
+  const onReviewComposerLiveChanges = useCallback(() => {
+    if (!activeTurnLiveDiffState.turnId) {
+      onOpenDiff();
+      return;
+    }
+    onOpenTurnDiff(activeTurnLiveDiffState.turnId);
+  }, [activeTurnLiveDiffState.turnId, onOpenDiff, onOpenTurnDiff]);
   const onNavigateToThread = useCallback(
     (nextThreadId: ThreadId) => {
       void navigate({
@@ -8083,7 +8092,7 @@ export default function ChatView({
     : null;
 
   const showComposerLiveChangesHeader =
-    latestTurnLive && activeTurnHasFileChangeWork && repoDiffTotals.fileCount > 0;
+    latestTurnLive && activeTurnLiveDiffState.fileCount > 0;
   const showComposerActiveTaskListCard = Boolean(activeTaskList && !planSidebarOpen);
 
   // Composer layout keeps the task list and footer actions in one render path so
@@ -8114,10 +8123,10 @@ export default function ChatView({
           <ComposerColumnFrame>
             {showComposerLiveChangesHeader ? (
               <ComposerLiveChangesHeader
-                fileCount={repoDiffTotals.fileCount}
-                additions={repoDiffTotals.additions}
-                deletions={repoDiffTotals.deletions}
-                onReview={onOpenDiff}
+                fileCount={activeTurnLiveDiffState.fileCount}
+                additions={activeTurnLiveDiffState.additions}
+                deletions={activeTurnLiveDiffState.deletions}
+                onReview={onReviewComposerLiveChanges}
               />
             ) : null}
             {renderActiveTaskListCard(showComposerLiveChangesHeader)}

--- a/apps/web/src/components/chat/ComposerLiveChangesHeader.tsx
+++ b/apps/web/src/components/chat/ComposerLiveChangesHeader.tsx
@@ -1,8 +1,7 @@
 // FILE: ComposerLiveChangesHeader.tsx
 // Purpose: Live "N files changed +X -Y" strip stacked flush onto the top of the
-// composer while a turn is running, mirroring the queued follow-up header. Reads the
-// same working-tree diff totals as the chat-header badge and offers a Review action
-// that opens the diff panel. Hidden when there are no changes.
+// composer while a turn is running, mirroring the queued follow-up header. The
+// caller supplies turn-scoped diff totals and the Review action target.
 // Layer: Chat composer UI
 // Exports: ComposerLiveChangesHeader
 


### PR DESCRIPTION
## Summary
- Scope the composer’s live file-changes card to the active turn instead of the whole workspace diff.
- Reuse unified-diff parsing for checkpoint files and live provider placeholders so turn-scoped totals stay consistent.
- Add provider capability gating so only providers with parseable live patches populate the live card.

## Testing
- Added unit coverage for turn-scoped live diff totals in the chat view logic.
- Added server tests for shared diff parsing, live placeholder updates on repeated turn.diff.updated events, and the non-patch provider path.
- Not run (not requested)