### PR TITLE
Fix Codex auth overlay on Windows

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -505,8 +505,10 @@ describe("buildCodexProcessEnv", () => {
       });
 
       expect(env.CODEX_HOME).toBe(overlayHome);
-      expect(lstatSync(overlayMemoryPath).isSymbolicLink()).toBe(true);
-      expect(readlinkSync(overlayMemoryPath)).toBe(sourceMemoryPath);
+      if (lstatSync(overlayMemoryPath).isSymbolicLink()) {
+        expect(readlinkSync(overlayMemoryPath)).toBe(sourceMemoryPath);
+      }
+      expect(readFileSync(overlayMemoryPath, "utf8")).toBe("fresh-source-db");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
       rmSync(runtimeHome, { recursive: true, force: true });
@@ -533,9 +535,18 @@ describe("buildCodexProcessEnv", () => {
       });
 
       expect(env.CODEX_HOME).toBe(overlayHome);
-      expect(lstatSync(overlayAuthPath).isSymbolicLink()).toBe(true);
-      expect(readlinkSync(overlayAuthPath)).toBe(sourceAuthPath);
+      if (lstatSync(overlayAuthPath).isSymbolicLink()) {
+        expect(readlinkSync(overlayAuthPath)).toBe(sourceAuthPath);
+      }
       expect(readFileSync(overlayAuthPath, "utf8")).toContain("fresh");
+
+      writeFileSync(sourceAuthPath, '{"tokens":{"access_token":"new"}}', "utf8");
+      buildCodexProcessEnv({
+        env: { SYNARA_HOME: runtimeHome },
+        homePath: tempDir,
+        platform: "darwin",
+      });
+      expect(readFileSync(overlayAuthPath, "utf8")).toContain("new");
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
       rmSync(runtimeHome, { recursive: true, force: true });

--- a/apps/server/src/codexProcessEnv.ts
+++ b/apps/server/src/codexProcessEnv.ts
@@ -5,7 +5,9 @@
 // Depends on: Codex home path helpers, shared Codex config parsing, login-shell env reader.
 
 import {
+  copyFileSync,
   existsSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   readdirSync,
@@ -99,7 +101,7 @@ export function disableDpCodeBrowserPluginInCodexConfig(config: string): string 
   return output.join("\n");
 }
 
-function ensureCodexOverlaySymlink(input: {
+function ensureCodexOverlayMirror(input: {
   readonly entryName: string;
   readonly sourcePath: string;
   readonly targetPath: string;
@@ -130,7 +132,22 @@ function ensureCodexOverlaySymlink(input: {
     }
   }
 
-  symlinkSync(input.sourcePath, input.targetPath, input.type);
+  try {
+    symlinkSync(input.sourcePath, input.targetPath, input.type);
+  } catch (symlinkError) {
+    if (input.type !== "file") {
+      throw symlinkError;
+    }
+
+    try {
+      linkSync(input.sourcePath, input.targetPath);
+    } catch {
+      if (!CODEX_OVERLAY_SHARED_STATE_FILES.has(input.entryName)) {
+        throw symlinkError;
+      }
+      copyFileSync(input.sourcePath, input.targetPath);
+    }
+  }
 }
 
 function prepareDpCodeCodexHomeOverlay(input: {
@@ -145,24 +162,33 @@ function prepareDpCodeCodexHomeOverlay(input: {
 
   mkdirSync(overlayHomePath, { recursive: true });
 
-  try {
-    for (const entry of readdirSync(sourceHomePath)) {
-      if (entry === "config.toml") {
-        continue;
-      }
-      const sourcePath = path.join(sourceHomePath, entry);
-      const targetPath = path.join(overlayHomePath, entry);
+  const sourceEntries = (() => {
+    try {
+      return readdirSync(sourceHomePath);
+    } catch {
+      return [];
+    }
+  })();
+
+  for (const entry of sourceEntries) {
+    if (entry === "config.toml") {
+      continue;
+    }
+    const sourcePath = path.join(sourceHomePath, entry);
+    const targetPath = path.join(overlayHomePath, entry);
+    try {
       const stat = lstatSync(sourcePath);
-      ensureCodexOverlaySymlink({
+      ensureCodexOverlayMirror({
         entryName: entry,
         sourcePath,
         targetPath,
         type: stat.isDirectory() ? "dir" : "file",
       });
+    } catch {
+      // Keep preparing the overlay if one mirrored entry cannot be linked.
+      // Codex can lazily recreate non-shared state, while shared auth has a
+      // hard-link/copy fallback above for Windows hosts without symlink rights.
     }
-  } catch {
-    // If the source home is partially missing, Codex can still start with the
-    // overlay config and create any required state lazily.
   }
 
   const sourceConfigPath = path.join(sourceHomePath, "config.toml");


### PR DESCRIPTION
﻿## Summary

Fixes Codex provider authentication detection on Windows when Synara prepares its Codex home overlay.

## Root cause

Synara disables the local dpcode-browser plugin by launching Codex with an overlay `CODEX_HOME`. The overlay mirrors state from the user's real Codex home, including `auth.json`, using filesystem symlinks. On Windows hosts without symlink privileges, creating those file symlinks can fail. The overlay preparation swallowed that failure and continued with no `auth.json`, so `codex login status` ran against an unauthenticated overlay even though the real `~/.codex/auth.json` was valid.

## Changes

- Fall back from symlink to hard link for mirrored Codex home files when file symlink creation fails.
- Fall back to copying only for shared `auth.json` if both symlink and hard link fail, so external `codex login` changes are still refreshed on the next overlay preparation.
- Keep preparing the overlay if one non-critical mirrored entry cannot be linked.
- Update overlay tests to verify behavior instead of assuming every mirrored file is a symlink.

## Verification

- `bunx oxfmt --check apps/server/src/codexProcessEnv.ts apps/server/src/codexAppServerManager.test.ts`
- `bun run --filter t3 typecheck`
- `bun run --filter t3 test -- codexAppServerManager.test.ts`
- Windows manual repro: built a temp overlay from a real ChatGPT-authenticated `~/.codex`; overlay `auth.json` existed as a non-symlink fallback and `CODEX_HOME=<overlay> codex --strict-config doctor --summary` reported auth configured and WebSocket connected.

## Note

I intentionally did not run the full root `bun fmt`, `bun lint`, or `bun typecheck` commands because the repository instructions say not to run those heavyweight workspace checks unless explicitly requested.
