### PR TITLE
[codex] Fix environment panel auto-open behavior

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -15,6 +15,7 @@ import {
   resolveActiveTurnLiveDiffState,
   resolveCommittedProviderModel,
   resolveDefaultEnvironmentPanelOpen,
+  resolveEnvironmentPanelOpen,
   resolveEnvironmentPanelVisible,
   resolveProjectScriptTerminalTarget,
   resolveRuntimeModeAfterApprovalDecision,
@@ -257,16 +258,18 @@ describe("environment panel visibility", () => {
         environmentEnabled: true,
         isCenteredEmptyLanding: false,
         isTerminalPrimarySurface: false,
+        isConstrainedChatLayout: false,
       }),
     ).toBe(true);
   });
 
-  it("keeps empty landing and terminal-primary surfaces closed by default", () => {
+  it("keeps empty landing, terminal-primary, and constrained layouts closed by default", () => {
     expect(
       resolveDefaultEnvironmentPanelOpen({
         environmentEnabled: true,
         isCenteredEmptyLanding: true,
         isTerminalPrimarySurface: false,
+        isConstrainedChatLayout: false,
       }),
     ).toBe(false);
     expect(
@@ -274,8 +277,38 @@ describe("environment panel visibility", () => {
         environmentEnabled: true,
         isCenteredEmptyLanding: false,
         isTerminalPrimarySurface: true,
+        isConstrainedChatLayout: false,
       }),
     ).toBe(false);
+    expect(
+      resolveDefaultEnvironmentPanelOpen({
+        environmentEnabled: true,
+        isCenteredEmptyLanding: false,
+        isTerminalPrimarySurface: false,
+        isConstrainedChatLayout: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("lets a manual preference override the default while switching chats", () => {
+    expect(
+      resolveEnvironmentPanelOpen({
+        defaultOpen: true,
+        userPreferenceOpen: null,
+      }),
+    ).toBe(true);
+    expect(
+      resolveEnvironmentPanelOpen({
+        defaultOpen: true,
+        userPreferenceOpen: false,
+      }),
+    ).toBe(false);
+    expect(
+      resolveEnvironmentPanelOpen({
+        defaultOpen: false,
+        userPreferenceOpen: true,
+      }),
+    ).toBe(true);
   });
 
   it("renders the panel when the user toggles it open on empty landing", () => {

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -294,21 +294,48 @@ describe("environment panel visibility", () => {
     expect(
       resolveEnvironmentPanelOpen({
         defaultOpen: true,
+        actionDismissed: false,
         userPreferenceOpen: null,
       }),
     ).toBe(true);
     expect(
       resolveEnvironmentPanelOpen({
         defaultOpen: true,
+        actionDismissed: false,
         userPreferenceOpen: false,
       }),
     ).toBe(false);
     expect(
       resolveEnvironmentPanelOpen({
         defaultOpen: false,
+        actionDismissed: false,
         userPreferenceOpen: true,
       }),
     ).toBe(true);
+  });
+
+  it("treats action dismissals as transient closes instead of stored preferences", () => {
+    expect(
+      resolveEnvironmentPanelOpen({
+        defaultOpen: true,
+        actionDismissed: true,
+        userPreferenceOpen: null,
+      }),
+    ).toBe(false);
+    expect(
+      resolveEnvironmentPanelOpen({
+        defaultOpen: true,
+        actionDismissed: false,
+        userPreferenceOpen: null,
+      }),
+    ).toBe(true);
+    expect(
+      resolveEnvironmentPanelOpen({
+        defaultOpen: false,
+        actionDismissed: true,
+        userPreferenceOpen: true,
+      }),
+    ).toBe(false);
   });
 
   it("renders the panel when the user toggles it open on empty landing", () => {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -106,10 +106,21 @@ export function resolveDefaultEnvironmentPanelOpen(input: {
   environmentEnabled: boolean;
   isCenteredEmptyLanding: boolean;
   isTerminalPrimarySurface: boolean;
+  isConstrainedChatLayout: boolean;
 }): boolean {
   return (
-    input.environmentEnabled && !input.isCenteredEmptyLanding && !input.isTerminalPrimarySurface
+    input.environmentEnabled &&
+    !input.isCenteredEmptyLanding &&
+    !input.isTerminalPrimarySurface &&
+    !input.isConstrainedChatLayout
   );
+}
+
+export function resolveEnvironmentPanelOpen(input: {
+  defaultOpen: boolean;
+  userPreferenceOpen: boolean | null;
+}): boolean {
+  return input.userPreferenceOpen ?? input.defaultOpen;
 }
 
 export function resolveEnvironmentPanelVisible(input: {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -118,8 +118,12 @@ export function resolveDefaultEnvironmentPanelOpen(input: {
 
 export function resolveEnvironmentPanelOpen(input: {
   defaultOpen: boolean;
+  actionDismissed: boolean;
   userPreferenceOpen: boolean | null;
 }): boolean {
+  if (input.actionDismissed) {
+    return false;
+  }
   return input.userPreferenceOpen ?? input.defaultOpen;
 }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -132,6 +132,7 @@ import {
   resolveActiveTurnLiveDiffState,
   resolveCommittedProviderModel,
   resolveDefaultEnvironmentPanelOpen,
+  resolveEnvironmentPanelOpen,
   resolveEnvironmentPanelVisible,
   resolveProjectScriptTerminalTarget,
   shouldEnableComposerPastedTextCollapse,
@@ -3733,18 +3734,21 @@ export default function ChatView({
   // threads; disposable (temporary/draft) threads keep the legacy inline controls.
   const isDisposableThread = useIsDisposableThread(threadId);
   const environmentEnabled = !isDisposableThread && !isEditorRail;
+  const environmentUsesFloatingOverlay =
+    isTerminalEnvironmentContext || isMobileViewport || rightDockOpen || surfaceMode === "split";
   const environmentDefaultOpen = resolveDefaultEnvironmentPanelOpen({
     environmentEnabled,
     isCenteredEmptyLanding,
     isTerminalPrimarySurface,
+    isConstrainedChatLayout: environmentUsesFloatingOverlay,
   });
-  const [environmentPanelOpen, setEnvironmentPanelOpen] = useState(() => environmentDefaultOpen);
-  useEffect(() => {
-    // Terminal threads keep the Environment panel closed by default so the full
-    // workspace stays untouched until the user explicitly toggles the overlay.
-    // Each normal chat thread starts open; empty/disposable views stay hidden.
-    setEnvironmentPanelOpen(environmentDefaultOpen);
-  }, [environmentDefaultOpen, threadId]);
+  const [environmentPanelPreferenceOpen, setEnvironmentPanelPreferenceOpen] = useState<
+    boolean | null
+  >(null);
+  const environmentPanelOpen = resolveEnvironmentPanelOpen({
+    defaultOpen: environmentDefaultOpen,
+    userPreferenceOpen: environmentPanelPreferenceOpen,
+  });
   const environmentPanelVisible = resolveEnvironmentPanelVisible({
     environmentEnabled,
     environmentPanelOpen,
@@ -8392,19 +8396,17 @@ export default function ChatView({
     onRenameThreadMarker: handleRenameThreadMarker,
     onNotesChange: handleNotesChange,
     onOpenEditorView: viewModeAction?.onClick ?? null,
-    onClose: () => setEnvironmentPanelOpen(false),
+    onClose: () => setEnvironmentPanelPreferenceOpen(false),
   };
   // Full-width single chat: overlay plus transcript/composer inset. Floating overlay when the
   // column is already narrow — right dock open or a split pane (same as header compact mode).
   // Terminal surfaces always float so opening Environment never resizes the terminal workspace.
-  const environmentUsesFloatingOverlay =
-    isTerminalEnvironmentContext || isMobileViewport || rightDockOpen || surfaceMode === "split";
   const environmentAppliesContentInset = environmentPanelVisible && !environmentUsesFloatingOverlay;
   const environmentOverlayVariant = environmentUsesFloatingOverlay ? "floating" : "docked";
   const environmentHeaderState = environmentEnabled
     ? {
         open: environmentPanelVisible,
-        onOpenChange: setEnvironmentPanelOpen,
+        onOpenChange: setEnvironmentPanelPreferenceOpen,
       }
     : null;
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3745,8 +3745,15 @@ export default function ChatView({
   const [environmentPanelPreferenceOpen, setEnvironmentPanelPreferenceOpen] = useState<
     boolean | null
   >(null);
+  const [environmentPanelActionDismissedThreadId, setEnvironmentPanelActionDismissedThreadId] =
+    useState<ThreadId | null>(null);
+  // Action clicks close the current panel, but only the header toggle owns cross-chat preference.
+  useEffect(() => {
+    setEnvironmentPanelActionDismissedThreadId(null);
+  }, [threadId]);
   const environmentPanelOpen = resolveEnvironmentPanelOpen({
     defaultOpen: environmentDefaultOpen,
+    actionDismissed: environmentPanelActionDismissedThreadId === threadId,
     userPreferenceOpen: environmentPanelPreferenceOpen,
   });
   const environmentPanelVisible = resolveEnvironmentPanelVisible({
@@ -8396,7 +8403,7 @@ export default function ChatView({
     onRenameThreadMarker: handleRenameThreadMarker,
     onNotesChange: handleNotesChange,
     onOpenEditorView: viewModeAction?.onClick ?? null,
-    onClose: () => setEnvironmentPanelPreferenceOpen(false),
+    onClose: () => setEnvironmentPanelActionDismissedThreadId(threadId),
   };
   // Full-width single chat: overlay plus transcript/composer inset. Floating overlay when the
   // column is already narrow — right dock open or a split pane (same as header compact mode).
@@ -8406,7 +8413,10 @@ export default function ChatView({
   const environmentHeaderState = environmentEnabled
     ? {
         open: environmentPanelVisible,
-        onOpenChange: setEnvironmentPanelPreferenceOpen,
+        onOpenChange: (open: boolean) => {
+          setEnvironmentPanelActionDismissedThreadId(null);
+          setEnvironmentPanelPreferenceOpen(open);
+        },
       }
     : null;
 


### PR DESCRIPTION
## Summary
- keep the Environment panel closed by default in constrained/floating chat layouts
- preserve explicit Environment open/close preference across chat switches
- add focused ChatView logic coverage for constrained defaults and manual overrides

## Verification
- bun run --cwd apps/web test src/components/ChatView.logic.test.ts
- git diff --check
- separate Codex /review thread reported no blocking findings