### PR TITLE
Add local profile stats and soft-delete thread retention

### DIFF
--- a/.plans/profile-data-source-audit.md
+++ b/.plans/profile-data-source-audit.md
@@ -1,0 +1,78 @@
+# Audit (READ-ONLY): Profile stats data-source scoping — make it production-correct, no dev/prod mixing
+
+You are GPT-5.5 (xhigh) in the Synara monorepo at `/Users/emanueledipietro/Developer/synara`.
+This is a **diagnosis / research task — DO NOT EDIT ANY FILES.** Produce a findings report + options.
+We (you + Claude/Opus + the user) will decide the fix together afterward.
+
+## The problem to investigate
+
+The new Profile/stats feature must respect each instance's OWN folders: the **real app** must read the
+real app's data, a **dev** instance must read the dev instance's data — NEVER a mix. It is going to
+production, so the resolution of every data source must be correct and consistent with how the rest of
+the app already resolves those sources.
+
+## What we already verified (trust these; confirm + go deeper)
+
+- `config.homeDir` = `OS.homedir()` ALWAYS (`apps/server/src/main.ts:172,217`) — it is NOT affected by
+  `--home-dir`.
+- `config.baseDir` = `--home-dir` / `SYNARA_HOME` (dev: `./.synara/electron-dev`; prod: `~/.synara` or
+  `~/Documents/Synara`). `config.dbPath` = `baseDir/{dev|userdata}/state.sqlite`.
+- So the **projection DB is correctly per-instance** (dev→dev 40 turns, prod→prod 437 turns). ✅
+- The **token archives** are read via `config.homeDir`: codex = `codexHomePath || process.env.CODEX_HOME
+  || homeDir/.codex`; claude = `homeDir/.claude/projects` (see `apps/server/src/providerUsageSnapshot.ts`).
+  Because `homeDir` is always the OS home, BOTH dev and prod read the GLOBAL `~/.codex` and `~/.claude`.
+- The dev runner sets `SYNARA_HOME/DPCODE_HOME/T3CODE_HOME=baseDir` but does NOT set `CODEX_HOME` or
+  `CLAUDE_CONFIG_DIR`; the dev baseDir has no `.codex`/`.claude` of its own. So dev's own Codex/Claude
+  sessions ALSO land in the global `~/.codex`/`~/.claude`.
+- The Usage panel passes a `homePath` (the `codexHomePath` setting = `settings.providers.codex.homePath`)
+  into `server.getProviderUsageSnapshot` (`serverProviderUsageSnapshotQueryOptions`,
+  `useProviderUsageSummary`). The **Profile token RPC does NOT pass `codexHomePath`** — it calls
+  `api.stats.getProfileTokenStats({ utcOffsetMinutes })` only (`serverProfileTokenStatsQueryOptions`).
+  Right now `codexHomePath` is empty so it doesn't bite, but it is a latent divergence.
+
+## Your tasks (with checks)
+
+1. **Build the canonical resolution map.** For the running instance, determine the exact, authoritative
+   way the app resolves each of these (cite file:line):
+   - the projection SQLite DB path
+   - the Codex sessions root (the home the *active Codex provider* actually reads/writes — trace
+     provider start options / `ProviderStartOptions.codex.homePath` / `CODEX_HOME` / settings
+     `providers.codex.homePath`, and `ProviderHealth`/`makeCodexProbeEnv`)
+   - the Claude transcripts root (does anything honor `CLAUDE_CONFIG_DIR`? where does Claude actually
+     write `projects/*.jsonl` for this instance?)
+2. **Diff the Profile against the canonical resolution.** Enumerate every place the Profile's two RPCs
+   (`apps/server/src/profileStats.ts`, the token loaders in `apps/server/src/providerUsageSnapshot.ts`)
+   read a DIFFERENT location than the running instance actually uses, or ignore a setting/env the rest of
+   the app honors. Confirm: does the Profile token RPC ignore `settings.providers.codex.homePath`? Does it
+   ignore `CLAUDE_CONFIG_DIR`? Any hardcoded `~/.codex` / `~/.claude`?
+3. **Characterize the dev/prod "mix".** Confirm precisely which Profile metrics come from `baseDir`
+   (per-instance) vs `OS home` (global), and explain why dev shows small SQL stats next to large real
+   token totals. State whether this is a *correctness bug* in production (prod reads real DB + real
+   archives = consistent?) or only a dev-time artifact.
+4. **Determine the production-correct rule.** Define how the Profile SHOULD resolve codex/claude homes so
+   that it reads EXACTLY what the running instance uses, in BOTH dev and prod, with no mixing. Account for
+   the reality that the codex/claude CLIs write to a global home unless `CODEX_HOME`/`CLAUDE_CONFIG_DIR`
+   are overridden per instance.
+5. **Run the checks** to back every claim:
+   - `sqlite3` on `./.synara/electron-dev/dev/state.sqlite` (dev) and `~/.synara/userdata/state.sqlite`
+     (prod) where relevant.
+   - filesystem checks: existence of `~/.codex/sessions`, `~/.claude/projects`, any baseDir-local
+     `.codex`/`.claude`, the `homePath` value in each `settings.json`.
+   - grep the provider-start / env-injection path to see what home the active provider actually uses.
+
+## Deliverable (NO code edits)
+
+A markdown report with:
+- A **resolution table**: source × (canonical resolution file:line) × (what Profile currently does) ×
+  (dev value) × (prod value) × (mismatch? Y/N).
+- A clear statement of the **production-correct rule**.
+- **2–3 concrete options** to achieve "dev reads dev, prod reads prod, no mixing", each with: exact files
+  to change, tradeoffs, and risk. At minimum cover:
+  (a) make the Profile honor the same codex/claude home resolution as the rest of the app (pass
+      `codexHomePath`, honor `CODEX_HOME`/`CLAUDE_CONFIG_DIR`) — the minimal production-correct fix;
+  (b) fully isolate dev by scoping the codex/claude home to `baseDir` (and what else must change so the
+      dev instance also WRITES its sessions there) — and whether that breaks prod;
+  (c) any hybrid / disclaimer-only approach.
+- A **recommendation** with justification, optimized for production correctness and least risk.
+
+Keep it concrete (exact file:line, exact paths, exact settings keys). Do not edit anything.

--- a/.plans/profile-stats-codex-brief.md
+++ b/.plans/profile-stats-codex-brief.md
@@ -1,0 +1,192 @@
+# Brief: Fix & harden Profile-stats data layer (server + contract + query hooks)
+
+You are GPT-5.5 (xhigh) working in the Synara monorepo at `/Users/emanueledipietro/Developer/synara`.
+A "Profile / stats" feature was just built. The DATA is wrong in three places and the loading is
+slow. Your job is the DATA/LOGIC/PERF layer ONLY. A separate agent (Opus) owns all React UI.
+
+## Strict file ownership — DO NOT TOUCH UI FILES
+
+YOU OWN (edit freely):
+- `packages/contracts/src/stats.ts` (the ProfileStats schemas)
+- `apps/server/src/profileStats.ts` (the SQL stats service)
+- `apps/server/src/providerUsageSnapshot.ts` (token-archive loaders)
+- RPC wiring: `packages/contracts/src/ws.ts`, `packages/contracts/src/rpc.ts`,
+  `packages/contracts/src/ipc.ts`, `apps/web/src/wsNativeApi.ts`, `apps/server/src/wsRpc.ts`
+- `apps/web/src/lib/serverReactQuery.ts` (React Query factory functions ONLY)
+- A new SQLite index migration if you add one (`apps/server/src/persistence/Migrations/*` + register in `Migrations.ts`)
+
+DO NOT TOUCH (Opus owns these — editing them will cause merge conflicts):
+- Anything under `apps/web/src/components/profile/**`
+- `apps/web/src/routes/**`, `apps/web/src/components/Sidebar.tsx`, `apps/web/src/settingsNavigation.ts`,
+  `apps/web/src/routes/_chat.settings.tsx`, `apps/web/src/lib/icons.tsx`
+
+## Two databases to validate against (BOTH have live data)
+
+- BRANCH dev DB (what the dev instance uses): `./.synara/electron-dev/dev/state.sqlite`  (~40 turns)
+- REAL app DB: `~/.synara/userdata/state.sqlite`  (~437 turns, 192 MB) — the important one
+
+Use the `sqlite3` CLI to validate every query against BOTH before and after your change.
+
+## Verified data shapes (trust these; confirm if unsure)
+
+- `projection_turns.requested_at` = ISO-8601 UTC, e.g. `2026-06-14T00:26:11.226Z`.
+  `DATETIME(requested_at, '+02:00')` parses it and shifts to local — VERIFIED working.
+- `projection_threads.model_selection_json` = `{provider, model, options?: {reasoningEffort?|effort?, fastMode?, ...}}`.
+  Codex/Cursor use `options.reasoningEffort`; Claude uses `options.effort`. Many rows have NO options.
+- `projection_thread_messages.skills_json` (role='user') = `[{name, path}]` (slash-command SKILLS), e.g.
+  `[{"name":"check-code","path":".../check-code/SKILL.md"}]`. Sparse (24 of 540 msgs in real DB).
+- `projection_thread_messages.mentions_json` (role='user') = `[{name, path}]` (AGENTS/plugins), e.g.
+  `[{"name":"linear","path":"plugin://linear@openai-curated"}]`. Even sparser but real.
+- `orchestration_events` rows of `event_type='thread.turn-start-requested'` carry
+  `payload_json.modelSelection.{provider, model, options}` PER TURN (the canonical per-turn selection).
+  Also `event_type='thread.message-sent'` carries `payload_json.skills`.
+- `projection_thread_activities` rows with `tone='tool'` have `kind` = generic lifecycle
+  (`tool.started`/`tool.completed`/`tool.updated`) — the skill/command name is NOT in `kind`, it is buried
+  in `payload_json.detail`. DO NOT use this table for skill-name counts. (Investigated and rejected.)
+
+## CONFIRMED BUGS (with evidence) — fix all three
+
+### BUG 1 — reasoning / fast-mode / provider-model are THREAD-weighted, must be PER-TURN
+Current code joins `projection_turns` → `projection_threads.model_selection_json`, i.e. it attributes
+every turn to the thread's CURRENT/last model selection. A thread's selection changes over its life, so
+this is wrong. The correct source is the per-turn snapshot in `orchestration_events` (`thread.turn-start-requested`).
+
+Evidence (real DB):
+- provider per-turn(events): cursor 206 / claudeAgent 148 / codex 91  (total 445)
+- provider thread-weighted:   cursor 205 / claudeAgent 147 / codex 86  (total 438)  ← undercounts, wrong split
+- reasoning per-turn vs thread-weighted distributions differ materially (e.g. xhigh 320 vs 323, max 27 vs 44).
+- fastMode per-turn 156/445 = 35% vs thread-weighted 150/438 = 34%.
+
+FIX: compute provider/model mix, reasoning distribution, and fast-mode % from
+`orchestration_events WHERE event_type='thread.turn-start-requested'`, reading
+`json_extract(payload_json,'$.modelSelection.provider' | '$.modelSelection.model' |
+'$.modelSelection.options.reasoningEffort' | '$.modelSelection.options.effort' | '$.modelSelection.options.fastMode')`.
+When an event has no `modelSelection` (older events), fall back to that thread's current
+`projection_threads.model_selection_json` joined on `payload_json.threadId` (= `stream_id`). Keep
+`COALESCE(reasoningEffort, effort)` for the reasoning label. `topReasoning` = most common NON-null value;
+percent = its share of all per-turn selections that have a reasoning set (decide and document the denominator).
+
+### BUG 2 — skills metric is incomplete (missing agents) and unformatted
+`skills_json` is the right source for SKILLS but it omits AGENTS (`mentions_json`). The reference
+"Most used plugins" mixes `$skill` and `@agent`. Combine both:
+- skills from `projection_thread_messages.skills_json` (role='user') → `kind:"skill"`, displayName `$name`
+- agents from `projection_thread_messages.mentions_json` (role='user') → `kind:"agent"`, displayName `@name`
+Use `json_each(...)` with the same defensive `CASE WHEN json_valid(...) AND json_type(...)='array'` guard
+already in the code. Count occurrences across user messages, group by name+kind, order by count desc.
+Definitions: `skillsExplored` = distinct (name,kind) used; `totalSkillsUsed` = sum of all occurrences.
+`mostUsedSkill` = top row. Keep counts honest — they ARE small (this is correct; the reference numbers are mock).
+
+### BUG 3 — heatmap should be TOKEN activity (per local day), with a turn-count fallback
+The reference titles it "Token activity". The current heatmap uses turn counts and, critically, the
+per-day TOKEN buckets are already computed in `providerUsageSnapshot.ts` (`accumulate*Tokens` builds
+`acc.byDay`) and then THROWN AWAY. Surface them.
+FIX: have the token loader expose a per-LOCAL-day token bucket array (codex + claude), capped to the
+heatmap window (last 371 days). The token-based heatmap is authoritative WHEN token data exists; when a
+user has no readable token archive (cursor/grok/etc.), the UI falls back to the turn-count heatmap.
+So expose BOTH: keep the turn-count heatmap in the fast/core payload (instant, universal) AND add a
+token-based per-day heatmap in the token payload. Each cell: `{day, count, weekday, intensity}` plus
+the metric label.
+
+## PERFORMANCE / LOADING / COMPLEXITY (the second half of the job)
+
+The expensive operation is the JSONL archive walk (`loadLocalProviderUsageTokenStats`) which reads up to
+6000 files fully and sequentially on first load — it blocks the whole RPC, so the page can't paint until
+the disk walk finishes. The SQL is trivially cheap (hundreds of rows). Restructure for fast first paint:
+
+1. SPLIT THE RPC into two:
+   - `stats.getProfileStats` → CORE, SQL-only, returns in <50ms. Streaks, turn-heatmap, active hours,
+     per-turn provider/model mix, per-turn reasoning + fast-mode, skills+agents, prompt/thread totals,
+     identity, local Codex quota (the quota already comes from the cheap local snapshot — keep it, but if
+     it requires the archive walk, move it to the token call). The page renders fully from this.
+   - `stats.getProfileTokenStats` → SLOW, archive-backed: lifetime tokens, peak-day tokens+date,
+     per-day token heatmap (371-day window), providers/unavailableProviders. Cached (reuse the existing
+     5-min TTL + pending-coalescing pattern). The UI shows skeletons for the 2 token tiles and upgrades
+     the heatmap when this resolves.
+2. Make the token walk cheaper:
+   - Parallelize file reads with a bounded concurrency (e.g. 16) instead of the sequential `for await`.
+   - Split "lifetime" (needs all files, last `token_count` per codex session file) from "per-day heatmap"
+     (only needs files within the 371-day window). Don't full-parse window files you don't need.
+   - For codex session files only the LAST `token_count` event matters — you may read from the end of the
+     file rather than parsing every line, if it's a clean win (optional).
+3. SQL perf: the global `GROUP BY day/hour` and `(role,source)` scans have no covering index (only
+   thread-scoped ones exist). Tables are small today so it's fine, but add a lightweight migration with
+   `CREATE INDEX IF NOT EXISTS` on `projection_turns(requested_at) WHERE turn_id IS NOT NULL`,
+   `projection_thread_messages(role, source)`, and an events index on
+   `orchestration_events(event_type)` IF one doesn't already cover it. Register it in `Migrations.ts`.
+   Keep index additions minimal — do not slow the hot insert path needlessly; justify each.
+4. Reduce complexity: the `getProfileStats` Effect is a long single function. Factor the per-metric SQL
+   into small named helpers. Keep every query wrapped in the existing `safeQuery`/`orElseSucceed([])`
+   so one missing column never blanks the card. Keep error channel `never` (graceful degradation).
+
+## PINNED CONTRACT (both you and the UI build to this — keep these exact names)
+
+```ts
+// stats.getProfileStats  (CORE, fast)
+ProfileStats {
+  generatedAt: string
+  timezone: { utcOffsetMinutes: number; today: string }
+  identity: { homeDirBasename: string; initials: string; defaultHandle: string }
+  activity: {
+    currentStreakDays: number; longestStreakDays: number
+    totalPromptsSent: number; totalThreads: number; promptsToday: number
+    heatmapMetric: "turns"                       // core heatmap is always turn-based
+    heatmap: Array<{ day: string; count: number; weekday: number; intensity: number }>
+  }
+  activeHours: { startHour: number|null; endHour: number|null; turnCount: number; label: string|null }
+  insights: {
+    fastModePercent: number|null
+    topReasoning: string|null; topReasoningPercent: number|null
+    skillsExplored: number; totalSkillsUsed: number
+  }
+  providerModels: Array<{ provider: ProviderKind|"unknown"; model: string; turnCount: number; percent: number }>
+  skills: Array<{ name: string; displayName: string; kind: "skill"|"agent"; runCount: number }>
+  mostUsedSkill: { name: string; displayName: string; kind: "skill"|"agent"; runCount: number } | null
+  quota: { status: "available"|"unavailable"; provider: ProviderKind|null; window: string|null;
+           usedPercent: number|null; resetsAt: string|null; planName: string|null }
+}
+
+// stats.getProfileTokenStats(input: { utcOffsetMinutes: number; codexHomePath?: string })  (SLOW, archive)
+ProfileTokenStats {
+  available: boolean
+  lifetimeTotalTokens: number|null
+  peakDayTokens: number|null
+  peakDay: string|null                            // YYYY-MM-DD
+  providers: ProviderKind[]
+  unavailableProviders: ProviderKind[]
+  heatmapMetric: "tokens"
+  heatmap: Array<{ day: string; count: number; weekday: number; intensity: number }>  // tokens/day, 371d window
+}
+```
+
+Notes:
+- Move the quota into whichever call keeps the CORE call fast & network-free. Quota MUST stay on-device
+  (read from the local Codex session archive's `rate_limits`, as today) — NEVER call provider HTTP APIs.
+- Keep `StatsGetProfileStatsInput { utcOffsetMinutes: number; codexHomePath?: string }`.
+- Intensity = 0..4 bucket relative to the window max (keep the existing helper).
+- `heatmap[].weekday` = 0..6 (Sun..Sat); cells span the trailing 371 local days inclusive of today.
+
+## Effect / codebase idioms to follow
+
+- Service: `ProfileStatsQuery` is a `ServiceMap.Service` with `Layer.effect`, wired in
+  `serverLayers.ts` already. Add the token call either to the same service or a sibling — your choice —
+  but keep it provided through `makeServerRuntimeServicesLayer` and yielded in `makeWsRpcLayer`.
+- RPC: follow the existing `Rpc.make(...)` + `WsRpcGroup.make(...)` + `WS_METHODS` + `tagRequestBody` +
+  `NativeApi` + `wsNativeApi.ts transport.request` pattern exactly (the existing `stats.getProfileStats`
+  is your template — add `stats.getProfileTokenStats` the same way).
+- React Query: in `serverReactQuery.ts` add `serverProfileTokenStatsQueryOptions()` next to the existing
+  `serverProfileStatsQueryOptions()`. Keep both keyed by `utcOffsetMinutes`. The UI will call both.
+- Use `sql<{ readonly col: type }>\`...\`` typed raw queries (see existing code). Bind the tz modifier as
+  a parameter (`${tz}`) — verified that SQLite accepts it inside `DATETIME(col, ?)`.
+- `noUncheckedIndexedAccess` is ON — guard array index access.
+
+## Validation (do this before declaring done)
+
+1. For each fixed metric, run the OLD vs NEW SQL against BOTH DBs with `sqlite3` and paste the numbers in
+   your summary, showing the per-turn vs thread-weighted difference is resolved.
+2. `npx turbo run typecheck --filter=@t3tools/contracts --filter=t3` must pass. DO NOT run the web
+   (`@t3tools/web`) typecheck — its UI is being rewritten in parallel and will be red until Opus finishes.
+3. `bun fmt` and `bun lint` (lint must have 0 errors; warnings ok). NEVER run `bun test`.
+4. In your final summary, document: the exact final `ProfileStats` + `ProfileTokenStats` field list, the
+   exact exported query-factory names in `serverReactQuery.ts`, and any contract deviation from the pin.
+
+Take your time; correctness of the per-turn attribution and the fast-first-paint split are the priorities.

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -303,7 +303,7 @@ const makeServerProgram = (input: CliInput) =>
     const orchestrationEngine = yield* OrchestrationEngineService;
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
     // Start the retention loop after the server is live so startup can serve
-    // existing history first, then prune inactive threads in the background.
+    // existing history first, then hide inactive threads from the app in the background.
     yield* startThreadRetentionJob(orchestrationEngine, projectionSnapshotQuery);
     yield* Effect.forkChild(recordStartupHeartbeat);
 

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -58,6 +58,7 @@ import Migration0039 from "./Migrations/039_ReconcileLegacyPinnedThreads.ts";
 import Migration0040 from "./Migrations/040_ProjectionThreadsPinnedMessagesNotes.ts";
 import Migration0041 from "./Migrations/041_ProjectionProjectsPinned.ts";
 import Migration0042 from "./Migrations/042_ProjectionThreadsMarkers.ts";
+import Migration0043 from "./Migrations/043_ProfileStatsIndexes.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -112,6 +113,7 @@ export const migrationEntries = [
   [40, "ProjectionThreadsPinnedMessagesNotes", Migration0040],
   [41, "ProjectionProjectsPinned", Migration0041],
   [42, "ProjectionThreadsMarkers", Migration0042],
+  [43, "ProfileStatsIndexes", Migration0043],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/043_ProfileStatsIndexes.ts
+++ b/apps/server/src/persistence/Migrations/043_ProfileStatsIndexes.ts
@@ -1,0 +1,25 @@
+/**
+ * Adds lightweight covering indexes for Profile stats queries.
+ * These support prompt bucketing, per-turn model events, and token delta scans.
+ */
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_thread_messages_profile_prompt_activity
+    ON projection_thread_messages(role, source, created_at)
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_orchestration_events_profile_turn_events
+    ON orchestration_events(event_type, stream_id)
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_thread_activities_profile_token_activity
+    ON projection_thread_activities(kind, thread_id, sequence, created_at, activity_id)
+  `;
+});

--- a/apps/server/src/profileStats.test.ts
+++ b/apps/server/src/profileStats.test.ts
@@ -1,0 +1,271 @@
+// FILE: profileStats.test.ts
+// Purpose: Focused coverage for Profile stats SQL aggregation against the migrated SQLite schema.
+// Layer: Server stats tests
+// Exports: Vitest coverage for ProfileStatsQuery.
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect, Layer } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { describe, expect, it } from "vitest";
+
+import { ServerConfig } from "./config";
+import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite";
+import { ProfileStatsQuery, ProfileStatsQueryLive } from "./profileStats";
+
+const testLayer = ProfileStatsQueryLive.pipe(
+  Layer.provideMerge(SqlitePersistenceMemory),
+  Layer.provide(
+    ServerConfig.layerTest(process.cwd(), {
+      prefix: "synara-profile-stats-test-",
+    }),
+  ),
+  Layer.provide(NodeServices.layer),
+);
+
+function runProfileStatsTest<A, E>(
+  effect: Effect.Effect<A, E, ProfileStatsQuery | SqlClient.SqlClient>,
+) {
+  return effect.pipe(Effect.provide(testLayer), Effect.scoped, Effect.runPromise);
+}
+
+describe("ProfileStatsQuery", () => {
+  it("aggregates prompts, model usage, provider usage, and reasoning from local projections", async () => {
+    await runProfileStatsTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const statsQuery = yield* ProfileStatsQuery;
+
+        yield* sql`
+          INSERT INTO projection_threads (
+            thread_id,
+            project_id,
+            title,
+            model_selection_json,
+            runtime_mode,
+            interaction_mode,
+            env_mode,
+            created_at,
+            updated_at,
+            deleted_at
+          )
+          VALUES
+            (
+              'thread-codex',
+              'project-profile',
+              'Codex Thread',
+              '{"provider":"codex","model":"gpt-5-codex","options":{"reasoningEffort":"high"}}',
+              'full-access',
+              'default',
+              'local',
+              '2026-06-13T09:00:00.000Z',
+              '2026-06-13T09:00:00.000Z',
+              NULL
+            ),
+            (
+              'thread-claude',
+              'project-profile',
+              'Claude Thread',
+              '{"provider":"claudeAgent","model":"claude-sonnet-4-6","options":{"effort":"max"}}',
+              'full-access',
+              'default',
+              'local',
+              '2026-06-13T10:00:00.000Z',
+              '2026-06-13T10:00:00.000Z',
+              NULL
+            )
+        `;
+
+        yield* sql`
+          INSERT INTO projection_thread_messages (
+            message_id,
+            thread_id,
+            turn_id,
+            role,
+            text,
+            is_streaming,
+            source,
+            created_at,
+            updated_at
+          )
+          VALUES
+            (
+              'message-codex-1',
+              'thread-codex',
+              'turn-codex-1',
+              'user',
+              'first',
+              0,
+              'native',
+              '2026-06-13T09:05:00.000Z',
+              '2026-06-13T09:05:00.000Z'
+            ),
+            (
+              'message-codex-2',
+              'thread-codex',
+              'turn-codex-2',
+              'user',
+              'second',
+              0,
+              'native',
+              '2026-06-13T09:35:00.000Z',
+              '2026-06-13T09:35:00.000Z'
+            ),
+            (
+              'message-claude-1',
+              'thread-claude',
+              'turn-claude-1',
+              'user',
+              'third',
+              0,
+              'native',
+              '2026-06-14T10:05:00.000Z',
+              '2026-06-14T10:05:00.000Z'
+            )
+        `;
+
+        yield* sql`
+          INSERT INTO orchestration_events (
+            event_id,
+            aggregate_kind,
+            stream_id,
+            stream_version,
+            event_type,
+            occurred_at,
+            actor_kind,
+            payload_json,
+            metadata_json
+          )
+          VALUES
+            (
+              'event-codex-1',
+              'thread',
+              'thread-codex',
+              1,
+              'thread.turn-start-requested',
+              '2026-06-13T09:05:00.000Z',
+              'client',
+              '{"threadId":"thread-codex","modelSelection":{"provider":"codex","model":"gpt-5-codex","options":{"reasoningEffort":"high"}}}',
+              '{}'
+            ),
+            (
+              'event-codex-2',
+              'thread',
+              'thread-codex',
+              2,
+              'thread.turn-start-requested',
+              '2026-06-13T09:35:00.000Z',
+              'client',
+              '{"threadId":"thread-codex","modelSelection":{"provider":"codex","model":"gpt-5-codex","options":{"reasoningEffort":"high"}}}',
+              '{}'
+            ),
+            (
+              'event-claude-1',
+              'thread',
+              'thread-claude',
+              1,
+              'thread.turn-start-requested',
+              '2026-06-14T10:05:00.000Z',
+              'client',
+              '{"threadId":"thread-claude","modelSelection":{"provider":"claudeAgent","model":"claude-sonnet-4-6","options":{"effort":"max"}}}',
+              '{}'
+            )
+        `;
+
+        const stats = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
+
+        expect(stats.activity.totalPromptsSent).toBe(3);
+        expect(stats.activity.totalThreads).toBe(2);
+        expect(stats.activeHours.startHour).toBe(9);
+        expect(stats.activeHours.turnCount).toBe(2);
+        expect(stats.insights.topProvider).toBe("codex");
+        expect(stats.insights.topProviderPercent).toBeCloseTo(66.7);
+        expect(stats.insights.topReasoning).toBe("high");
+        expect(stats.insights.topReasoningPercent).toBeCloseTo(66.7);
+        expect(stats.providerModels[0]).toMatchObject({
+          provider: "codex",
+          model: "gpt-5-codex",
+          turnCount: 2,
+        });
+      }),
+    );
+  });
+
+  it("keeps token stats available when a legacy thread has malformed model JSON", async () => {
+    await runProfileStatsTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const statsQuery = yield* ProfileStatsQuery;
+
+        yield* sql`
+          INSERT INTO projection_threads (
+            thread_id,
+            project_id,
+            title,
+            model_selection_json,
+            runtime_mode,
+            interaction_mode,
+            env_mode,
+            created_at,
+            updated_at,
+            deleted_at
+          )
+          VALUES (
+            'thread-legacy-bad-json',
+            'project-profile',
+            'Legacy Bad JSON',
+            '{bad-json',
+            'full-access',
+            'default',
+            'local',
+            '2026-06-14T09:00:00.000Z',
+            '2026-06-14T09:00:00.000Z',
+            NULL
+          )
+        `;
+
+        yield* sql`
+          INSERT INTO projection_thread_activities (
+            activity_id,
+            thread_id,
+            turn_id,
+            tone,
+            kind,
+            summary,
+            payload_json,
+            sequence,
+            created_at
+          )
+          VALUES
+            (
+              'activity-token-1',
+              'thread-legacy-bad-json',
+              'turn-legacy-1',
+              'info',
+              'context-window.updated',
+              'tokens updated',
+              '{"totalProcessedTokens":1000}',
+              1,
+              '2026-06-14T09:05:00.000Z'
+            ),
+            (
+              'activity-token-2',
+              'thread-legacy-bad-json',
+              'turn-legacy-1',
+              'info',
+              'context-window.updated',
+              'tokens updated',
+              '{"totalProcessedTokens":1500}',
+              2,
+              '2026-06-14T09:10:00.000Z'
+            )
+        `;
+
+        const tokenStats = yield* statsQuery.getProfileTokenStats({ utcOffsetMinutes: 0 });
+
+        expect(tokenStats.available).toBe(true);
+        expect(tokenStats.lifetimeTotalTokens).toBe(1500);
+        expect(tokenStats.providers).toEqual([]);
+      }),
+    );
+  });
+});

--- a/apps/server/src/profileStats.ts
+++ b/apps/server/src/profileStats.ts
@@ -1,0 +1,711 @@
+// FILE: profileStats.ts
+// Purpose: Compute Profile-page stats from Synara's local projection DB only.
+// The share card never reads provider archives or cloud services for metrics.
+// Layer: server stats query service (SqlClient + ServerConfig).
+
+import nodePath from "node:path";
+
+import type {
+  ProfileQuota,
+  ProfileStats,
+  ProfileTokenStats,
+  ProviderKind,
+  StatsGetProfileStatsInput,
+  StatsGetProfileTokenStatsInput,
+} from "@t3tools/contracts";
+import { Effect, Layer, ServiceMap } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { ServerConfig } from "./config";
+
+const HEATMAP_WINDOW_DAYS = 274; // ~9 months, GitHub-style contribution grid.
+const SKILL_RESULT_LIMIT = 12;
+const PROVIDER_KINDS = new Set<ProviderKind>([
+  "codex",
+  "claudeAgent",
+  "cursor",
+  "gemini",
+  "grok",
+  "kilo",
+  "opencode",
+  "pi",
+]);
+
+type HeatmapCell = ProfileStats["activity"]["heatmap"][number];
+type ProviderModelUsage = ProfileStats["providerModels"][number];
+type SkillUsage = ProfileStats["skills"][number];
+
+interface CountRow {
+  readonly count: number;
+}
+
+interface PromptActivityRow extends CountRow {
+  readonly day: string | null;
+  readonly hour: number | null;
+}
+
+interface TurnInsightRow extends CountRow {
+  readonly provider: string | null;
+  readonly model: string | null;
+  readonly reasoning: string | null;
+}
+
+interface SkillUsageRow {
+  readonly name: string | null;
+  readonly displayName: string | null;
+  readonly kind: string | null;
+  readonly runCount: number;
+}
+
+interface TokenDayRow {
+  readonly day: string | null;
+  readonly provider: string | null;
+  readonly tokens: number;
+}
+
+// ── Pure helpers ───────────────────────────────────────────────────────
+
+// SQLite DATETIME() modifier that shifts UTC timestamps into the caller's LOCAL
+// wall-clock time (for example "+02:00" / "-05:00").
+export function sqliteModifierFromUtcOffsetMinutes(offsetMinutes: number): string {
+  const safe = Number.isFinite(offsetMinutes) ? Math.trunc(offsetMinutes) : 0;
+  const sign = safe < 0 ? "-" : "+";
+  const abs = Math.abs(safe);
+  const hh = String(Math.floor(abs / 60)).padStart(2, "0");
+  const mm = String(abs % 60).padStart(2, "0");
+  return `${sign}${hh}:${mm}`;
+}
+
+function localToday(utcOffsetMinutes: number): string {
+  return new Date(Date.now() + utcOffsetMinutes * 60_000).toISOString().slice(0, 10);
+}
+
+function num(value: unknown): number {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function addDaysIso(day: string, delta: number): string {
+  const [year = 1970, month = 1, date = 1] = day.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, date) + delta * 86_400_000).toISOString().slice(0, 10);
+}
+
+function weekdayOf(day: string): number {
+  const [year = 1970, month = 1, date = 1] = day.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, date)).getUTCDay();
+}
+
+function heatmapIntensity(count: number, max: number): number {
+  if (count <= 0 || max <= 0) {
+    return 0;
+  }
+  const ratio = count / max;
+  if (ratio <= 0.25) return 1;
+  if (ratio <= 0.5) return 2;
+  if (ratio <= 0.75) return 3;
+  return 4;
+}
+
+function percent1(part: number, total: number): number {
+  return total > 0 ? Math.round((part / total) * 1000) / 10 : 0;
+}
+
+function compareNullableText(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): number {
+  return (left ?? "").localeCompare(right ?? "");
+}
+
+function deriveInitials(name: string): string {
+  const parts = name.split(/[\s._-]+/u).filter((part) => part.length > 0);
+  if (parts.length >= 2) {
+    return `${parts[0]?.[0] ?? ""}${parts[1]?.[0] ?? ""}`.toUpperCase() || "SY";
+  }
+  const single = parts[0] ?? name;
+  return (single.slice(0, 2) || "SY").toUpperCase();
+}
+
+function sanitizeHandle(basename: string): string {
+  const slug = basename.toLowerCase().replace(/[^a-z0-9_]/gu, "");
+  return `@${slug || "synara"}`;
+}
+
+function formatHour(hour: number): string {
+  const normalized = ((hour % 24) + 24) % 24;
+  if (normalized === 0) return "12 AM";
+  if (normalized === 12) return "12 PM";
+  return normalized < 12 ? `${normalized} AM` : `${normalized - 12} PM`;
+}
+
+function arcName(startHour: number): string {
+  if (startHour < 5) return "Late-Night Dev Arc";
+  if (startHour < 9) return "Early Bird Arc";
+  if (startHour < 12) return "Morning Arc";
+  if (startHour < 17) return "Afternoon Arc";
+  if (startHour < 21) return "Evening Arc";
+  return "Night Owl Arc";
+}
+
+function normalizeProviderKind(value: unknown): ProviderKind | "unknown" {
+  const provider = nonEmptyString(value);
+  return provider && PROVIDER_KINDS.has(provider as ProviderKind)
+    ? (provider as ProviderKind)
+    : "unknown";
+}
+
+function computeStreaks(
+  activeDaysAsc: ReadonlyArray<string>,
+  todayKey: string,
+): { current: number; longest: number } {
+  if (activeDaysAsc.length === 0) {
+    return { current: 0, longest: 0 };
+  }
+  const set = new Set(activeDaysAsc);
+
+  let longest = 0;
+  let run = 0;
+  let previous: string | null = null;
+  for (const day of activeDaysAsc) {
+    run = previous && addDaysIso(previous, 1) === day ? run + 1 : 1;
+    if (run > longest) {
+      longest = run;
+    }
+    previous = day;
+  }
+
+  // Keep the streak alive through the current local day: if yesterday was active
+  // but today is still empty, the user still has today to extend it.
+  let anchor: string | null = set.has(todayKey)
+    ? todayKey
+    : set.has(addDaysIso(todayKey, -1))
+      ? addDaysIso(todayKey, -1)
+      : null;
+  let current = 0;
+  while (anchor && set.has(anchor)) {
+    current += 1;
+    anchor = addDaysIso(anchor, -1);
+  }
+
+  return { current, longest };
+}
+
+// Rolling 6-month window ending today.
+function buildHeatmap(countByDay: ReadonlyMap<string, number>, todayKey: string): HeatmapCell[] {
+  const windowStart = addDaysIso(todayKey, -(HEATMAP_WINDOW_DAYS - 1));
+
+  let windowMax = 0;
+  for (const [day, count] of countByDay) {
+    if (day >= windowStart && day <= todayKey && count > windowMax) {
+      windowMax = count;
+    }
+  }
+
+  const heatmap: HeatmapCell[] = [];
+  for (let offset = 0; offset < HEATMAP_WINDOW_DAYS; offset += 1) {
+    const day = addDaysIso(windowStart, offset);
+    const count = countByDay.get(day) ?? 0;
+    heatmap.push({
+      day,
+      count,
+      weekday: weekdayOf(day),
+      intensity: heatmapIntensity(count, windowMax),
+    });
+  }
+  return heatmap;
+}
+
+function emptyQuota(): ProfileQuota {
+  return {
+    status: "unavailable",
+    provider: null,
+    window: null,
+    usedPercent: null,
+    resetsAt: null,
+    planName: null,
+  };
+}
+
+// ── Service ────────────────────────────────────────────────────────────
+
+export interface ProfileStatsQueryShape {
+  readonly getProfileStats: (
+    input: StatsGetProfileStatsInput,
+  ) => Effect.Effect<ProfileStats, unknown>;
+  readonly getProfileTokenStats: (
+    input: StatsGetProfileTokenStatsInput,
+  ) => Effect.Effect<ProfileTokenStats, unknown>;
+}
+
+export class ProfileStatsQuery extends ServiceMap.Service<
+  ProfileStatsQuery,
+  ProfileStatsQueryShape
+>()("synara/profileStats/ProfileStatsQuery") {}
+
+const makeProfileStatsQuery = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+  const config = yield* ServerConfig;
+
+  function profileStatsErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  function isMissingLegacyColumnError(error: unknown): boolean {
+    return /\bno such column\b/iu.test(profileStatsErrorMessage(error));
+  }
+
+  // Imported legacy databases can briefly miss columns added after their original
+  // lineage. Only that compatibility case degrades; real SQL failures should reach
+  // the UI retry path instead of producing believable zero-stats.
+  const legacyCompatibleQuery = <T>(
+    operation: string,
+    query: Effect.Effect<ReadonlyArray<T>, unknown>,
+  ) =>
+    query.pipe(
+      Effect.catchIf(isMissingLegacyColumnError, (error) =>
+        Effect.logWarning("profile stats query skipped due to missing legacy column", {
+          error: profileStatsErrorMessage(error),
+          operation,
+        }).pipe(Effect.as([] as ReadonlyArray<T>)),
+      ),
+    );
+
+  // ── SQL helpers ──────────────────────────────────────────────────────
+
+  // Activity = days/hours the user actually sent a Synara prompt. One day-hour
+  // grouping gives day totals, hour totals, and lifetime prompt count in TS.
+  const queryPromptActivity = (tz: string) =>
+    legacyCompatibleQuery(
+      "profileStats.promptActivity",
+      sql<PromptActivityRow>`
+        SELECT
+          STRFTIME('%Y-%m-%d', DATETIME(created_at, ${tz})) AS day,
+          CAST(STRFTIME('%H', DATETIME(created_at, ${tz})) AS INTEGER) AS hour,
+          COUNT(*) AS count
+        FROM projection_thread_messages
+        WHERE role = 'user' AND source = 'native'
+        GROUP BY day, hour
+        ORDER BY day ASC, hour ASC
+      `,
+    );
+
+  // Token usage for EVERY provider, straight from Synara's own DB (no external
+  // ~/.codex/~/.claude archives, so it is provider-agnostic AND per-instance). Each
+  // `context-window.updated` activity carries the running `totalProcessedTokens`; the
+  // positive per-thread delta is the tokens processed in that step, bucketed by the
+  // caller's local day and attributed to the thread's provider.
+  const queryTokenActivity = (tz: string) =>
+    legacyCompatibleQuery(
+      "profileStats.tokenActivity",
+      sql<TokenDayRow>`
+        WITH ev AS (
+          SELECT
+            a.thread_id AS thread_id,
+            STRFTIME('%Y-%m-%d', DATETIME(a.created_at, ${tz})) AS day,
+            CASE
+              WHEN th.model_selection_json IS NOT NULL AND json_valid(th.model_selection_json)
+              THEN COALESCE(json_extract(th.model_selection_json, '$.provider'), 'unknown')
+              ELSE 'unknown'
+            END AS provider,
+            CAST(json_extract(a.payload_json, '$.totalProcessedTokens') AS INTEGER) AS tot,
+            a.sequence AS sequence,
+            a.created_at AS created_at,
+            a.activity_id AS activity_id
+          FROM projection_thread_activities a
+          JOIN projection_threads th ON th.thread_id = a.thread_id
+          WHERE a.kind = 'context-window.updated'
+            AND json_extract(a.payload_json, '$.totalProcessedTokens') IS NOT NULL
+        ),
+        delta AS (
+          SELECT
+            day,
+            provider,
+            MAX(0, tot - LAG(tot, 1, 0) OVER (
+              PARTITION BY thread_id
+              ORDER BY
+                CASE WHEN sequence IS NULL THEN 0 ELSE 1 END ASC,
+                sequence ASC,
+                created_at ASC,
+                activity_id ASC
+            )) AS d
+          FROM ev
+        )
+        SELECT day, provider, SUM(d) AS tokens
+        FROM delta
+        GROUP BY day, provider
+      `,
+    );
+
+  const queryTotalThreads = () =>
+    legacyCompatibleQuery(
+      "profileStats.totalThreads",
+      sql<CountRow>`
+        SELECT COUNT(*) AS count FROM projection_threads
+      `,
+    );
+
+  const queryTurnInsights = () =>
+    legacyCompatibleQuery(
+      "profileStats.turnInsights",
+      sql<TurnInsightRow>`
+        WITH per_turn AS (
+          SELECT
+            CASE
+              WHEN json_type(e.payload_json, '$.modelSelection') = 'object'
+              THEN json_extract(e.payload_json, '$.modelSelection.provider')
+              ELSE CASE
+                WHEN t.model_selection_json IS NOT NULL AND json_valid(t.model_selection_json)
+                THEN json_extract(t.model_selection_json, '$.provider')
+              END
+            END AS provider,
+            CASE
+              WHEN json_type(e.payload_json, '$.modelSelection') = 'object'
+              THEN json_extract(e.payload_json, '$.modelSelection.model')
+              ELSE CASE
+                WHEN t.model_selection_json IS NOT NULL AND json_valid(t.model_selection_json)
+                THEN json_extract(t.model_selection_json, '$.model')
+              END
+            END AS model,
+            CASE
+              WHEN json_type(e.payload_json, '$.modelSelection') = 'object'
+              THEN COALESCE(
+                json_extract(e.payload_json, '$.modelSelection.options.reasoningEffort'),
+                json_extract(e.payload_json, '$.modelSelection.options.effort')
+              )
+              ELSE CASE
+                WHEN t.model_selection_json IS NOT NULL AND json_valid(t.model_selection_json)
+                THEN COALESCE(
+                  json_extract(t.model_selection_json, '$.options.reasoningEffort'),
+                  json_extract(t.model_selection_json, '$.options.effort')
+                )
+              END
+            END AS reasoning
+          FROM orchestration_events e
+          LEFT JOIN projection_threads t
+            ON t.thread_id = COALESCE(json_extract(e.payload_json, '$.threadId'), e.stream_id)
+          WHERE e.event_type = 'thread.turn-start-requested'
+        )
+        SELECT provider, model, reasoning, COUNT(*) AS count
+        FROM per_turn
+        GROUP BY provider, model, reasoning
+        ORDER BY count DESC, provider ASC, model ASC, reasoning ASC
+      `,
+    );
+
+  const querySkillUsage = () =>
+    legacyCompatibleQuery(
+      "profileStats.skillUsage",
+      sql<SkillUsageRow>`
+        WITH raw_usage AS (
+          SELECT json_extract(skill.value, '$.name') AS name, 'skill' AS kind
+          FROM projection_thread_messages m
+          JOIN json_each(
+            CASE
+              WHEN m.skills_json IS NOT NULL
+                AND json_valid(m.skills_json)
+                AND json_type(m.skills_json) = 'array'
+              THEN m.skills_json
+              ELSE '[]'
+            END
+          ) AS skill
+          WHERE m.role = 'user'
+          UNION ALL
+          SELECT json_extract(agent.value, '$.name') AS name, 'agent' AS kind
+          FROM projection_thread_messages m
+          JOIN json_each(
+            CASE
+              WHEN m.mentions_json IS NOT NULL
+                AND json_valid(m.mentions_json)
+                AND json_type(m.mentions_json) = 'array'
+              THEN m.mentions_json
+              ELSE '[]'
+            END
+          ) AS agent
+          WHERE m.role = 'user'
+        ), grouped AS (
+          SELECT name, kind, COUNT(*) AS runCount
+          FROM raw_usage
+          WHERE name IS NOT NULL AND name <> ''
+          GROUP BY name, kind
+        )
+        SELECT
+          name,
+          CASE kind WHEN 'skill' THEN '$' || name ELSE '@' || name END AS displayName,
+          kind,
+          runCount
+        FROM grouped
+        ORDER BY runCount DESC, kind ASC, name ASC
+      `,
+    );
+
+  // ── Result builders ─────────────────────────────────────────────────
+
+  const getProfileStats = (
+    input: StatsGetProfileStatsInput,
+  ): Effect.Effect<ProfileStats, unknown> =>
+    Effect.gen(function* () {
+      const tz = sqliteModifierFromUtcOffsetMinutes(input.utcOffsetMinutes);
+      const todayKey = localToday(input.utcOffsetMinutes);
+
+      const promptActivityRows = yield* queryPromptActivity(tz);
+      const totalThreadRows = yield* queryTotalThreads();
+      const turnInsightRows = yield* queryTurnInsights();
+      const skillRows = yield* querySkillUsage();
+
+      // ── Activity / heatmap / streaks ──
+      const countByDay = new Map<string, number>();
+      const hourCounts = Array.from({ length: 24 }, () => 0);
+      let totalPromptsSent = 0;
+      for (const row of promptActivityRows) {
+        const day = nonEmptyString(row.day);
+        const count = num(row.count);
+        if (day) {
+          countByDay.set(day, (countByDay.get(day) ?? 0) + count);
+        }
+        const hour = ((Math.trunc(num(row.hour)) % 24) + 24) % 24;
+        hourCounts[hour] = (hourCounts[hour] ?? 0) + count;
+        totalPromptsSent += count;
+      }
+      const heatmap = buildHeatmap(countByDay, todayKey);
+      const activeDaysAsc = heatmap
+        .filter((cell) => cell.count > 0)
+        .map((cell) => cell.day)
+        .toSorted();
+      const { current: currentStreakDays, longest: longestStreakDays } = computeStreaks(
+        activeDaysAsc,
+        todayKey,
+      );
+
+      // ── Peak hour (single highest local-hour bucket) ──
+      const totalHourTurns = hourCounts.reduce((sum, value) => sum + value, 0);
+      let bestHour: number | null = null;
+      let bestHourCount = 0;
+      if (totalHourTurns > 0) {
+        for (let hour = 0; hour < 24; hour += 1) {
+          const hourCount = hourCounts[hour] ?? 0;
+          if (hourCount > bestHourCount) {
+            bestHourCount = hourCount;
+            bestHour = hour;
+          }
+        }
+      }
+      const activeHours =
+        bestHour === null
+          ? { startHour: null, endHour: null, turnCount: 0, label: null }
+          : {
+              startHour: bestHour,
+              endHour: null,
+              turnCount: bestHourCount,
+              label: `${formatHour(bestHour)} · ${arcName(bestHour)}`,
+            };
+
+      // ── Provider / model mix ──
+      const providerModelCounts = new Map<
+        string,
+        { readonly provider: string | null; readonly model: string | null; count: number }
+      >();
+      const reasoningCounts = new Map<string, { readonly reasoning: string; count: number }>();
+
+      for (const row of turnInsightRows) {
+        const count = num(row.count);
+        const provider = nonEmptyString(row.provider);
+        const model = nonEmptyString(row.model);
+        const providerModelKey = `${provider ?? ""}\u0000${model ?? ""}`;
+        const existingProviderModel = providerModelCounts.get(providerModelKey);
+        if (existingProviderModel) {
+          existingProviderModel.count += count;
+        } else {
+          providerModelCounts.set(providerModelKey, { provider, model, count });
+        }
+
+        const reasoning = nonEmptyString(row.reasoning);
+        if (reasoning) {
+          const existingReasoning = reasoningCounts.get(reasoning);
+          if (existingReasoning) {
+            existingReasoning.count += count;
+          } else {
+            reasoningCounts.set(reasoning, { reasoning, count });
+          }
+        }
+      }
+
+      const providerModelRows = [...providerModelCounts.values()].toSorted(
+        (left, right) =>
+          right.count - left.count ||
+          compareNullableText(left.provider, right.provider) ||
+          compareNullableText(left.model, right.model),
+      );
+      const totalModelTurns = providerModelRows.reduce((sum, row) => sum + num(row.count), 0);
+      const providerModels: ProviderModelUsage[] = providerModelRows.slice(0, 8).map((row) => {
+        const count = num(row.count);
+        return {
+          provider: normalizeProviderKind(row.provider),
+          model: nonEmptyString(row.model) ?? "unknown",
+          turnCount: count,
+          percent: percent1(count, totalModelTurns),
+        };
+      });
+
+      const providerTurnCounts = new Map<ProviderKind, number>();
+      // "Most used provider" should reflect actual turns, not how many threads were created.
+      for (const row of providerModelRows) {
+        const provider = normalizeProviderKind(row.provider);
+        if (provider === "unknown") {
+          continue;
+        }
+        providerTurnCounts.set(provider, (providerTurnCounts.get(provider) ?? 0) + num(row.count));
+      }
+      const totalKnownProviderTurns = [...providerTurnCounts.values()].reduce(
+        (sum, count) => sum + count,
+        0,
+      );
+      let topProvider: ProviderKind | null = null;
+      let topProviderTurns = 0;
+      for (const [provider, count] of providerTurnCounts) {
+        if (count > topProviderTurns) {
+          topProvider = provider;
+          topProviderTurns = count;
+        }
+      }
+
+      // ── Insights (top provider, top reasoning) ──
+      const topProviderPercent =
+        topProvider && totalKnownProviderTurns > 0
+          ? percent1(topProviderTurns, totalKnownProviderTurns)
+          : null;
+
+      const reasoningRows = [...reasoningCounts.values()].toSorted(
+        (left, right) =>
+          right.count - left.count || compareNullableText(left.reasoning, right.reasoning),
+      );
+      const totalReasonedSelections = reasoningRows.reduce((sum, row) => sum + num(row.count), 0);
+      const topReasoningRow = reasoningRows[0];
+      const topReasoning = topReasoningRow?.reasoning ?? null;
+      // Denominator excludes null reasoning values; those turns had no reasoning option set.
+      const topReasoningPercent =
+        topReasoningRow && totalReasonedSelections > 0
+          ? percent1(num(topReasoningRow.count), totalReasonedSelections)
+          : null;
+
+      // ── Skills and agent mentions ──
+      const allSkillUsages: SkillUsage[] = skillRows
+        .map((row) => {
+          const name = nonEmptyString(row.name);
+          if (!name) {
+            return null;
+          }
+          const kind = row.kind === "agent" ? "agent" : "skill";
+          return {
+            name,
+            displayName:
+              nonEmptyString(row.displayName) ?? `${kind === "skill" ? "$" : "@"}${name}`,
+            kind,
+            runCount: num(row.runCount),
+          } satisfies SkillUsage;
+        })
+        .filter((skill): skill is SkillUsage => skill !== null);
+      const skills = allSkillUsages.slice(0, SKILL_RESULT_LIMIT);
+      const totalSkillsUsed = allSkillUsages.reduce((sum, row) => sum + row.runCount, 0);
+
+      // ── Identity ──
+      const homeDirBasename = nodePath.basename(config.homeDir) || "synara";
+
+      return {
+        generatedAt: new Date().toISOString(),
+        timezone: { utcOffsetMinutes: input.utcOffsetMinutes, today: todayKey },
+        identity: {
+          homeDirBasename,
+          initials: deriveInitials(homeDirBasename),
+          defaultHandle: sanitizeHandle(homeDirBasename),
+        },
+        activity: {
+          currentStreakDays,
+          longestStreakDays,
+          totalPromptsSent,
+          totalThreads: num(totalThreadRows[0]?.count),
+          promptsToday: countByDay.get(todayKey) ?? 0,
+          heatmapMetric: "prompts",
+          heatmap,
+        },
+        activeHours,
+        insights: {
+          topProvider,
+          topProviderPercent,
+          topReasoning,
+          topReasoningPercent,
+          skillsExplored: allSkillUsages.length,
+          totalSkillsUsed,
+        },
+        providerModels,
+        skills,
+        mostUsedSkill: skills[0] ?? null,
+        quota: emptyQuota(),
+      } satisfies ProfileStats;
+    });
+
+  const getProfileTokenStats = (
+    input: StatsGetProfileTokenStatsInput,
+  ): Effect.Effect<ProfileTokenStats, unknown> =>
+    Effect.gen(function* () {
+      const tz = sqliteModifierFromUtcOffsetMinutes(input.utcOffsetMinutes);
+      const todayKey = localToday(input.utcOffsetMinutes);
+      const rows = yield* queryTokenActivity(tz);
+
+      const tokensByDay = new Map<string, number>();
+      const tokensByProvider = new Map<ProviderKind, number>();
+      let lifetime = 0;
+      for (const row of rows) {
+        const day = nonEmptyString(row.day);
+        const tokens = num(row.tokens);
+        if (!day || tokens <= 0) {
+          continue;
+        }
+        tokensByDay.set(day, (tokensByDay.get(day) ?? 0) + tokens);
+        lifetime += tokens;
+        const provider = normalizeProviderKind(row.provider);
+        if (provider !== "unknown") {
+          tokensByProvider.set(provider, (tokensByProvider.get(provider) ?? 0) + tokens);
+        }
+      }
+
+      let peakDay: string | null = null;
+      let peakDayTokens: number | null = null;
+      for (const [day, tokens] of tokensByDay) {
+        if (peakDayTokens === null || tokens > peakDayTokens) {
+          peakDayTokens = tokens;
+          peakDay = day;
+        }
+      }
+
+      const providers = [...tokensByProvider.entries()]
+        .filter(([, tokens]) => tokens > 0)
+        .toSorted((a, b) => b[1] - a[1])
+        .map(([provider]) => provider);
+      const available = lifetime > 0;
+
+      return {
+        available,
+        lifetimeTotalTokens: available ? lifetime : null,
+        peakDayTokens,
+        peakDay,
+        providers,
+        unavailableProviders: [],
+        heatmapMetric: "tokens",
+        heatmap: buildHeatmap(tokensByDay, todayKey),
+      } satisfies ProfileTokenStats;
+    });
+
+  return { getProfileStats, getProfileTokenStats } satisfies ProfileStatsQueryShape;
+});
+
+export const ProfileStatsQueryLive = Layer.effect(ProfileStatsQuery, makeProfileStatsQuery);

--- a/apps/server/src/providerUsageSnapshot.ts
+++ b/apps/server/src/providerUsageSnapshot.ts
@@ -1,6 +1,5 @@
 // FILE: providerUsageSnapshot.ts
-// Purpose: Read provider-specific local usage archives so the UI can show
-// recent usage even when the active thread has no fresh rate-limit events.
+// Purpose: Read provider-specific local usage archives for recent usage snapshots.
 
 import type { Dirent, Stats } from "node:fs";
 import fs from "node:fs/promises";
@@ -25,6 +24,7 @@ const USAGE_CACHE_TTL_MS = 30_000;
 // Keep enough recent archives to make the 30d summary materially different from 7d
 // for heavy local usage without scanning the full historical archive every refresh.
 const MAX_RECENT_USAGE_FILES = 2_000;
+const PROVIDER_USAGE_FILE_READ_CONCURRENCY = 16;
 
 type UsageSnapshot = Exclude<ServerGetProviderUsageSnapshotResult, null>;
 
@@ -100,15 +100,6 @@ function formatRecentSessionsSubtitle(sessionCount: number): string | undefined 
   return `${new Intl.NumberFormat(undefined).format(sessionCount)} recent ${sessionCount === 1 ? "session" : "sessions"}`;
 }
 
-function formatUsageTimestamp(timestampMs: number): string {
-  return new Intl.DateTimeFormat(undefined, {
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    month: "short",
-  }).format(timestampMs);
-}
-
 async function safeReadDir(path: string): Promise<ReadonlyArray<Dirent>> {
   try {
     return await fs.readdir(path, { withFileTypes: true });
@@ -125,17 +116,53 @@ async function safeStat(path: string): Promise<Stats | null> {
   }
 }
 
-async function listRecentFiles(paths: ReadonlyArray<string>): Promise<ReadonlyArray<string>> {
-  const filesWithStats = await Promise.all(
-    paths.map(async (path) => ({
+// Bounds archive reads so a cold stats load does useful parallel work without
+// flooding the filesystem with thousands of simultaneous readFile calls.
+async function mapWithConcurrency<T, R>(
+  items: ReadonlyArray<T>,
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: Array<{ index: number; value: R }> = [];
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= items.length) {
+          return;
+        }
+        const item = items[index];
+        if (item === undefined) {
+          continue;
+        }
+        results.push({ index, value: await mapper(item) });
+      }
+    }),
+  );
+
+  return results.toSorted((left, right) => left.index - right.index).map((entry) => entry.value);
+}
+
+async function listRecentFiles(
+  paths: ReadonlyArray<string>,
+  maxFiles: number = MAX_RECENT_USAGE_FILES,
+): Promise<ReadonlyArray<string>> {
+  const filesWithStats = await mapWithConcurrency(
+    paths,
+    PROVIDER_USAGE_FILE_READ_CONCURRENCY,
+    async (path) => ({
       path,
       mtimeMs: (await safeStat(path))?.mtimeMs ?? 0,
-    })),
+    }),
   );
 
   return filesWithStats
-    .sort((left, right) => right.mtimeMs - left.mtimeMs)
-    .slice(0, MAX_RECENT_USAGE_FILES)
+    .toSorted((left, right) => right.mtimeMs - left.mtimeMs)
+    .slice(0, maxFiles)
     .map((entry) => entry.path);
 }
 
@@ -262,10 +289,10 @@ async function readCodexSessionSummary(path: string): Promise<CodexSessionSummar
     return null;
   }
 
-  let latestSummary: CodexSessionSummary | null = null;
   const lines = fileContents.split(/\r?\n/u);
-  for (const line of lines) {
-    if (!line.trim()) {
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index];
+    if (!line || !line.trim()) {
       continue;
     }
 
@@ -297,12 +324,12 @@ async function readCodexSessionSummary(path: string): Promise<CodexSessionSummar
       limits: normalizeCodexUsageLimits(payload.rate_limits ?? payload.rateLimits),
     } satisfies CodexSessionSummary;
 
-    if (!latestSummary || summary.timestampMs > latestSummary.timestampMs) {
-      latestSummary = summary;
-    }
+    // Codex session JSONL is chronological; only the final token_count event is
+    // needed for lifetime accounting and the latest quota snapshot per file.
+    return summary;
   }
 
-  return latestSummary;
+  return null;
 }
 
 function readClaudeTotalTokens(value: unknown): number {
@@ -386,8 +413,17 @@ function readClaudeToolResultSample(input: {
   };
 }
 
+// Claude Code stores transcripts under `<CLAUDE_CONFIG_DIR>/projects`, defaulting to
+// `~/.claude/projects`. Honor the override so the Profile reads the SAME transcripts
+// the active Claude provider does (the adapter inherits `process.env`).
+function resolveClaudeProjectsRoot(homeDir: string): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR?.trim();
+  return nodePath.join(configDir || nodePath.join(homeDir, ".claude"), "projects");
+}
+
 async function listRecentClaudeTranscriptFiles(
   projectsRoot: string,
+  maxFiles: number = MAX_RECENT_USAGE_FILES,
 ): Promise<ReadonlyArray<string>> {
   const candidates: string[] = [];
   const projectEntries = await safeReadDir(projectsRoot);
@@ -406,7 +442,7 @@ async function listRecentClaudeTranscriptFiles(
     }
   }
 
-  return listRecentFiles(candidates);
+  return listRecentFiles(candidates, maxFiles);
 }
 
 async function readClaudeUsageSamples(path: string): Promise<ReadonlyArray<ClaudeUsageSample>> {
@@ -468,13 +504,13 @@ async function loadCodexUsageSnapshot(input: {
     return null;
   }
 
-  const sessionSummaries: CodexSessionSummary[] = [];
-  for (const sessionFile of sessionFiles) {
-    const summary = await readCodexSessionSummary(sessionFile);
-    if (summary) {
-      sessionSummaries.push(summary);
-    }
-  }
+  const sessionSummaries = (
+    await mapWithConcurrency(
+      sessionFiles,
+      PROVIDER_USAGE_FILE_READ_CONCURRENCY,
+      readCodexSessionSummary,
+    )
+  ).filter((summary): summary is CodexSessionSummary => summary !== null);
 
   if (sessionSummaries.length === 0) {
     return null;
@@ -509,16 +545,19 @@ async function loadCodexUsageSnapshot(input: {
 }
 
 async function loadClaudeUsageSnapshot(input: { homeDir: string }): Promise<UsageSnapshot | null> {
-  const projectsRoot = nodePath.join(input.homeDir, ".claude", "projects");
+  const projectsRoot = resolveClaudeProjectsRoot(input.homeDir);
   const transcriptFiles = await listRecentClaudeTranscriptFiles(projectsRoot);
   if (transcriptFiles.length === 0) {
     return null;
   }
 
-  const usageSamples: ClaudeUsageSample[] = [];
-  for (const transcriptFile of transcriptFiles) {
-    usageSamples.push(...(await readClaudeUsageSamples(transcriptFile)));
-  }
+  const usageSamples = (
+    await mapWithConcurrency(
+      transcriptFiles,
+      PROVIDER_USAGE_FILE_READ_CONCURRENCY,
+      readClaudeUsageSamples,
+    )
+  ).flat();
 
   if (usageSamples.length === 0) {
     return null;
@@ -575,7 +614,7 @@ async function getCachedProviderUsageSnapshot(input: {
   homeDir: string;
   homePath?: string;
 }): Promise<ServerGetProviderUsageSnapshotResult> {
-  const cacheKey = `${input.provider}:${input.homeDir}:${input.homePath?.trim() ?? ""}`;
+  const cacheKey = `${input.provider}:${input.homeDir}:${input.homePath?.trim() ?? ""}:${process.env.CLAUDE_CONFIG_DIR?.trim() ?? ""}`;
   const nowMs = Date.now();
   const existing = usageSnapshotCache.get(cacheKey);
 

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -22,6 +22,7 @@ import { ServerAuthLive } from "./auth/Layers/ServerAuth";
 import { ServerAuthPolicyLive } from "./auth/Layers/ServerAuthPolicy";
 import { ServerSecretStoreLive } from "./auth/Layers/ServerSecretStore";
 import { SessionCredentialServiceLive } from "./auth/Layers/SessionCredentialService";
+import { ProfileStatsQueryLive } from "./profileStats";
 import { ServerLifecycleEventsLive } from "./serverLifecycleEvents";
 import { ServerRuntimeStartupLive } from "./serverRuntimeStartup";
 import { ServerSettingsLive } from "./serverSettings";
@@ -100,6 +101,7 @@ export function makeServerRuntimeServicesLayer() {
     KeybindingsLive,
     ServerSettingsLive,
     ServerEnvironmentLive,
+    ProfileStatsQueryLive,
     authServicesLayer,
     ServerLifecycleEventsLive,
     ServerRuntimeStartupLive,

--- a/apps/server/src/serverLifecycleEvents.ts
+++ b/apps/server/src/serverLifecycleEvents.ts
@@ -17,12 +17,10 @@ export interface ServerLifecycleReadyPayload {
 
 export interface ServerLifecycleMaintenancePayload {
   readonly task: "thread-retention";
-  readonly state: "started" | "progress" | "compacting" | "completed" | "failed";
+  readonly state: "started" | "progress" | "completed" | "failed";
   readonly at: string;
   readonly deletedCount?: number;
-  readonly purgedCount?: number;
   readonly totalCount?: number;
-  readonly freePageCount?: number;
   readonly error?: string;
 }
 

--- a/apps/server/src/threadRetention.test.ts
+++ b/apps/server/src/threadRetention.test.ts
@@ -1,21 +1,15 @@
 // FILE: threadRetention.test.ts
-// Purpose: Verifies inactive-thread retention selection without running the server loop.
+// Purpose: Verifies inactive-thread selection without running the server loop.
 // Layer: Server maintenance tests
 // Exports: Vitest coverage for threadRetention helpers.
 
 import { ProjectId, ThreadId, type OrchestrationReadModel } from "@t3tools/contracts";
-import { it as effectIt } from "@effect/vitest";
-import { Effect } from "effect";
-import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { describe, expect, it } from "vitest";
 
 import {
   getInactiveThreadIdsForRetention,
-  getSoftDeletedThreadIdsForRetentionPurge,
-  purgeThreadDatabaseRows,
   THREAD_RETENTION_UNUSED_MS,
 } from "./threadRetention";
-import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite";
 
 function makeReadModelThread(
   overrides: Partial<OrchestrationReadModel["threads"][number]> = {},
@@ -51,7 +45,7 @@ function makeReadModel(threads: OrchestrationReadModel["threads"]): Orchestratio
 }
 
 describe("thread retention", () => {
-  it("selects inactive threads older than the seven-day retention window", () => {
+  it("selects inactive threads older than the seven-day hide window", () => {
     const nowMs = Date.parse("2026-04-20T00:00:00.000Z");
     const staleThread = makeReadModelThread({
       id: ThreadId.makeUnsafe("thread-stale"),
@@ -115,229 +109,4 @@ describe("thread retention", () => {
       getInactiveThreadIdsForRetention(makeReadModel([pinnedThread, unpinnedThread]), nowMs),
     ).toEqual([unpinnedThread.id]);
   });
-
-  it("selects already deleted threads for physical purge retry", () => {
-    const deletedThread = makeReadModelThread({
-      id: ThreadId.makeUnsafe("thread-deleted"),
-      deletedAt: "2026-04-19T12:00:00.000Z",
-    });
-    const liveThread = makeReadModelThread({
-      id: ThreadId.makeUnsafe("thread-live"),
-      deletedAt: null,
-    });
-
-    expect(
-      getSoftDeletedThreadIdsForRetentionPurge(makeReadModel([deletedThread, liveThread])),
-    ).toEqual([deletedThread.id]);
-  });
-});
-
-const sqliteLayer = effectIt.layer(SqlitePersistenceMemory);
-
-sqliteLayer("thread retention database purge", (it) => {
-  it.effect("physically removes retained thread rows while preserving other threads", () =>
-    Effect.gen(function* () {
-      const sql = yield* SqlClient.SqlClient;
-      const purgedThreadId = ThreadId.makeUnsafe("thread-purge");
-      const keptThreadId = ThreadId.makeUnsafe("thread-keep");
-      const now = "2026-04-20T00:00:00.000Z";
-
-      yield* sql`
-        INSERT INTO projection_threads (
-          thread_id,
-          project_id,
-          title,
-          model_selection_json,
-          runtime_mode,
-          interaction_mode,
-          env_mode,
-          created_at,
-          updated_at,
-          deleted_at
-        )
-        VALUES
-          (
-            ${purgedThreadId},
-            'project-1',
-            'Thread purge',
-            '{"provider":"codex","model":"gpt-5-codex"}',
-            'full-access',
-            'default',
-            'local',
-            ${now},
-            ${now},
-            ${now}
-          ),
-          (
-            ${keptThreadId},
-            'project-1',
-            'Thread keep',
-            '{"provider":"codex","model":"gpt-5-codex"}',
-            'full-access',
-            'default',
-            'local',
-            ${now},
-            ${now},
-            NULL
-          )
-      `;
-
-      yield* sql`
-        INSERT INTO projection_thread_messages (
-          message_id,
-          thread_id,
-          turn_id,
-          role,
-          text,
-          is_streaming,
-          created_at,
-          updated_at
-        )
-        VALUES
-          ('message-purge', ${purgedThreadId}, 'turn-1', 'user', 'old', 0, ${now}, ${now}),
-          ('message-keep', ${keptThreadId}, 'turn-2', 'user', 'new', 0, ${now}, ${now})
-      `;
-      yield* sql`
-        INSERT INTO projection_thread_activities (
-          activity_id,
-          thread_id,
-          turn_id,
-          tone,
-          kind,
-          summary,
-          payload_json,
-          created_at
-        )
-        VALUES ('activity-purge', ${purgedThreadId}, 'turn-1', 'info', 'event', 'old', '{}', ${now})
-      `;
-      yield* sql`
-        INSERT INTO projection_thread_sessions (
-          thread_id,
-          status,
-          provider_name,
-          provider_session_id,
-          provider_thread_id,
-          active_turn_id,
-          last_error,
-          updated_at
-        )
-        VALUES (${purgedThreadId}, 'stopped', 'codex', 'session-1', 'provider-thread-1', NULL, NULL, ${now})
-      `;
-      yield* sql`
-        INSERT INTO projection_turns (
-          thread_id,
-          turn_id,
-          pending_message_id,
-          assistant_message_id,
-          state,
-          requested_at,
-          checkpoint_files_json
-        )
-        VALUES (${purgedThreadId}, 'turn-1', NULL, NULL, 'completed', ${now}, '[]')
-      `;
-      yield* sql`
-        INSERT INTO projection_thread_proposed_plans (
-          plan_id,
-          thread_id,
-          turn_id,
-          plan_markdown,
-          created_at,
-          updated_at
-        )
-        VALUES ('plan-purge', ${purgedThreadId}, 'turn-1', '# Old plan', ${now}, ${now})
-      `;
-      yield* sql`
-        INSERT INTO projection_pending_approvals (
-          request_id,
-          thread_id,
-          turn_id,
-          status,
-          decision,
-          created_at,
-          resolved_at
-        )
-        VALUES ('approval-purge', ${purgedThreadId}, 'turn-1', 'pending', NULL, ${now}, NULL)
-      `;
-      yield* sql`
-        INSERT INTO provider_session_runtime (
-          thread_id,
-          provider_name,
-          adapter_key,
-          runtime_mode,
-          status,
-          last_seen_at,
-          resume_cursor_json,
-          runtime_payload_json
-        )
-        VALUES (${purgedThreadId}, 'codex', 'codex', 'full-access', 'stopped', ${now}, NULL, '{}')
-      `;
-      yield* sql`
-        INSERT INTO checkpoint_diff_blobs (
-          thread_id,
-          from_turn_count,
-          to_turn_count,
-          diff,
-          created_at
-        )
-        VALUES (${purgedThreadId}, 1, 2, 'diff', ${now})
-      `;
-      yield* sql`
-        INSERT INTO orchestration_command_receipts (
-          command_id,
-          aggregate_kind,
-          aggregate_id,
-          accepted_at,
-          result_sequence,
-          status,
-          error
-        )
-        VALUES
-          ('command-purge', 'thread', ${purgedThreadId}, ${now}, 1, 'accepted', NULL),
-          ('command-keep', 'thread', ${keptThreadId}, ${now}, 2, 'accepted', NULL)
-      `;
-      yield* sql`
-        INSERT INTO orchestration_events (
-          event_id,
-          aggregate_kind,
-          stream_id,
-          stream_version,
-          event_type,
-          occurred_at,
-          actor_kind,
-          payload_json,
-          metadata_json
-        )
-        VALUES
-          ('event-purge', 'thread', ${purgedThreadId}, 1, 'thread.created', ${now}, 'system', '{}', '{}'),
-          ('event-keep', 'thread', ${keptThreadId}, 1, 'thread.created', ${now}, 'system', '{}', '{}')
-      `;
-
-      yield* purgeThreadDatabaseRows(purgedThreadId);
-
-      const purgedRows = yield* sql<{ readonly count: number }>`
-        SELECT
-          (SELECT COUNT(*) FROM projection_threads WHERE thread_id = ${purgedThreadId}) +
-          (SELECT COUNT(*) FROM projection_thread_messages WHERE thread_id = ${purgedThreadId}) +
-          (SELECT COUNT(*) FROM projection_thread_activities WHERE thread_id = ${purgedThreadId}) +
-          (SELECT COUNT(*) FROM projection_thread_sessions WHERE thread_id = ${purgedThreadId}) +
-          (SELECT COUNT(*) FROM projection_turns WHERE thread_id = ${purgedThreadId}) +
-          (SELECT COUNT(*) FROM projection_thread_proposed_plans WHERE thread_id = ${purgedThreadId}) +
-          (SELECT COUNT(*) FROM projection_pending_approvals WHERE thread_id = ${purgedThreadId}) +
-          (SELECT COUNT(*) FROM provider_session_runtime WHERE thread_id = ${purgedThreadId}) +
-          (SELECT COUNT(*) FROM checkpoint_diff_blobs WHERE thread_id = ${purgedThreadId}) +
-          (SELECT COUNT(*) FROM orchestration_command_receipts WHERE aggregate_id = ${purgedThreadId}) +
-          (SELECT COUNT(*) FROM orchestration_events WHERE stream_id = ${purgedThreadId}) AS count
-      `;
-      const keptRows = yield* sql<{ readonly count: number }>`
-        SELECT
-          (SELECT COUNT(*) FROM projection_threads WHERE thread_id = ${keptThreadId}) +
-          (SELECT COUNT(*) FROM projection_thread_messages WHERE thread_id = ${keptThreadId}) +
-          (SELECT COUNT(*) FROM orchestration_command_receipts WHERE aggregate_id = ${keptThreadId}) +
-          (SELECT COUNT(*) FROM orchestration_events WHERE stream_id = ${keptThreadId}) AS count
-      `;
-
-      expect(purgedRows[0]?.count).toBe(0);
-      expect(keptRows[0]?.count).toBe(4);
-    }),
-  );
 });

--- a/apps/server/src/threadRetention.ts
+++ b/apps/server/src/threadRetention.ts
@@ -1,7 +1,7 @@
 // FILE: threadRetention.ts
-// Purpose: Runs the server-side cleanup loop for inactive orchestration threads.
+// Purpose: Runs the server-side retention loop that hides inactive orchestration threads.
 // Layer: Server maintenance
-// Exports: retention constants, stale-thread selection, and scoped job startup.
+// Exports: retention constants, inactive-thread selection, and scoped job startup.
 
 import {
   CommandId,
@@ -10,7 +10,6 @@ import {
   type ThreadId,
 } from "@t3tools/contracts";
 import { Effect } from "effect";
-import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { randomUUID } from "node:crypto";
 
 import type { OrchestrationEngineShape } from "./orchestration/Services/OrchestrationEngine";
@@ -22,13 +21,12 @@ export const THREAD_RETENTION_INITIAL_SWEEP_DELAY_MS = 5 * 60 * 1000;
 export const THREAD_RETENTION_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const THREAD_RETENTION_BATCH_SIZE = 25;
 const THREAD_RETENTION_BATCH_PAUSE_MS = 50;
-const RETENTION_COMPACT_FREE_PAGE_THRESHOLD = 8192;
 
 type RetentionThread =
   | OrchestrationReadModel["threads"][number]
   | OrchestrationShellSnapshot["threads"][number];
 
-type RetentionMaintenanceState = "started" | "progress" | "compacting" | "completed" | "failed";
+type RetentionMaintenanceState = "started" | "progress" | "completed" | "failed";
 
 function parseIsoMs(value: string | null | undefined): number | null {
   if (!value) return null;
@@ -84,9 +82,7 @@ const publishRetentionMaintenance = Effect.fn("publishRetentionMaintenance")(fun
   state: RetentionMaintenanceState,
   details: {
     readonly deletedCount?: number;
-    readonly purgedCount?: number;
     readonly totalCount?: number;
-    readonly freePageCount?: number;
     readonly error?: string;
   } = {},
 ) {
@@ -110,84 +106,7 @@ const publishRetentionMaintenance = Effect.fn("publishRetentionMaintenance")(fun
     );
 });
 
-export const purgeThreadDatabaseRows = Effect.fn("purgeThreadDatabaseRows")(function* (
-  threadId: ThreadId,
-) {
-  const sql = yield* SqlClient.SqlClient;
-
-  // Retention is destructive: remove replay events plus derived rows so old
-  // threads do not keep bloating production SQLite forever.
-  yield* sql.withTransaction(
-    Effect.gen(function* () {
-      yield* sql`
-        DELETE FROM projection_pending_approvals
-        WHERE thread_id = ${threadId}
-      `;
-      yield* sql`
-        DELETE FROM projection_thread_proposed_plans
-        WHERE thread_id = ${threadId}
-      `;
-      yield* sql`
-        DELETE FROM projection_turns
-        WHERE thread_id = ${threadId}
-      `;
-      yield* sql`
-        DELETE FROM projection_thread_sessions
-        WHERE thread_id = ${threadId}
-      `;
-      yield* sql`
-        DELETE FROM projection_thread_activities
-        WHERE thread_id = ${threadId}
-      `;
-      yield* sql`
-        DELETE FROM projection_thread_messages
-        WHERE thread_id = ${threadId}
-      `;
-      yield* sql`
-        DELETE FROM provider_session_runtime
-        WHERE thread_id = ${threadId}
-      `;
-      yield* sql`
-        DELETE FROM checkpoint_diff_blobs
-        WHERE thread_id = ${threadId}
-      `;
-      yield* sql`
-        DELETE FROM projection_threads
-        WHERE thread_id = ${threadId}
-      `;
-      yield* sql`
-        DELETE FROM orchestration_command_receipts
-        WHERE aggregate_kind = 'thread'
-          AND aggregate_id = ${threadId}
-      `;
-      yield* sql`
-        DELETE FROM orchestration_events
-        WHERE aggregate_kind = 'thread'
-          AND stream_id = ${threadId}
-      `;
-    }),
-  );
-});
-
-const compactDatabaseAfterRetention = Effect.fn("compactDatabaseAfterRetention")(function* () {
-  const sql = yield* SqlClient.SqlClient;
-  const freePageRows = yield* sql<{ readonly freelist_count: number }>`
-    PRAGMA freelist_count
-  `;
-  const freePageCount = freePageRows[0]?.freelist_count ?? 0;
-  if (freePageCount < RETENTION_COMPACT_FREE_PAGE_THRESHOLD) {
-    return { compacted: false, freePageCount };
-  }
-
-  yield* publishRetentionMaintenance("compacting", { freePageCount });
-  yield* Effect.sleep(250);
-  yield* sql`PRAGMA optimize`;
-  yield* sql`VACUUM`;
-  yield* sql`PRAGMA wal_checkpoint(TRUNCATE)`;
-  return { compacted: true, freePageCount };
-});
-
-// Picks the same threads manual deletion can delete, while protecting active work.
+// Picks inactive threads to soft-delete from the app while keeping their DB rows for stats.
 export function getInactiveThreadIdsForRetention(
   readModel: Pick<OrchestrationReadModel, "threads"> | Pick<OrchestrationShellSnapshot, "threads">,
   nowMs = Date.now(),
@@ -207,57 +126,21 @@ export function getInactiveThreadIdsForRetention(
   return inactiveThreadIds;
 }
 
-export function getSoftDeletedThreadIdsForRetentionPurge(
-  readModel: OrchestrationReadModel,
-): ThreadId[] {
-  const deletedThreadIds: ThreadId[] = [];
-  for (const thread of readModel.threads) {
-    if (thread.deletedAt === null) continue;
-    deletedThreadIds.push(thread.id);
-  }
-  return deletedThreadIds;
-}
-
-const listSoftDeletedThreadIdsFromDatabase = Effect.fn("listSoftDeletedThreadIdsFromDatabase")(
-  function* () {
-    const sql = yield* SqlClient.SqlClient;
-    const rows = yield* sql<{ readonly threadId: ThreadId }>`
-    SELECT thread_id AS "threadId"
-    FROM projection_threads
-    WHERE deleted_at IS NOT NULL
-    ORDER BY deleted_at ASC, thread_id ASC
-  `;
-    return rows.map((row) => row.threadId);
-  },
-);
-
 export const runThreadRetentionSweep = Effect.fn("runThreadRetentionSweep")(function* (
   orchestrationEngine: OrchestrationEngineShape,
   projectionSnapshotQuery: ProjectionSnapshotQueryShape,
 ) {
   const shellSnapshot = yield* projectionSnapshotQuery.getShellSnapshot();
   const inactiveThreadIds = getInactiveThreadIdsForRetention(shellSnapshot);
-  const purgeThreadIds = new Set<ThreadId>([
-    ...(yield* listSoftDeletedThreadIdsFromDatabase().pipe(
-      Effect.catch((error) =>
-        Effect.logWarning("failed to list soft-deleted threads for retention purge").pipe(
-          Effect.annotateLogs({ error: String(error) }),
-          Effect.as([] as ThreadId[]),
-        ),
-      ),
-    )),
-  ]);
-  const totalCandidateCount = inactiveThreadIds.length + purgeThreadIds.size;
+  const totalCandidateCount = inactiveThreadIds.length;
   let deletedCount = 0;
-  let purgedCount = 0;
 
   if (inactiveThreadIds.length > 0) {
     yield* publishRetentionMaintenance("started", {
       deletedCount,
-      purgedCount,
       totalCount: totalCandidateCount,
     });
-    yield* Effect.logInfo("deleting inactive orchestration threads").pipe(
+    yield* Effect.logInfo("hiding inactive orchestration threads").pipe(
       Effect.annotateLogs({ count: inactiveThreadIds.length }),
     );
   }
@@ -278,11 +161,10 @@ export const runThreadRetentionSweep = Effect.fn("runThreadRetentionSweep")(func
               Effect.tap(() =>
                 Effect.sync(() => {
                   deletedCount += 1;
-                  purgeThreadIds.add(threadId);
                 }),
               ),
               Effect.catch((error) =>
-                Effect.logWarning("failed to delete inactive thread during retention sweep").pipe(
+                Effect.logWarning("failed to hide inactive thread during retention sweep").pipe(
                   Effect.annotateLogs({
                     threadId,
                     error: String(error),
@@ -295,7 +177,6 @@ export const runThreadRetentionSweep = Effect.fn("runThreadRetentionSweep")(func
         Effect.tap(() =>
           publishRetentionMaintenance("progress", {
             deletedCount,
-            purgedCount,
             totalCount: totalCandidateCount,
           }),
         ),
@@ -304,79 +185,12 @@ export const runThreadRetentionSweep = Effect.fn("runThreadRetentionSweep")(func
     { concurrency: 1 },
   ).pipe(Effect.asVoid);
 
-  if (purgeThreadIds.size > 0) {
-    if (inactiveThreadIds.length === 0) {
-      yield* publishRetentionMaintenance("started", {
-        deletedCount,
-        purgedCount,
-        totalCount: totalCandidateCount,
-      });
-    }
-    yield* Effect.logInfo("purging retained deleted thread rows").pipe(
-      Effect.annotateLogs({ count: purgeThreadIds.size }),
-    );
+  if (totalCandidateCount > 0) {
+    yield* publishRetentionMaintenance("completed", {
+      deletedCount,
+      totalCount: totalCandidateCount,
+    });
   }
-
-  yield* Effect.forEach(
-    chunkThreadIds(purgeThreadIds),
-    (threadBatch) =>
-      Effect.forEach(
-        threadBatch,
-        (threadId) =>
-          purgeThreadDatabaseRows(threadId).pipe(
-            Effect.tap(() =>
-              Effect.sync(() => {
-                purgedCount += 1;
-              }),
-            ),
-            Effect.catch((error) =>
-              Effect.logWarning("failed to purge deleted thread database rows").pipe(
-                Effect.annotateLogs({
-                  threadId,
-                  error: String(error),
-                }),
-              ),
-            ),
-          ),
-        { concurrency: 1 },
-      ).pipe(
-        Effect.tap(() =>
-          publishRetentionMaintenance("progress", {
-            deletedCount,
-            purgedCount,
-            totalCount: totalCandidateCount,
-          }),
-        ),
-        Effect.tap(() => pauseBetweenRetentionBatches),
-      ),
-    { concurrency: 1 },
-  ).pipe(Effect.asVoid);
-
-  yield* compactDatabaseAfterRetention().pipe(
-    Effect.tap(({ compacted, freePageCount }) =>
-      totalCandidateCount > 0 || compacted
-        ? publishRetentionMaintenance("completed", {
-            deletedCount,
-            purgedCount,
-            totalCount: totalCandidateCount,
-            freePageCount,
-          })
-        : Effect.void,
-    ),
-    Effect.catch((error) =>
-      Effect.logWarning("failed to compact database after retention sweep").pipe(
-        Effect.annotateLogs({ error: String(error) }),
-        Effect.andThen(
-          publishRetentionMaintenance("failed", {
-            deletedCount,
-            purgedCount,
-            totalCount: totalCandidateCount,
-            error: String(error),
-          }),
-        ),
-      ),
-    ),
-  );
 });
 
 export const startThreadRetentionJob = Effect.fn("startThreadRetentionJob")(function* (
@@ -384,7 +198,7 @@ export const startThreadRetentionJob = Effect.fn("startThreadRetentionJob")(func
   projectionSnapshotQuery: ProjectionSnapshotQueryShape,
 ) {
   // Give startup/projection bootstrap a short settling window, then run one
-  // cleanup promptly so desktop installs do not need to stay open for 24 hours.
+  // hide pass promptly so desktop installs do not need to stay open for 24 hours.
   yield* Effect.gen(function* () {
     yield* Effect.sleep(THREAD_RETENTION_INITIAL_SWEEP_DELAY_MS);
     yield* runThreadRetentionSweep(orchestrationEngine, projectionSnapshotQuery);

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -47,6 +47,7 @@ import { ProviderHealth } from "./provider/Services/ProviderHealth";
 import { ProviderService } from "./provider/Services/ProviderService";
 import { listProviderUsage } from "./providerUsage";
 import { getProviderUsageSnapshot } from "./providerUsageSnapshot";
+import { ProfileStatsQuery } from "./profileStats";
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents";
 import { ServerRuntimeStartup } from "./serverRuntimeStartup";
@@ -334,6 +335,7 @@ export const makeWsRpcLayer = () =>
       const open = yield* Open;
       const orchestrationEngine = yield* OrchestrationEngineService;
       const path = yield* Path.Path;
+      const profileStatsQuery = yield* ProfileStatsQuery;
       const projectionReadModelQuery = yield* ProjectionSnapshotQuery;
       const providerAdapterRegistry = yield* ProviderAdapterRegistry;
       const providerDiscoveryService = yield* ProviderDiscoveryService;
@@ -910,6 +912,13 @@ export const makeWsRpcLayer = () =>
           ),
         [WS_METHODS.serverStopLocalServer]: (input) =>
           rpcEffect(stopLocalServerAndTrackedProjectRun(input), "Failed to stop local server"),
+        [WS_METHODS.statsGetProfileStats]: (input) =>
+          rpcEffect(profileStatsQuery.getProfileStats(input), "Failed to load profile stats"),
+        [WS_METHODS.statsGetProfileTokenStats]: (input) =>
+          rpcEffect(
+            profileStatsQuery.getProfileTokenStats(input),
+            "Failed to load profile token stats",
+          ),
         [WS_METHODS.serverGetProviderUsageSnapshot]: (input) =>
           rpcEffect(getProviderUsageSnapshot(input), "Failed to load provider usage"),
         [WS_METHODS.serverListProviderUsage]: (input) =>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "effect": "catalog:",
+    "html-to-image": "^1.11.13",
     "katex": "^0.16.45",
     "lexical": "^0.41.0",
     "pdfjs-dist": "^5.4.296",

--- a/apps/web/src/components/profile/ActivityHeatmap.tsx
+++ b/apps/web/src/components/profile/ActivityHeatmap.tsx
@@ -1,0 +1,251 @@
+// FILE: ActivityHeatmap.tsx
+// Purpose: GitHub-style contribution heatmap shared by the Profile page and the
+// shareable card. Renders columns of week × weekday cells with pre-bucketed
+// intensity. Sizing uses inline px so html-to-image reproduces it exactly.
+// Layer: web profile feature.
+
+import { type CSSProperties, useMemo } from "react";
+import type { ProfileHeatmapCell } from "@t3tools/contracts";
+import { cn } from "~/lib/utils";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import { formatCompact, formatShortDate } from "./profileFormatting";
+
+// Single-hue ramp built from the theme accent (`--info`, defaults to blue-500) for the
+// in-app page (level 0 → 4). Mixes toward transparent so it sits well on light/dark.
+export const APP_HEATMAP_INTENSITY_CLASSES: readonly string[] = [
+  "bg-muted/70 dark:bg-white/[0.06]",
+  "bg-[color-mix(in_srgb,var(--info)_24%,transparent)]",
+  "bg-[color-mix(in_srgb,var(--info)_46%,transparent)]",
+  "bg-[color-mix(in_srgb,var(--info)_72%,transparent)]",
+  "bg-[var(--info)]",
+];
+
+// Accent ramp for the exported card. Mixes toward white so the steps stay opaque on the
+// card's white background and reproduce identically via html-to-image.
+export const CARD_HEATMAP_INTENSITY_CLASSES: readonly string[] = [
+  "bg-slate-200/80",
+  "bg-[color-mix(in_srgb,var(--info)_22%,white)]",
+  "bg-[color-mix(in_srgb,var(--info)_45%,white)]",
+  "bg-[color-mix(in_srgb,var(--info)_70%,white)]",
+  "bg-[var(--info)]",
+];
+
+const MONTH_LABELS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+interface ActivityHeatmapProps {
+  readonly cells: ReadonlyArray<ProfileHeatmapCell>;
+  readonly cellSize?: number;
+  readonly gap?: number;
+  readonly radius?: number;
+  readonly intensityClasses?: readonly string[];
+  readonly showMonths?: boolean;
+  readonly monthsPosition?: "top" | "bottom";
+  readonly monthLabelClassName?: string;
+  /**
+   * Stretch columns to fill the container width (responsive square cells) instead
+   * of using a fixed `cellSize`. Used by the in-app panel so the grid never scrolls
+   * horizontally; the exported card keeps fixed px so html-to-image is exact.
+   */
+  readonly fill?: boolean;
+  /**
+   * In `fill` mode, stretch week columns across the container. When set, `maxCellSize`
+   * caps each square cell's maximum size; columns shrink below that cap if needed so the
+   * grid never overflows horizontally.
+   */
+  readonly maxCellSize?: number;
+  /** Show a styled tooltip on hover. Leave off for the exported card (html-to-image). */
+  readonly tooltip?: boolean;
+  /** Noun used in the tooltip, e.g. "prompts" or "tokens". */
+  readonly tooltipUnit?: string;
+  readonly className?: string;
+}
+
+function heatmapTooltipText(cell: ProfileHeatmapCell, unit: string): string {
+  const date = formatShortDate(cell.day) ?? cell.day;
+  if (cell.count <= 0) {
+    return `No ${unit} on ${date}`;
+  }
+  const noun = cell.count === 1 && unit.endsWith("s") ? unit.slice(0, -1) : unit;
+  return `${formatCompact(cell.count)} ${noun} on ${date}`;
+}
+
+type Slot =
+  | { readonly kind: "cell"; readonly cell: ProfileHeatmapCell }
+  | { readonly kind: "pad"; readonly id: string };
+
+interface Column {
+  readonly key: string;
+  readonly slots: ReadonlyArray<Slot>;
+}
+
+export function ActivityHeatmap({
+  cells,
+  cellSize = 13,
+  gap = 3,
+  radius = 4,
+  intensityClasses = APP_HEATMAP_INTENSITY_CLASSES,
+  showMonths = false,
+  monthsPosition = "top",
+  monthLabelClassName,
+  fill = false,
+  maxCellSize,
+  tooltip = false,
+  tooltipUnit = "prompts",
+  className,
+}: ActivityHeatmapProps) {
+  const columns = useMemo<Column[]>(() => {
+    if (cells.length === 0) {
+      return [];
+    }
+    const slots: Slot[] = [];
+    for (let index = 0; index < cells[0]!.weekday; index += 1) {
+      slots.push({ kind: "pad", id: `pad-lead-${index}` });
+    }
+    for (const cell of cells) {
+      slots.push({ kind: "cell", cell });
+    }
+    while (slots.length % 7 !== 0) {
+      slots.push({ kind: "pad", id: `pad-tail-${slots.length}` });
+    }
+
+    const result: Column[] = [];
+    for (let index = 0; index < slots.length; index += 7) {
+      const week = slots.slice(index, index + 7);
+      const firstCell = week.find(
+        (slot): slot is Extract<Slot, { kind: "cell" }> => slot.kind === "cell",
+      );
+      result.push({ key: firstCell ? firstCell.cell.day : `col-${index}`, slots: week });
+    }
+    return result;
+  }, [cells]);
+
+  const monthByColumn = useMemo<(string | null)[]>(() => {
+    let previousMonth = -1;
+    return columns.map((column) => {
+      const firstCell = column.slots.find(
+        (slot): slot is Extract<Slot, { kind: "cell" }> => slot.kind === "cell",
+      );
+      if (!firstCell) {
+        return null;
+      }
+      const monthIndex = Number(firstCell.cell.day.split("-")[1]) - 1;
+      if (monthIndex === previousMonth || monthIndex < 0) {
+        return null;
+      }
+      previousMonth = monthIndex;
+      return MONTH_LABELS[monthIndex] ?? null;
+    });
+  }, [columns]);
+
+  const columnCount = columns.length;
+  const responsiveFill = fill && maxCellSize != null;
+  const resolvedCellSize = fill ? maxCellSize ?? cellSize : cellSize;
+
+  const columnStyle: CSSProperties = { gap: `${gap}px` };
+  const cellStyle: CSSProperties = fill
+    ? { borderRadius: `${radius}px` }
+    : {
+        width: `${resolvedCellSize}px`,
+        height: `${resolvedCellSize}px`,
+        borderRadius: `${radius}px`,
+      };
+  const cellClass = fill ? "aspect-square w-full min-w-0" : "shrink-0";
+  const fillColumnStyle: CSSProperties = responsiveFill
+    ? { ...columnStyle, flex: "1 1 0%", maxWidth: `${maxCellSize}px`, minWidth: 0 }
+    : columnStyle;
+  const columnClass = fill ? "flex min-w-0 flex-1 flex-col" : "flex shrink-0 flex-col";
+  const monthLabelWidth: CSSProperties | undefined = fill
+    ? responsiveFill
+      ? { flex: "1 1 0%", maxWidth: `${maxCellSize}px`, minWidth: 0 }
+      : undefined
+    : { width: `${resolvedCellSize}px` };
+  const monthLabelClass = fill ? "min-w-0 flex-1" : "shrink-0";
+  const rowClass = fill ? "flex w-full min-w-0" : "flex w-max";
+  const gridWidth =
+    !fill && columnCount > 0
+      ? columnCount * resolvedCellSize + Math.max(0, columnCount - 1) * gap
+      : 0;
+  const rowStyle: CSSProperties = {
+    ...columnStyle,
+    ...(gridWidth > 0 ? { width: `${gridWidth}px` } : {}),
+  };
+
+  const monthRow = showMonths ? (
+    <div className={rowClass} style={rowStyle}>
+      {columns.map((column, index) => (
+        <div
+          key={column.key}
+          className={cn(
+            "overflow-visible whitespace-nowrap text-[10px] font-medium leading-none text-muted-foreground",
+            monthLabelClass,
+            monthLabelClassName,
+          )}
+          style={monthLabelWidth}
+        >
+          {monthByColumn[index] ?? ""}
+        </div>
+      ))}
+    </div>
+  ) : null;
+
+  return (
+    <div
+      className={cn(
+        fill ? "flex w-full min-w-0 flex-col" : "inline-flex flex-col",
+        className,
+      )}
+      style={{ gap: `${gap}px` }}
+    >
+      {showMonths && monthsPosition === "top" ? monthRow : null}
+      <div className={rowClass} style={rowStyle}>
+        {columns.map((column) => (
+          <div key={column.key} className={columnClass} style={fillColumnStyle}>
+            {column.slots.map((slot) => {
+              if (slot.kind !== "cell") {
+                return (
+                  <div key={slot.id} className={cn(cellClass, "bg-transparent")} style={cellStyle} />
+                );
+              }
+              const cellClassName = cn(
+                cellClass,
+                intensityClasses[slot.cell.intensity] ?? intensityClasses[0],
+              );
+              if (!tooltip) {
+                return (
+                  <div
+                    key={slot.cell.day}
+                    className={cellClassName}
+                    style={cellStyle}
+                    title={`${slot.cell.day} · ${slot.cell.count.toLocaleString()}`}
+                  />
+                );
+              }
+              return (
+                <Tooltip key={slot.cell.day}>
+                  <TooltipTrigger render={<div className={cellClassName} style={cellStyle} />} />
+                  <TooltipPopup side="top" sideOffset={6}>
+                    {heatmapTooltipText(slot.cell, tooltipUnit)}
+                  </TooltipPopup>
+                </Tooltip>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      {showMonths && monthsPosition === "bottom" ? monthRow : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/profile/EditProfileDialog.tsx
+++ b/apps/web/src/components/profile/EditProfileDialog.tsx
@@ -1,0 +1,256 @@
+// FILE: EditProfileDialog.tsx
+// Purpose: "Edit profile" modal — edits the local display name, @handle, avatar photo, and
+// accent color. The photo is compressed on-device before it's handed back. Drafts are held
+// locally and only committed on Save.
+// Layer: web profile feature (all changes persist to localStorage via the parent hooks).
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { Dialog, DialogClose, DialogPopup, DialogTitle } from "~/components/ui/dialog";
+import { Button } from "~/components/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+} from "~/components/ui/input-group";
+import { CentralIcon } from "~/lib/central-icons";
+import { cn } from "~/lib/utils";
+import { normalizeHandle } from "./profileFormatting";
+import { PROFILE_AVATAR_COLORS } from "./useProfileAvatarColor";
+import { AvatarImageError, compressAvatarImage } from "./avatarImage";
+import { ProfileAvatar } from "./ProfileAvatar";
+
+// Inputs and footer buttons share one fixed height + radius so every control in
+// the dialog reads as the same size. The visible border keeps the fields legible
+// even when unfocused (the default --input border is ~6% and reads as "no box").
+const fieldControlClassName = "h-9 rounded-xl border-foreground/12";
+const dialogButtonClassName = "h-11 rounded-lg px-4";
+
+interface EditProfileDialogProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly initials: string;
+  readonly name: string;
+  readonly handle: string;
+  readonly avatarColor: string;
+  readonly avatarImage: string | null;
+  readonly onSave: (next: {
+    name: string;
+    handle: string;
+    avatarColor: string;
+    avatarImage: string | null;
+  }) => void;
+}
+
+export function EditProfileDialog({
+  open,
+  onOpenChange,
+  initials,
+  name,
+  handle,
+  avatarColor,
+  avatarImage,
+  onSave,
+}: EditProfileDialogProps) {
+  const [draftName, setDraftName] = useState(name);
+  const [draftHandle, setDraftHandle] = useState(handle.replace(/^@+/, ""));
+  const [draftColor, setDraftColor] = useState(avatarColor);
+  const [draftImage, setDraftImage] = useState<string | null>(avatarImage);
+  const [showEditor, setShowEditor] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [processing, setProcessing] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Re-seed drafts from the live values whenever the dialog (re)opens.
+  useEffect(() => {
+    if (open) {
+      setDraftName(name);
+      setDraftHandle(handle.replace(/^@+/, ""));
+      setDraftColor(avatarColor);
+      setDraftImage(avatarImage);
+      setShowEditor(false);
+      setError(null);
+      setProcessing(false);
+    }
+  }, [open, name, handle, avatarColor, avatarImage]);
+
+  const handlePickFile = async (file: File | undefined) => {
+    if (!file) {
+      return;
+    }
+    setError(null);
+    setProcessing(true);
+    try {
+      setDraftImage(await compressAvatarImage(file));
+    } catch (cause) {
+      setError(cause instanceof AvatarImageError ? cause.message : "Could not process that image.");
+    } finally {
+      setProcessing(false);
+    }
+  };
+
+  const handleSave = () => {
+    onSave({
+      name: draftName.trim(),
+      handle: normalizeHandle(draftHandle),
+      avatarColor: draftColor,
+      avatarImage: draftImage,
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup surface="solid" showCloseButton={false} className="sm:max-w-[500px]">
+        <DialogTitle className="px-4 pt-4 text-lg">Edit profile</DialogTitle>
+
+        <div className="flex flex-col gap-4 px-4 pt-3">
+          {/* Avatar */}
+          <div className="flex flex-col items-center gap-3">
+            <div className="relative">
+              <ProfileAvatar
+                initials={initials}
+                color={draftColor}
+                image={draftImage}
+                className="size-20"
+                textClassName="text-2xl"
+              />
+              <button
+                type="button"
+                onClick={() => setShowEditor((value) => !value)}
+                aria-label="Edit avatar"
+                className={cn(
+                  "absolute bottom-0 end-0 flex size-7 items-center justify-center rounded-full",
+                  "bg-black/45 text-white backdrop-blur-sm transition-colors hover:bg-black/60",
+                )}
+              >
+                <CentralIcon name="pencil" className="size-3 opacity-100" />
+              </button>
+            </div>
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(event) => {
+                void handlePickFile(event.target.files?.[0]);
+                event.target.value = "";
+              }}
+            />
+
+            {showEditor && (
+              <div className="flex flex-col items-center gap-3">
+                <div className="flex items-center justify-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    className="gap-1.5"
+                    disabled={processing}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <CentralIcon name="add-image" className="size-3.5" />
+                    {processing ? "Processing…" : draftImage ? "Replace photo" : "Upload photo"}
+                  </Button>
+                  {draftImage && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      className="gap-1.5 text-muted-foreground"
+                      onClick={() => {
+                        setDraftImage(null);
+                        setError(null);
+                      }}
+                    >
+                      <CentralIcon name="trash-can-simple" className="size-3.5" />
+                      Remove
+                    </Button>
+                  )}
+                </div>
+
+                <div className="flex items-center justify-center gap-2">
+                  {PROFILE_AVATAR_COLORS.map((color) => (
+                    <button
+                      key={color}
+                      type="button"
+                      onClick={() => setDraftColor(color)}
+                      aria-label={`Use ${color}`}
+                      className={cn(
+                        "size-5 rounded-full transition-transform hover:scale-110",
+                        !draftImage &&
+                          draftColor === color &&
+                          "ring-2 ring-foreground/70 ring-offset-2 ring-offset-popover",
+                      )}
+                      style={{ backgroundColor: color }}
+                    />
+                  ))}
+                </div>
+
+                {draftImage && (
+                  <p className="text-center text-xs text-muted-foreground">
+                    Colors apply when no photo is set.
+                  </p>
+                )}
+              </div>
+            )}
+
+            {error && <p className="text-center text-xs text-destructive">{error}</p>}
+          </div>
+
+          {/* Fields */}
+          <div className="divide-y divide-border/60 overflow-hidden rounded-xl border border-border/60">
+            <Field label="Display name">
+              <InputGroup className={fieldControlClassName}>
+                <InputGroupInput
+                  value={draftName}
+                  onChange={(event) => setDraftName(event.target.value)}
+                  placeholder="Your name"
+                />
+              </InputGroup>
+            </Field>
+            <Field label="Username">
+              <InputGroup className={fieldControlClassName}>
+                <InputGroupAddon>
+                  <InputGroupText>@</InputGroupText>
+                </InputGroupAddon>
+                <InputGroupInput
+                  value={draftHandle}
+                  onChange={(event) =>
+                    setDraftHandle(event.target.value.replace(/^@+/, "").replace(/\s+/g, ""))
+                  }
+                  placeholder="username"
+                />
+              </InputGroup>
+            </Field>
+          </div>
+        </div>
+
+        <div className="flex flex-col-reverse gap-2 px-4 pb-4 pt-4 sm:flex-row sm:justify-end">
+          <DialogClose render={<Button variant="ghost" size="default" className={dialogButtonClassName} />}>
+            Cancel
+          </DialogClose>
+          <Button
+            variant="default"
+            size="default"
+            className={dialogButtonClassName}
+            onClick={handleSave}
+            disabled={processing}
+          >
+            Save
+          </Button>
+        </div>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-4 px-3.5 py-3">
+      <span className="shrink-0 text-sm text-muted-foreground">{label}</span>
+      <div className="w-56 shrink-0">{children}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/profile/ProfileAvatar.tsx
+++ b/apps/web/src/components/profile/ProfileAvatar.tsx
@@ -1,0 +1,41 @@
+// FILE: ProfileAvatar.tsx
+// Purpose: Single source of truth for the profile avatar — renders the user's photo when
+// set, otherwise the accent-colored circle with initials. Shared by the Profile header,
+// the Edit dialog, and the shareable card so the three never drift.
+// Layer: web profile feature.
+
+import { cn } from "~/lib/utils";
+
+interface ProfileAvatarProps {
+  readonly initials: string;
+  readonly color: string;
+  readonly image?: string | null;
+  /** Sizing/shape utility classes for the circle, e.g. "size-16". */
+  readonly className?: string;
+  /** Type scale for the initials fallback, e.g. "text-xl". */
+  readonly textClassName?: string;
+}
+
+export function ProfileAvatar({
+  initials,
+  color,
+  image,
+  className,
+  textClassName,
+}: ProfileAvatarProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center overflow-hidden rounded-full text-white",
+        className,
+      )}
+      style={image ? undefined : { backgroundColor: color }}
+    >
+      {image ? (
+        <img src={image} alt="" draggable={false} className="size-full object-cover" />
+      ) : (
+        <span className={cn("font-semibold tracking-tight", textClassName)}>{initials}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/profile/ShareCard.tsx
+++ b/apps/web/src/components/profile/ShareCard.tsx
@@ -1,0 +1,98 @@
+// FILE: ShareCard.tsx
+// Purpose: Fixed-size, theme-independent "virality" card rendered to PNG via html-to-image.
+// Uses explicit colors (not theme tokens) so the exported image looks identical in light
+// and dark mode. Fixed width AND height keep the exported PNG a clean wide card with no
+// trailing whitespace, regardless of how dense the heatmap data is.
+// Layer: web profile feature.
+
+import { forwardRef } from "react";
+import type { ProfileStats, ProfileTokenStats } from "@t3tools/contracts";
+import { SynaraLogo } from "~/components/SynaraLogo";
+import { ActivityHeatmap, CARD_HEATMAP_INTENSITY_CLASSES } from "./ActivityHeatmap";
+import { ProfileAvatar } from "./ProfileAvatar";
+import { formatCompact, formatDays } from "./profileFormatting";
+
+export const SHARE_CARD_WIDTH = 860;
+export const SHARE_CARD_HEIGHT = 440;
+
+// The in-app panel shows a longer window; the share card trims to the most recent ~6 months
+// so the grid stays large and legible inside the fixed card width.
+const CARD_HEATMAP_DAYS = 183;
+
+interface ShareCardProps {
+  readonly stats: ProfileStats;
+  readonly tokenStats: ProfileTokenStats | null;
+  readonly displayName: string;
+  readonly handle: string;
+  readonly avatarColor: string;
+  readonly avatarImage: string | null;
+}
+
+interface Tile {
+  readonly value: string;
+  readonly label: string;
+}
+
+export const ShareCard = forwardRef<HTMLDivElement, ShareCardProps>(function ShareCard(
+  { stats, tokenStats, displayName, handle, avatarColor, avatarImage },
+  ref,
+) {
+  const tiles: Tile[] = [
+    { value: formatCompact(tokenStats?.lifetimeTotalTokens ?? null), label: "lifetime tokens" },
+    { value: formatCompact(tokenStats?.peakDayTokens ?? null), label: "peak day" },
+    { value: formatDays(stats.activity.currentStreakDays), label: "current streak" },
+    { value: formatDays(stats.activity.longestStreakDays), label: "longest streak" },
+  ];
+
+  const heatmapCells = stats.activity.heatmap.slice(-CARD_HEATMAP_DAYS);
+
+  return (
+    <div
+      ref={ref}
+      style={{ width: `${SHARE_CARD_WIDTH}px`, height: `${SHARE_CARD_HEIGHT}px` }}
+      className="flex flex-col justify-center gap-7 overflow-hidden bg-white px-12 font-sans text-slate-900"
+    >
+      {/* Header: user-edited identity truncates before it can collide with the fixed brand. */}
+      <div className="flex min-w-0 items-center justify-between gap-6">
+        <div className="flex min-w-0 flex-1 items-center gap-4">
+          <ProfileAvatar
+            initials={stats.identity.initials}
+            color={avatarColor}
+            image={avatarImage}
+            className="size-16 shrink-0 text-lg font-medium"
+            textClassName="text-lg font-medium"
+          />
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="truncate text-2xl font-normal leading-tight tracking-tight">
+              {displayName}
+            </span>
+            <span className="truncate text-base font-normal text-slate-400">{handle}</span>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 text-slate-600">
+          <SynaraLogo className="size-6 text-slate-700" />
+          <span className="text-xl font-normal tracking-tight">Synara</span>
+        </div>
+      </div>
+
+      {/* Heatmap — recent ~6 months; cells sized so the grid fills the card width */}
+      <ActivityHeatmap
+        cells={heatmapCells}
+        cellSize={22}
+        gap={4}
+        radius={5}
+        intensityClasses={CARD_HEATMAP_INTENSITY_CLASSES}
+      />
+
+      {/* Stat tiles — left-aligned columns, no dividers (reference style) */}
+      <div className="flex items-stretch">
+        {tiles.map((tile) => (
+          <div key={tile.label} className="flex flex-1 flex-col items-start gap-1">
+            <span className="text-2xl font-normal leading-none tracking-tight">{tile.value}</span>
+            <span className="text-sm font-normal text-slate-400">{tile.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+});

--- a/apps/web/src/components/profile/ShareDialog.tsx
+++ b/apps/web/src/components/profile/ShareDialog.tsx
@@ -1,0 +1,208 @@
+// FILE: ShareDialog.tsx
+// Purpose: "Share your activity" dialog — previews the virality card and exports it to
+// PNG fully on-device, then copies to clipboard + opens a social composer, or saves the
+// file. Mirrors the reference share sheet (X / LinkedIn / Reddit / Save).
+// Layer: web profile feature.
+
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { SiReddit, SiX } from "react-icons/si";
+import { FaLinkedinIn } from "react-icons/fa6";
+import type { ProfileStats, ProfileTokenStats } from "@t3tools/contracts";
+import { Dialog, DialogPopup, DialogTitle } from "~/components/ui/dialog";
+import { DownloadIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import { SHARE_CARD_HEIGHT, SHARE_CARD_WIDTH, ShareCard } from "./ShareCard";
+import {
+  copyImageToClipboard,
+  downloadBlob,
+  openExternalUrl,
+  renderNodeToPngBlob,
+  type ShareTarget,
+  shareIntentUrl,
+} from "./shareCardExport";
+
+const PREVIEW_WIDTH = 480;
+const CARD_EXPORT_SIZE = { width: SHARE_CARD_WIDTH, height: SHARE_CARD_HEIGHT } as const;
+
+interface ShareDialogProps {
+  readonly stats: ProfileStats;
+  readonly tokenStats: ProfileTokenStats | null;
+  readonly displayName: string;
+  readonly handle: string;
+  readonly avatarColor: string;
+  readonly avatarImage: string | null;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+export function ShareDialog({
+  stats,
+  tokenStats,
+  displayName,
+  handle,
+  avatarColor,
+  avatarImage,
+  open,
+  onOpenChange,
+}: ShareDialogProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const previewRef = useRef<HTMLDivElement>(null);
+  const [busy, setBusy] = useState<ShareTarget | "save" | null>(null);
+  const [previewWidth, setPreviewWidth] = useState(PREVIEW_WIDTH);
+  const [status, setStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const node = previewRef.current;
+    if (!node) {
+      return;
+    }
+
+    const updatePreviewWidth = (width: number) => {
+      setPreviewWidth(Math.max(1, Math.min(PREVIEW_WIDTH, Math.floor(width))));
+    };
+    updatePreviewWidth(node.clientWidth || PREVIEW_WIDTH);
+
+    if (typeof ResizeObserver === "undefined") {
+      const handleResize = () => updatePreviewWidth(node.clientWidth || PREVIEW_WIDTH);
+      window.addEventListener("resize", handleResize);
+      return () => window.removeEventListener("resize", handleResize);
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      updatePreviewWidth(entries[0]?.contentRect.width ?? node.clientWidth ?? PREVIEW_WIDTH);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [open]);
+
+  const handleShare = useCallback(async (target: ShareTarget) => {
+    const node = cardRef.current;
+    if (!node) {
+      return;
+    }
+    setBusy(target);
+    setStatus(null);
+    try {
+      const blob = await renderNodeToPngBlob(node, CARD_EXPORT_SIZE);
+      const copied = blob ? await copyImageToClipboard(blob) : false;
+      openExternalUrl(shareIntentUrl(target));
+      setStatus(
+        copied
+          ? "Image copied to clipboard — paste it into your post."
+          : "Composer opened — use Save to attach the image.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    const node = cardRef.current;
+    if (!node) {
+      return;
+    }
+    setBusy("save");
+    setStatus(null);
+    try {
+      const blob = await renderNodeToPngBlob(node, CARD_EXPORT_SIZE);
+      if (blob) {
+        downloadBlob(blob, `synara-stats-${stats.timezone.today}.png`);
+        setStatus("Saved PNG to your downloads.");
+      } else {
+        setStatus("Could not render the image.");
+      }
+    } finally {
+      setBusy(null);
+    }
+  }, [stats.timezone.today]);
+
+  const previewScale = previewWidth / SHARE_CARD_WIDTH;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup surface="solid" className="sm:max-w-[560px]">
+        <DialogTitle className="text-center text-xl">Share your activity</DialogTitle>
+        <div className="mt-5 flex flex-col items-center gap-7 px-2 pb-3">
+          <div
+            ref={previewRef}
+            className="w-full max-w-[480px] overflow-hidden rounded-2xl border bg-white shadow-sm"
+            style={{ aspectRatio: `${SHARE_CARD_WIDTH} / ${SHARE_CARD_HEIGHT}` }}
+          >
+            <div
+              style={{
+                width: SHARE_CARD_WIDTH,
+                transform: `scale(${previewScale})`,
+                transformOrigin: "top left",
+              }}
+            >
+              <ShareCard
+                ref={cardRef}
+                stats={stats}
+                tokenStats={tokenStats}
+                displayName={displayName}
+                handle={handle}
+                avatarColor={avatarColor}
+                avatarImage={avatarImage}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-start justify-center gap-6">
+            <ShareButton label="X" busy={busy === "x"} onClick={() => void handleShare("x")}>
+              <SiX className="size-5" />
+            </ShareButton>
+            <ShareButton
+              label="LinkedIn"
+              busy={busy === "linkedin"}
+              onClick={() => void handleShare("linkedin")}
+            >
+              <FaLinkedinIn className="size-5" />
+            </ShareButton>
+            <ShareButton
+              label="Reddit"
+              busy={busy === "reddit"}
+              onClick={() => void handleShare("reddit")}
+            >
+              <SiReddit className="size-5" />
+            </ShareButton>
+            <ShareButton label="Save" busy={busy === "save"} onClick={() => void handleSave()}>
+              <DownloadIcon className="size-5" />
+            </ShareButton>
+          </div>
+
+          <p className="h-4 text-center text-xs text-muted-foreground">{status ?? ""}</p>
+        </div>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+interface ShareButtonProps {
+  readonly label: string;
+  readonly busy: boolean;
+  readonly onClick: () => void;
+  readonly children: ReactNode;
+}
+
+function ShareButton({ label, busy, onClick, children }: ShareButtonProps) {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={busy}
+        aria-label={`Share to ${label}`}
+        className={cn(
+          "flex size-14 items-center justify-center rounded-full bg-foreground text-background transition-opacity",
+          "hover:opacity-90 disabled:opacity-50",
+        )}
+      >
+        {children}
+      </button>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/profile/avatarImage.ts
+++ b/apps/web/src/components/profile/avatarImage.ts
@@ -1,0 +1,72 @@
+// FILE: avatarImage.ts
+// Purpose: Compress a user-picked profile photo entirely on-device into a tiny, square
+// data URL so it can be persisted in localStorage without consuming much space. No I/O
+// leaves the device.
+// Layer: web profile feature.
+
+// Square output edge in CSS px. 160 covers the largest avatar (size-20 / share card) at 2x
+// without storing anything close to the original photo.
+const AVATAR_MAX_EDGE = 160;
+const AVATAR_QUALITY = 0.82;
+
+// Hard cap on the encoded string so a pathological image can never blow the localStorage
+// budget. Comfortable for a 160px square (~5–12 KB typical).
+export const AVATAR_MAX_DATA_URL_LENGTH = 200_000;
+
+export class AvatarImageError extends Error {}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : "");
+    reader.onerror = () => reject(new AvatarImageError("Could not read the selected file."));
+    reader.readAsDataURL(file);
+  });
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new AvatarImageError("That file isn't a readable image."));
+    img.src = src;
+  });
+}
+
+// Resize + center-crop to a square and re-encode (WebP, JPEG fallback) at low quality.
+export async function compressAvatarImage(file: File): Promise<string> {
+  if (!file.type.startsWith("image/")) {
+    throw new AvatarImageError("Please choose an image file.");
+  }
+
+  const sourceUrl = await readFileAsDataUrl(file);
+  const img = await loadImage(sourceUrl);
+
+  const sourceEdge = Math.min(img.naturalWidth || img.width, img.naturalHeight || img.height);
+  if (sourceEdge <= 0) {
+    throw new AvatarImageError("That image has no pixels.");
+  }
+  const edge = Math.min(AVATAR_MAX_EDGE, sourceEdge);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = edge;
+  canvas.height = edge;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new AvatarImageError("Image compression isn't supported in this browser.");
+  }
+
+  const sx = ((img.naturalWidth || img.width) - sourceEdge) / 2;
+  const sy = ((img.naturalHeight || img.height) - sourceEdge) / 2;
+  ctx.drawImage(img, sx, sy, sourceEdge, sourceEdge, 0, 0, edge, edge);
+
+  const webp = canvas.toDataURL("image/webp", AVATAR_QUALITY);
+  const dataUrl = webp.startsWith("data:image/webp")
+    ? webp
+    : canvas.toDataURL("image/jpeg", AVATAR_QUALITY);
+
+  if (dataUrl.length > AVATAR_MAX_DATA_URL_LENGTH) {
+    throw new AvatarImageError("That image is too large even after compression.");
+  }
+  return dataUrl;
+}

--- a/apps/web/src/components/profile/profileFormatting.ts
+++ b/apps/web/src/components/profile/profileFormatting.ts
@@ -1,0 +1,77 @@
+// FILE: profileFormatting.ts
+// Purpose: Pure display formatters shared by the Profile page and the shareable card.
+// Layer: web profile feature (no I/O, safe to use during html-to-image render).
+
+// Compact token/count formatting matching the reference card ("17bn", "538m", "1.2k").
+export function formatCompact(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return "—";
+  }
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000_000) {
+    return `${trimZero(value / 1_000_000_000)}bn`;
+  }
+  if (abs >= 1_000_000) {
+    return `${trimZero(value / 1_000_000)}m`;
+  }
+  if (abs >= 1_000) {
+    return `${trimZero(value / 1_000)}k`;
+  }
+  return `${Math.round(value)}`;
+}
+
+function trimZero(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1);
+}
+
+// Thousands-separated integer ("4,934").
+export function formatNumber(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return "—";
+  }
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(value);
+}
+
+export function formatDays(value: number): string {
+  return `${formatNumber(value)} ${value === 1 ? "day" : "days"}`;
+}
+
+// Title-case a home-directory basename into a friendly display name.
+export function toDisplayName(basename: string): string {
+  const cleaned = basename
+    .replace(/[._-]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+  if (!cleaned) {
+    return "Synara";
+  }
+  return cleaned
+    .split(" ")
+    .map((part) => (part.length > 0 ? part[0]!.toUpperCase() + part.slice(1) : part))
+    .join(" ");
+}
+
+export function normalizeHandle(value: string): string {
+  const slug = value
+    .trim()
+    .replace(/^@+/, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, "")
+    .slice(0, 30);
+  return `@${slug || "synara"}`;
+}
+
+// Pretty short date for "peak day" tooltips ("Apr 3").
+export function formatShortDate(day: string | null): string | null {
+  if (!day) {
+    return null;
+  }
+  const [year, month, date] = day.split("-").map(Number);
+  if (!year || !month || !date) {
+    return null;
+  }
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(
+    new Date(Date.UTC(year, month - 1, date)),
+  );
+}

--- a/apps/web/src/components/profile/shareCardExport.ts
+++ b/apps/web/src/components/profile/shareCardExport.ts
@@ -1,0 +1,82 @@
+// FILE: shareCardExport.ts
+// Purpose: Fully offline rendering of the share card to a PNG, plus clipboard copy,
+// file download, and social-intent URLs. No data leaves the device to BUILD the image;
+// opening a social composer is an explicit, user-initiated action.
+// Layer: web profile feature.
+
+import { toBlob } from "html-to-image";
+import { readNativeApi } from "~/nativeApi";
+
+const SHARE_BRAND_HANDLE = "@trySynara";
+export const SHARE_TWEET_TEXT = `Just checking my ${SHARE_BRAND_HANDLE} dev stats. Absolute masterpiece of an IDE.`;
+const SHARE_URL = "https://trysynara.com";
+
+export type ShareTarget = "x" | "linkedin" | "reddit";
+
+// Renders the given node to a PNG blob entirely on-device (canvas serialization).
+// Passing explicit width/height keeps the export deterministic and free of trailing
+// whitespace regardless of layout measurement quirks.
+export async function renderNodeToPngBlob(
+  node: HTMLElement,
+  size?: { width: number; height: number },
+): Promise<Blob | null> {
+  try {
+    return await toBlob(node, {
+      pixelRatio: 2,
+      cacheBust: true,
+      backgroundColor: "#ffffff",
+      ...(size ? { width: size.width, height: size.height } : {}),
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function copyImageToClipboard(blob: Blob): Promise<boolean> {
+  try {
+    if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) {
+      return false;
+    }
+    await navigator.clipboard.write([new ClipboardItem({ [blob.type || "image/png"]: blob })]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  try {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+// Opens an external URL via the desktop shell when available, else a new browser tab.
+export function openExternalUrl(url: string): void {
+  const api = readNativeApi();
+  if (api?.shell?.openExternal) {
+    void api.shell.openExternal(url);
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+export function shareIntentUrl(target: ShareTarget): string {
+  switch (target) {
+    case "x":
+      return `https://x.com/intent/tweet?text=${encodeURIComponent(SHARE_TWEET_TEXT)}`;
+    case "linkedin":
+      return `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(SHARE_URL)}`;
+    case "reddit":
+      return `https://www.reddit.com/submit?url=${encodeURIComponent(
+        SHARE_URL,
+      )}&title=${encodeURIComponent("My Synara dev stats")}`;
+  }
+}

--- a/apps/web/src/components/profile/useProfileAvatarColor.ts
+++ b/apps/web/src/components/profile/useProfileAvatarColor.ts
@@ -1,0 +1,46 @@
+// FILE: useProfileAvatarColor.ts
+// Purpose: Locally-persisted accent color for the Profile avatar (the green circle behind the
+// initials). Backs the avatar "edit" affordance in the Edit-profile dialog. Local-only, no I/O.
+// Layer: web profile feature.
+
+import { useCallback } from "react";
+import { Schema } from "effect";
+import { useLocalStorage } from "~/hooks/useLocalStorage";
+
+const PROFILE_AVATAR_COLOR_STORAGE_KEY = "synara:profile:avatarColor:v1";
+
+// A compact palette of solid avatar accents. The first entry is the default.
+export const PROFILE_AVATAR_COLORS: readonly string[] = [
+  "#22c55e", // emerald (default)
+  "#3b82f6", // blue
+  "#8b5cf6", // violet
+  "#ec4899", // pink
+  "#f59e0b", // amber
+  "#ef4444", // red
+  "#14b8a6", // teal
+  "#64748b", // slate
+];
+
+const DEFAULT_AVATAR_COLOR = PROFILE_AVATAR_COLORS[0]!;
+
+// Empty string means "use the default".
+const StoredColorSchema = Schema.String;
+
+export function useProfileAvatarColor() {
+  const [stored, setStored] = useLocalStorage(
+    PROFILE_AVATAR_COLOR_STORAGE_KEY,
+    "",
+    StoredColorSchema,
+  );
+
+  const color = stored.trim().length > 0 ? stored.trim() : DEFAULT_AVATAR_COLOR;
+
+  const setColor = useCallback(
+    (next: string) => {
+      setStored(next === DEFAULT_AVATAR_COLOR ? "" : next);
+    },
+    [setStored],
+  );
+
+  return { color, setColor } as const;
+}

--- a/apps/web/src/components/profile/useProfileAvatarImage.ts
+++ b/apps/web/src/components/profile/useProfileAvatarImage.ts
@@ -1,0 +1,32 @@
+// FILE: useProfileAvatarImage.ts
+// Purpose: Locally-persisted profile photo (a small, compressed data URL) for the avatar.
+// When set it takes precedence over the accent color. Local-only, no I/O.
+// Layer: web profile feature.
+
+import { useCallback } from "react";
+import { Schema } from "effect";
+import { useLocalStorage } from "~/hooks/useLocalStorage";
+
+const PROFILE_AVATAR_IMAGE_STORAGE_KEY = "synara:profile:avatarImage:v1";
+
+// Empty string means "no photo".
+const StoredImageSchema = Schema.String;
+
+export function useProfileAvatarImage() {
+  const [stored, setStored] = useLocalStorage(
+    PROFILE_AVATAR_IMAGE_STORAGE_KEY,
+    "",
+    StoredImageSchema,
+  );
+
+  const image = stored.trim().length > 0 ? stored : null;
+
+  const setImage = useCallback(
+    (next: string | null) => {
+      setStored(next ?? "");
+    },
+    [setStored],
+  );
+
+  return { image, setImage } as const;
+}

--- a/apps/web/src/components/profile/useProfileHandle.ts
+++ b/apps/web/src/components/profile/useProfileHandle.ts
@@ -1,0 +1,33 @@
+// FILE: useProfileHandle.ts
+// Purpose: Editable, locally-persisted @handle for the Profile card. Falls back to the
+// server-derived default (home-dir basename) until the user overrides it. Local-only.
+// Layer: web profile feature.
+
+import { useCallback } from "react";
+import { useLocalStorage } from "~/hooks/useLocalStorage";
+import { Schema } from "effect";
+import { normalizeHandle } from "./profileFormatting";
+
+const PROFILE_HANDLE_STORAGE_KEY = "synara:profile:handle:v1";
+
+// Empty string means "use the server default".
+const StoredHandleSchema = Schema.String;
+
+export function useProfileHandle(defaultHandle: string) {
+  const [stored, setStored] = useLocalStorage(PROFILE_HANDLE_STORAGE_KEY, "", StoredHandleSchema);
+
+  const handle = stored.trim().length > 0 ? normalizeHandle(stored) : defaultHandle;
+
+  const setHandle = useCallback(
+    (next: string) => {
+      const normalized = normalizeHandle(next);
+      // Storing the bare default back as empty keeps "reset to default" behavior.
+      setStored(normalized === defaultHandle ? "" : normalized);
+    },
+    [defaultHandle, setStored],
+  );
+
+  const resetHandle = useCallback(() => setStored(""), [setStored]);
+
+  return { handle, setHandle, resetHandle, isCustom: stored.trim().length > 0 } as const;
+}

--- a/apps/web/src/components/profile/useProfileName.ts
+++ b/apps/web/src/components/profile/useProfileName.ts
@@ -1,0 +1,29 @@
+// FILE: useProfileName.ts
+// Purpose: Editable, locally-persisted display name for the Profile. Falls back to the
+// server-derived default (home-dir basename) until the user overrides it. Local-only.
+// Layer: web profile feature.
+
+import { useCallback } from "react";
+import { Schema } from "effect";
+import { useLocalStorage } from "~/hooks/useLocalStorage";
+
+const PROFILE_NAME_STORAGE_KEY = "synara:profile:name:v1";
+
+// Empty string means "use the server default".
+const StoredNameSchema = Schema.String;
+
+export function useProfileName(defaultName: string) {
+  const [stored, setStored] = useLocalStorage(PROFILE_NAME_STORAGE_KEY, "", StoredNameSchema);
+
+  const name = stored.trim().length > 0 ? stored.trim() : defaultName;
+
+  const setName = useCallback(
+    (next: string) => {
+      const trimmed = next.trim();
+      setStored(trimmed === defaultName ? "" : trimmed);
+    },
+    [defaultName, setStored],
+  );
+
+  return { name, setName } as const;
+}

--- a/apps/web/src/components/settings/ProfileSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProfileSettingsPanel.tsx
@@ -1,0 +1,391 @@
+// FILE: ProfileSettingsPanel.tsx
+// Purpose: Local-first profile / stats dashboard rendered inside Settings → Profile. Core
+// stats render instantly from a fast SQL RPC; lifetime/peak token figures stream in from a
+// second DB-backed RPC and upgrade the token tiles in place. Centered, low-chrome layout
+// with an explicit edit mode for the local name + handle.
+// Layer: web profile feature (settings panel body).
+
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  type ProfileStats,
+  type ProfileTokenStats,
+  type ProviderKind,
+} from "@t3tools/contracts";
+import {
+  serverProfileStatsQueryOptions,
+  serverProfileTokenStatsQueryOptions,
+} from "~/lib/serverReactQuery";
+import { CentralIcon } from "~/lib/central-icons";
+import { ProviderIcon } from "~/components/ProviderIcon";
+import { Button } from "~/components/ui/button";
+import { Skeleton } from "~/components/ui/skeleton";
+import { ActivityHeatmap } from "../profile/ActivityHeatmap";
+import { ShareDialog } from "../profile/ShareDialog";
+import { EditProfileDialog } from "../profile/EditProfileDialog";
+import { useProfileHandle } from "../profile/useProfileHandle";
+import { useProfileName } from "../profile/useProfileName";
+import { useProfileAvatarColor } from "../profile/useProfileAvatarColor";
+import { useProfileAvatarImage } from "../profile/useProfileAvatarImage";
+import { ProfileAvatar } from "../profile/ProfileAvatar";
+import {
+  formatCompact,
+  formatDays,
+  formatNumber,
+  toDisplayName,
+} from "../profile/profileFormatting";
+
+
+export function ProfileSettingsPanel() {
+  const coreQuery = useQuery(serverProfileStatsQueryOptions());
+  const tokenQuery = useQuery(serverProfileTokenStatsQueryOptions());
+
+  if (coreQuery.isPending) {
+    return <ProfileSkeleton />;
+  }
+  if (coreQuery.isError || !coreQuery.data) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-24 text-center">
+        <p className="text-sm text-muted-foreground">Couldn’t load your local stats.</p>
+        <Button variant="outline" size="sm" onClick={() => void coreQuery.refetch()}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <ProfileContent
+      stats={coreQuery.data}
+      tokenStats={tokenQuery.data ?? null}
+      tokensPending={tokenQuery.isPending}
+    />
+  );
+}
+
+function ProfileContent({
+  stats,
+  tokenStats,
+  tokensPending,
+}: {
+  stats: ProfileStats;
+  tokenStats: ProfileTokenStats | null;
+  tokensPending: boolean;
+}) {
+  const [shareOpen, setShareOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+
+  const defaultName = useMemo(
+    () => toDisplayName(stats.identity.homeDirBasename),
+    [stats.identity.homeDirBasename],
+  );
+  const { name, setName } = useProfileName(defaultName);
+  const { handle, setHandle } = useProfileHandle(stats.identity.defaultHandle);
+  const { color: avatarColor, setColor: setAvatarColor } = useProfileAvatarColor();
+  const { image: avatarImage, setImage: setAvatarImage } = useProfileAvatarImage();
+
+  const heatmapCells = stats.activity.heatmap;
+  const peakHourLabel = formatPeakHourLabel(stats.activeHours.startHour);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-7">
+      {/* Action row */}
+      <div className="flex items-center justify-end gap-2">
+        <Button variant="outline" size="sm" onClick={() => setShareOpen(true)}>
+          <CentralIcon name="share-os" />
+          Share
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
+          <CentralIcon name="pencil" />
+          Edit
+        </Button>
+      </div>
+
+      {/* Centered identity header */}
+      <header className="flex flex-col items-center gap-3 text-center">
+        <ProfileAvatar
+          initials={stats.identity.initials}
+          color={avatarColor}
+          image={avatarImage}
+          className="size-16 shadow-sm"
+          textClassName="text-xl"
+        />
+        <div className="flex flex-col items-center gap-1.5">
+          <h2 className="text-2xl font-semibold tracking-tight">{name}</h2>
+          <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+            <span>{handle}</span>
+            <span aria-hidden>·</span>
+            <span className="rounded-full border px-1.5 py-px text-xs text-muted-foreground">
+              Synara
+            </span>
+          </div>
+        </div>
+      </header>
+
+      {/* Stat tiles */}
+      <div className="grid grid-cols-2 divide-x divide-y divide-border/50 overflow-hidden rounded-2xl border border-border/60 sm:grid-cols-3 lg:grid-cols-5 lg:divide-y-0">
+        <StatTile
+          label="Lifetime tokens"
+          value={tokensPending ? null : formatCompact(tokenStats?.lifetimeTotalTokens ?? null)}
+        />
+        <StatTile
+          label="Peak day"
+          value={tokensPending ? null : formatCompact(tokenStats?.peakDayTokens ?? null)}
+        />
+        <StatTile label="Total prompts" value={formatNumber(stats.activity.totalPromptsSent)} />
+        <StatTile label="Current streak" value={formatDays(stats.activity.currentStreakDays)} />
+        <StatTile label="Longest streak" value={formatDays(stats.activity.longestStreakDays)} />
+      </div>
+
+      {/* Heatmap */}
+      <section className="flex min-w-0 flex-col gap-3">
+        <h3 className="text-sm font-medium">Activity</h3>
+        <ActivityHeatmap
+          cells={heatmapCells}
+          fill
+          radius={4}
+          gap={3}
+          tooltip
+          tooltipUnit="prompts"
+          showMonths
+          monthsPosition="bottom"
+        />
+      </section>
+
+      {/* Insights + plugins */}
+      <div className="grid gap-x-12 gap-y-7 md:grid-cols-2">
+        <section className="flex flex-col gap-3">
+          <h3 className="text-sm font-medium">Activity insights</h3>
+          <dl className="flex flex-col gap-2.5">
+            <InsightRow
+              label="Most used provider"
+              value={
+                stats.insights.topProvider
+                  ? `${formatProviderLabel(stats.insights.topProvider)}${
+                      stats.insights.topProviderPercent !== null
+                        ? ` · ${stats.insights.topProviderPercent}%`
+                        : ""
+                    }`
+                  : "—"
+              }
+            />
+            <InsightRow
+              label="Most used reasoning"
+              value={
+                stats.insights.topReasoning
+                  ? `${capitalize(stats.insights.topReasoning)}${
+                      stats.insights.topReasoningPercent !== null
+                        ? ` · ${stats.insights.topReasoningPercent}%`
+                        : ""
+                    }`
+                  : "—"
+              }
+            />
+            <InsightRow label="Most active hour" value={peakHourLabel} />
+            <InsightRow
+              label="Skills explored"
+              value={formatNumber(stats.insights.skillsExplored)}
+            />
+            <InsightRow
+              label="Total skills used"
+              value={formatNumber(stats.insights.totalSkillsUsed)}
+            />
+            <InsightRow label="Total threads" value={formatNumber(stats.activity.totalThreads)} />
+          </dl>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h3 className="text-sm font-medium">Most used plugins</h3>
+          {stats.skills.length > 0 ? (
+            <ul className="flex flex-col gap-2.5">
+              {stats.skills.slice(0, 6).map((skill) => (
+                <li
+                  key={`${skill.kind}:${skill.name}`}
+                  className="flex items-center justify-between gap-3"
+                >
+                  <span className="flex min-w-0 items-center gap-2.5">
+                    <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted/60">
+                      <CentralIcon
+                        name={skill.kind === "agent" ? "agent" : "building-blocks"}
+                        className="size-3"
+                      />
+                    </span>
+                    <span className="truncate text-sm">{skill.displayName}</span>
+                  </span>
+                  <span className="shrink-0 text-sm tabular-nums text-muted-foreground">
+                    {formatNumber(skill.runCount)} runs
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">No skills or agents used yet.</p>
+          )}
+        </section>
+      </div>
+
+      {/* Model usage */}
+      <section className="flex flex-col gap-3">
+        <h3 className="text-sm font-medium">Model usage</h3>
+        {stats.providerModels.length > 0 ? (
+          <ul className="grid grid-cols-1 gap-x-12 gap-y-3 sm:grid-cols-2">
+            {stats.providerModels.slice(0, 6).map((entry) => (
+              <ModelUsageRow
+                key={`${entry.provider}:${entry.model}`}
+                provider={entry.provider}
+                model={entry.model}
+                percent={entry.percent}
+              />
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-muted-foreground">No model activity yet.</p>
+        )}
+      </section>
+
+      <ShareDialog
+        stats={stats}
+        tokenStats={tokenStats}
+        displayName={name}
+        handle={handle}
+        avatarColor={avatarColor}
+        avatarImage={avatarImage}
+        open={shareOpen}
+        onOpenChange={setShareOpen}
+      />
+
+      <EditProfileDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        initials={stats.identity.initials}
+        name={name}
+        handle={handle}
+        avatarColor={avatarColor}
+        avatarImage={avatarImage}
+        onSave={({
+          name: nextName,
+          handle: nextHandle,
+          avatarColor: nextColor,
+          avatarImage: nextImage,
+        }) => {
+          setName(nextName);
+          setHandle(nextHandle);
+          setAvatarColor(nextColor);
+          setAvatarImage(nextImage);
+        }}
+      />
+    </div>
+  );
+}
+
+// ── Small pieces ───────────────────────────────────────────────────────
+
+function StatTile({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="flex flex-col items-center gap-0.5 px-3 py-3">
+      {value === null ? (
+        <Skeleton className="h-4 w-12" />
+      ) : (
+        <span className="text-sm font-normal tabular-nums text-foreground">{value}</span>
+      )}
+      <span className="text-sm font-normal text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+function InsightRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <dt className="shrink-0 text-sm text-muted-foreground">{label}</dt>
+      <dd className="truncate text-sm font-normal tabular-nums" title={value}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function formatHour(hour: number): string {
+  const normalized = ((hour % 24) + 24) % 24;
+  if (normalized === 0) return "12 AM";
+  if (normalized === 12) return "12 PM";
+  return normalized < 12 ? `${normalized} AM` : `${normalized - 12} PM`;
+}
+
+function formatPeakHourLabel(startHour: number | null): string {
+  return startHour === null ? "—" : formatHour(startHour);
+}
+
+function formatProviderLabel(provider: ProviderKind): string {
+  switch (provider) {
+    case "codex":
+      return "Codex";
+    case "claudeAgent":
+      return "Claude";
+    case "cursor":
+      return "Cursor";
+    case "gemini":
+      return "Gemini";
+    case "grok":
+      return "Grok";
+    case "kilo":
+      return "Kilo";
+    case "opencode":
+      return "OpenCode";
+    case "pi":
+      return "Pi";
+  }
+}
+
+function ModelUsageRow({
+  provider,
+  model,
+  percent,
+}: {
+  provider: ProviderKind | "unknown";
+  model: string;
+  percent: number;
+}) {
+  return (
+    <li className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between gap-3 text-sm">
+        <span className="flex min-w-0 items-center gap-2">
+          {provider !== "unknown" ? (
+            <ProviderIcon provider={provider} className="size-3.5 shrink-0" />
+          ) : (
+            <CentralIcon name="chart-2" className="size-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <span className="truncate">{model}</span>
+        </span>
+        <span className="shrink-0 tabular-nums text-muted-foreground">{percent}%</span>
+      </div>
+      <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-[var(--info)]"
+          style={{ width: `${Math.min(100, Math.max(2, percent))}%` }}
+        />
+      </div>
+    </li>
+  );
+}
+
+function ProfileSkeleton() {
+  return (
+    <div className="flex flex-col items-center gap-7">
+      <Skeleton className="size-16 rounded-full" />
+      <div className="flex flex-col items-center gap-1.5">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-3 w-24" />
+      </div>
+      <Skeleton className="h-[72px] w-full rounded-2xl" />
+      <Skeleton className="h-24 w-full rounded-lg" />
+      <div className="grid w-full gap-7 md:grid-cols-2">
+        <Skeleton className="h-40 w-full rounded-lg" />
+        <Skeleton className="h-40 w-full rounded-lg" />
+      </div>
+    </div>
+  );
+}
+
+function capitalize(value: string): string {
+  return value.length > 0 ? value[0]!.toUpperCase() + value.slice(1) : value;
+}

--- a/apps/web/src/lib/icons.tsx
+++ b/apps/web/src/lib/icons.tsx
@@ -23,8 +23,10 @@ import {
   IconBrain,
   IconBug,
   IconCamera,
+  IconChartBar,
   IconCheck,
   IconChevronDown,
+  IconClock,
   IconChevronLeft,
   IconChevronRight,
   IconChevronUp,
@@ -36,7 +38,9 @@ import {
   IconEye,
   IconFile,
   IconFlag,
+  IconFlame,
   IconFlask2,
+  IconHash,
   IconFolder,
   IconFolderOpen,
   IconEdit,
@@ -66,12 +70,15 @@ import {
   IconRotate2,
   IconSelector,
   IconSettings,
+  IconShare3,
+  IconSparkles,
   IconStar,
   IconStarFilled,
   IconSun,
   IconTextWrap,
   IconTool,
   IconTrash,
+  IconTrophy,
   IconWorld,
   IconX,
   type TablerIcon,
@@ -140,6 +147,13 @@ export const CopyIcon = centralIconWrapper("square-behind-square-6");
 export const LinkIcon = centralIconWrapper("chain-link-3");
 export const DiffIcon = centralIconWrapper("difference-modified");
 export const DownloadIcon = adaptIcon(IconDownload);
+export const FlameIcon = adaptIcon(IconFlame);
+export const TrophyIcon = adaptIcon(IconTrophy);
+export const ClockIcon = adaptIcon(IconClock);
+export const ChartBarIcon = adaptIcon(IconChartBar);
+export const ShareIcon = adaptIcon(IconShare3);
+export const SparklesIcon = adaptIcon(IconSparkles);
+export const HashIcon = adaptIcon(IconHash);
 export const EllipsisIcon = adaptIcon(IconDots);
 export const ExternalLinkIcon = adaptIcon(IconExternalLink);
 export const EyeIcon = adaptIcon(IconEye);

--- a/apps/web/src/lib/serverReactQuery.ts
+++ b/apps/web/src/lib/serverReactQuery.ts
@@ -21,6 +21,10 @@ export const serverQueryKeys = {
   providerUsage: (provider: ProviderKind | null | undefined, homePath?: string | null) =>
     ["server", "providerUsage", provider ?? null, homePath ?? null] as const,
   allProviderUsage: () => ["server", "allProviderUsage"] as const,
+  profileStats: (utcOffsetMinutes: number) =>
+    ["server", "profileStats", "peak-hour-v2", utcOffsetMinutes] as const,
+  profileTokenStats: (utcOffsetMinutes: number) =>
+    ["server", "profileTokenStats", utcOffsetMinutes] as const,
 };
 
 export const serverMutationKeys = {
@@ -149,6 +153,44 @@ export function serverProviderUsageSnapshotQueryOptions(input: {
 export async function fetchAllProviderUsage(input: ServerListProviderUsageInput = {}) {
   const api = ensureNativeApi();
   return api.server.listProviderUsage(input);
+}
+
+// Local profile + shareable-card core statistics. The client passes its own fixed
+// UTC offset; all metrics are computed from Synara's local DB projections.
+export function serverProfileStatsQueryOptions(input: { enabled?: boolean } = {}) {
+  const utcOffsetMinutes = -new Date().getTimezoneOffset();
+  return queryOptions({
+    queryKey: serverQueryKeys.profileStats(utcOffsetMinutes),
+    enabled: input.enabled ?? true,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    retry: false,
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      return api.stats.getProfileStats({
+        utcOffsetMinutes,
+      });
+    },
+  });
+}
+
+// DB-backed token totals and token heatmap, split from core stats so the Profile
+// page can paint first and upgrade token-only surfaces later.
+export function serverProfileTokenStatsQueryOptions(input: { enabled?: boolean } = {}) {
+  const utcOffsetMinutes = -new Date().getTimezoneOffset();
+  return queryOptions({
+    queryKey: serverQueryKeys.profileTokenStats(utcOffsetMinutes),
+    enabled: input.enabled ?? true,
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+    retry: false,
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      return api.stats.getProfileTokenStats({
+        utcOffsetMinutes,
+      });
+    },
+  });
 }
 
 // Live remaining-usage for every supported provider at once, powering Settings and active usage UI.

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -89,6 +89,7 @@ import {
   SettingsSelectPopup,
 } from "../components/settings/SettingsPanelPrimitives";
 import { ProviderUsageSettingsPanel } from "../components/settings/ProviderUsageSettingsPanel";
+import { ProfileSettingsPanel } from "../components/settings/ProfileSettingsPanel";
 import { SkillsSettingsPanel } from "../components/settings/SkillsSettingsPanel";
 import {
   CHAT_CONTENT_CARD_CLASS_NAME,
@@ -3252,6 +3253,8 @@ function SettingsRouteView() {
         return renderModelsPanel();
       case "providers":
         return renderProvidersPanel();
+      case "profile":
+        return <ProfileSettingsPanel />;
       case "skills":
         return <SkillsSettingsPanel />;
       case "usage":
@@ -3299,30 +3302,37 @@ function SettingsRouteView() {
         </div>
         <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
           <div className="flex-1 overflow-y-auto">
-            <div className="mx-auto w-full max-w-2xl px-6 py-8">
-              <div className="mb-8 flex items-start justify-between gap-4">
-                <div className="min-w-0">
-                  <h1 className="text-xl font-medium tracking-tight text-foreground">
-                    {activeSectionItem.label}
-                  </h1>
-                  <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
-                    {activeSectionItem.description}
-                  </p>
+            {activeSection === "profile" ? (
+              // Profile is a self-contained dashboard: it owns its own header (avatar,
+              // name, share) so it skips the section title bar, and gets a slightly wider
+              // pane than the form sections to fit the heatmap + two-column layout.
+              <div className="mx-auto w-full max-w-3xl px-6 py-8">{renderActivePanel()}</div>
+            ) : (
+              <div className="mx-auto w-full max-w-2xl px-6 py-8">
+                <div className="mb-8 flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <h1 className="text-xl font-medium tracking-tight text-foreground">
+                      {activeSectionItem.label}
+                    </h1>
+                    <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+                      {activeSectionItem.description}
+                    </p>
+                  </div>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    className="shrink-0"
+                    disabled={changedSettingLabels.length === 0}
+                    onClick={() => void restoreDefaults()}
+                  >
+                    <RotateCcwIcon className="size-3.5" />
+                    Restore defaults
+                  </Button>
                 </div>
-                <Button
-                  size="xs"
-                  variant="outline"
-                  className="shrink-0"
-                  disabled={changedSettingLabels.length === 0}
-                  onClick={() => void restoreDefaults()}
-                >
-                  <RotateCcwIcon className="size-3.5" />
-                  Restore defaults
-                </Button>
-              </div>
 
-              {renderActivePanel()}
-            </div>
+                {renderActivePanel()}
+              </div>
+            )}
           </div>
         </div>
         {/* Mounted at the route level (outside the scrollable panel) so the

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -71,7 +71,7 @@ function ThreadRetentionMaintenanceToast() {
         return;
       }
 
-      const { state, purgedCount, totalCount, freePageCount, error } = event.payload;
+      const { state, deletedCount, totalCount, error } = event.payload;
       const eventMs = Date.parse(event.payload.at);
       const isStaleEvent = Number.isFinite(eventMs)
         ? Date.now() - eventMs > MAINTENANCE_EVENT_STALE_MS
@@ -83,8 +83,8 @@ function ThreadRetentionMaintenanceToast() {
       if (state === "started") {
         toastIdRef.current = toastManager.add({
           type: "loading",
-          title: "Cleaning old chats...",
-          description: "Preparing background cleanup.",
+          title: "Hiding old chats...",
+          description: "Preparing background maintenance.",
           timeout: 0,
           data: { allowCrossThreadVisibility: true },
         });
@@ -96,41 +96,18 @@ function ThreadRetentionMaintenanceToast() {
           toastIdRef.current ??
           toastManager.add({
             type: "loading",
-            title: "Cleaning old chats...",
+            title: "Hiding old chats...",
             timeout: 0,
             data: { allowCrossThreadVisibility: true },
           });
         toastIdRef.current = toastId;
         toastManager.update(toastId, {
           type: "loading",
-          title: "Cleaning old chats...",
+          title: "Hiding old chats...",
           description:
             totalCount && totalCount > 0
-              ? `${purgedCount ?? 0} of ${totalCount} chats removed.`
-              : `${purgedCount ?? 0} chats removed.`,
-          timeout: 0,
-          data: { allowCrossThreadVisibility: true },
-        });
-        return;
-      }
-
-      if (state === "compacting") {
-        const toastId =
-          toastIdRef.current ??
-          toastManager.add({
-            type: "loading",
-            title: "Compacting chat database...",
-            timeout: 0,
-            data: { allowCrossThreadVisibility: true },
-          });
-        toastIdRef.current = toastId;
-        toastManager.update(toastId, {
-          type: "loading",
-          title: "Compacting chat database...",
-          description:
-            freePageCount && freePageCount > 0
-              ? "Reclaiming unused database space."
-              : "Finishing cleanup.",
+              ? `${deletedCount ?? 0} of ${totalCount} chats hidden.`
+              : `${deletedCount ?? 0} chats hidden.`,
           timeout: 0,
           data: { allowCrossThreadVisibility: true },
         });
@@ -143,7 +120,7 @@ function ThreadRetentionMaintenanceToast() {
         if (toastId) {
           toastManager.update(toastId, {
             type: "warning",
-            title: "Cleanup paused",
+          title: "Chat maintenance paused",
             description: error ?? "Old chats will be retried later.",
             timeout: 6000,
             data: { allowCrossThreadVisibility: true },
@@ -152,7 +129,7 @@ function ThreadRetentionMaintenanceToast() {
         }
         toastManager.add({
           type: "warning",
-          title: "Cleanup paused",
+          title: "Chat maintenance paused",
           description: error ?? "Old chats will be retried later.",
           timeout: 6000,
           data: { allowCrossThreadVisibility: true },
@@ -165,11 +142,11 @@ function ThreadRetentionMaintenanceToast() {
       if (!toastId) return;
       toastManager.update(toastId, {
         type: "success",
-        title: "Old chats cleaned",
+        title: "Old chats hidden",
         description:
-          purgedCount && purgedCount > 0
-            ? `${purgedCount} chats removed from the database.`
-            : "No old chats needed cleanup.",
+          deletedCount && deletedCount > 0
+            ? `${deletedCount} old chats hidden from the app.`
+            : "No old chats needed hiding.",
         timeout: 3500,
         data: { allowCrossThreadVisibility: true },
       });

--- a/apps/web/src/settingsNavigation.ts
+++ b/apps/web/src/settingsNavigation.ts
@@ -5,6 +5,7 @@
 
 export const SETTINGS_SECTION_IDS = [
   "general",
+  "profile",
   "appearance",
   "notifications",
   "behavior",
@@ -60,6 +61,14 @@ export const SETTINGS_NAV_ITEMS: readonly SettingsNavItem[] = [
     description: "Default provider, thread mode, and sidebar organization.",
     icon: "settings-gear-1",
     eyebrow: "Workflow defaults",
+  },
+  {
+    id: "profile",
+    group: "app",
+    label: "Profile",
+    description: "Your local activity, streaks, and a shareable stats card.",
+    icon: "user",
+    eyebrow: "Your stats",
   },
   {
     id: "appearance",

--- a/apps/web/src/whatsNew/entries.ts
+++ b/apps/web/src/whatsNew/entries.ts
@@ -896,9 +896,9 @@ export const WHATS_NEW_ENTRIES: readonly WhatsNewEntry[] = [
       },
       {
         id: "thread-retention-cleanup",
-        title: "Old inactive threads clean up after seven days",
+        title: "Old inactive threads hide after seven days",
         description:
-          "A safer retention job now removes stale inactive threads in batches, publishes maintenance progress, protects running work and approvals, and compacts SQLite when enough space can be reclaimed.",
+          "The retention job now hides stale inactive threads from the app in batches, publishes maintenance progress, and protects running work and approvals while keeping database history available for long-term stats.",
       },
       {
         id: "websocket-and-server-polish",

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -626,6 +626,11 @@ export function createWsNativeApi(): NativeApi {
       },
       upsertKeybinding: (input) => transport.request(WS_METHODS.serverUpsertKeybinding, input),
     },
+    stats: {
+      getProfileStats: (input) => transport.request(WS_METHODS.statsGetProfileStats, input),
+      getProfileTokenStats: (input) =>
+        transport.request(WS_METHODS.statsGetProfileTokenStats, input),
+    },
     provider: {
       getComposerCapabilities: (input) =>
         transport.request(WS_METHODS.providerGetComposerCapabilities, input),

--- a/bun.lock
+++ b/bun.lock
@@ -113,6 +113,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "effect": "catalog:",
+        "html-to-image": "^1.11.13",
         "katex": "^0.16.45",
         "lexical": "^0.41.0",
         "pdfjs-dist": "^5.4.296",
@@ -1753,6 +1754,8 @@
     "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
 
     "html-escaper": ["html-escaper@3.0.3", "", {}, "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="],
+
+    "html-to-image": ["html-to-image@1.11.13", "", {}, "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10,6 +10,7 @@ export * from "./agentMentions";
 export * from "./ws";
 export * from "./keybindings";
 export * from "./server";
+export * from "./stats";
 export * from "./settings";
 export * from "./git";
 export * from "./orchestration";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -144,6 +144,12 @@ import type {
   ProviderReadPluginResult,
 } from "./providerDiscovery";
 import type { ProviderCompactThreadInput } from "./provider";
+import type {
+  StatsGetProfileStatsInput,
+  StatsGetProfileStatsResult,
+  StatsGetProfileTokenStatsInput,
+  StatsGetProfileTokenStatsResult,
+} from "./stats";
 
 export interface ContextMenuItem<T extends string = string> {
   id: T;
@@ -486,6 +492,12 @@ export interface NativeApi {
       input: ServerVoiceTranscriptionInput,
     ) => Promise<ServerVoiceTranscriptionResult>;
     upsertKeybinding: (input: ServerUpsertKeybindingInput) => Promise<ServerUpsertKeybindingResult>;
+  };
+  stats: {
+    getProfileStats: (input: StatsGetProfileStatsInput) => Promise<StatsGetProfileStatsResult>;
+    getProfileTokenStats: (
+      input: StatsGetProfileTokenStatsInput,
+    ) => Promise<StatsGetProfileTokenStatsResult>;
   };
   provider: {
     getComposerCapabilities: (

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -131,6 +131,12 @@ import {
   TerminalSessionSnapshot,
   TerminalWriteInput,
 } from "./terminal";
+import {
+  StatsGetProfileStatsInput,
+  StatsGetProfileStatsResult,
+  StatsGetProfileTokenStatsInput,
+  StatsGetProfileTokenStatsResult,
+} from "./stats";
 import { WS_METHODS } from "./ws";
 
 export class WsRpcError extends Schema.TaggedErrorClass<WsRpcError>()("WsRpcError", {
@@ -567,6 +573,18 @@ export const WsServerListProviderUsageRpc = Rpc.make(WS_METHODS.serverListProvid
   error: WsRpcError,
 });
 
+export const WsStatsGetProfileStatsRpc = Rpc.make(WS_METHODS.statsGetProfileStats, {
+  payload: StatsGetProfileStatsInput,
+  success: StatsGetProfileStatsResult,
+  error: WsRpcError,
+});
+
+export const WsStatsGetProfileTokenStatsRpc = Rpc.make(WS_METHODS.statsGetProfileTokenStats, {
+  payload: StatsGetProfileTokenStatsInput,
+  success: StatsGetProfileTokenStatsResult,
+  error: WsRpcError,
+});
+
 export const WsServerGetDiagnosticsRpc = Rpc.make(WS_METHODS.serverGetDiagnostics, {
   payload: Schema.Struct({}),
   success: ServerDiagnosticsResult,
@@ -746,6 +764,8 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerStopLocalServerRpc,
   WsServerGetProviderUsageSnapshotRpc,
   WsServerListProviderUsageRpc,
+  WsStatsGetProfileStatsRpc,
+  WsStatsGetProfileTokenStatsRpc,
   WsServerGetDiagnosticsRpc,
   WsServerTranscribeVoiceRpc,
   WsServerGenerateThreadRecapRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -332,12 +332,10 @@ export const ServerLifecycleStreamEvent = Schema.Union([
     type: Schema.Literal("maintenance"),
     payload: Schema.Struct({
       task: Schema.Literal("thread-retention"),
-      state: Schema.Literals(["started", "progress", "compacting", "completed", "failed"]),
+      state: Schema.Literals(["started", "progress", "completed", "failed"]),
       at: IsoDateTime,
       deletedCount: Schema.optional(Schema.Number),
-      purgedCount: Schema.optional(Schema.Number),
       totalCount: Schema.optional(Schema.Number),
-      freePageCount: Schema.optional(Schema.Number),
       error: Schema.optional(Schema.String),
     }),
   }),

--- a/packages/contracts/src/stats.ts
+++ b/packages/contracts/src/stats.ts
@@ -1,0 +1,140 @@
+// FILE: stats.ts
+// Purpose: Schemas for the local profile-stats RPCs that power the Profile page and
+// the shareable activity card. All metrics are backed by Synara's local DB
+// projections; no provider archive or cloud data is part of this contract.
+// Layer: shared contracts (schema-only, no runtime logic)
+
+import { Schema } from "effect";
+import { IsoDateTime, NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas";
+import { ProviderKind } from "./orchestration";
+
+// ── Input ────────────────────────────────────────────────────────────
+
+// The client passes its own fixed UTC offset (minutes east of UTC, i.e.
+// `-new Date().getTimezoneOffset()`) so the server can bucket activity by the
+// user's LOCAL day/hour rather than UTC.
+export const StatsGetProfileStatsInput = Schema.Struct({
+  utcOffsetMinutes: Schema.Int,
+});
+export type StatsGetProfileStatsInput = typeof StatsGetProfileStatsInput.Type;
+
+export const StatsGetProfileTokenStatsInput = StatsGetProfileStatsInput;
+export type StatsGetProfileTokenStatsInput = typeof StatsGetProfileTokenStatsInput.Type;
+
+// ── Building blocks ──────────────────────────────────────────────────
+
+// One day in the GitHub-style heatmap. `intensity` is a pre-bucketed 0–4 level so
+// the client never has to know the count distribution. `weekday` is 0 (Sun)–6 (Sat).
+export const ProfileHeatmapCell = Schema.Struct({
+  day: TrimmedNonEmptyString,
+  count: NonNegativeInt,
+  weekday: Schema.Int,
+  intensity: NonNegativeInt,
+});
+export type ProfileHeatmapCell = typeof ProfileHeatmapCell.Type;
+
+export const ProfileProviderUsage = Schema.Struct({
+  provider: Schema.Union([ProviderKind, Schema.Literal("unknown")]),
+  model: TrimmedNonEmptyString,
+  turnCount: NonNegativeInt,
+  percent: Schema.Number,
+});
+export type ProfileProviderUsage = typeof ProfileProviderUsage.Type;
+
+export const ProfileSkillUsage = Schema.Struct({
+  name: TrimmedNonEmptyString,
+  displayName: TrimmedNonEmptyString,
+  kind: Schema.Literals(["skill", "agent"]),
+  runCount: NonNegativeInt,
+});
+export type ProfileSkillUsage = typeof ProfileSkillUsage.Type;
+
+export const ProfileQuota = Schema.Struct({
+  status: Schema.Literals(["available", "unavailable"]),
+  provider: Schema.NullOr(ProviderKind),
+  window: Schema.NullOr(Schema.String),
+  usedPercent: Schema.NullOr(Schema.Number),
+  resetsAt: Schema.NullOr(IsoDateTime),
+  planName: Schema.NullOr(Schema.String),
+});
+export type ProfileQuota = typeof ProfileQuota.Type;
+
+export const ProfileActivity = Schema.Struct({
+  currentStreakDays: NonNegativeInt,
+  longestStreakDays: NonNegativeInt,
+  totalPromptsSent: NonNegativeInt,
+  totalThreads: NonNegativeInt,
+  promptsToday: NonNegativeInt,
+  // Activity heatmap counts native user prompts per local day (same source as
+  // totalPromptsSent), i.e. days the user actually used Synara.
+  heatmapMetric: Schema.Literal("prompts"),
+  heatmap: Schema.Array(ProfileHeatmapCell),
+});
+export type ProfileActivity = typeof ProfileActivity.Type;
+
+export const ProfileActiveHours = Schema.Struct({
+  startHour: Schema.NullOr(Schema.Int),
+  endHour: Schema.NullOr(Schema.Int),
+  turnCount: NonNegativeInt,
+  label: Schema.NullOr(Schema.String),
+});
+export type ProfileActiveHours = typeof ProfileActiveHours.Type;
+
+export const ProfileInsights = Schema.Struct({
+  topProvider: Schema.NullOr(ProviderKind),
+  topProviderPercent: Schema.NullOr(Schema.Number),
+  topReasoning: Schema.NullOr(Schema.String),
+  topReasoningPercent: Schema.NullOr(Schema.Number),
+  skillsExplored: NonNegativeInt,
+  totalSkillsUsed: NonNegativeInt,
+});
+export type ProfileInsights = typeof ProfileInsights.Type;
+
+export const ProfileIdentity = Schema.Struct({
+  homeDirBasename: Schema.String,
+  initials: Schema.String,
+  defaultHandle: Schema.String,
+});
+export type ProfileIdentity = typeof ProfileIdentity.Type;
+
+export const ProfileTimezone = Schema.Struct({
+  utcOffsetMinutes: Schema.Int,
+  today: TrimmedNonEmptyString,
+});
+export type ProfileTimezone = typeof ProfileTimezone.Type;
+
+// ── Aggregate result ─────────────────────────────────────────────────
+
+export const ProfileStats = Schema.Struct({
+  generatedAt: IsoDateTime,
+  timezone: ProfileTimezone,
+  identity: ProfileIdentity,
+  activity: ProfileActivity,
+  activeHours: ProfileActiveHours,
+  insights: ProfileInsights,
+  providerModels: Schema.Array(ProfileProviderUsage),
+  skills: Schema.Array(ProfileSkillUsage),
+  mostUsedSkill: Schema.NullOr(ProfileSkillUsage),
+  quota: ProfileQuota,
+});
+export type ProfileStats = typeof ProfileStats.Type;
+
+export const StatsGetProfileStatsResult = ProfileStats;
+export type StatsGetProfileStatsResult = typeof StatsGetProfileStatsResult.Type;
+
+// Token totals come from Synara's projected context-window updates. `available`
+// is false when the DB has not recorded token totals yet.
+export const ProfileTokenStats = Schema.Struct({
+  available: Schema.Boolean,
+  lifetimeTotalTokens: Schema.NullOr(NonNegativeInt),
+  peakDayTokens: Schema.NullOr(NonNegativeInt),
+  peakDay: Schema.NullOr(TrimmedNonEmptyString),
+  providers: Schema.Array(ProviderKind),
+  unavailableProviders: Schema.Array(ProviderKind),
+  heatmapMetric: Schema.Literal("tokens"),
+  heatmap: Schema.Array(ProfileHeatmapCell),
+});
+export type ProfileTokenStats = typeof ProfileTokenStats.Type;
+
+export const StatsGetProfileTokenStatsResult = ProfileTokenStats;
+export type StatsGetProfileTokenStatsResult = typeof StatsGetProfileTokenStatsResult.Type;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -82,6 +82,7 @@ import {
   ServerStopLocalServerInput,
   ServerVoiceTranscriptionInput,
 } from "./server";
+import { StatsGetProfileStatsInput, StatsGetProfileTokenStatsInput } from "./stats";
 import {
   ProviderListCommandsInput,
   ProviderGetComposerCapabilitiesInput,
@@ -163,6 +164,8 @@ export const WS_METHODS = {
   serverStopLocalServer: "server.stopLocalServer",
   serverGetProviderUsageSnapshot: "server.getProviderUsageSnapshot",
   serverListProviderUsage: "server.listProviderUsage",
+  statsGetProfileStats: "stats.getProfileStats",
+  statsGetProfileTokenStats: "stats.getProfileTokenStats",
   serverGetDiagnostics: "server.getDiagnostics",
   serverTranscribeVoice: "server.transcribeVoice",
   serverGenerateThreadRecap: "server.generateThreadRecap",
@@ -295,6 +298,8 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.serverStopLocalServer, ServerStopLocalServerInput),
   tagRequestBody(WS_METHODS.serverGetProviderUsageSnapshot, ServerGetProviderUsageSnapshotInput),
   tagRequestBody(WS_METHODS.serverListProviderUsage, ServerListProviderUsageInput),
+  tagRequestBody(WS_METHODS.statsGetProfileStats, StatsGetProfileStatsInput),
+  tagRequestBody(WS_METHODS.statsGetProfileTokenStats, StatsGetProfileTokenStatsInput),
   tagRequestBody(WS_METHODS.serverGetDiagnostics, Schema.Struct({})),
   tagRequestBody(WS_METHODS.serverTranscribeVoice, ServerVoiceTranscriptionInput),
   tagRequestBody(WS_METHODS.serverGenerateThreadRecap, ServerGenerateThreadRecapInput),


### PR DESCRIPTION
## Summary
- Adds a new local Profile dashboard backed by server stats RPCs and a shareable stats card export flow.
- Splits profile data into core stats and token stats, with new contracts, WS methods, React Query hooks, and server wiring.
- Changes thread retention from physical purge to soft-delete so inactive threads stay in SQLite for stats while disappearing from the app.
- Adds supporting migration indexes, UI navigation updates, and release notes.

## Testing
- Added focused server coverage for profile stats aggregation and token stats handling.
- Updated retention coverage to match the new hide-only flow.
- Not run (not requested).