### PR TITLE
[codex] Add curated app improvements

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -49,7 +49,10 @@ import {
 import { isNonFatalCodexErrorMessage } from "./codexErrorClassification.ts";
 import { buildCodexProcessEnv } from "./codexProcessEnv.ts";
 import { ensureIsolatedScratchWorkspace } from "./scratchWorkspaces.ts";
+import { createLogger } from "./logger";
 import { transcribeVoiceWithChatGptSession } from "./voiceTranscription.ts";
+
+const log = createLogger("codex");
 
 type PendingRequestKey = string;
 
@@ -734,7 +737,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     } catch (error) {
       // Older codex builds (< extra-roots support) keep working; Synara-only
       // skills simply stay invisible to codex on those versions.
-      console.log("codex skills/extraRoots/set unavailable", error);
+      log.warn("skills/extraRoots/set unavailable", { error });
     }
   }
 
@@ -810,21 +813,21 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       await this.registerSynaraSkillsRoot(context);
       try {
         const modelListResponse = await this.sendRequest(context, "model/list", {});
-        console.log("codex model/list response", modelListResponse);
+        log.info("model/list response", { modelListResponse });
       } catch (error) {
-        console.log("codex model/list failed", error);
+        log.warn("model/list failed", { error });
       }
       try {
         const accountReadResponse = await this.sendRequest(context, "account/read", {});
-        console.log("codex account/read response", accountReadResponse);
+        log.info("account/read response", { accountReadResponse });
         context.account = readCodexAccountSnapshot(accountReadResponse);
-        console.log("codex subscription status", {
+        log.info("subscription status", {
           type: context.account.type,
           planType: context.account.planType,
           sparkEnabled: context.account.sparkEnabled,
         });
       } catch (error) {
-        console.log("codex account/read failed", error);
+        log.warn("account/read failed", { error });
       }
 
       const normalizedModel = resolveCodexModelForAccount(
@@ -1193,7 +1196,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
     const turnId = TurnId.makeUnsafe(turnIdRaw);
     context.reviewTurnIds.add(turnId);
-    console.log("[codex-review] review/start acknowledged", {
+    log.info("[codex-review] review/start acknowledged", {
       threadId: context.session.threadId,
       providerThreadId,
       turnId,
@@ -1233,7 +1236,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         resumeCursor: context.session.resumeCursor,
       });
     if (!effectiveTurnId || !providerThreadId) {
-      console.log("[codex-review] turn/interrupt skipped", {
+      log.info("[codex-review] turn/interrupt skipped", {
         threadId,
         requestedTurnId: turnId ?? null,
         activeTurnId: context.session.activeTurnId ?? null,
@@ -1242,7 +1245,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       return;
     }
 
-    console.log("[codex-review] turn/interrupt requested", {
+    log.info("[codex-review] turn/interrupt requested", {
       threadId,
       providerThreadId,
       turnId: effectiveTurnId,
@@ -1253,13 +1256,13 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         threadId: providerThreadId,
         turnId: effectiveTurnId,
       });
-      console.log("[codex-review] turn/interrupt acknowledged", {
+      log.info("[codex-review] turn/interrupt acknowledged", {
         threadId,
         providerThreadId,
         turnId: effectiveTurnId,
       });
     } catch (error) {
-      console.log("[codex-review] turn/interrupt failed", {
+      log.warn("[codex-review] turn/interrupt failed", {
         threadId,
         providerThreadId,
         turnId: effectiveTurnId,
@@ -1272,7 +1275,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
       const snapshot = await this.readThread(threadId);
       const latestReviewTurnId = this.findLatestReviewTurnId(snapshot);
-      console.log("[codex-review] review interrupt recovery snapshot", {
+      log.info("[codex-review] review interrupt recovery snapshot", {
         threadId,
         currentTurnId: effectiveTurnId,
         latestReviewTurnId: latestReviewTurnId ?? null,
@@ -1283,7 +1286,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       });
 
       if (latestReviewTurnId && this.isExitedReviewTurn(snapshot, latestReviewTurnId)) {
-        console.log("[codex-review] settling review from thread/read exitedReviewMode", {
+        log.info("[codex-review] settling review from thread/read exitedReviewMode", {
           threadId,
           turnId: latestReviewTurnId,
         });
@@ -1295,7 +1298,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       }
 
       if (latestReviewTurnId && latestReviewTurnId !== effectiveTurnId) {
-        console.log("[codex-review] retrying turn/interrupt with refreshed review turn", {
+        log.info("[codex-review] retrying turn/interrupt with refreshed review turn", {
           threadId,
           previousTurnId: effectiveTurnId,
           nextTurnId: latestReviewTurnId,
@@ -2256,7 +2259,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         context.reviewTurnIds.has(context.session.activeTurnId)
       ) {
         context.reviewTurnIds.add(turnId);
-        console.log("[codex-review] extending tracked review turn set on turn/started", {
+        log.info("[codex-review] extending tracked review turn set on turn/started", {
           threadId: context.session.threadId,
           previousTurnId: context.session.activeTurnId,
           nextTurnId: turnId,
@@ -2319,7 +2322,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       const activeTurnTracked =
         context.session.activeTurnId !== undefined &&
         context.reviewTurnIds.has(context.session.activeTurnId);
-      console.log("[codex-review] exitedReviewMode notification", {
+      log.info("[codex-review] exitedReviewMode notification", {
         threadId: context.session.threadId,
         reviewTurnId: reviewTurnId ?? null,
         activeTurnId: context.session.activeTurnId ?? null,
@@ -2333,7 +2336,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         !reviewTurnTracked &&
         !activeTurnTracked
       ) {
-        console.log("[codex-review] exitedReviewMode ignored due to turn mismatch", {
+        log.info("[codex-review] exitedReviewMode ignored due to turn mismatch", {
           threadId: context.session.threadId,
           reviewTurnId,
           activeTurnId: context.session.activeTurnId,
@@ -2344,7 +2347,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       // before the terminal `turn/completed` notification arrives. If that
       // completion never shows up, settle the session here instead of leaving
       // native review stuck in "running" forever.
-      console.log("[codex-review] settling review from exitedReviewMode notification", {
+      log.info("[codex-review] settling review from exitedReviewMode notification", {
         threadId: context.session.threadId,
         reviewTurnId: reviewTurnId ?? null,
       });

--- a/apps/server/src/terminal/Layers/Manager.test.ts
+++ b/apps/server/src/terminal/Layers/Manager.test.ts
@@ -17,7 +17,11 @@ import {
   type PtyProcess,
   type PtySpawnInput,
 } from "../Services/PTY";
-import { TerminalManagerRuntime, type TerminalSubprocessActivity } from "./Manager";
+import {
+  __terminalManagerShellTesting,
+  TerminalManagerRuntime,
+  type TerminalSubprocessActivity,
+} from "./Manager";
 import { Effect, Encoding } from "effect";
 
 class FakePtyProcess implements PtyProcess {
@@ -185,6 +189,36 @@ describe("TerminalManager", () => {
     for (const dir of tempDirs.splice(0, tempDirs.length)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("prefers PowerShell for new Windows terminals before cmd.exe fallbacks", () => {
+    const candidates = __terminalManagerShellTesting.resolveShellCandidates(
+      () => __terminalManagerShellTesting.windowsDefaultTerminalShell,
+      {
+        envComSpec: "C:\\Windows\\System32\\cmd.exe",
+        platform: "win32",
+      },
+    );
+
+    expect(candidates.map((candidate) => candidate.shell)).toEqual([
+      "powershell.exe",
+      "C:\\Windows\\System32\\cmd.exe",
+      "cmd.exe",
+    ]);
+  });
+
+  it("keeps explicit Windows shell requests ahead of PowerShell defaults", () => {
+    const candidates = __terminalManagerShellTesting.resolveShellCandidates(() => "pwsh.exe", {
+      envComSpec: "C:\\Windows\\System32\\cmd.exe",
+      platform: "win32",
+    });
+
+    expect(candidates.map((candidate) => candidate.shell)).toEqual([
+      "pwsh.exe",
+      "C:\\Windows\\System32\\cmd.exe",
+      "powershell.exe",
+      "cmd.exe",
+    ]);
   });
 
   function makeManager(
@@ -478,11 +512,12 @@ describe("TerminalManager", () => {
     expect(process).toBeDefined();
     if (!process) return;
 
-    process.emitData("\u001b[?2004h\u001b[>7u");
+    process.emitData("\u001b[?2004h\u001b[?1002h\u001b[>7u");
     const snapshot = await manager.open(openInput());
 
     expect(snapshot.replayPreamble).toContain("\u001b[?2004h");
     expect(snapshot.replayPreamble).toContain("\u001b[=7;1u");
+    expect(snapshot.replayPreamble ?? "").not.toContain("?1002h");
 
     process.emitData("\u001b[?2004l\u001b[=0;1u");
     const resetSnapshot = await manager.open(openInput());

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -187,19 +187,30 @@ function normalizeProviderOutputSignature(visibleText: string): string {
     .slice(-256);
 }
 
+const WINDOWS_DEFAULT_TERMINAL_SHELL = "powershell.exe";
+
+type ShellResolutionOptions = {
+  platform?: NodeJS.Platform;
+  envShell?: string;
+  envComSpec?: string;
+};
+
 function defaultShellResolver(): string {
   if (process.platform === "win32") {
-    return process.env.ComSpec ?? "cmd.exe";
+    return WINDOWS_DEFAULT_TERMINAL_SHELL;
   }
   return process.env.SHELL ?? "bash";
 }
 
-function normalizeShellCommand(value: string | undefined): string | null {
+function normalizeShellCommand(
+  value: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
   if (!value) return null;
   const trimmed = value.trim();
   if (trimmed.length === 0) return null;
 
-  if (process.platform === "win32") {
+  if (platform === "win32") {
     return trimmed;
   }
 
@@ -208,10 +219,13 @@ function normalizeShellCommand(value: string | undefined): string | null {
   return firstToken.replace(/^['"]|['"]$/g, "");
 }
 
-function shellCandidateFromCommand(command: string | null): ShellCandidate | null {
+function shellCandidateFromCommand(
+  command: string | null,
+  platform: NodeJS.Platform = process.platform,
+): ShellCandidate | null {
   if (!command || command.length === 0) return null;
   const shellName = path.basename(command).toLowerCase();
-  if (process.platform !== "win32" && shellName === "zsh") {
+  if (platform !== "win32" && shellName === "zsh") {
     return { shell: command, args: ["-l", "-o", "nopromptsp"] };
   }
   return { shell: command };
@@ -235,29 +249,44 @@ function uniqueShellCandidates(candidates: Array<ShellCandidate | null>): ShellC
   return ordered;
 }
 
-function resolveShellCandidates(shellResolver: () => string): ShellCandidate[] {
-  const requested = shellCandidateFromCommand(normalizeShellCommand(shellResolver()));
+function resolveShellCandidates(
+  shellResolver: () => string,
+  options: ShellResolutionOptions = {},
+): ShellCandidate[] {
+  const platform = options.platform ?? process.platform;
+  const requested = shellCandidateFromCommand(
+    normalizeShellCommand(shellResolver(), platform),
+    platform,
+  );
 
-  if (process.platform === "win32") {
+  if (platform === "win32") {
     return uniqueShellCandidates([
       requested,
-      shellCandidateFromCommand(process.env.ComSpec ?? null),
-      shellCandidateFromCommand("powershell.exe"),
-      shellCandidateFromCommand("cmd.exe"),
+      shellCandidateFromCommand(options.envComSpec ?? process.env.ComSpec ?? null, platform),
+      shellCandidateFromCommand(WINDOWS_DEFAULT_TERMINAL_SHELL, platform),
+      shellCandidateFromCommand("cmd.exe", platform),
     ]);
   }
 
   return uniqueShellCandidates([
     requested,
-    shellCandidateFromCommand(normalizeShellCommand(process.env.SHELL)),
-    shellCandidateFromCommand("/bin/zsh"),
-    shellCandidateFromCommand("/bin/bash"),
-    shellCandidateFromCommand("/bin/sh"),
-    shellCandidateFromCommand("zsh"),
-    shellCandidateFromCommand("bash"),
-    shellCandidateFromCommand("sh"),
+    shellCandidateFromCommand(
+      normalizeShellCommand(options.envShell ?? process.env.SHELL, platform),
+      platform,
+    ),
+    shellCandidateFromCommand("/bin/zsh", platform),
+    shellCandidateFromCommand("/bin/bash", platform),
+    shellCandidateFromCommand("/bin/sh", platform),
+    shellCandidateFromCommand("zsh", platform),
+    shellCandidateFromCommand("bash", platform),
+    shellCandidateFromCommand("sh", platform),
   ]);
 }
+
+export const __terminalManagerShellTesting = {
+  resolveShellCandidates,
+  windowsDefaultTerminalShell: WINDOWS_DEFAULT_TERMINAL_SHELL,
+};
 
 function isRetryableShellSpawnError(error: unknown): boolean {
   const queue: unknown[] = [error];

--- a/apps/server/src/terminal/terminalModeReplay.test.ts
+++ b/apps/server/src/terminal/terminalModeReplay.test.ts
@@ -47,18 +47,29 @@ describe("createTerminalModeReplayTracker", () => {
     });
   });
 
-  it("tracks bracketed paste, focus reporting, mouse tracking, and cursor visibility", () => {
+  it("tracks bracketed paste, focus reporting, and cursor visibility", () => {
     withTracker((tracker) => {
       tracker.feed("\u001b[?2004h\u001b[?1004h\u001b[?1002h\u001b[?25l");
 
       const preamble = tracker.buildPreamble();
       expect(preamble).toContain("\u001b[?2004h");
       expect(preamble).toContain("\u001b[?1004h");
-      expect(preamble).toContain("\u001b[?1002h");
       expect(preamble).toContain("\u001b[?25l");
 
       tracker.feed("\u001b[?2004l");
       expect(tracker.buildPreamble()).not.toContain("?2004");
+    });
+  });
+
+  it("does not replay mouse tracking modes on renderer reattach", () => {
+    withTracker((tracker) => {
+      tracker.feed("\u001b[?9h\u001b[?1000h\u001b[?1002h\u001b[?1003h");
+
+      const preamble = tracker.buildPreamble();
+      expect(preamble).not.toContain("?9h");
+      expect(preamble).not.toContain("?1000h");
+      expect(preamble).not.toContain("?1002h");
+      expect(preamble).not.toContain("?1003h");
     });
   });
 

--- a/apps/server/src/terminal/terminalModeReplay.ts
+++ b/apps/server/src/terminal/terminalModeReplay.ts
@@ -118,22 +118,9 @@ export function createTerminalModeReplayTracker(
       if (!modes.wraparoundMode) parts.push("\u001b[?7l");
       if (internals._core?.coreService?.isCursorHidden === true) parts.push("\u001b[?25l");
 
-      switch (modes.mouseTrackingMode) {
-        case "x10":
-          parts.push("\u001b[?9h");
-          break;
-        case "vt200":
-          parts.push("\u001b[?1000h");
-          break;
-        case "drag":
-          parts.push("\u001b[?1002h");
-          break;
-        case "any":
-          parts.push("\u001b[?1003h");
-          break;
-        case "none":
-          break;
-      }
+      // Do not replay mouse tracking modes. After app restart the TUI that
+      // enabled mouse reporting may be gone, and reasserting it makes ordinary
+      // mouse movement print raw escape sequences into the shell.
 
       if (kittyKeyboardState.flags > 0) {
         parts.push(`\u001b[=${kittyKeyboardState.flags};1u`);

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -182,6 +182,7 @@ export const AppSettingsSchema = Schema.Struct({
   showEnvironmentRecap: Schema.Boolean.pipe(withDefaults(() => true)),
   showEnvironmentPinned: Schema.Boolean.pipe(withDefaults(() => true)),
   showEnvironmentMarkers: Schema.Boolean.pipe(withDefaults(() => true)),
+  showEnvironmentInstructions: Schema.Boolean.pipe(withDefaults(() => true)),
   showEnvironmentNotepad: Schema.Boolean.pipe(withDefaults(() => true)),
   enableAssistantStreaming: Schema.Boolean.pipe(withDefaults(() => false)),
   enableNativeFontSmoothing: Schema.Boolean.pipe(withDefaults(getDefaultNativeFontSmoothing)),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -332,6 +332,7 @@ import {
 import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "./ComposerPromptEditor";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { ChatHeader } from "./chat/ChatHeader";
+import { dispatchThreadNotes } from "~/pinnedMessages";
 import {
   mergeProjectInstructionsIntoThreadNotes,
   useProjectInstructionsStore,
@@ -6124,13 +6125,21 @@ export default function ChatView({
             branch: nextThreadBranch,
             worktreePath: nextThreadWorktreePath,
             lastKnownPr: activeThread.lastKnownPr ?? null,
-            ...(inheritedThreadNotes !== threadNotes && inheritedThreadNotes.trim().length > 0
-              ? { notes: inheritedThreadNotes }
-              : {}),
             createdAt: activeThread.createdAt,
           },
           api,
         );
+        // `thread.create` does not carry notes, so seed the freshly created
+        // server thread's notepad with the inherited project instructions via a
+        // dedicated meta update. Best-effort: a failure here must not abort the turn.
+        if (inheritedThreadNotes !== threadNotes && inheritedThreadNotes.trim().length > 0) {
+          try {
+            await dispatchThreadNotes(threadIdForSend, inheritedThreadNotes);
+          } catch {
+            // Seeding is non-critical; project instructions can still be copied
+            // into the notepad manually from the Environment panel.
+          }
+        }
         if (targetProjectKindForSend === "chat") {
           await api.orchestration.dispatchCommand({
             type: "project.meta.update",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -333,6 +333,10 @@ import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "./Compose
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { ChatHeader } from "./chat/ChatHeader";
 import {
+  mergeProjectInstructionsIntoThreadNotes,
+  useProjectInstructionsStore,
+} from "~/projectInstructionsStore";
+import {
   ENVIRONMENT_DOCKED_CONTENT_INSET_PX,
   EnvironmentPanel,
   type EnvironmentPanelProps,
@@ -1194,6 +1198,10 @@ export default function ChatView({
   const activeProject = useStore(
     useMemo(() => createProjectSelector(activeProjectId), [activeProjectId]),
   );
+  const projectInstructions = useProjectInstructionsStore((state) =>
+    activeProjectId ? (state.instructionsByProjectId[activeProjectId] ?? "") : "",
+  );
+  const setProjectInstructions = useProjectInstructionsStore((state) => state.setInstructions);
   const homeDir = useWorkspaceStore((state) => state.homeDir);
   const chatWorkspaceRoot = useWorkspaceStore((state) => state.chatWorkspaceRoot);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
@@ -2325,6 +2333,28 @@ export default function ChatView({
     handleRenamePinnedMessage,
     handleNotesChange,
   } = usePinnedMessageActions({ activeThreadId, pinnedMessages });
+  const handleCopyProjectInstructionsToNotes = useCallback(() => {
+    if (!activeThreadId) {
+      return;
+    }
+    const nextNotes = mergeProjectInstructionsIntoThreadNotes({
+      threadNotes,
+      projectInstructions,
+    });
+    if (nextNotes === threadNotes) {
+      return;
+    }
+    void handleNotesChange(activeThreadId, nextNotes)
+      .then(() => {
+        toastManager.add({
+          type: "success",
+          title: "Project instructions added to notepad.",
+        });
+      })
+      .catch(() => {
+        // `handleNotesChange` already surfaces the save failure through the shared notes toast.
+      });
+  }, [activeThreadId, handleNotesChange, projectInstructions, threadNotes]);
   const handleJumpToPinnedMessage = useCallback((messageId: MessageId) => {
     timelineControllerRef.current?.scrollToMessage(messageId);
   }, []);
@@ -6073,6 +6103,13 @@ export default function ChatView({
       );
 
       if (isLocalDraftThread) {
+        const inheritedProjectInstructions =
+          useProjectInstructionsStore.getState().instructionsByProjectId[targetProjectIdForSend] ??
+          "";
+        const inheritedThreadNotes = mergeProjectInstructionsIntoThreadNotes({
+          threadNotes,
+          projectInstructions: inheritedProjectInstructions,
+        });
         await promoteThreadCreate(
           {
             type: "thread.create",
@@ -6087,6 +6124,9 @@ export default function ChatView({
             branch: nextThreadBranch,
             worktreePath: nextThreadWorktreePath,
             lastKnownPr: activeThread.lastKnownPr ?? null,
+            ...(inheritedThreadNotes !== threadNotes && inheritedThreadNotes.trim().length > 0
+              ? { notes: inheritedThreadNotes }
+              : {}),
             createdAt: activeThread.createdAt,
           },
           api,
@@ -8120,6 +8160,11 @@ export default function ChatView({
     pinnedMessageTextById,
     markerMessageTextById,
     notes: threadNotes,
+    activeProjectId,
+    projectInstructions,
+    canCopyProjectInstructionsToNotes: !isLocalDraftThread,
+    onProjectInstructionsChange: setProjectInstructions,
+    onCopyProjectInstructionsToNotes: handleCopyProjectInstructionsToNotes,
     onToggleDiff,
     onOpenGithubRepository: openBrowserUrl,
     onJumpToPinnedMessage: handleJumpToPinnedMessage,

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -486,6 +486,12 @@ export default function DiffPanel({
     enabled: gitStatusQueriesEnabled,
   });
   const gitRepoStatus = gitBranchesQuery.isSuccess ? gitBranchesQuery.data.isRepo : undefined;
+  const gitRepoStatusError =
+    gitBranchesQuery.error instanceof Error
+      ? gitBranchesQuery.error.message
+      : gitBranchesQuery.error
+        ? "Failed to check git repository."
+        : null;
   const isGitRepo = gitRepoStatus === true;
   const turnDiffSummaries = activeThreadContext?.turnDiffSummaries ?? [];
   const inferredCheckpointTurnCountByTurnId = useMemo(
@@ -1099,6 +1105,10 @@ export default function DiffPanel({
       ) : gitRepoStatus === false ? (
         <PanelStateMessage density="compact" fill="flex">
           Turn diffs are unavailable because this project is not a git repository.
+        </PanelStateMessage>
+      ) : gitRepoStatusError ? (
+        <PanelStateMessage density="compact" fill="flex">
+          {gitRepoStatusError}
         </PanelStateMessage>
       ) : gitRepoStatus === undefined && diffQueriesEnabled && activeCwd ? (
         <DiffPanelLoadingState label="Checking git repository..." />

--- a/apps/web/src/components/chat/ComposerColumnFrame.test.tsx
+++ b/apps/web/src/components/chat/ComposerColumnFrame.test.tsx
@@ -52,7 +52,7 @@ describe("ComposerStackedHeaderFrame", () => {
     );
 
     expect(markup).toContain('class="pointer-events-none w-full"');
-    expect(markup).toContain('class="pointer-events-auto mx-auto -mb-px w-11/12 min-w-0"');
+    expect(markup).toContain('class="pointer-events-auto mx-auto -mb-px w-full min-w-0"');
     expect(markup).toContain('data-testid="content"');
   });
 });

--- a/apps/web/src/components/chat/ComposerColumnFrame.tsx
+++ b/apps/web/src/components/chat/ComposerColumnFrame.tsx
@@ -1,5 +1,5 @@
 // FILE: ComposerColumnFrame.tsx
-// Purpose: Shared composer column wrapper and the 11/12 stacked-activity rail that must
+// Purpose: Shared composer column wrapper and the stacked-activity rail that must
 // live inside it (queued follow-ups, active plan/task activity). Keeps stacked panels
 // aligned with the composer input instead of the full gutter viewport.
 // Layer: Chat composer layout
@@ -26,7 +26,7 @@ function useComposerColumnFrameContext(componentName: string) {
   const insideComposerColumnFrame = useContext(ComposerColumnFrameContext);
   if (import.meta.env.DEV && !insideComposerColumnFrame) {
     console.warn(
-      `${componentName} must render inside ComposerColumnFrame so stacked activity stays at 11/12 of the composer input width.`,
+      `${componentName} must render inside ComposerColumnFrame so stacked activity stays aligned to the composer input width.`,
     );
   }
   return insideComposerColumnFrame;
@@ -56,7 +56,7 @@ interface ComposerStackedHeaderFrameProps extends HTMLAttributes<HTMLDivElement>
   passthroughSideMargins?: boolean;
 }
 
-/** 11/12-width rail for panels stacked flush above the composer input. */
+/** Full-width rail for panels stacked flush above the composer input. */
 export const ComposerStackedHeaderFrame = memo(function ComposerStackedHeaderFrame({
   children,
   className,

--- a/apps/web/src/components/chat/composerPickerStyles.ts
+++ b/apps/web/src/components/chat/composerPickerStyles.ts
@@ -108,13 +108,13 @@ export const COMPOSER_COLUMN_FRAME_CLASS_NAME = CHAT_COLUMN_FRAME_CLASS_NAME;
 
 /**
  * Frame for rows stacked above the composer (queued steer/queue rows, active task
- * list). Keeps stacked activity on the same 11/12-width rail as queued rows so
- * the composer input can remain a distinct, fully rounded surface underneath.
+ * list). Keeps stacked activity on the same width as the composer input so wide
+ * screens do not make plan/task rows drift wider than the field they belong to.
  *
  * Prefer ComposerStackedPanel inside ComposerColumnFrame instead of using this
  * token directly so chrome and attached-radius behavior stay centralized.
  */
-export const COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME = "mx-auto -mb-px w-11/12 min-w-0";
+export const COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME = "mx-auto -mb-px w-full min-w-0";
 
 /** Opaque base behind the composer shell: the composer overlaps the scrolling
  *  transcript (`-mt-5`), so without a solid backing the frosted surface would let

--- a/apps/web/src/components/chat/composerStackedHeaderFrame.test.ts
+++ b/apps/web/src/components/chat/composerStackedHeaderFrame.test.ts
@@ -8,13 +8,13 @@ import { describe, expect, it } from "vitest";
 import { COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME } from "./composerPickerStyles";
 
 describe("COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME", () => {
-  it("keeps the stacked rail narrower than the composer column", () => {
+  it("keeps the stacked rail aligned to the composer column", () => {
     const classes = COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME.split(/\s+/);
 
     expect(classes).toContain("mx-auto");
     expect(classes).toContain("-mb-px");
-    expect(classes).toContain("w-11/12");
+    expect(classes).toContain("w-full");
     expect(classes).toContain("min-w-0");
-    expect(classes).not.toContain("w-full");
+    expect(classes).not.toContain("w-11/12");
   });
 });

--- a/apps/web/src/components/chat/environment/EnvironmentPanel.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentPanel.tsx
@@ -12,6 +12,7 @@ import type {
   EditorId,
   MessageId,
   PinnedMessage,
+  ProjectId,
   ProviderKind,
   ResolvedKeybindingsConfig,
   ThreadId,
@@ -40,6 +41,7 @@ import { EnvironmentLocalServersSection } from "./EnvironmentLocalServersSection
 import { EnvironmentMarkersSection } from "./EnvironmentMarkersSection";
 import { EnvironmentNotesSection } from "./EnvironmentNotesSection";
 import { EnvironmentPinnedSection } from "./EnvironmentPinnedSection";
+import { EnvironmentProjectInstructionsSection } from "./EnvironmentProjectInstructionsSection";
 import { ENVIRONMENT_PANEL_RECAP_MARKDOWN_CLASS_NAME } from "./environmentPanelStyles";
 import {
   ENVIRONMENT_ROW_ICON_CLASS_NAME,
@@ -107,6 +109,16 @@ export interface EnvironmentPanelProps {
   markerMessageTextById: ReadonlyMap<MessageId, string>;
   /** Per-thread freeform scratchpad notes (server-synced). */
   notes: string;
+  /** Active project whose local instructions should be edited. */
+  activeProjectId: ProjectId | null;
+  /** Per-project freeform instructions, persisted locally and optionally copied into notes. */
+  projectInstructions: string;
+  /** Whether the current thread is server-backed enough to accept notepad updates. */
+  canCopyProjectInstructionsToNotes: boolean;
+  /** Persist local project instruction edits. */
+  onProjectInstructionsChange: (projectId: ProjectId, instructions: string) => void;
+  /** Copy/append current project instructions into the active thread's notepad. */
+  onCopyProjectInstructionsToNotes: () => void;
   /** Toggle the Diff panel/route (same handler the header diff toggle used). */
   onToggleDiff: () => void;
   /** Open the repository URL in the in-app browser panel. */
@@ -187,6 +199,11 @@ export function EnvironmentPanel({
   pinnedMessageTextById,
   markerMessageTextById,
   notes,
+  activeProjectId,
+  projectInstructions,
+  canCopyProjectInstructionsToNotes,
+  onProjectInstructionsChange,
+  onCopyProjectInstructionsToNotes,
   onToggleDiff,
   onOpenGithubRepository,
   onJumpToPinnedMessage,
@@ -325,6 +342,21 @@ export function EnvironmentPanel({
             onToggleDone={onToggleThreadMarkerDone}
             onRemove={onRemoveThreadMarker}
             onRename={onRenameThreadMarker}
+          />
+        </>
+      ) : null}
+
+      {settings.showEnvironmentInstructions && activeProjectId ? (
+        <>
+          <EnvironmentSectionDivider />
+          <EnvironmentProjectInstructionsSection
+            key={activeProjectId}
+            projectId={activeProjectId}
+            instructions={projectInstructions}
+            threadNotes={notes}
+            canCopyToThreadNotes={canCopyProjectInstructionsToNotes}
+            onInstructionsChange={onProjectInstructionsChange}
+            onCopyToThreadNotes={onCopyProjectInstructionsToNotes}
           />
         </>
       ) : null}

--- a/apps/web/src/components/chat/environment/EnvironmentProjectInstructionsSection.browser.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentProjectInstructionsSection.browser.tsx
@@ -1,0 +1,58 @@
+// FILE: EnvironmentProjectInstructionsSection.browser.tsx
+// Purpose: Browser-level regression tests for project instructions autosave behavior.
+// Layer: Vitest browser tests
+
+import "../../../index.css";
+
+import { ProjectId } from "@t3tools/contracts";
+import { useState } from "react";
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { EnvironmentProjectInstructionsSection } from "./EnvironmentProjectInstructionsSection";
+
+const PROJECT_A = ProjectId.makeUnsafe("project-instructions-a");
+const PROJECT_B = ProjectId.makeUnsafe("project-instructions-b");
+
+describe("EnvironmentProjectInstructionsSection", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("flushes pending edits to the original project before switching projects", async () => {
+    const onInstructionsChange = vi.fn();
+
+    function ProjectSwitchHarness() {
+      const [projectId, setProjectId] = useState<ProjectId>(PROJECT_A);
+      return (
+        <>
+          <button type="button" onClick={() => setProjectId(PROJECT_B)}>
+            Switch project
+          </button>
+          <EnvironmentProjectInstructionsSection
+            projectId={projectId}
+            instructions={
+              projectId === PROJECT_A ? "Saved instructions for A" : "Saved instructions for B"
+            }
+            threadNotes=""
+            canCopyToThreadNotes
+            onInstructionsChange={onInstructionsChange}
+            onCopyToThreadNotes={vi.fn()}
+          />
+        </>
+      );
+    }
+
+    await render(<ProjectSwitchHarness />);
+
+    await page.getByPlaceholder("Architecture notes, conventions, repo links").fill("Draft for A");
+    await page.getByRole("button", { name: "Switch project" }).click();
+
+    expect(onInstructionsChange).toHaveBeenCalledWith(PROJECT_A, "Draft for A");
+    expect(onInstructionsChange).not.toHaveBeenCalledWith(PROJECT_B, "Draft for A");
+    expect(document.querySelector<HTMLTextAreaElement>("textarea")?.value).toBe(
+      "Saved instructions for B",
+    );
+  });
+});

--- a/apps/web/src/components/chat/environment/EnvironmentProjectInstructionsSection.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentProjectInstructionsSection.tsx
@@ -92,30 +92,33 @@ function useProjectInstructionsAutosave({
     };
   }, [flush]);
 
-  const handleChange = useCallback<ChangeEventHandler<HTMLTextAreaElement>>((event) => {
-    const nextValue = event.target.value;
-    valueRef.current = nextValue;
-    setValue(nextValue);
-    const currentProjectId = projectIdRef.current;
-    if (!currentProjectId) {
-      pendingSaveRef.current = null;
+  const handleChange = useCallback<ChangeEventHandler<HTMLTextAreaElement>>(
+    (event) => {
+      const nextValue = event.target.value;
+      valueRef.current = nextValue;
+      setValue(nextValue);
+      const currentProjectId = projectIdRef.current;
+      if (!currentProjectId) {
+        pendingSaveRef.current = null;
+        if (debounceRef.current !== null) {
+          window.clearTimeout(debounceRef.current);
+          debounceRef.current = null;
+        }
+        return;
+      }
+      // Keep the project id with the pending payload; active projects can switch before debounce fires.
+      pendingSaveRef.current = {
+        projectId: currentProjectId,
+        value: nextValue,
+        lastCommitted: lastCommittedRef.current,
+      };
       if (debounceRef.current !== null) {
         window.clearTimeout(debounceRef.current);
-        debounceRef.current = null;
       }
-      return;
-    }
-    // Keep the project id with the pending payload; active projects can switch before debounce fires.
-    pendingSaveRef.current = {
-      projectId: currentProjectId,
-      value: nextValue,
-      lastCommitted: lastCommittedRef.current,
-    };
-    if (debounceRef.current !== null) {
-      window.clearTimeout(debounceRef.current);
-    }
-    debounceRef.current = window.setTimeout(flush, PROJECT_INSTRUCTIONS_AUTOSAVE_DEBOUNCE_MS);
-  }, [flush]);
+      debounceRef.current = window.setTimeout(flush, PROJECT_INSTRUCTIONS_AUTOSAVE_DEBOUNCE_MS);
+    },
+    [flush],
+  );
 
   return {
     value,

--- a/apps/web/src/components/chat/environment/EnvironmentProjectInstructionsSection.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentProjectInstructionsSection.tsx
@@ -1,0 +1,183 @@
+// FILE: EnvironmentProjectInstructionsSection.tsx
+// Purpose: Environment-panel section for project-scoped instructions that seed thread notes.
+// Layer: Environment panel section
+// Exports: EnvironmentProjectInstructionsSection
+
+import { useCallback, useEffect, useRef, useState, type ChangeEventHandler } from "react";
+import { THREAD_NOTES_MAX_CHARS, type ProjectId } from "@t3tools/contracts";
+
+import { Textarea } from "~/components/ui/textarea";
+import { Button } from "~/components/ui/button";
+import { CopyIcon } from "~/lib/icons";
+
+import { EnvironmentCollapsibleSection } from "./EnvironmentRow";
+
+const PROJECT_INSTRUCTIONS_AUTOSAVE_DEBOUNCE_MS = 500;
+
+interface PendingProjectInstructionsSave {
+  readonly projectId: ProjectId;
+  readonly value: string;
+  readonly lastCommitted: string;
+}
+
+function useProjectInstructionsAutosave({
+  projectId,
+  instructions,
+  onChange,
+}: {
+  readonly projectId: ProjectId | null;
+  readonly instructions: string;
+  readonly onChange: (projectId: ProjectId, instructions: string) => void;
+}) {
+  const [value, setValue] = useState(instructions);
+  const [focused, setFocused] = useState(false);
+  const debounceRef = useRef<number | null>(null);
+  const valueRef = useRef(value);
+  const lastCommittedRef = useRef(instructions);
+  const projectIdRef = useRef(projectId);
+  const pendingSaveRef = useRef<PendingProjectInstructionsSave | null>(null);
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    valueRef.current = value;
+  }, [value]);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  const flush = useCallback(() => {
+    if (debounceRef.current !== null) {
+      window.clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    const pendingSave = pendingSaveRef.current;
+    pendingSaveRef.current = null;
+    if (pendingSave === null || pendingSave.value === pendingSave.lastCommitted) {
+      return;
+    }
+    onChangeRef.current(pendingSave.projectId, pendingSave.value);
+    if (projectIdRef.current === pendingSave.projectId) {
+      lastCommittedRef.current = pendingSave.value;
+    }
+  }, []);
+
+  useEffect(() => {
+    const projectChanged = projectIdRef.current !== projectId;
+    if (projectChanged) {
+      flush();
+      projectIdRef.current = projectId;
+      pendingSaveRef.current = null;
+      valueRef.current = instructions;
+      lastCommittedRef.current = instructions;
+      setValue(instructions);
+      return;
+    }
+    projectIdRef.current = projectId;
+    if (
+      !focused &&
+      debounceRef.current === null &&
+      pendingSaveRef.current === null &&
+      instructions !== valueRef.current
+    ) {
+      valueRef.current = instructions;
+      lastCommittedRef.current = instructions;
+      setValue(instructions);
+    }
+  }, [flush, focused, instructions, projectId]);
+
+  useEffect(() => {
+    return () => {
+      flush();
+    };
+  }, [flush]);
+
+  const handleChange = useCallback<ChangeEventHandler<HTMLTextAreaElement>>((event) => {
+    const nextValue = event.target.value;
+    valueRef.current = nextValue;
+    setValue(nextValue);
+    const currentProjectId = projectIdRef.current;
+    if (!currentProjectId) {
+      pendingSaveRef.current = null;
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      return;
+    }
+    // Keep the project id with the pending payload; active projects can switch before debounce fires.
+    pendingSaveRef.current = {
+      projectId: currentProjectId,
+      value: nextValue,
+      lastCommitted: lastCommittedRef.current,
+    };
+    if (debounceRef.current !== null) {
+      window.clearTimeout(debounceRef.current);
+    }
+    debounceRef.current = window.setTimeout(flush, PROJECT_INSTRUCTIONS_AUTOSAVE_DEBOUNCE_MS);
+  }, [flush]);
+
+  return {
+    value,
+    onChange: handleChange,
+    onFocus: () => setFocused(true),
+    onBlur: () => {
+      setFocused(false);
+      flush();
+    },
+  };
+}
+
+export function EnvironmentProjectInstructionsSection({
+  projectId,
+  instructions,
+  threadNotes,
+  canCopyToThreadNotes,
+  onInstructionsChange,
+  onCopyToThreadNotes,
+}: {
+  projectId: ProjectId | null;
+  instructions: string;
+  threadNotes: string;
+  canCopyToThreadNotes: boolean;
+  onInstructionsChange: (projectId: ProjectId, instructions: string) => void;
+  onCopyToThreadNotes: () => void;
+}) {
+  const autosave = useProjectInstructionsAutosave({
+    projectId,
+    instructions,
+    onChange: onInstructionsChange,
+  });
+  const hasInstructions = autosave.value.trim().length > 0;
+  const copyLabel = threadNotes.trim().length === 0 ? "Copy to notepad" : "Append to notepad";
+
+  return (
+    <EnvironmentCollapsibleSection label="Project instructions" defaultOpen={hasInstructions}>
+      <div className="flex flex-col gap-2 px-2 pb-1">
+        <Textarea
+          unstyled
+          className="relative inline-flex w-full rounded-lg border border-[color:var(--color-border-light)] bg-transparent text-[length:var(--app-font-size-ui,12px)] text-foreground transition-colors has-focus-visible:border-foreground/25 [&_[data-slot=textarea]]:px-3 [&_[data-slot=textarea]]:py-2"
+          value={autosave.value}
+          onChange={autosave.onChange}
+          onFocus={autosave.onFocus}
+          onBlur={autosave.onBlur}
+          placeholder="Architecture notes, conventions, repo links"
+          maxLength={THREAD_NOTES_MAX_CHARS}
+          disabled={!projectId}
+        />
+        {hasInstructions && canCopyToThreadNotes ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="self-start"
+            onClick={onCopyToThreadNotes}
+          >
+            <CopyIcon className="size-3.5" />
+            {copyLabel}
+          </Button>
+        ) : null}
+      </div>
+    </EnvironmentCollapsibleSection>
+  );
+}

--- a/apps/web/src/lib/codeFence.test.ts
+++ b/apps/web/src/lib/codeFence.test.ts
@@ -31,6 +31,18 @@ describe("parseCodeFenceInfo", () => {
     });
   });
 
+  it("treats a Windows-style bare path as a file reference", () => {
+    const fence = parseCodeFenceInfo("src\\components\\Button.tsx");
+    expect(fence).toMatchObject({
+      isFileReference: true,
+      filePath: "src\\components\\Button.tsx",
+      fileName: "Button.tsx",
+      directory: "src\\components",
+      lineRange: null,
+      language: "tsx",
+    });
+  });
+
   it("resolves a language for files without a directory", () => {
     const fence = parseCodeFenceInfo("12:20:Dockerfile");
     expect(fence.isFileReference).toBe(true);
@@ -47,8 +59,25 @@ describe("parseCodeFenceInfo", () => {
     });
   });
 
+  it("trims whitespace around bare language tokens", () => {
+    expect(parseCodeFenceInfo("  python  ")).toMatchObject({
+      isFileReference: false,
+      language: "python",
+      filePath: null,
+    });
+  });
+
+  it("keeps root-level filename-looking tokens as language tokens", () => {
+    expect(parseCodeFenceInfo("package.json")).toMatchObject({
+      isFileReference: false,
+      language: "package.json",
+      filePath: null,
+    });
+  });
+
   it("falls back to text for an empty info string and maps gitignore to ini", () => {
     expect(parseCodeFenceInfo("").language).toBe("text");
+    expect(parseCodeFenceInfo("   ").language).toBe("text");
     expect(parseCodeFenceInfo("gitignore").language).toBe("ini");
   });
 
@@ -75,5 +104,18 @@ describe("dedentCode", () => {
 
   it("leaves single-line snippets untouched when flush", () => {
     expect(dedentCode("const value = 42;")).toBe("const value = 42;");
+  });
+
+  it("dedents a single indented line", () => {
+    expect(dedentCode("    const value = 42;")).toBe("const value = 42;");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(dedentCode("")).toBe("");
+  });
+
+  it("handles tab indentation", () => {
+    const input = ["\t\talpha();", "\t\tbeta();"].join("\n");
+    expect(dedentCode(input)).toBe(["alpha();", "beta();"].join("\n"));
   });
 });

--- a/apps/web/src/lib/lruCache.test.ts
+++ b/apps/web/src/lib/lruCache.test.ts
@@ -40,4 +40,79 @@ describe("LRUCache", () => {
     expect(cache.get("b")).toBe("B");
     expect(cache.get("c")).toBe("C");
   });
+
+  it("correctly tracks size when overwriting an existing key", () => {
+    const cache = new LRUCache<string>(5, 100);
+    cache.set("a", "A", 10);
+    cache.set("a", "AA", 30);
+    cache.set("b", "B", 10);
+    cache.set("c", "C", 10);
+    cache.set("d", "D", 10);
+    cache.set("e", "E", 10);
+
+    expect(cache.get("a")).toBe("AA");
+    expect(cache.get("b")).toBe("B");
+    expect(cache.get("c")).toBe("C");
+    expect(cache.get("d")).toBe("D");
+    expect(cache.get("e")).toBe("E");
+  });
+
+  it("clear empties the cache and resets size", () => {
+    const cache = new LRUCache<string>(5, 100);
+    cache.set("a", "A", 10);
+    cache.set("b", "B", 10);
+    cache.clear();
+
+    expect(cache.get("a")).toBeNull();
+    expect(cache.get("b")).toBeNull();
+    cache.set("c", "C", 10);
+    expect(cache.get("c")).toBe("C");
+  });
+
+  it("handles maxEntries of 1", () => {
+    const cache = new LRUCache<string>(1, 100);
+    cache.set("a", "A", 10);
+    cache.set("b", "B", 10);
+
+    expect(cache.get("a")).toBeNull();
+    expect(cache.get("b")).toBe("B");
+  });
+
+  it("evicts enough entries when a large item is inserted", () => {
+    const cache = new LRUCache<number>(10, 50);
+    cache.set("a", 1, 10);
+    cache.set("b", 2, 10);
+    cache.set("c", 3, 10);
+    cache.set("d", 4, 10);
+    cache.set("e", 5, 40);
+
+    expect(cache.get("a")).toBeNull();
+    expect(cache.get("b")).toBeNull();
+    expect(cache.get("c")).toBeNull();
+    expect(cache.get("d")).toBe(4);
+    expect(cache.get("e")).toBe(5);
+  });
+
+  it("get on existing key does not change cache entry count", () => {
+    const cache = new LRUCache<string>(2, 1_000);
+    cache.set("a", "A", 10);
+    cache.set("b", "B", 10);
+
+    expect(cache.get("a")).toBe("A");
+    cache.set("c", "C", 10);
+    expect(cache.get("a")).toBe("A");
+    expect(cache.get("b")).toBeNull();
+    expect(cache.get("c")).toBe("C");
+  });
+
+  it("does not evict when within both entry and memory limits", () => {
+    const cache = new LRUCache<string>(5, 100);
+    cache.set("a", "A", 10);
+    cache.set("b", "B", 10);
+    cache.set("c", "C", 10);
+
+    expect(cache.get("a")).toBe("A");
+    expect(cache.get("b")).toBe("B");
+    expect(cache.get("c")).toBe("C");
+  });
 });

--- a/apps/web/src/lib/relativeTime.test.ts
+++ b/apps/web/src/lib/relativeTime.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRelativeTime } from "./relativeTime";
+
+describe("formatRelativeTime", () => {
+  it('returns "now" for timestamps less than 1 minute ago', () => {
+    const iso = new Date(Date.now() - 30_000).toISOString();
+    expect(formatRelativeTime(iso)).toBe("now");
+  });
+
+  it("returns minutes for timestamps under an hour", () => {
+    const iso = new Date(Date.now() - 5 * 60_000).toISOString();
+    expect(formatRelativeTime(iso)).toBe("5m");
+  });
+
+  it("returns hours for timestamps under a day", () => {
+    const iso = new Date(Date.now() - 3 * 60 * 60_000).toISOString();
+    expect(formatRelativeTime(iso)).toBe("3h");
+  });
+
+  it("returns days for timestamps over a day", () => {
+    const iso = new Date(Date.now() - 2 * 24 * 60 * 60_000).toISOString();
+    expect(formatRelativeTime(iso)).toBe("2d");
+  });
+
+  it('returns "now" for future timestamps caused by clock skew', () => {
+    const iso = new Date(Date.now() + 60_000).toISOString();
+    expect(formatRelativeTime(iso)).toBe("now");
+  });
+});

--- a/apps/web/src/lib/relativeTime.ts
+++ b/apps/web/src/lib/relativeTime.ts
@@ -3,7 +3,7 @@
 // Layer: Web UI utility
 
 export function formatRelativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
+  const diff = Math.max(0, Date.now() - new Date(iso).getTime());
   const minutes = Math.floor(diff / 60_000);
   if (minutes < 1) return "now";
   if (minutes < 60) return `${minutes}m`;

--- a/apps/web/src/projectInstructionsStore.test.ts
+++ b/apps/web/src/projectInstructionsStore.test.ts
@@ -1,0 +1,80 @@
+// FILE: projectInstructionsStore.test.ts
+// Purpose: Verifies project instructions merge into thread notes without clobbering user text.
+// Layer: UI state store test
+
+import { describe, expect, it } from "vitest";
+
+import { mergeProjectInstructionsIntoThreadNotes } from "./projectInstructionsStore";
+
+describe("mergeProjectInstructionsIntoThreadNotes", () => {
+  it("leaves notes unchanged when project instructions are empty", () => {
+    expect(
+      mergeProjectInstructionsIntoThreadNotes({
+        threadNotes: "Keep this thread focused on tests.",
+        projectInstructions: "   ",
+      }),
+    ).toBe("Keep this thread focused on tests.");
+  });
+
+  it("uses project instructions as notes when the thread notepad is empty", () => {
+    expect(
+      mergeProjectInstructionsIntoThreadNotes({
+        threadNotes: "",
+        projectInstructions: "Prefer small focused changes.",
+      }),
+    ).toBe("Prefer small focused changes.");
+  });
+
+  it("appends instructions as a separate block", () => {
+    expect(
+      mergeProjectInstructionsIntoThreadNotes({
+        threadNotes: "Thread-specific note.",
+        projectInstructions: "Prefer small focused changes.",
+      }),
+    ).toBe("Thread-specific note.\n\nPrefer small focused changes.");
+  });
+
+  it("does not append an exact instruction block twice", () => {
+    const notes = "Thread-specific note.\n\nPrefer small focused changes.";
+
+    expect(
+      mergeProjectInstructionsIntoThreadNotes({
+        threadNotes: notes,
+        projectInstructions: "Prefer small focused changes.",
+      }),
+    ).toBe(notes);
+  });
+
+  it("matches exact instruction blocks across CRLF notes", () => {
+    const notes = "Thread-specific note.\r\n\r\nPrefer small focused changes.";
+
+    expect(
+      mergeProjectInstructionsIntoThreadNotes({
+        threadNotes: notes,
+        projectInstructions: "Prefer small focused changes.",
+      }),
+    ).toBe(notes);
+  });
+
+  it("treats punctuation in instructions as literal text", () => {
+    const notes = "Thread-specific note.\n\nUse foo.*[bar]? literally.";
+
+    expect(
+      mergeProjectInstructionsIntoThreadNotes({
+        threadNotes: notes,
+        projectInstructions: "Use foo.*[bar]? literally.",
+      }),
+    ).toBe(notes);
+  });
+
+  it("does append when the instructions only appear as a substring", () => {
+    expect(
+      mergeProjectInstructionsIntoThreadNotes({
+        threadNotes: "Thread-specific note: prefer small focused changes when possible.",
+        projectInstructions: "prefer small focused changes",
+      }),
+    ).toBe(
+      "Thread-specific note: prefer small focused changes when possible.\n\nprefer small focused changes",
+    );
+  });
+});

--- a/apps/web/src/projectInstructionsStore.ts
+++ b/apps/web/src/projectInstructionsStore.ts
@@ -1,0 +1,84 @@
+// FILE: projectInstructionsStore.ts
+// Purpose: Persist per-project instructions and merge them into thread notes when requested.
+// Layer: Web UI state store
+// Exports: useProjectInstructionsStore, mergeProjectInstructionsIntoThreadNotes
+
+import type { ProjectId } from "@t3tools/contracts";
+import { clampThreadNotes } from "@t3tools/shared/pinnedMessages";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+const PROJECT_INSTRUCTIONS_STORAGE_KEY = "synara:project-instructions:v1";
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function threadNotesContainInstructionBlock(threadNotes: string, instructions: string): boolean {
+  const current = threadNotes.replace(/\r\n/g, "\n").trim();
+  if (current.length === 0) {
+    return false;
+  }
+  const normalizedInstructions = instructions.replace(/\r\n/g, "\n").trim();
+  const exactBlockPattern = new RegExp(
+    `(?:^|\\n\\n)${escapeRegExp(normalizedInstructions)}(?:\\n\\n|$)`,
+  );
+  return exactBlockPattern.test(current);
+}
+
+interface ProjectInstructionsStore {
+  /** Freeform instructions keyed by orchestration project id. */
+  instructionsByProjectId: Record<string, string>;
+  /** Set or replace a project's instructions; empty strings clear persisted clutter. */
+  setInstructions: (projectId: ProjectId, instructions: string) => void;
+  /** Clear a project's instructions. */
+  clearInstructions: (projectId: ProjectId) => void;
+}
+
+export const useProjectInstructionsStore = create<ProjectInstructionsStore>()(
+  persist(
+    (set) => ({
+      instructionsByProjectId: {},
+      setInstructions: (projectId, instructions) =>
+        set((state) => {
+          const next = { ...state.instructionsByProjectId };
+          const clamped = clampThreadNotes(instructions);
+          if (clamped.trim().length === 0) {
+            delete next[projectId];
+          } else {
+            next[projectId] = clamped;
+          }
+          return { instructionsByProjectId: next };
+        }),
+      clearInstructions: (projectId) =>
+        set((state) => {
+          const next = { ...state.instructionsByProjectId };
+          delete next[projectId];
+          return { instructionsByProjectId: next };
+        }),
+    }),
+    {
+      name: PROJECT_INSTRUCTIONS_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
+
+// Appends project instructions without clobbering thread notes a user already wrote.
+export function mergeProjectInstructionsIntoThreadNotes(input: {
+  readonly threadNotes: string;
+  readonly projectInstructions: string;
+}): string {
+  const instructions = input.projectInstructions.trim();
+  if (instructions.length === 0) {
+    return input.threadNotes;
+  }
+  const current = input.threadNotes.trim();
+  if (current.length === 0) {
+    return clampThreadNotes(instructions);
+  }
+  if (threadNotesContainInstructionBlock(current, instructions)) {
+    return input.threadNotes;
+  }
+  return clampThreadNotes(`${input.threadNotes.trimEnd()}\n\n${instructions}`);
+}

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -1726,6 +1726,14 @@ function SettingsRouteView() {
           })}
 
           {renderBooleanSettingRow({
+            settingKey: "showEnvironmentInstructions",
+            title: "Project instructions",
+            description: "Show project-level instructions in the Environment panel.",
+            resetLabel: "project instructions section",
+            ariaLabel: "Show the Project instructions section in the Environment panel",
+          })}
+
+          {renderBooleanSettingRow({
             settingKey: "showEnvironmentNotepad",
             title: "Notepad",
             description: "Show the per-thread notepad in the Environment panel.",


### PR DESCRIPTION
## Summary

This is a curated rescue of the best recent PR ideas, folded into one branch with the broken/risky pieces fixed instead of cherry-picked blindly. It includes the good `arjunkshah` ideas plus the worthwhile recent `matdac12` fixes (#194, #195, #196).

## What changed

- Added project-level instructions in the Environment panel, persisted per project in localStorage.
- Seeds new server-backed thread notes from saved project instructions on first send.
- Adds a safe manual copy/append action into the thread notepad for existing saved threads.
- Added an Environment settings toggle for the new Project instructions section.
- Clamped future relative-time labels to `now` for clock-skewed timestamps.
- Replaced raw Codex app-server `console.log` diagnostics with the existing structured logger.
- Improved Diff panel git repository detection failures so unexpected branch-query errors stop showing an infinite spinner without pretending they are non-repo directories.
- Prefer PowerShell for new Windows terminal sessions, while keeping ComSpec/cmd.exe fallbacks.
- Stopped replaying terminal mouse tracking modes on renderer reattach, preventing restored terminals from printing raw mouse escape sequences after app restart.
- Aligned composer-stacked plan/task rows to the composer input width on wide layouts.
- Added corrected focused coverage for `codeFence`, `LRUCache`, `relativeTime`, project instructions, composer stacked header sizing, Windows shell ordering, and terminal mode replay edge cases.

## Notes on intentionally skipped ideas

I did not include the unconditional credential `console.warn` changes. Missing auth files and keychain entries are expected during provider usage probing, so that version would make normal states noisy. If we want that observability later, it should be scoped/debug-level or warn only on unexpected failures.

## Validation

- `git diff --check origin/main...HEAD` passed.
- `bun run --cwd apps/server test src/terminal/Layers/Manager.test.ts src/terminal/terminalModeReplay.test.ts` passed.
- `bun run --cwd apps/web test src/components/chat/ComposerColumnFrame.test.tsx src/components/chat/composerStackedHeaderFrame.test.ts src/projectInstructionsStore.test.ts src/lib/relativeTime.test.ts src/lib/lruCache.test.ts src/lib/codeFence.test.ts` passed.
- `bun run --cwd apps/web test:browser src/components/chat/environment/EnvironmentProjectInstructionsSection.browser.tsx src/components/chat/environment/EnvironmentNotesSection.browser.tsx` passed.

Draft until a full dependency-backed fmt/lint/typecheck pass runs.