### PR TITLE
[codex] Fix worktree file previews

### DIFF
--- a/apps/web/src/routes/-chatThreadRoute.logic.test.ts
+++ b/apps/web/src/routes/-chatThreadRoute.logic.test.ts
@@ -2,6 +2,7 @@ import { ThreadId, TurnId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
 import {
+  resolveFilePreviewWorkspaceRoot,
   resolveRoutePanelBootstrap,
   resolveSplitPaneCloseDecision,
   resolveSplitPaneMaximizeDecision,
@@ -23,6 +24,38 @@ describe("resolveThreadPickerTitle", () => {
 
   it("preserves non-empty thread titles", () => {
     expect(resolveThreadPickerTitle("Bug bash")).toBe("Bug bash");
+  });
+});
+
+describe("resolveFilePreviewWorkspaceRoot", () => {
+  it("uses the project cwd for local threads", () => {
+    expect(
+      resolveFilePreviewWorkspaceRoot({
+        projectCwd: "/repo/project",
+        threadEnvMode: "local",
+        threadWorktreePath: null,
+      }),
+    ).toBe("/repo/project");
+  });
+
+  it("uses the materialized worktree for worktree-backed threads", () => {
+    expect(
+      resolveFilePreviewWorkspaceRoot({
+        projectCwd: "/repo/project",
+        threadEnvMode: "worktree",
+        threadWorktreePath: "/repo/.worktrees/feature",
+      }),
+    ).toBe("/repo/.worktrees/feature");
+  });
+
+  it("does not fall back to the project cwd while a worktree is still pending", () => {
+    expect(
+      resolveFilePreviewWorkspaceRoot({
+        projectCwd: "/repo/project",
+        threadEnvMode: "worktree",
+        threadWorktreePath: null,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/routes/-chatThreadRoute.logic.ts
+++ b/apps/web/src/routes/-chatThreadRoute.logic.ts
@@ -3,7 +3,8 @@
 // Layer: Route UI logic helpers.
 // Exports: thread title fallback, deep-link bootstrap replay handling, and panel toggle helpers.
 
-import type { ThreadId, TurnId } from "@t3tools/contracts";
+import type { ThreadEnvironmentMode, ThreadId, TurnId } from "@t3tools/contracts";
+import { resolveThreadWorkspaceCwd } from "@t3tools/shared/threadEnvironment";
 
 import type { ChatRightPanel, DiffRouteSearch } from "../diffRouteSearch";
 
@@ -47,6 +48,19 @@ export type SplitPaneCloseDecision =
 
 export function resolveThreadPickerTitle(title: string | null): string {
   return title || "New chat";
+}
+
+// File previews follow the thread runtime cwd so worktree chats open the files they actually edit.
+export function resolveFilePreviewWorkspaceRoot(input: {
+  projectCwd?: string | null | undefined;
+  threadEnvMode?: ThreadEnvironmentMode | null | undefined;
+  threadWorktreePath?: string | null | undefined;
+}): string | null {
+  return resolveThreadWorkspaceCwd({
+    projectCwd: input.projectCwd,
+    envMode: input.threadEnvMode,
+    worktreePath: input.threadWorktreePath,
+  });
 }
 
 function createRoutePanelSearchKey(input: {

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -126,9 +126,9 @@ import {
   createAllThreadsSelector,
   createProjectSelector,
   createSidebarThreadSummariesSelector,
-  createThreadSelector,
   createThreadExistsSelector,
   createThreadProjectIdSelector,
+  createThreadWorkspaceMetadataSelector,
 } from "../storeSelectors";
 import { sortThreadsForSidebar } from "../components/Sidebar.logic";
 import { Button } from "../components/ui/button";
@@ -1426,8 +1426,8 @@ function SingleChatSurface(props: {
   const activeProject = useStore(
     useMemo(() => createProjectSelector(props.projectId), [props.projectId]),
   );
-  const activeThread = useStore(
-    useMemo(() => createThreadSelector(props.threadId), [props.threadId]),
+  const threadWorkspaceMetadata = useStore(
+    useMemo(() => createThreadWorkspaceMetadataSelector(props.threadId), [props.threadId]),
   );
   const draftThread = useComposerDraftStore(
     (store) => store.draftThreadsByThreadId[props.threadId] ?? null,
@@ -1436,10 +1436,8 @@ function SingleChatSurface(props: {
   // worktree-backed threads resolve links against their materialized worktree.
   const workspaceRoot = resolveFilePreviewWorkspaceRoot({
     projectCwd: activeProject?.cwd ?? null,
-    threadEnvMode: activeThread ? (activeThread.envMode ?? null) : (draftThread?.envMode ?? null),
-    threadWorktreePath: activeThread
-      ? (activeThread.worktreePath ?? null)
-      : (draftThread?.worktreePath ?? null),
+    threadEnvMode: threadWorkspaceMetadata.envMode ?? draftThread?.envMode ?? null,
+    threadWorktreePath: threadWorkspaceMetadata.worktreePath ?? draftThread?.worktreePath ?? null,
   });
   const projects = useStore((store) => store.projects);
   const { settings: appSettings } = useAppSettings();

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -126,6 +126,7 @@ import {
   createAllThreadsSelector,
   createProjectSelector,
   createSidebarThreadSummariesSelector,
+  createThreadSelector,
   createThreadExistsSelector,
   createThreadProjectIdSelector,
 } from "../storeSelectors";
@@ -141,6 +142,7 @@ import {
   DialogTitle,
 } from "../components/ui/dialog";
 import {
+  resolveFilePreviewWorkspaceRoot,
   resolveRoutePanelBootstrap,
   resolveSplitPaneCloseDecision,
   resolveSplitPaneMaximizeDecision,
@@ -1424,7 +1426,21 @@ function SingleChatSurface(props: {
   const activeProject = useStore(
     useMemo(() => createProjectSelector(props.projectId), [props.projectId]),
   );
-  const workspaceRoot = activeProject?.cwd ?? null;
+  const activeThread = useStore(
+    useMemo(() => createThreadSelector(props.threadId), [props.threadId]),
+  );
+  const draftThread = useComposerDraftStore(
+    (store) => store.draftThreadsByThreadId[props.threadId] ?? null,
+  );
+  // File preview must follow the same runtime cwd as chat markdown, diffs, and git:
+  // worktree-backed threads resolve links against their materialized worktree.
+  const workspaceRoot = resolveFilePreviewWorkspaceRoot({
+    projectCwd: activeProject?.cwd ?? null,
+    threadEnvMode: activeThread ? (activeThread.envMode ?? null) : (draftThread?.envMode ?? null),
+    threadWorktreePath: activeThread
+      ? (activeThread.worktreePath ?? null)
+      : (draftThread?.worktreePath ?? null),
+  });
   const projects = useStore((store) => store.projects);
   const { settings: appSettings } = useAppSettings();
   const { handleNewThread } = useHandleNewThread();

--- a/apps/web/src/storeSelectors.test.ts
+++ b/apps/web/src/storeSelectors.test.ts
@@ -8,6 +8,7 @@ import {
   createThreadExistsSelector,
   createThreadProjectIdSelector,
   createThreadShellsSelector,
+  createThreadWorkspaceMetadataSelector,
 } from "./storeSelectors";
 import type { ThreadShell } from "./types";
 
@@ -117,5 +118,32 @@ describe("thread shell route selectors", () => {
 
     expect(createThreadExistsSelector(threadIdA)(state)).toBe(true);
     expect(createThreadProjectIdSelector(threadIdA)(state)).toBe(projectId);
+  });
+
+  it("keeps workspace metadata stable while streaming messages change", () => {
+    const selectWorkspaceMetadata = createThreadWorkspaceMetadataSelector(threadIdA);
+    const threadIds = [threadIdA];
+    const threadShellById = {
+      [threadIdA]: {
+        ...shellA,
+        envMode: "worktree",
+        worktreePath: "/repo/.worktrees/feature",
+      },
+    };
+
+    const before = selectWorkspaceMetadata(makeState({ threadIds, threadShellById }));
+    const after = selectWorkspaceMetadata(
+      makeState({
+        threadIds,
+        threadShellById,
+        messageIdsByThreadId: { [threadIdA]: [messageId] },
+      }),
+    );
+
+    expect(after).toBe(before);
+    expect(after).toEqual({
+      envMode: "worktree",
+      worktreePath: "/repo/.worktrees/feature",
+    });
   });
 });

--- a/apps/web/src/storeSelectors.ts
+++ b/apps/web/src/storeSelectors.ts
@@ -2,13 +2,23 @@
 // Purpose: Stable Zustand selectors for entity lookups and lightweight sidebar projections.
 // Exports: Selector factories used by routes and sidebar-heavy components.
 
-import type { ProjectId, ThreadId } from "@t3tools/contracts";
+import type { ProjectId, ThreadEnvironmentMode, ThreadId } from "@t3tools/contracts";
 
 import type { AppState } from "./store";
 import { collectByIds, getThreadFromState, getThreadsFromState } from "./threadDerivation";
 import type { Project, SidebarThreadSummary, Thread, ThreadShell } from "./types";
 
 const EMPTY_THREAD_SHELLS: ThreadShell[] = [];
+
+export interface ThreadWorkspaceMetadata {
+  envMode: ThreadEnvironmentMode | undefined;
+  worktreePath: string | null;
+}
+
+const EMPTY_THREAD_WORKSPACE_METADATA: ThreadWorkspaceMetadata = Object.freeze({
+  envMode: undefined,
+  worktreePath: null,
+});
 
 function createStableEntitySelector<T extends { id: string }>(
   selectItems: (state: AppState) => readonly T[],
@@ -143,6 +153,36 @@ export function createThreadProjectIdSelector(
       state.threads.find((thread) => thread.id === threadId)?.projectId ??
       null
     );
+  };
+}
+
+export function createThreadWorkspaceMetadataSelector(
+  threadId: ThreadId | null | undefined,
+): (state: AppState) => ThreadWorkspaceMetadata {
+  let previousEnvMode: ThreadEnvironmentMode | undefined = undefined;
+  let previousWorktreePath: string | null = null;
+  let previousResult = EMPTY_THREAD_WORKSPACE_METADATA;
+
+  return (state) => {
+    if (!threadId) {
+      return EMPTY_THREAD_WORKSPACE_METADATA;
+    }
+
+    // Shell-only: avoid subscribing preview panes to live message/activity detail slices.
+    const source = state.threadShellById?.[threadId];
+    const envMode = source?.envMode;
+    const worktreePath = source?.worktreePath ?? null;
+    if (previousEnvMode === envMode && previousWorktreePath === worktreePath) {
+      return previousResult;
+    }
+
+    previousEnvMode = envMode;
+    previousWorktreePath = worktreePath;
+    previousResult =
+      envMode === undefined && worktreePath === null
+        ? EMPTY_THREAD_WORKSPACE_METADATA
+        : { envMode, worktreePath };
+    return previousResult;
   };
 }
 


### PR DESCRIPTION
## Summary
- Fix file/PDF previews from chat links so worktree-backed threads open in the right dock instead of falling back to the default editor/main surface.
- Reuse the thread runtime workspace resolution for the file preview root.
- Add focused route logic coverage for local, materialized worktree, and pending worktree states.

## Root Cause
Chat markdown links were resolved against the thread runtime cwd, but the dock file opener still validated them against the base project cwd. For worktree-backed chats, absolute paths under the materialized worktree looked outside the preview workspace, so the opener returned unhandled and fell back to the preferred editor.

## Validation
- `bun run --cwd apps/web test src/routes/-chatThreadRoute.logic.test.ts src/lib/workspaceFileOpener.test.ts`
- `git diff --check`