### PR TITLE
Fix automation creation hardening

### DIFF
--- a/apps/server/src/automation/Layers/AutomationScheduler.ts
+++ b/apps/server/src/automation/Layers/AutomationScheduler.ts
@@ -14,8 +14,7 @@ function shouldWakeScheduler(event: AutomationStreamEvent): boolean {
   return (
     event.type === "definition-upserted" ||
     event.type === "definition-deleted" ||
-    (event.type === "run-upserted" &&
-      event.run.result?.completionEvaluation !== undefined)
+    (event.type === "run-upserted" && event.run.result?.completionEvaluation !== undefined)
   );
 }
 

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -792,6 +792,46 @@ layer("AutomationService", (it) => {
     }),
   );
 
+  it.effect("keeps exhausted one-shot automations disabled after a manual rerun", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-once-manual-rerun");
+      const runAt = "2026-06-16T10:00:15.000Z";
+
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("local"),
+          schedule: { type: "once", runAt },
+          maxIterations: 1,
+        },
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      const scheduled = yield* service.runDueOnce({
+        now: runAt,
+        limit: 10,
+        leaseOwnerId: "test-scheduler",
+      });
+      const manual = yield* service.runNow({ automationId });
+      const listed = yield* service.list({ projectId });
+      const definition = listed.definitions.find((entry) => entry.id === automationId);
+
+      assert.strictEqual(scheduled.length, 1);
+      assert.strictEqual(manual.run.status, "running");
+      assert.strictEqual(manual.run.trigger.type, "manual");
+      assert.strictEqual(definition?.enabled, false);
+      assert.strictEqual(definition?.nextRunAt, null);
+      assert.strictEqual(definition?.iterationCount, 1);
+      assert.strictEqual(
+        listed.runs.filter((entry) => entry.automationId === automationId).length,
+        2,
+      );
+    }),
+  );
+
   it.effect("reconciles a completed turn into a succeeded run", () =>
     Effect.gen(function* () {
       resetHarness();

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -143,16 +143,18 @@ function makeThreadDetailForRun(input: {
   readonly messageId: MessageId;
   readonly userText: string;
   readonly assistantText: string | null;
-  readonly extraMessages?: ReadonlyArray<{
-    readonly id: MessageId;
-    readonly role: string;
-    readonly text: string;
-    readonly turnId: TurnId | null;
-    readonly streaming: boolean;
-    readonly source: string;
-    readonly createdAt: string;
-    readonly updatedAt: string;
-  }>;
+  readonly extraMessages?:
+    | ReadonlyArray<{
+        readonly id: MessageId;
+        readonly role: string;
+        readonly text: string;
+        readonly turnId: TurnId | null;
+        readonly streaming: boolean;
+        readonly source: string;
+        readonly createdAt: string;
+        readonly updatedAt: string;
+      }>
+    | undefined;
 }) {
   return {
     ...makeThreadShell({
@@ -1250,7 +1252,9 @@ layer("AutomationService", (it) => {
       });
 
       const reconciled = yield* Effect.race(
-        service.reconcileThread({ threadId: targetThreadId }).pipe(Effect.as("reconciled" as const)),
+        service
+          .reconcileThread({ threadId: targetThreadId })
+          .pipe(Effect.as("reconciled" as const)),
         realDelay(50).pipe(Effect.as("timeout" as const)),
       );
       assert.strictEqual(reconciled, "reconciled");
@@ -1375,7 +1379,10 @@ layer("AutomationService", (it) => {
           listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation
             ?.stopMatched === true,
       });
-      assert.strictEqual(listed.definitions.find((entry) => entry.id === created.id)?.enabled, false);
+      assert.strictEqual(
+        listed.definitions.find((entry) => entry.id === created.id)?.enabled,
+        false,
+      );
     }),
   );
 
@@ -1420,8 +1427,7 @@ layer("AutomationService", (it) => {
         service,
         description: "stale-policy stop evaluation",
         predicate: (listed) =>
-          listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation
-            ?.reason ===
+          listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation?.reason ===
           "Stop check ignored because the automation changed before evaluation finished.",
       });
       const updatedDefinition = listed.definitions.find((entry) => entry.id === created.id);
@@ -1487,8 +1493,7 @@ layer("AutomationService", (it) => {
         service,
         description: "stale-definition stop evaluation",
         predicate: (listed) =>
-          listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation
-            ?.reason ===
+          listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation?.reason ===
           "Stop check ignored because the automation changed before evaluation finished.",
       });
       const updatedDefinition = listed.definitions.find((entry) => entry.id === created.id);
@@ -1597,8 +1602,8 @@ layer("AutomationService", (it) => {
         service,
         description: "missing-thread stop evaluation",
         predicate: (listed) =>
-          listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation
-            ?.reason === "Stop check skipped because the target thread could not be found.",
+          listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation?.reason ===
+          "Stop check skipped because the target thread could not be found.",
       });
       const updatedRun = listed.runs.find((entry) => entry.id === run.id);
       assert.strictEqual(updatedRun?.result?.completionEvaluation?.stopMatched, false);
@@ -1691,10 +1696,12 @@ layer("AutomationService", (it) => {
           listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation
             ?.stopMatched === false,
       });
-      assert.strictEqual(listed.definitions.find((entry) => entry.id === created.id)?.enabled, true);
       assert.strictEqual(
-        listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation
-          ?.stopMatched,
+        listed.definitions.find((entry) => entry.id === created.id)?.enabled,
+        true,
+      );
+      assert.strictEqual(
+        listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation?.stopMatched,
         false,
       );
       assert.strictEqual(
@@ -1803,14 +1810,14 @@ layer("AutomationService", (it) => {
         },
       });
       const updatedRun = listed.runs.find((entry) => entry.id === run.id);
-      assert.strictEqual(listed.definitions.find((entry) => entry.id === created.id)?.enabled, true);
+      assert.strictEqual(
+        listed.definitions.find((entry) => entry.id === created.id)?.enabled,
+        true,
+      );
       assert.strictEqual(updatedRun?.result?.completionEvaluation?.stopMatched, false);
       assert.strictEqual(updatedRun?.result?.unread, false);
       assert.strictEqual(updatedRun?.result?.archivedAt, archived.run.result?.archivedAt);
-      assert.isAtLeast(
-        Date.parse(updatedRun?.updatedAt ?? ""),
-        Date.parse(archived.run.updatedAt),
-      );
+      assert.isAtLeast(Date.parse(updatedRun?.updatedAt ?? ""), Date.parse(archived.run.updatedAt));
     }),
   );
 
@@ -1851,7 +1858,10 @@ layer("AutomationService", (it) => {
             ?.confidence === 0.52,
       });
       const updatedRun = listed.runs.find((entry) => entry.id === run.id);
-      assert.strictEqual(listed.definitions.find((entry) => entry.id === created.id)?.enabled, true);
+      assert.strictEqual(
+        listed.definitions.find((entry) => entry.id === created.id)?.enabled,
+        true,
+      );
       assert.strictEqual(updatedRun?.result?.completionEvaluation?.stopMatched, true);
       assert.strictEqual(updatedRun?.result?.completionEvaluation?.confidence, 0.52);
       assert.strictEqual(
@@ -1861,44 +1871,52 @@ layer("AutomationService", (it) => {
     }),
   );
 
-  it.effect("keeps a heartbeat automation active and records history when stop evaluation fails", () =>
-    Effect.gen(function* () {
-      resetHarness();
-      const service = yield* AutomationService;
-      const targetThreadId = ThreadId.makeUnsafe("heartbeat-stop-evaluator-failure");
-      const automationTurnId = TurnId.makeUnsafe("turn-stop-evaluator-failure");
-      threadShell = Option.some(makeThreadShell({ id: targetThreadId }));
-      completionEvaluationFailure = new Error("provider unavailable");
+  it.effect(
+    "keeps a heartbeat automation active and records history when stop evaluation fails",
+    () =>
+      Effect.gen(function* () {
+        resetHarness();
+        const service = yield* AutomationService;
+        const targetThreadId = ThreadId.makeUnsafe("heartbeat-stop-evaluator-failure");
+        const automationTurnId = TurnId.makeUnsafe("turn-stop-evaluator-failure");
+        threadShell = Option.some(makeThreadShell({ id: targetThreadId }));
+        completionEvaluationFailure = new Error("provider unavailable");
 
-      const created = yield* service.create({
-        ...createInput("local"),
-        mode: "heartbeat",
-        targetThreadId,
-        completionPolicy: heartbeatCompletionPolicy("the PR is ready"),
-      });
-      const { run } = yield* service.runNow({ automationId: created.id });
-      yield* completeHeartbeatRun({
-        run,
-        threadId: targetThreadId,
-        turnId: automationTurnId,
-      });
+        const created = yield* service.create({
+          ...createInput("local"),
+          mode: "heartbeat",
+          targetThreadId,
+          completionPolicy: heartbeatCompletionPolicy("the PR is ready"),
+        });
+        const { run } = yield* service.runNow({ automationId: created.id });
+        yield* completeHeartbeatRun({
+          run,
+          threadId: targetThreadId,
+          turnId: automationTurnId,
+        });
 
-      yield* service.reconcileThread({ threadId: targetThreadId });
+        yield* service.reconcileThread({ threadId: targetThreadId });
 
-      const listed = yield* waitForAutomationList({
-        service,
-        description: "failed stop evaluation",
-        predicate: (listed) =>
-          listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation
-            ?.confidence === 0,
-      });
-      const updatedRun = listed.runs.find((entry) => entry.id === run.id);
-      assert.strictEqual(listed.definitions.find((entry) => entry.id === created.id)?.enabled, true);
-      assert.strictEqual(updatedRun?.result?.completionEvaluation?.stopMatched, false);
-      assert.strictEqual(updatedRun?.result?.completionEvaluation?.confidence, 0);
-      assert.include(updatedRun?.result?.summary ?? "", "Stop check failed:");
-      assert.include(updatedRun?.result?.completionEvaluation?.reason ?? "", "Stop check failed:");
-    }),
+        const listed = yield* waitForAutomationList({
+          service,
+          description: "failed stop evaluation",
+          predicate: (listed) =>
+            listed.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation
+              ?.confidence === 0,
+        });
+        const updatedRun = listed.runs.find((entry) => entry.id === run.id);
+        assert.strictEqual(
+          listed.definitions.find((entry) => entry.id === created.id)?.enabled,
+          true,
+        );
+        assert.strictEqual(updatedRun?.result?.completionEvaluation?.stopMatched, false);
+        assert.strictEqual(updatedRun?.result?.completionEvaluation?.confidence, 0);
+        assert.include(updatedRun?.result?.summary ?? "", "Stop check failed:");
+        assert.include(
+          updatedRun?.result?.completionEvaluation?.reason ?? "",
+          "Stop check failed:",
+        );
+      }),
   );
 
   it.effect("does not auto-stop a heartbeat automation without a completion policy", () =>
@@ -1930,7 +1948,10 @@ layer("AutomationService", (it) => {
 
       const listed = yield* service.list({ projectId });
       const updatedRun = listed.runs.find((entry) => entry.id === run.id);
-      assert.strictEqual(listed.definitions.find((entry) => entry.id === created.id)?.enabled, true);
+      assert.strictEqual(
+        listed.definitions.find((entry) => entry.id === created.id)?.enabled,
+        true,
+      );
       assert.isUndefined(updatedRun?.result?.completionEvaluation);
     }),
   );
@@ -1966,6 +1987,36 @@ layer("AutomationService", (it) => {
     }),
   );
 
+  it.effect("rejects creating a standalone automation for an unknown project", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+
+      const error = yield* service
+        .create({
+          ...createInput("local"),
+          projectId: ProjectId.makeUnsafe("missing-project"),
+        })
+        .pipe(Effect.flip);
+
+      assert.match(error.message, /project was not found/);
+    }),
+  );
+
+  it.effect("rejects moving a standalone automation to an unknown project", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const created = yield* service.create(createInput("local"));
+
+      const error = yield* service
+        .update({ id: created.id, projectId: ProjectId.makeUnsafe("missing-project") })
+        .pipe(Effect.flip);
+
+      assert.match(error.message, /project was not found/);
+    }),
+  );
+
   it.effect("rejects moving a heartbeat automation away from its target thread project", () =>
     Effect.gen(function* () {
       resetHarness();
@@ -1997,7 +2048,7 @@ layer("AutomationService", (it) => {
     }),
   );
 
-  it.effect("clears heartbeat max iterations when switching back to standalone", () =>
+  it.effect("preserves max iterations when switching back to standalone", () =>
     Effect.gen(function* () {
       resetHarness();
       const service = yield* AutomationService;
@@ -2017,7 +2068,13 @@ layer("AutomationService", (it) => {
       });
 
       assert.strictEqual(updated.mode, "standalone");
-      assert.strictEqual(updated.maxIterations, null);
+      assert.strictEqual(updated.maxIterations, 3);
+
+      const cleared = yield* service.update({
+        id: created.id,
+        maxIterations: null,
+      });
+      assert.strictEqual(cleared.maxIterations, null);
     }),
   );
 
@@ -2046,11 +2103,114 @@ layer("AutomationService", (it) => {
       const created = yield* service.create({
         ...createInput("local"),
         schedule: { type: "interval", everySeconds: 15 },
+        maxIterations: 10,
         acknowledgedRisks: ["fast-interval", "local-checkout"],
       });
 
       assert.strictEqual(created.schedule.type, "interval");
+      assert.strictEqual(created.maxIterations, 10);
       assert.deepStrictEqual(created.acknowledgedRisks, ["fast-interval", "local-checkout"]);
+    }),
+  );
+
+  it.effect("rejects acknowledged fast recurring intervals without a hard iteration cap", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+
+      const error = yield* service
+        .create({
+          ...createInput("local"),
+          schedule: { type: "interval", everySeconds: 15 },
+          acknowledgedRisks: ["fast-interval", "local-checkout"],
+        })
+        .pipe(Effect.flip);
+
+      assert.match(error.message, /max iterations.*10 runs or fewer/);
+    }),
+  );
+
+  it.effect("rejects acknowledged fast recurring intervals above the hard iteration cap", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+
+      const error = yield* service
+        .create({
+          ...createInput("local"),
+          schedule: { type: "interval", everySeconds: 15 },
+          maxIterations: 25,
+          acknowledgedRisks: ["fast-interval", "local-checkout"],
+        })
+        .pipe(Effect.flip);
+
+      assert.match(error.message, /max iterations.*10 runs or fewer/);
+    }),
+  );
+
+  it.effect("does not treat heartbeat stop policies as a hard fast-interval bound", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const targetThreadId = ThreadId.makeUnsafe("fast-stop-policy-thread");
+      threadShell = Option.some(makeThreadShell({ id: targetThreadId }));
+
+      const error = yield* service
+        .create({
+          ...createInput("local"),
+          mode: "heartbeat",
+          targetThreadId,
+          schedule: { type: "interval", everySeconds: 15 },
+          completionPolicy: heartbeatCompletionPolicy("the condition is met"),
+          acknowledgedRisks: ["fast-interval", "local-checkout"],
+        })
+        .pipe(Effect.flip);
+
+      assert.match(error.message, /max iterations.*10 runs or fewer/);
+    }),
+  );
+
+  it.effect("rejects updates that remove the hard cap from fast recurring intervals", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const created = yield* service.create({
+        ...createInput("local"),
+        schedule: { type: "interval", everySeconds: 15 },
+        maxIterations: 3,
+        acknowledgedRisks: ["fast-interval", "local-checkout"],
+      });
+
+      const error = yield* service
+        .update({ id: created.id, maxIterations: null })
+        .pipe(Effect.flip);
+
+      assert.match(error.message, /max iterations.*10 runs or fewer/);
+    }),
+  );
+
+  it.effect("allows pausing legacy acknowledged fast intervals without an iteration cap", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const created = yield* service.create({
+        ...createInput("local"),
+        schedule: { type: "interval", everySeconds: 15 },
+        maxIterations: 3,
+        acknowledgedRisks: ["fast-interval", "local-checkout"],
+      });
+      yield* repository.saveDefinition({ ...created, maxIterations: null });
+
+      const paused = yield* service.update({ id: created.id, enabled: false });
+
+      assert.strictEqual(paused.enabled, false);
+      assert.strictEqual(paused.maxIterations, null);
+
+      const reenableError = yield* service
+        .update({ id: created.id, enabled: true })
+        .pipe(Effect.flip);
+      assert.match(reenableError.message, /max iterations.*10 runs or fewer/);
     }),
   );
 
@@ -2151,6 +2311,23 @@ layer("AutomationService", (it) => {
     }),
   );
 
+  it.effect("rejects retry policies on update until retry attempts are modeled", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const created = yield* service.create(createInput("local"));
+
+      const error = yield* service
+        .update({
+          id: created.id,
+          retryPolicy: { type: "fixed", maxAttempts: 3, delaySeconds: 30 },
+        })
+        .pipe(Effect.flip);
+
+      assert.match(error.message, /retry policies are not supported/);
+    }),
+  );
+
   it.effect("disables a scheduled automation that has reached its iteration cap", () =>
     Effect.gen(function* () {
       resetHarness();
@@ -2189,6 +2366,62 @@ layer("AutomationService", (it) => {
         reloaded.runs.filter((entry) => entry.automationId === automationId).length,
         0,
       );
+    }),
+  );
+
+  it.effect("restarts an exhausted bounded loop when run manually", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-manual-restart-max-iters");
+      const targetThreadId = ThreadId.makeUnsafe("thread-manual-restart-max-iters");
+
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("local"),
+          name: "Say hi",
+          prompt: "say hi",
+          schedule: { type: "interval", everySeconds: 15 },
+          mode: "heartbeat",
+          targetThreadId,
+          maxIterations: 3,
+        },
+        now: "2026-06-16T10:00:00.000Z",
+      });
+      yield* Effect.forEach(
+        [0, 1, 2],
+        () =>
+          repository.incrementDefinitionIterationCount({
+            id: automationId,
+            now: "2026-06-16T10:00:00.000Z",
+          }),
+        { discard: true },
+      );
+      yield* repository.disableDefinition({
+        id: automationId,
+        now: "2026-06-16T10:01:00.000Z",
+      });
+
+      const result = yield* service.runNow({ automationId });
+      const turnStart = dispatchedCommands.find((command) => command.type === "thread.turn.start");
+
+      assert.strictEqual(result.run.status, "running");
+      assert.strictEqual(result.run.trigger.type, "manual");
+      assert.strictEqual(turnStart?.type, "thread.turn.start");
+      if (turnStart?.type !== "thread.turn.start") {
+        assert.fail("Expected thread.turn.start command.");
+      }
+      assert.strictEqual(turnStart.threadId, targetThreadId);
+      assert.strictEqual(turnStart.message.text, "say hi");
+
+      const reloaded = yield* service.list({ projectId });
+      const definition = reloaded.definitions.find((entry) => entry.id === automationId);
+      assert.strictEqual(definition?.enabled, true);
+      assert.strictEqual(definition?.iterationCount, 1);
+      assert.strictEqual(definition?.maxIterations, 3);
+      assert.isNotNull(definition?.nextRunAt ?? null);
     }),
   );
 

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -2427,6 +2427,7 @@ layer("AutomationService", (it) => {
           mode: "heartbeat",
           targetThreadId,
           maxIterations: 3,
+          acknowledgedRisks: ["fast-interval", "local-checkout"],
         },
         now: "2026-06-16T10:00:00.000Z",
       });
@@ -2462,6 +2463,47 @@ layer("AutomationService", (it) => {
       assert.strictEqual(definition?.iterationCount, 1);
       assert.strictEqual(definition?.maxIterations, 3);
       assert.isNotNull(definition?.nextRunAt ?? null);
+    }),
+  );
+
+  it.effect("keeps legacy fast loops over the hard cap disabled after a manual rerun", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+
+      const created = yield* service.create({
+        ...createInput("local"),
+        schedule: { type: "interval", everySeconds: 15 },
+        maxIterations: 10,
+        acknowledgedRisks: ["fast-interval", "local-checkout"],
+      });
+      const automationId = created.id;
+      yield* repository.saveDefinition({ ...created, maxIterations: 25 });
+      yield* Effect.forEach(
+        Array.from({ length: 25 }),
+        () =>
+          repository.incrementDefinitionIterationCount({
+            id: automationId,
+            now: "2026-06-16T10:00:00.000Z",
+          }),
+        { discard: true },
+      );
+      yield* repository.disableDefinition({
+        id: automationId,
+        now: "2026-06-16T10:01:00.000Z",
+      });
+
+      const result = yield* service.runNow({ automationId });
+      const listed = yield* service.list({ projectId });
+      const definition = listed.definitions.find((entry) => entry.id === automationId);
+
+      assert.strictEqual(result.run.status, "running");
+      assert.strictEqual(result.run.trigger.type, "manual");
+      assert.strictEqual(definition?.enabled, false);
+      assert.strictEqual(definition?.nextRunAt, null);
+      assert.strictEqual(definition?.iterationCount, 1);
+      assert.strictEqual(definition?.maxIterations, 25);
     }),
   );
 

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -1790,15 +1790,18 @@ export const AutomationServiceLive = Layer.effect(
         definition.schedule.type === "manual"
           ? null
           : computeNextAutomationRunAtAfter(definition.schedule, now, now);
+      // One-shot automations can be manually rerun, but they should not become
+      // active forever when there is no future scheduled occurrence to wait for.
+      const enabled = definition.schedule.type !== "once" || nextRunAt !== null;
       const restarted = {
         ...definition,
-        enabled: true,
+        enabled,
         iterationCount: 0,
         nextRunAt,
         updatedAt: now,
       };
       return automationRepository
-        .restartDefinitionLoop({ id: definition.id, nextRunAt, updatedAt: now })
+        .restartDefinitionLoop({ id: definition.id, enabled, nextRunAt, updatedAt: now })
         .pipe(
           Effect.mapError(toServiceError("Failed to restart automation loop.")),
           Effect.as(restarted),

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -1779,35 +1779,48 @@ export const AutomationServiceLive = Layer.effect(
         return { activeRuns, pendingCompletionEvaluations };
       });
 
-    const restartExhaustedBoundedDefinition = (definition: AutomationDefinition, now: string) => {
-      if (
-        definition.maxIterations === null ||
-        definition.iterationCount < definition.maxIterations
-      ) {
-        return Effect.succeed(definition);
-      }
-      const nextRunAt =
-        definition.schedule.type === "manual"
-          ? null
-          : computeNextAutomationRunAtAfter(definition.schedule, now, now);
-      // One-shot automations can be manually rerun, but they should not become
-      // active forever when there is no future scheduled occurrence to wait for.
-      const enabled = definition.schedule.type !== "once" || nextRunAt !== null;
-      const restarted = {
-        ...definition,
-        enabled,
-        iterationCount: 0,
-        nextRunAt,
-        updatedAt: now,
-      };
-      return automationRepository
-        .restartDefinitionLoop({ id: definition.id, enabled, nextRunAt, updatedAt: now })
-        .pipe(
-          Effect.mapError(toServiceError("Failed to restart automation loop.")),
-          Effect.as(restarted),
-          Effect.tap((definition) => publish({ type: "definition-upserted", definition })),
-        );
-    };
+    const restartExhaustedBoundedDefinition = (definition: AutomationDefinition, now: string) =>
+      Effect.gen(function* () {
+        if (
+          definition.maxIterations === null ||
+          definition.iterationCount < definition.maxIterations
+        ) {
+          return definition;
+        }
+        const computedNextRunAt =
+          definition.schedule.type === "manual"
+            ? null
+            : computeNextAutomationRunAtAfter(definition.schedule, now, now);
+        // Manual reruns should not revive legacy definitions that cannot pass today's
+        // active-schedule policy, such as oversized sub-minute loops.
+        let canBecomeEnabled = false;
+        if (definition.schedule.type === "manual" || computedNextRunAt !== null) {
+          canBecomeEnabled = yield* validateSchedulePolicy({
+            schedule: definition.schedule,
+            enabled: true,
+            maxIterations: definition.maxIterations,
+            minimumIntervalSeconds: definition.minimumIntervalSeconds,
+            acknowledgedRisks: definition.acknowledgedRisks,
+            now,
+          }).pipe(Effect.as(true), Effect.catch(() => Effect.succeed(false)));
+        }
+        const enabled = canBecomeEnabled;
+        const nextRunAt = enabled ? computedNextRunAt : null;
+        const restarted = {
+          ...definition,
+          enabled,
+          iterationCount: 0,
+          nextRunAt,
+          updatedAt: now,
+        };
+        return yield* automationRepository
+          .restartDefinitionLoop({ id: definition.id, enabled, nextRunAt, updatedAt: now })
+          .pipe(
+            Effect.mapError(toServiceError("Failed to restart automation loop.")),
+            Effect.as(restarted),
+            Effect.tap((definition) => publish({ type: "definition-upserted", definition })),
+          );
+      });
 
     const runNow: AutomationServiceShape["runNow"] = (input) =>
       Effect.gen(function* () {

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -4,6 +4,7 @@ import {
   AutomationId,
   AutomationRunId,
   CommandId,
+  DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS,
   DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS,
   MessageId,
   ThreadId,
@@ -123,9 +124,7 @@ function isSameAiCompletionPolicy(
   left: Extract<AutomationCompletionPolicy, { type: "ai-evaluated" }>,
   right: Extract<AutomationCompletionPolicy, { type: "ai-evaluated" }>,
 ): boolean {
-  return (
-    left.stopWhen === right.stopWhen && left.confidenceThreshold === right.confidenceThreshold
-  );
+  return left.stopWhen === right.stopWhen && left.confidenceThreshold === right.confidenceThreshold;
 }
 
 function isSameCompletionPolicy(
@@ -141,15 +140,34 @@ function isSameCompletionPolicy(
   return right.type === "ai-evaluated" && isSameAiCompletionPolicy(left, right);
 }
 
+const DEFAULT_COMPLETION_POLICY = { type: "none" } as const satisfies AutomationCompletionPolicy;
+
+function completionPolicyForDefinition(
+  definition: AutomationDefinition,
+): AutomationCompletionPolicy {
+  return definition.completionPolicy ?? DEFAULT_COMPLETION_POLICY;
+}
+
+function completionPolicyVersionForDefinition(definition: AutomationDefinition): number {
+  return definition.completionPolicyVersion ?? 1;
+}
+
+function completionPolicyUpdatedAtForDefinition(definition: AutomationDefinition): string {
+  return definition.completionPolicyUpdatedAt ?? definition.createdAt;
+}
+
 function runUsesCurrentCompletionPolicy(
   run: AutomationRun,
   definition: AutomationDefinition,
 ): boolean {
   if (run.permissionSnapshot.completionPolicyVersion !== undefined) {
-    return run.permissionSnapshot.completionPolicyVersion === definition.completionPolicyVersion;
+    return (
+      run.permissionSnapshot.completionPolicyVersion ===
+      completionPolicyVersionForDefinition(definition)
+    );
   }
   const runPolicyAnchorMs = Date.parse(run.startedAt ?? run.createdAt);
-  const policyUpdatedAtMs = Date.parse(definition.completionPolicyUpdatedAt);
+  const policyUpdatedAtMs = Date.parse(completionPolicyUpdatedAtForDefinition(definition));
   return (
     Number.isFinite(runPolicyAnchorMs) &&
     Number.isFinite(policyUpdatedAtMs) &&
@@ -222,7 +240,7 @@ function makePermissionSnapshot(definition: AutomationDefinition, now: string) {
     provider: definition.modelSelection.provider,
     modelSelection: definition.modelSelection,
     ...(definition.providerOptions ? { providerOptions: definition.providerOptions } : {}),
-    completionPolicyVersion: definition.completionPolicyVersion,
+    completionPolicyVersion: completionPolicyVersionForDefinition(definition),
     runtimeMode: definition.runtimeMode,
     interactionMode: definition.interactionMode,
     worktreeMode: definition.worktreeMode,
@@ -325,14 +343,20 @@ function mergeDefinitionUpdate(
         : (current.nextRunAt ?? safeComputeNextRunAt(schedule, now, null));
   const providerOptions = input.providerOptions ?? current.providerOptions;
   const mode = input.mode ?? current.mode;
+  const currentCompletionPolicy = completionPolicyForDefinition(current);
   const completionPolicy =
     mode === "standalone"
       ? { type: "none" as const }
-      : (input.completionPolicy ?? current.completionPolicy);
+      : (input.completionPolicy ?? currentCompletionPolicy);
   const completionPolicyChanged = !isSameCompletionPolicy(
-    current.completionPolicy,
+    currentCompletionPolicy,
     completionPolicy,
   );
+  // Run caps apply to both standalone and heartbeat definitions; chat parsing uses
+  // them for bounded requests like "every 15 seconds for 3 times".
+  const maxIterations = hasOwn(input, "maxIterations")
+    ? ((input.maxIterations as AutomationDefinition["maxIterations"] | undefined) ?? null)
+    : current.maxIterations;
   const nextDefinition: AutomationDefinition = {
     ...current,
     projectId: input.projectId ?? current.projectId,
@@ -352,18 +376,15 @@ function mergeDefinitionUpdate(
     targetThreadId: hasOwn(input, "targetThreadId")
       ? ((input.targetThreadId as AutomationDefinition["targetThreadId"] | undefined) ?? null)
       : current.targetThreadId,
-    maxIterations:
-      mode === "standalone"
-        ? null
-        : hasOwn(input, "maxIterations")
-          ? ((input.maxIterations as AutomationDefinition["maxIterations"] | undefined) ?? null)
-          : current.maxIterations,
+    maxIterations,
     stopOnError: input.stopOnError ?? current.stopOnError,
     completionPolicy,
     completionPolicyVersion: completionPolicyChanged
-      ? current.completionPolicyVersion + 1
-      : current.completionPolicyVersion,
-    completionPolicyUpdatedAt: completionPolicyChanged ? now : current.completionPolicyUpdatedAt,
+      ? completionPolicyVersionForDefinition(current) + 1
+      : completionPolicyVersionForDefinition(current),
+    completionPolicyUpdatedAt: completionPolicyChanged
+      ? now
+      : completionPolicyUpdatedAtForDefinition(current),
     minimumIntervalSeconds: input.minimumIntervalSeconds ?? current.minimumIntervalSeconds,
     maxRuntimeSeconds: hasOwn(input, "maxRuntimeSeconds")
       ? ((input.maxRuntimeSeconds as AutomationDefinition["maxRuntimeSeconds"] | undefined) ?? null)
@@ -511,6 +532,7 @@ export const AutomationServiceLive = Layer.effect(
     const validateSchedulePolicy = (input: {
       readonly schedule: AutomationDefinition["schedule"];
       readonly enabled: boolean;
+      readonly maxIterations: AutomationDefinition["maxIterations"];
       readonly minimumIntervalSeconds: number;
       readonly acknowledgedRisks: readonly string[];
       readonly now: string;
@@ -518,6 +540,26 @@ export const AutomationServiceLive = Layer.effect(
       Effect.try({
         try: () => {
           const spacingSeconds = computeAutomationScheduleSpacingSeconds(input.schedule, input.now);
+          if (
+            spacingSeconds !== null &&
+            spacingSeconds < DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS
+          ) {
+            if (!input.acknowledgedRisks.includes("fast-interval")) {
+              throw new Error(
+                `Automation schedule must run at least ${DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS} seconds apart.`,
+              );
+            }
+            const exceedsFastIterationCap =
+              input.maxIterations === null ||
+              input.maxIterations > DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS;
+            // Pausing a legacy fast loop must always remain possible; enforce the new
+            // hard cap only for definitions that will continue running.
+            if (input.enabled && exceedsFastIterationCap) {
+              throw new Error(
+                `Fast interval automations must set max iterations to ${DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS} runs or fewer.`,
+              );
+            }
+          }
           const minimumIntervalSeconds = effectiveMinimumIntervalSeconds(input);
           if (spacingSeconds !== null && spacingSeconds < minimumIntervalSeconds) {
             throw new Error(
@@ -1072,12 +1114,16 @@ export const AutomationServiceLive = Layer.effect(
     const shouldUseStopPolicyForDefinition = (
       definition: AutomationDefinition,
       policy: Extract<AutomationCompletionPolicy, { type: "ai-evaluated" }>,
-    ): boolean =>
-      definition.mode === "heartbeat" &&
-      definition.enabled &&
-      definition.archivedAt === null &&
-      definition.completionPolicy.type === "ai-evaluated" &&
-      isSameAiCompletionPolicy(definition.completionPolicy, policy);
+    ): boolean => {
+      const currentPolicy = completionPolicyForDefinition(definition);
+      return (
+        definition.mode === "heartbeat" &&
+        definition.enabled &&
+        definition.archivedAt === null &&
+        currentPolicy.type === "ai-evaluated" &&
+        isSameAiCompletionPolicy(currentPolicy, policy)
+      );
+    };
 
     const loadCurrentStopDefinition = (
       definition: AutomationDefinition,
@@ -1136,9 +1182,8 @@ export const AutomationServiceLive = Layer.effect(
           run,
           thread,
         });
-        const textGenerationInput = yield* resolveAutomationCompletionTextGenerationInput(
-          definition,
-        );
+        const textGenerationInput =
+          yield* resolveAutomationCompletionTextGenerationInput(definition);
         const evaluationRaw = yield* textGeneration
           .evaluateAutomationCompletion({
             cwd: project.workspaceRoot,
@@ -1250,10 +1295,11 @@ export const AutomationServiceLive = Layer.effect(
           Option.match(definitionOption, {
             onNone: () => Effect.void,
             onSome: (definition) => {
-              if (definition.completionPolicy.type !== "ai-evaluated") {
+              const policy = completionPolicyForDefinition(definition);
+              if (policy.type !== "ai-evaluated") {
                 return Effect.void;
               }
-              if (!shouldUseStopPolicyForDefinition(definition, definition.completionPolicy)) {
+              if (!shouldUseStopPolicyForDefinition(definition, policy)) {
                 return Effect.void;
               }
               if (!runUsesCurrentCompletionPolicy(run, definition)) {
@@ -1262,7 +1308,7 @@ export const AutomationServiceLive = Layer.effect(
               return enqueueCompletionEvaluationJob({
                 definition,
                 run,
-                policy: definition.completionPolicy,
+                policy,
               });
             },
           }),
@@ -1327,16 +1373,17 @@ export const AutomationServiceLive = Layer.effect(
               const reachedMax =
                 definition.maxIterations !== null &&
                 definition.iterationCount >= definition.maxIterations;
+              const completionPolicy = completionPolicyForDefinition(definition);
               const enqueueAiStop =
                 !reachedMax &&
                 status === "succeeded" &&
                 definition.mode === "heartbeat" &&
-                definition.completionPolicy.type === "ai-evaluated" &&
+                completionPolicy.type === "ai-evaluated" &&
                 runUsesCurrentCompletionPolicy(run, definition)
                   ? enqueueCompletionEvaluationJob({
                       definition,
                       run,
-                      policy: definition.completionPolicy,
+                      policy: completionPolicy,
                     })
                   : Effect.void;
               return enqueueAiStop.pipe(
@@ -1592,9 +1639,11 @@ export const AutomationServiceLive = Layer.effect(
     const create: AutomationServiceShape["create"] = (input) =>
       Effect.gen(function* () {
         const now = isoNow();
+        yield* requireProject(input.projectId);
         yield* validateSchedulePolicy({
           schedule: input.schedule,
           enabled: input.enabled ?? true,
+          maxIterations: input.maxIterations ?? null,
           minimumIntervalSeconds:
             input.minimumIntervalSeconds ?? DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS,
           acknowledgedRisks: input.acknowledgedRisks ?? [],
@@ -1629,9 +1678,11 @@ export const AutomationServiceLive = Layer.effect(
         const now = isoNow();
         const current = yield* requireDefinition(input.id);
         const updated = mergeDefinitionUpdate(current, input, now);
+        yield* requireProject(updated.projectId);
         yield* validateSchedulePolicy({
           schedule: updated.schedule,
           enabled: updated.enabled,
+          maxIterations: updated.maxIterations,
           minimumIntervalSeconds: updated.minimumIntervalSeconds,
           acknowledgedRisks: updated.acknowledgedRisks,
           now,
@@ -1723,16 +1774,42 @@ export const AutomationServiceLive = Layer.effect(
         const pendingCompletionEvaluations = yield* automationRepository
           .countPendingCompletionEvaluationsForThread({ threadId })
           .pipe(
-            Effect.mapError(
-              toServiceError("Failed to count pending automation stop evaluations."),
-            ),
+            Effect.mapError(toServiceError("Failed to count pending automation stop evaluations.")),
           );
         return { activeRuns, pendingCompletionEvaluations };
       });
 
+    const restartExhaustedBoundedDefinition = (definition: AutomationDefinition, now: string) => {
+      if (
+        definition.maxIterations === null ||
+        definition.iterationCount < definition.maxIterations
+      ) {
+        return Effect.succeed(definition);
+      }
+      const nextRunAt =
+        definition.schedule.type === "manual"
+          ? null
+          : computeNextAutomationRunAtAfter(definition.schedule, now, now);
+      const restarted = {
+        ...definition,
+        enabled: true,
+        iterationCount: 0,
+        nextRunAt,
+        updatedAt: now,
+      };
+      return automationRepository
+        .restartDefinitionLoop({ id: definition.id, nextRunAt, updatedAt: now })
+        .pipe(
+          Effect.mapError(toServiceError("Failed to restart automation loop.")),
+          Effect.as(restarted),
+          Effect.tap((definition) => publish({ type: "definition-upserted", definition })),
+        );
+    };
+
     const runNow: AutomationServiceShape["runNow"] = (input) =>
       Effect.gen(function* () {
         const definition = yield* requireDefinition(input.automationId);
+        const now = isoNow();
         // Heartbeat automations continue a single shared thread, so a manual run must not
         // race a scheduled (or earlier manual) run that is still in flight. Standalone
         // automations spawn independent threads, so concurrent manual runs are fine.
@@ -1760,8 +1837,13 @@ export const AutomationServiceLive = Layer.effect(
             );
           }
         }
-        const now = isoNow();
-        const { run, inserted } = yield* createPendingRun(definition, { type: "manual" }, now, now);
+        const runnableDefinition = yield* restartExhaustedBoundedDefinition(definition, now);
+        const { run, inserted } = yield* createPendingRun(
+          runnableDefinition,
+          { type: "manual" },
+          now,
+          now,
+        );
         if (!inserted) {
           return yield* Effect.fail(
             new AutomationServiceError({
@@ -1770,9 +1852,9 @@ export const AutomationServiceLive = Layer.effect(
           );
         }
         yield* automationRepository
-          .incrementDefinitionIterationCount({ id: definition.id, now })
+          .incrementDefinitionIterationCount({ id: runnableDefinition.id, now })
           .pipe(Effect.mapError(toServiceError("Failed to update automation iteration count.")));
-        return yield* dispatchRun(definition, run, now);
+        return yield* dispatchRun(runnableDefinition, run, now);
       });
 
     const cancelRun: AutomationServiceShape["cancelRun"] = (input) =>

--- a/apps/server/src/automation/runResult.ts
+++ b/apps/server/src/automation/runResult.ts
@@ -46,13 +46,12 @@ export function automationCompletionRunResult(input: {
   readonly severity?: NonNullable<AutomationRunResult["severity"]>;
   readonly unread?: boolean;
 }): AutomationRunResult {
-  const base =
-    input.baseResult ?? {
-      outcome: "unknown" as const,
-      summary: null,
-      unread: true,
-      archivedAt: null,
-    };
+  const base = input.baseResult ?? {
+    outcome: "unknown" as const,
+    summary: null,
+    unread: true,
+    archivedAt: null,
+  };
 
   return {
     ...base,

--- a/apps/server/src/automation/schedule.test.ts
+++ b/apps/server/src/automation/schedule.test.ts
@@ -97,6 +97,30 @@ describe("computeNextAutomationRunAt", () => {
     ).toBe("2026-06-08T09:00:00.000Z");
   });
 
+  it("accepts 7 as Sunday in cron day-of-week fields", () => {
+    expect(
+      computeNextAutomationRunAt(
+        { type: "cron", expression: "0 9 * * 7", timezone: "UTC" },
+        "2026-06-21T08:00:00.000Z",
+      ),
+    ).toBe("2026-06-21T09:00:00.000Z");
+  });
+
+  it("accepts named cron day-of-week fields", () => {
+    expect(
+      computeNextAutomationRunAt(
+        { type: "cron", expression: "0 9 * * SUN", timezone: "UTC" },
+        "2026-06-21T08:00:00.000Z",
+      ),
+    ).toBe("2026-06-21T09:00:00.000Z");
+    expect(
+      computeNextAutomationRunAt(
+        { type: "cron", expression: "0 9 * * MON-FRI", timezone: "UTC" },
+        "2026-06-21T10:00:00.000Z",
+      ),
+    ).toBe("2026-06-22T09:00:00.000Z");
+  });
+
   it("treats stepped cron day wildcards as restricted day fields", () => {
     expect(
       computeNextAutomationRunAt(

--- a/apps/server/src/automation/schedule.ts
+++ b/apps/server/src/automation/schedule.ts
@@ -211,7 +211,40 @@ function parseCronInteger(
   return Number(raw);
 }
 
-function parseCronField(raw: string, min: number, max: number, name: string): CronField {
+const CRON_DAY_OF_WEEK_NAMES = new Map([
+  ["sun", 0],
+  ["mon", 1],
+  ["tue", 2],
+  ["wed", 3],
+  ["thu", 4],
+  ["fri", 5],
+  ["sat", 6],
+]);
+
+function parseCronDayOfWeekValue(
+  raw: string | undefined,
+  name: string,
+  errorReason: "bad step" | "out of range",
+): number {
+  const namedValue = raw ? CRON_DAY_OF_WEEK_NAMES.get(raw.toLowerCase()) : undefined;
+  if (namedValue !== undefined) {
+    return namedValue;
+  }
+  return parseCronInteger(raw, name, errorReason);
+}
+
+function normalizeCronDayOfWeekValue(value: number): number {
+  return value === 7 ? 0 : value;
+}
+
+function parseCronField(
+  raw: string,
+  min: number,
+  max: number,
+  name: string,
+  parseValue = parseCronInteger,
+  normalizeValue = (value: number) => value,
+): CronField {
   const values = new Set<number>();
   let isWildcard = false;
   for (const token of raw.split(",")) {
@@ -237,8 +270,8 @@ function parseCronField(raw: string, min: number, max: number, name: string): Cr
       throw new Error(`Invalid cron ${name}: out of range`);
     }
     const [startRaw, endRaw] = rangeParts;
-    const start = parseCronInteger(startRaw, name, "out of range");
-    const end = parseCronInteger(endRaw ?? startRaw, name, "out of range");
+    const start = parseValue(startRaw, name, "out of range");
+    const end = parseValue(endRaw ?? startRaw, name, "out of range");
     if (
       !Number.isInteger(start) ||
       !Number.isInteger(end) ||
@@ -249,7 +282,7 @@ function parseCronField(raw: string, min: number, max: number, name: string): Cr
       throw new Error(`Invalid cron ${name}: out of range`);
     }
     for (let value = start; value <= end; value += step) {
-      values.add(value);
+      values.add(normalizeValue(value));
     }
   }
   return { values, isWildcard };
@@ -265,7 +298,14 @@ function parseCronExpression(expression: string) {
     hour: parseCronField(fields[1] ?? "", 0, 23, "hour"),
     dayOfMonth: parseCronField(fields[2] ?? "", 1, 31, "day-of-month"),
     month: parseCronField(fields[3] ?? "", 1, 12, "month"),
-    dayOfWeek: parseCronField(fields[4] ?? "", 0, 6, "day-of-week"),
+    dayOfWeek: parseCronField(
+      fields[4] ?? "",
+      0,
+      7,
+      "day-of-week",
+      parseCronDayOfWeekValue,
+      normalizeCronDayOfWeekValue,
+    ),
   };
 }
 

--- a/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
@@ -59,14 +59,13 @@ function createTextGenerationDouble(label: string) {
       reason: null,
     }),
   );
-  const evaluateAutomationCompletion = vi.fn<
-    TextGenerationShape["evaluateAutomationCompletion"]
-  >(() =>
-    Effect.succeed({
-      stopMatched: false,
-      confidence: 0.2,
-      reason: `${label} completion`,
-    }),
+  const evaluateAutomationCompletion = vi.fn<TextGenerationShape["evaluateAutomationCompletion"]>(
+    () =>
+      Effect.succeed({
+        stopMatched: false,
+        confidence: 0.2,
+        reason: `${label} completion`,
+      }),
   );
 
   return {

--- a/apps/server/src/git/textGenerationSelection.ts
+++ b/apps/server/src/git/textGenerationSelection.ts
@@ -24,7 +24,9 @@ export function resolveTextGenerationInputForSelection(
     return {
       modelSelection,
       ...(providerOptions ? { providerOptions } : {}),
-      ...(providerOptions?.codex?.homePath ? { codexHomePath: providerOptions.codex.homePath } : {}),
+      ...(providerOptions?.codex?.homePath
+        ? { codexHomePath: providerOptions.codex.homePath }
+        : {}),
     };
   }
 

--- a/apps/server/src/git/textGenerationShared.test.ts
+++ b/apps/server/src/git/textGenerationShared.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildAutomationCompletionEvaluationPrompt,
+  buildAutomationIntentPrompt,
   decodeStructuredTextGenerationOutput,
 } from "./textGenerationShared.ts";
 
@@ -39,5 +40,20 @@ describe("textGenerationShared", () => {
       confidence: 1.2,
       reason: "The run says the PR is ready.",
     });
+  });
+
+  it("asks automation intent generation for detailed prompts without invented context", () => {
+    const { prompt } = buildAutomationIntentPrompt({
+      message: "every 6h check the site",
+      nowIso: "2026-06-21T20:00:00.000Z",
+    });
+
+    expect(prompt).toContain("detailed, self-contained recurring instruction");
+    expect(prompt).toContain("Do not invent repo-specific files, commands");
+    expect(prompt).toContain("schedule, stop, or run-count scaffolding");
+    expect(prompt).toContain("maxIterations: positive integer");
+    expect(prompt).toContain("Task prompt quality checklist");
+    expect(prompt).toContain("Decision gates");
+    expect(prompt).toContain("commit/push only if there is an actual count change");
   });
 });

--- a/apps/server/src/git/textGenerationShared.ts
+++ b/apps/server/src/git/textGenerationShared.ts
@@ -397,13 +397,35 @@ export function buildAutomationIntentPrompt(input: {
       "- confidence: number from 0 to 1.",
       "- language: detected user language, or null.",
       "- name: short automation name, <= 160 chars, or null.",
-      "- taskPrompt: the actual recurring instruction to save, without /automation, @automation, or schedule scaffolding.",
+      "- taskPrompt: the detailed, self-contained recurring instruction to save, without /automation, @automation, schedule, stop, or run-count scaffolding.",
+      "- Expand terse tasks into a clear saved automation prompt only using facts the user provided.",
+      "- Preserve concrete user-provided workspace paths, commands, files, commit/push rules, verification steps, URLs, accounts, and constraints.",
+      "- Do not invent repo-specific files, commands, services, tests, tickets, product context, credentials, or success criteria.",
+      "- If the user only gave a tiny task, keep taskPrompt clear and short instead of padding it with fake details.",
       "- schedule: automation cadence, or null when missing/ambiguous.",
       "- mode: heartbeat or standalone.",
+      "- maxIterations: positive integer only when the user explicitly says for N times/runs/iterations/volte; otherwise null.",
       `- completionPolicy: use {"type":"ai-evaluated","stopWhen":"...","confidenceThreshold":${DEFAULT_AUTOMATION_STOP_CONFIDENCE_THRESHOLD}} only when the user explicitly says until/stop when/if X stop/fino a quando/finche. Otherwise use {"type":"none"}.`,
       "- missingFields: include schedule, taskPrompt, name, or mode when that field is null or too unclear.",
       "- needsConfirmation: true when schedule/task/mode is missing, ambiguous, or confidence < 0.75.",
       "- reason: short explanation when isAutomation=false or needsConfirmation=true; otherwise null.",
+      "",
+      "Task prompt quality checklist:",
+      "- Objective: state the concrete recurring task.",
+      "- Source of truth: keep any user-provided URLs, accounts, APIs, commands, files, or public-source constraints.",
+      "- Scope: name files, directories, branches, or repositories only when the user provided them.",
+      "- Procedure: preserve user-provided commands and ordered steps.",
+      "- Decision gates: include what to do when there is no change, ambiguity, failure, or conflicting evidence if the user specified it.",
+      "- Verification: preserve explicit build/lint/test checks and whether they are conditional.",
+      "- Publish rules: preserve explicit commit, push, branch, PR, or no-commit rules.",
+      "- Non-goals: preserve constraints like do not use APIs, do not change architecture, and do not stage unrelated files.",
+      "- Reporting: include concise output expectations when the user asked for them.",
+      "",
+      "Task prompt examples:",
+      '- User: "every day update my follower count without using the API, only the static file, build, commit and push if changed"',
+      '- taskPrompt: "Update the manually maintained follower count from a user-visible public source only. Do not use API credentials or existing runtime data code. Update only the specified static file when the count changes, run the requested build check, and commit/push only if there is an actual count change. Preserve unrelated working tree changes."',
+      '- User: "every 6h check this product URL until the black variant is available"',
+      '- taskPrompt: "Check the provided product URL and report whether the black variant is purchasable or pre-orderable. Treat conflicting page/session evidence as ambiguous instead of stopping early."',
       "",
       "Schedule rules:",
       '- For \'in N seconds/minutes/hours/days\', \'tra N secondi/minuti/ore/giorni\', or \'fra ...\', use {"type":"once","runAt":"<ISO timestamp>"} calculated from the current timestamp.',
@@ -418,7 +440,7 @@ export function buildAutomationIntentPrompt(input: {
       "- heartbeat means continue/report in the current thread on each run.",
       "- standalone means create independent scheduled runs.",
       "- Use the default unless the user clearly asks for the other behavior.",
-      "- Stop clauses are currently supported only for heartbeat automations; if mode is standalone, use completionPolicy {\"type\":\"none\"}.",
+      '- Stop clauses are currently supported only for heartbeat automations; if mode is standalone, use completionPolicy {"type":"none"}.',
       "",
       "User message:",
       limitSection(input.message, 16_000),
@@ -435,7 +457,7 @@ export function buildAutomationCompletionEvaluationPrompt(input: {
   readonly stopWhen: string;
   readonly runUserMessage: string;
   readonly runAssistantText: string;
-  readonly threadContext?: string;
+  readonly threadContext?: string | undefined;
 }) {
   return {
     prompt: [

--- a/apps/server/src/persistence/Layers/AutomationRepository.test.ts
+++ b/apps/server/src/persistence/Layers/AutomationRepository.test.ts
@@ -739,7 +739,7 @@ layer("AutomationRepository", (it) => {
           stopWhen: "the PR is ready",
           confidenceThreshold: DEFAULT_AUTOMATION_STOP_CONFIDENCE_THRESHOLD,
         },
-        completionPolicyVersion: definition.completionPolicyVersion + 1,
+        completionPolicyVersion: (definition.completionPolicyVersion ?? 1) + 1,
         completionPolicyUpdatedAt: "2026-06-16T10:02:00.000Z",
         updatedAt: "2026-06-16T10:02:00.000Z",
       });

--- a/apps/server/src/persistence/Layers/AutomationRepository.ts
+++ b/apps/server/src/persistence/Layers/AutomationRepository.ts
@@ -1067,10 +1067,10 @@ const makeAutomationRepository = Effect.gen(function* () {
 
   const restartDefinitionLoopRow = SqlSchema.void({
     Request: RestartAutomationDefinitionLoopInput,
-    execute: ({ id, nextRunAt, updatedAt }) =>
+    execute: ({ id, enabled, nextRunAt, updatedAt }) =>
       sql`
         UPDATE automation_definitions
-        SET enabled = 1,
+        SET enabled = ${enabled ? 1 : 0},
             iteration_count = 0,
             next_run_at = ${nextRunAt},
             updated_at = ${updatedAt}

--- a/apps/server/src/persistence/Layers/AutomationRepository.ts
+++ b/apps/server/src/persistence/Layers/AutomationRepository.ts
@@ -45,6 +45,7 @@ import {
   MarkAutomationRunStartedInput,
   MarkAutomationRunSucceededInput,
   MarkAutomationRunWaitingForApprovalInput,
+  RestartAutomationDefinitionLoopInput,
   SetAutomationDefinitionNextRunAtInput,
 } from "../Services/AutomationRepository.ts";
 
@@ -1064,6 +1065,19 @@ const makeAutomationRepository = Effect.gen(function* () {
       `,
   });
 
+  const restartDefinitionLoopRow = SqlSchema.void({
+    Request: RestartAutomationDefinitionLoopInput,
+    execute: ({ id, nextRunAt, updatedAt }) =>
+      sql`
+        UPDATE automation_definitions
+        SET enabled = 1,
+            iteration_count = 0,
+            next_run_at = ${nextRunAt},
+            updated_at = ${updatedAt}
+        WHERE automation_id = ${id}
+      `,
+  });
+
   const acquireLease = SqlSchema.findAll({
     Request: AcquireAutomationSchedulerLeaseInput,
     Result: Schema.Struct({ changed: Schema.Number }),
@@ -1137,6 +1151,9 @@ const makeAutomationRepository = Effect.gen(function* () {
       enabled: definition.enabled ? 1 : 0,
       stopOnError: definition.stopOnError ? 1 : 0,
       providerOptions: definition.providerOptions ?? null,
+      completionPolicy: definition.completionPolicy ?? { type: "none" },
+      completionPolicyVersion: definition.completionPolicyVersion ?? 1,
+      completionPolicyUpdatedAt: definition.completionPolicyUpdatedAt ?? definition.createdAt,
     }).pipe(
       Effect.mapError(toPersistenceSqlError("AutomationRepository.createDefinition:query")),
       Effect.as(definition),
@@ -1149,6 +1166,9 @@ const makeAutomationRepository = Effect.gen(function* () {
       enabled: definition.enabled ? 1 : 0,
       stopOnError: definition.stopOnError ? 1 : 0,
       providerOptions: definition.providerOptions ?? null,
+      completionPolicy: definition.completionPolicy ?? { type: "none" },
+      completionPolicyVersion: definition.completionPolicyVersion ?? 1,
+      completionPolicyUpdatedAt: definition.completionPolicyUpdatedAt ?? definition.createdAt,
     }).pipe(
       Effect.mapError(toPersistenceSqlError("AutomationRepository.saveDefinition:update")),
       Effect.as(definition),
@@ -1374,9 +1394,7 @@ const makeAutomationRepository = Effect.gen(function* () {
     (input) =>
       listRunsNeedingCompletionEvaluationRows(input).pipe(
         Effect.mapError(
-          toPersistenceSqlError(
-            "AutomationRepository.listRunsNeedingCompletionEvaluation:query",
-          ),
+          toPersistenceSqlError("AutomationRepository.listRunsNeedingCompletionEvaluation:query"),
         ),
         Effect.flatMap((rows) => Effect.forEach(rows, toRun, { concurrency: "unbounded" })),
       );
@@ -1460,14 +1478,15 @@ const makeAutomationRepository = Effect.gen(function* () {
       Effect.mapError(toPersistenceSqlError("AutomationRepository.disableDefinition:update")),
     );
 
-  const disableDefinitionIfUnchanged: AutomationRepositoryShape["disableDefinitionIfUnchanged"] =
-    (input) =>
-      disableDefinitionIfUnchangedRow(input).pipe(
-        Effect.mapError(
-          toPersistenceSqlError("AutomationRepository.disableDefinitionIfUnchanged:update"),
-        ),
-        Effect.map((rows) => rows.length > 0),
-      );
+  const disableDefinitionIfUnchanged: AutomationRepositoryShape["disableDefinitionIfUnchanged"] = (
+    input,
+  ) =>
+    disableDefinitionIfUnchangedRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlError("AutomationRepository.disableDefinitionIfUnchanged:update"),
+      ),
+      Effect.map((rows) => rows.length > 0),
+    );
 
   const incrementDefinitionIterationCount: AutomationRepositoryShape["incrementDefinitionIterationCount"] =
     (input) =>
@@ -1476,6 +1495,11 @@ const makeAutomationRepository = Effect.gen(function* () {
           toPersistenceSqlError("AutomationRepository.incrementDefinitionIterationCount:update"),
         ),
       );
+
+  const restartDefinitionLoop: AutomationRepositoryShape["restartDefinitionLoop"] = (input) =>
+    restartDefinitionLoopRow(input).pipe(
+      Effect.mapError(toPersistenceSqlError("AutomationRepository.restartDefinitionLoop:update")),
+    );
 
   const tryAcquireSchedulerLease: AutomationRepositoryShape["tryAcquireSchedulerLease"] = (input) =>
     acquireLease(input).pipe(
@@ -1514,6 +1538,7 @@ const makeAutomationRepository = Effect.gen(function* () {
     disableDefinition,
     disableDefinitionIfUnchanged,
     incrementDefinitionIterationCount,
+    restartDefinitionLoop,
     tryAcquireSchedulerLease,
   } satisfies AutomationRepositoryShape;
 });

--- a/apps/server/src/persistence/Services/AutomationRepository.ts
+++ b/apps/server/src/persistence/Services/AutomationRepository.ts
@@ -52,6 +52,7 @@ export type SetAutomationDefinitionNextRunAtInput =
 
 export const RestartAutomationDefinitionLoopInput = Schema.Struct({
   id: AutomationId,
+  enabled: Schema.Boolean,
   nextRunAt: Schema.NullOr(Schema.String),
   updatedAt: Schema.String,
 });

--- a/apps/server/src/persistence/Services/AutomationRepository.ts
+++ b/apps/server/src/persistence/Services/AutomationRepository.ts
@@ -50,6 +50,13 @@ export const SetAutomationDefinitionNextRunAtInput = Schema.Struct({
 export type SetAutomationDefinitionNextRunAtInput =
   typeof SetAutomationDefinitionNextRunAtInput.Type;
 
+export const RestartAutomationDefinitionLoopInput = Schema.Struct({
+  id: AutomationId,
+  nextRunAt: Schema.NullOr(Schema.String),
+  updatedAt: Schema.String,
+});
+export type RestartAutomationDefinitionLoopInput = typeof RestartAutomationDefinitionLoopInput.Type;
+
 export const ArchiveAutomationDefinitionInput = Schema.Struct({
   id: AutomationId,
   archivedAt: Schema.String,
@@ -297,6 +304,9 @@ export interface AutomationRepositoryShape {
   ) => Effect.Effect<boolean, AutomationRepositoryError>;
   readonly incrementDefinitionIterationCount: (
     input: IncrementAutomationIterationInput,
+  ) => Effect.Effect<void, AutomationRepositoryError>;
+  readonly restartDefinitionLoop: (
+    input: RestartAutomationDefinitionLoopInput,
   ) => Effect.Effect<void, AutomationRepositoryError>;
   readonly tryAcquireSchedulerLease: (
     input: AcquireAutomationSchedulerLeaseInput,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -4306,63 +4306,63 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         return withDiscoveryInventory(
           { binaryPath, ...(input.cwd ? { cwd: input.cwd } : {}) },
           ({ inventory, credentialProviderIDs }) =>
-          Effect.gen(function* () {
-            const preferredProviderIDs = new Set(
-              resolvePreferredOpenCodeModelProviders({
-                inventory,
-                credentialProviderIDs,
-              }).map((provider) => provider.id),
-            );
-            const inventoryModels = flattenOpenCodeModels({
-              inventory,
-              credentialProviderIDs,
-              ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
-            });
-            const cliModels = yield* openCodeRuntime
-              .listOpenCodeCliModels({
-                binaryPath,
-                cliSpec: adapterConfig.cliSpec,
-                ...(input.cwd ? { cwd: input.cwd } : {}),
-              })
-              .pipe(Effect.catch(() => Effect.succeed([])));
-            const preferredCliModels = cliModels.filter((model) =>
-              preferredProviderIDs.has(model.providerID),
-            );
-            const models = mergeOpenCodeCliModelDescriptors({
-              inventory,
-              models: inventoryModels,
-              cliModels: preferredCliModels.length > 0 ? preferredCliModels : cliModels,
-              ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
-            });
-            yield* Effect.logDebug(`${adapterConfig.displayName} model discovery resolved`, {
-              binaryPath,
-              connectedProviders: inventory.providerList.connected,
-              inventoryModelCount: inventoryModels.length,
-              cliModelCount: cliModels.length,
-              modelCount: models.length,
-              sampleModels: models.slice(0, 12).map((model) => model.slug),
-            });
-            return {
-              models,
-              source:
-                cliModels.length > 0
-                  ? adapterConfig.cliModelSource
-                  : adapterConfig.fallbackModelSource,
-              cached: false,
-            };
-          }).pipe(
-            Effect.catch(() =>
-              Effect.succeed({
-                models: flattenOpenCodeModels({
+            Effect.gen(function* () {
+              const preferredProviderIDs = new Set(
+                resolvePreferredOpenCodeModelProviders({
                   inventory,
                   credentialProviderIDs,
-                  ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
-                }),
-                source: adapterConfig.fallbackModelSource,
+                }).map((provider) => provider.id),
+              );
+              const inventoryModels = flattenOpenCodeModels({
+                inventory,
+                credentialProviderIDs,
+                ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
+              });
+              const cliModels = yield* openCodeRuntime
+                .listOpenCodeCliModels({
+                  binaryPath,
+                  cliSpec: adapterConfig.cliSpec,
+                  ...(input.cwd ? { cwd: input.cwd } : {}),
+                })
+                .pipe(Effect.catch(() => Effect.succeed([])));
+              const preferredCliModels = cliModels.filter((model) =>
+                preferredProviderIDs.has(model.providerID),
+              );
+              const models = mergeOpenCodeCliModelDescriptors({
+                inventory,
+                models: inventoryModels,
+                cliModels: preferredCliModels.length > 0 ? preferredCliModels : cliModels,
+                ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
+              });
+              yield* Effect.logDebug(`${adapterConfig.displayName} model discovery resolved`, {
+                binaryPath,
+                connectedProviders: inventory.providerList.connected,
+                inventoryModelCount: inventoryModels.length,
+                cliModelCount: cliModels.length,
+                modelCount: models.length,
+                sampleModels: models.slice(0, 12).map((model) => model.slug),
+              });
+              return {
+                models,
+                source:
+                  cliModels.length > 0
+                    ? adapterConfig.cliModelSource
+                    : adapterConfig.fallbackModelSource,
                 cached: false,
-              }),
+              };
+            }).pipe(
+              Effect.catch(() =>
+                Effect.succeed({
+                  models: flattenOpenCodeModels({
+                    inventory,
+                    credentialProviderIDs,
+                    ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
+                  }),
+                  source: adapterConfig.fallbackModelSource,
+                  cached: false,
+                }),
+              ),
             ),
-          ),
         );
       };
 

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1948,6 +1948,13 @@ describe("ChatView timeline estimator parity (full app)", () => {
         [PROJECT_ID]: THREAD_ID,
       },
     });
+    useComposerDraftStore.getState().setModelSelection(THREAD_ID, {
+      provider: "codex",
+      model: "gpt-5.4",
+      options: {
+        reasoningEffort: "low",
+      },
+    });
 
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,
@@ -1990,6 +1997,18 @@ describe("ChatView timeline estimator parity (full app)", () => {
             envMode: "worktree",
             branch: "feature/draft-automation",
             worktreePath: "/repo/worktrees/draft-automation",
+            associatedWorktreePath: "/repo/worktrees/draft-automation",
+            associatedWorktreeBranch: "feature/draft-automation",
+            associatedWorktreeRef: "feature/draft-automation",
+            modelSelection: {
+              provider: "codex",
+              model: "gpt-5.4",
+              options: {
+                reasoningEffort: "low",
+              },
+            },
+            runtimeMode: "full-access",
+            interactionMode: "default",
           });
 
           expect(wsRequests[automationCreateIndex]).toMatchObject({

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -2,6 +2,9 @@
 import "../index.css";
 
 import {
+  AutomationId,
+  type AutomationCreateInput,
+  type AutomationDefinition,
   EventId,
   MessageId,
   ORCHESTRATION_WS_METHODS,
@@ -490,6 +493,45 @@ function addThreadToSnapshot(
   };
 }
 
+function createAutomationDefinitionFromCreateRequest(
+  body: WsRequestEnvelope["body"],
+): AutomationDefinition {
+  const input = body as unknown as AutomationCreateInput;
+  const definition: AutomationDefinition = {
+    id: AutomationId.makeUnsafe(`automation-${wsRequests.length}`),
+    projectId: input.projectId,
+    sourceThreadId: input.sourceThreadId ?? null,
+    name: input.name,
+    prompt: input.prompt,
+    schedule: input.schedule,
+    enabled: input.enabled ?? true,
+    nextRunAt: null,
+    modelSelection: input.modelSelection,
+    runtimeMode: input.runtimeMode ?? "approval-required",
+    interactionMode: input.interactionMode ?? "default",
+    worktreeMode: input.worktreeMode ?? "auto",
+    mode: input.mode ?? "standalone",
+    targetThreadId: input.targetThreadId ?? null,
+    maxIterations: input.maxIterations ?? null,
+    stopOnError: input.stopOnError ?? true,
+    completionPolicy: input.completionPolicy ?? { type: "none" },
+    completionPolicyVersion: 1,
+    completionPolicyUpdatedAt: NOW_ISO,
+    minimumIntervalSeconds: input.minimumIntervalSeconds ?? 60,
+    maxRuntimeSeconds: input.maxRuntimeSeconds ?? 3_600,
+    retryPolicy: input.retryPolicy ?? { type: "none" },
+    misfirePolicy: input.misfirePolicy ?? "coalesce",
+    acknowledgedRisks: input.acknowledgedRisks ?? [],
+    iterationCount: 0,
+    createdAt: NOW_ISO,
+    updatedAt: NOW_ISO,
+    archivedAt: null,
+  };
+  return input.providerOptions === undefined
+    ? definition
+    : { ...definition, providerOptions: input.providerOptions };
+}
+
 function createDraftOnlySnapshot(): OrchestrationReadModel {
   const snapshot = createSnapshotForTargetUser({
     targetMessageId: "msg-user-draft-target" as MessageId,
@@ -808,6 +850,9 @@ function resolveWsRpc(body: WsRequestEnvelope["body"]): unknown {
   if (tag === ORCHESTRATION_WS_METHODS.dispatchCommand) {
     return { sequence: fixture.snapshot.snapshotSequence + 1 };
   }
+  if (tag === WS_METHODS.automationCreate) {
+    return createAutomationDefinitionFromCreateRequest(body);
+  }
   if (tag === WS_METHODS.serverGetConfig) {
     return fixture.serverConfig;
   }
@@ -1047,6 +1092,21 @@ async function waitForSendButton(): Promise<HTMLButtonElement> {
     () => document.querySelector<HTMLButtonElement>('button[aria-label="Send message"]'),
     "Unable to find send button.",
   );
+}
+
+function readDispatchedCommand(request: WsRequestEnvelope["body"]): Record<string, unknown> | null {
+  if (
+    request._tag !== ORCHESTRATION_WS_METHODS.dispatchCommand ||
+    typeof request.command !== "object" ||
+    request.command === null
+  ) {
+    return null;
+  }
+  return request.command as Record<string, unknown>;
+}
+
+function hasDispatchedCommandType(type: string): boolean {
+  return wsRequests.some((request) => readDispatchedCommand(request)?.type === type);
 }
 
 async function waitForEnvironmentModeButton(label: string): Promise<HTMLButtonElement> {
@@ -1708,6 +1768,297 @@ describe("ChatView timeline estimator parity (full app)", () => {
           expect(layout.distanceFromBottomPx).toBeLessThanOrEqual(AUTO_SCROLL_BOTTOM_THRESHOLD_PX);
         },
         { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("sends unmarked automation questions as normal chat messages", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-automation-question" as MessageId,
+        targetText: "automation question target",
+      }),
+    });
+
+    try {
+      const prompt = "how do automations work every day?";
+      useComposerDraftStore.getState().setPrompt(THREAD_ID, prompt);
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditor.textContent ?? "").toContain(prompt);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      wsRequests.length = 0;
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      sendButton.click();
+
+      await vi.waitFor(
+        () => {
+          const turnStartRequest = wsRequests.find((request) => {
+            const command = readDispatchedCommand(request);
+            return command?.type === "thread.turn.start";
+          });
+          expect(turnStartRequest).toBeTruthy();
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      expect(wsRequests.some((request) => request._tag === WS_METHODS.automationCreate)).toBe(
+        false,
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("creates composer automations as heartbeat runs on the current chat", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-current-chat-automation" as MessageId,
+        targetText: "current chat automation target",
+      }),
+    });
+
+    try {
+      useComposerDraftStore
+        .getState()
+        .setPrompt(THREAD_ID, "/automation say hi every 15 seconds 3 times total");
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditor.textContent ?? "").toContain("say hi every 15 seconds");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      wsRequests.length = 0;
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      sendButton.click();
+
+      await vi.waitFor(
+        () => {
+          const automationCreateRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.automationCreate,
+          );
+          expect(automationCreateRequest).toMatchObject({
+            _tag: WS_METHODS.automationCreate,
+            mode: "heartbeat",
+            targetThreadId: THREAD_ID,
+            sourceThreadId: THREAD_ID,
+            worktreeMode: "auto",
+            maxIterations: 3,
+            prompt: "say hi",
+            schedule: { type: "interval", everySeconds: 15 },
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+      await waitForLayout();
+
+      expect(hasDispatchedCommandType("thread.create")).toBe(false);
+      expect(hasDispatchedCommandType("thread.turn.start")).toBe(false);
+      expect(wsRequests.some((request) => request._tag === WS_METHODS.gitCreateWorktree)).toBe(
+        false,
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("creates polite composer automation requests as heartbeat runs", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-polite-chat-automation" as MessageId,
+        targetText: "polite current chat automation target",
+      }),
+    });
+
+    try {
+      useComposerDraftStore
+        .getState()
+        .setPrompt(THREAD_ID, "could you say hi every 15 seconds for 3 times");
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditor.textContent ?? "").toContain("could you say hi");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      wsRequests.length = 0;
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      sendButton.click();
+
+      await vi.waitFor(
+        () => {
+          const automationCreateRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.automationCreate,
+          );
+          expect(automationCreateRequest).toMatchObject({
+            _tag: WS_METHODS.automationCreate,
+            mode: "heartbeat",
+            targetThreadId: THREAD_ID,
+            sourceThreadId: THREAD_ID,
+            worktreeMode: "auto",
+            maxIterations: 3,
+            prompt: "say hi",
+            schedule: { type: "interval", everySeconds: 15 },
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+      await waitForLayout();
+
+      expect(hasDispatchedCommandType("thread.create")).toBe(false);
+      expect(hasDispatchedCommandType("thread.turn.start")).toBe(false);
+      expect(wsRequests.some((request) => request._tag === WS_METHODS.gitCreateWorktree)).toBe(
+        false,
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("promotes draft chats before creating composer heartbeat automations", async () => {
+    useComposerDraftStore.setState({
+      draftThreadsByThreadId: {
+        [THREAD_ID]: {
+          projectId: PROJECT_ID,
+          createdAt: NOW_ISO,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          entryPoint: "chat",
+          branch: "feature/draft-automation",
+          worktreePath: "/repo/worktrees/draft-automation",
+          envMode: "worktree",
+        },
+      },
+      projectDraftThreadIdByProjectId: {
+        [PROJECT_ID]: THREAD_ID,
+      },
+    });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+    });
+
+    try {
+      useComposerDraftStore
+        .getState()
+        .setPrompt(THREAD_ID, "/automation say hi every 15 seconds for 3 times");
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditor.textContent ?? "").toContain("say hi every 15 seconds");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      wsRequests.length = 0;
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      await sendButton.click();
+
+      await vi.waitFor(
+        () => {
+          const createThreadIndex = wsRequests.findIndex((request) => {
+            const command = readDispatchedCommand(request);
+            return command?.type === "thread.create" && command.threadId === THREAD_ID;
+          });
+          const automationCreateIndex = wsRequests.findIndex(
+            (request) => request._tag === WS_METHODS.automationCreate,
+          );
+          expect(createThreadIndex).toBeGreaterThanOrEqual(0);
+          expect(automationCreateIndex).toBeGreaterThan(createThreadIndex);
+
+          const createThreadCommand = readDispatchedCommand(wsRequests[createThreadIndex]!);
+          expect(createThreadCommand).toMatchObject({
+            type: "thread.create",
+            threadId: THREAD_ID,
+            envMode: "worktree",
+            branch: "feature/draft-automation",
+            worktreePath: "/repo/worktrees/draft-automation",
+          });
+
+          expect(wsRequests[automationCreateIndex]).toMatchObject({
+            _tag: WS_METHODS.automationCreate,
+            mode: "heartbeat",
+            targetThreadId: THREAD_ID,
+            sourceThreadId: THREAD_ID,
+            worktreeMode: "auto",
+            maxIterations: 3,
+            prompt: "say hi",
+            schedule: { type: "interval", everySeconds: 15 },
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+      await waitForLayout();
+
+      expect(hasDispatchedCommandType("thread.turn.start")).toBe(false);
+      expect(wsRequests.some((request) => request._tag === WS_METHODS.gitCreateWorktree)).toBe(
+        false,
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("does not promote draft chats until a reviewed automation is submitted", async () => {
+    useComposerDraftStore.setState({
+      draftThreadsByThreadId: {
+        [THREAD_ID]: {
+          projectId: PROJECT_ID,
+          createdAt: NOW_ISO,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          entryPoint: "chat",
+          branch: null,
+          worktreePath: null,
+          envMode: "local",
+        },
+      },
+      projectDraftThreadIdByProjectId: {
+        [PROJECT_ID]: THREAD_ID,
+      },
+    });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+    });
+
+    try {
+      useComposerDraftStore.getState().setPrompt(THREAD_ID, "/automation say hi every 15 seconds");
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditor.textContent ?? "").toContain("say hi every 15 seconds");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      wsRequests.length = 0;
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      await sendButton.click();
+
+      await expect.element(page.getByText("Fast recurring loop")).toBeInTheDocument();
+      expect(hasDispatchedCommandType("thread.create")).toBe(false);
+      expect(wsRequests.some((request) => request._tag === WS_METHODS.automationCreate)).toBe(
+        false,
       );
     } finally {
       await mounted.cleanup();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1423,9 +1423,9 @@ export default function ChatView({
       deriveAssociatedWorktreeMetadata({
         branch: activeThread?.branch ?? null,
         worktreePath: activeThread?.worktreePath ?? null,
-        associatedWorktreePath: activeThread?.associatedWorktreePath ?? null,
-        associatedWorktreeBranch: activeThread?.associatedWorktreeBranch ?? null,
-        associatedWorktreeRef: activeThread?.associatedWorktreeRef ?? null,
+        associatedWorktreePath: activeThread?.associatedWorktreePath,
+        associatedWorktreeBranch: activeThread?.associatedWorktreeBranch,
+        associatedWorktreeRef: activeThread?.associatedWorktreeRef,
       }),
     [
       activeThread?.associatedWorktreeBranch,
@@ -5945,9 +5945,9 @@ export default function ChatView({
   const ensureAutomationTargetThread = useCallback(
     async (input: {
       readonly titleSeed: string;
-      readonly modelSelection: ModelSelection;
-      readonly runtimeMode: RuntimeMode;
-      readonly interactionMode: ProviderInteractionMode;
+      readonly threadModelSelection: ModelSelection;
+      readonly threadRuntimeMode: RuntimeMode;
+      readonly threadInteractionMode: ProviderInteractionMode;
     }): Promise<ThreadId | null> => {
       const api = readNativeApi();
       if (!api || !activeProject || !activeThread) {
@@ -5971,12 +5971,15 @@ export default function ChatView({
             threadId: activeThread.id,
             projectId: activeProject.id,
             title,
-            modelSelection: input.modelSelection,
-            runtimeMode: input.runtimeMode,
-            interactionMode: input.interactionMode,
+            modelSelection: input.threadModelSelection,
+            runtimeMode: input.threadRuntimeMode,
+            interactionMode: input.threadInteractionMode,
             envMode: activeThread.envMode ?? (activeThread.worktreePath ? "worktree" : "local"),
             branch: activeThread.branch ?? null,
             worktreePath: activeThread.worktreePath ?? null,
+            associatedWorktreePath: activeThreadAssociatedWorktree.associatedWorktreePath,
+            associatedWorktreeBranch: activeThreadAssociatedWorktree.associatedWorktreeBranch,
+            associatedWorktreeRef: activeThreadAssociatedWorktree.associatedWorktreeRef,
             lastKnownPr: activeThread.lastKnownPr ?? null,
             createdAt: activeThread.createdAt,
           },
@@ -6015,7 +6018,7 @@ export default function ChatView({
         return null;
       }
     },
-    [activeProject, activeThread, isServerThread, threadNotes],
+    [activeProject, activeThread, activeThreadAssociatedWorktree, isServerThread, threadNotes],
   );
 
   const prepareAutomationFormForCreate = useCallback(
@@ -6037,9 +6040,9 @@ export default function ChatView({
       // the automation is actually submitted so cancelling review leaves no empty thread.
       const targetThreadId = await ensureAutomationTargetThread({
         titleSeed: form.prompt || form.name,
-        modelSelection: form.modelSelection,
-        runtimeMode: form.runtimeMode,
-        interactionMode,
+        threadModelSelection: selectedModelSelection,
+        threadRuntimeMode: runtimeMode,
+        threadInteractionMode: interactionMode,
       });
       if (!targetThreadId) {
         return null;
@@ -6049,7 +6052,14 @@ export default function ChatView({
         activityThreadId: targetThreadId,
       };
     },
-    [activeThread, ensureAutomationTargetThread, interactionMode, isServerThread],
+    [
+      activeThread,
+      ensureAutomationTargetThread,
+      interactionMode,
+      isServerThread,
+      runtimeMode,
+      selectedModelSelection,
+    ],
   );
 
   const openAutomationEditDialog = useCallback(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -125,12 +125,11 @@ import {
   readFileAsDataUrl,
 } from "../lib/composerSend";
 import { reconcileDeletedThreadFromClient } from "../lib/deletedThreadClientReconciliation";
+import { extractChatAutomationInvocation } from "../lib/automationIntent";
 import {
-  extractChatAutomationInvocation,
-  parseChatAutomationInvocation,
-  resolveChatAutomationIntent,
-} from "../lib/automationIntent";
-import { stopWhenFromCompletionPolicy } from "../lib/automationCompletionPolicy";
+  buildComposerAutomationDraft,
+  resolveComposerAutomationRequest,
+} from "../lib/composerAutomation";
 import {
   acknowledgedRiskIdsForDraft,
   buildAutomationDraftWarnings,
@@ -389,13 +388,13 @@ import { useRepoDiffTotals } from "~/hooks/useRepoDiffTotals";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import {
   acknowledgedRiskIdsForFormWarnings,
-  applyScheduleToForm,
   AutomationDialog,
   automationQueryKey,
   buildAutomationFormWarnings,
   createInputFromForm,
   formatCadence,
   formFromDefinition,
+  heartbeatAutomationsForThread,
   isFormSubmittable,
   providerOptionsForAutomationEdit,
   projectModelSelection as automationProjectModelSelection,
@@ -1356,10 +1355,7 @@ export default function ChatView({
   );
   const automationProjects = useStore((state) => state.projects);
   const automationThreads = useStore((state) => state.threads);
-  const {
-    data: automationData,
-    updateMutation: automationUpdateMutation,
-  } = useAutomations();
+  const { data: automationData, updateMutation: automationUpdateMutation } = useAutomations();
   const [automationDraftForm, setAutomationDraftForm] = useState<AutomationFormState | null>(null);
   const [automationEditingDefinition, setAutomationEditingDefinition] =
     useState<AutomationDefinition | null>(null);
@@ -5845,9 +5841,10 @@ export default function ChatView({
       readonly warnings: readonly AutomationDraftWarning[];
       readonly acknowledgedWarningIds: ReadonlySet<AutomationDraftWarningId>;
       readonly providerOptions?: ProviderStartOptions;
+      readonly activityThreadId?: ThreadId | null;
     }): Promise<boolean> => {
       const api = readNativeApi();
-      if (!api || !activeThread || !activeProject) {
+      if (!api || !activeProject) {
         return false;
       }
       if (automationDraftSubmittingRef.current) {
@@ -5863,23 +5860,26 @@ export default function ChatView({
         input.warnings,
         input.acknowledgedWarningIds,
       );
+      const activityThreadId =
+        input.activityThreadId ?? (isServerThread ? (activeThread?.id ?? null) : null);
       const createdAt = new Date().toISOString();
       const automationInput = createInputFromForm(
         input.form,
         input.providerOptions ?? providerOptionsForDispatch,
         acknowledgedRisks,
+        activityThreadId,
       );
       automationDraftSubmittingRef.current = true;
       setIsAutomationDraftSubmitting(true);
       try {
         const definition = await api.automation.create(automationInput);
-        if (isServerThread) {
+        if (activityThreadId) {
           void (async () => {
             try {
               await api.orchestration.dispatchCommand({
                 type: "thread.activity.append",
                 commandId: newCommandId(),
-                threadId: activeThread.id,
+                threadId: activityThreadId,
                 activity: {
                   id: EventId.makeUnsafe(randomUUID()),
                   tone: "info",
@@ -5909,7 +5909,7 @@ export default function ChatView({
           })();
         }
         void queryClient.invalidateQueries({ queryKey: automationQueryKey });
-        clearComposerInput(activeThread.id);
+        clearComposerInput(activeThread?.id ?? threadId);
         resetAutomationDraftState();
         toastManager.add({
           type: "success",
@@ -5938,7 +5938,118 @@ export default function ChatView({
       providerOptionsForDispatch,
       queryClient,
       resetAutomationDraftState,
+      threadId,
     ],
+  );
+
+  const ensureAutomationTargetThread = useCallback(
+    async (input: {
+      readonly titleSeed: string;
+      readonly modelSelection: ModelSelection;
+      readonly runtimeMode: RuntimeMode;
+      readonly interactionMode: ProviderInteractionMode;
+    }): Promise<ThreadId | null> => {
+      const api = readNativeApi();
+      if (!api || !activeProject || !activeThread) {
+        toastManager.add({
+          type: "warning",
+          title: "Chat required",
+          description: "Open a chat before creating a chat-bound automation.",
+        });
+        return null;
+      }
+      if (isServerThread) {
+        return activeThread.id;
+      }
+
+      const title = buildPromptThreadTitleFallback(input.titleSeed || GENERIC_CHAT_THREAD_TITLE);
+      try {
+        const result = await promoteThreadCreate(
+          {
+            type: "thread.create",
+            commandId: newCommandId(),
+            threadId: activeThread.id,
+            projectId: activeProject.id,
+            title,
+            modelSelection: input.modelSelection,
+            runtimeMode: input.runtimeMode,
+            interactionMode: input.interactionMode,
+            envMode: activeThread.envMode ?? (activeThread.worktreePath ? "worktree" : "local"),
+            branch: activeThread.branch ?? null,
+            worktreePath: activeThread.worktreePath ?? null,
+            lastKnownPr: activeThread.lastKnownPr ?? null,
+            createdAt: activeThread.createdAt,
+          },
+          api,
+          { force: true },
+        );
+        if (result === "unavailable") {
+          toastManager.add({
+            type: "error",
+            title: "Could not create chat",
+            description: "Synara could not promote this draft before saving the automation.",
+          });
+          return null;
+        }
+
+        const inheritedProjectInstructions =
+          useProjectInstructionsStore.getState().instructionsByProjectId[activeProject.id] ?? "";
+        const inheritedThreadNotes = mergeProjectInstructionsIntoThreadNotes({
+          threadNotes,
+          projectInstructions: inheritedProjectInstructions,
+        });
+        if (inheritedThreadNotes !== threadNotes && inheritedThreadNotes.trim().length > 0) {
+          void dispatchThreadNotes(activeThread.id, inheritedThreadNotes).catch(() => undefined);
+        }
+
+        return activeThread.id;
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Could not create chat",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Synara could not promote this draft before saving the automation.",
+        });
+        return null;
+      }
+    },
+    [activeProject, activeThread, isServerThread, threadNotes],
+  );
+
+  const prepareAutomationFormForCreate = useCallback(
+    async (
+      form: AutomationFormState,
+    ): Promise<{
+      readonly form: AutomationFormState;
+      readonly activityThreadId: ThreadId | null;
+    } | null> => {
+      const activityThreadId = isServerThread ? (activeThread?.id ?? null) : null;
+      if (form.mode !== "heartbeat" || !activeThread) {
+        return { form, activityThreadId };
+      }
+      if (isServerThread || form.targetThreadId !== activeThread.id) {
+        return { form, activityThreadId };
+      }
+
+      // Draft review can keep the local draft ID in the form; promote it only when
+      // the automation is actually submitted so cancelling review leaves no empty thread.
+      const targetThreadId = await ensureAutomationTargetThread({
+        titleSeed: form.prompt || form.name,
+        modelSelection: form.modelSelection,
+        runtimeMode: form.runtimeMode,
+        interactionMode,
+      });
+      if (!targetThreadId) {
+        return null;
+      }
+      return {
+        form: { ...form, targetThreadId },
+        activityThreadId: targetThreadId,
+      };
+    },
+    [activeThread, ensureAutomationTargetThread, interactionMode, isServerThread],
   );
 
   const openAutomationEditDialog = useCallback(
@@ -6027,10 +6138,21 @@ export default function ChatView({
       });
       return;
     }
+    if (
+      !isFormSubmittable(automationDraftForm) ||
+      hasBlockingAutomationDraftWarnings(automationDraftWarnings, acknowledgedAutomationWarnings)
+    ) {
+      return;
+    }
+    const preparedCreate = await prepareAutomationFormForCreate(automationDraftForm);
+    if (!preparedCreate) {
+      return;
+    }
     await createAutomationFromForm({
-      form: automationDraftForm,
+      form: preparedCreate.form,
       warnings: automationDraftWarnings,
       acknowledgedWarningIds: acknowledgedAutomationWarnings,
+      activityThreadId: preparedCreate.activityThreadId,
     });
   }, [
     acknowledgedAutomationWarnings,
@@ -6038,6 +6160,7 @@ export default function ChatView({
     automationDraftForm,
     automationDraftWarnings,
     createAutomationFromForm,
+    prepareAutomationFormForCreate,
     updateAutomationFromForm,
   ]);
 
@@ -6279,101 +6402,55 @@ export default function ChatView({
     }
     if (!activeProject) return false;
     if (queuedChatTurn === null) {
-      // Explicit automation triggers create a saved automation instead of sending a provider turn.
-      const automationInvocation = extractChatAutomationInvocation(trimmed);
-      if (automationInvocation !== null) {
-        const automationMessage = automationInvocation.trim();
-        const nowIso = new Date().toISOString();
-        const deterministicAutomationIntent = parseChatAutomationInvocation(automationInvocation, {
-          nowIso,
-        });
-        const generatedAutomationIntent =
-          !deterministicAutomationIntent && automationMessage.length > 0
-            ? await api.server
-                .generateAutomationIntent({
-                  cwd: activeProject.cwd,
-                  message: automationMessage,
-                  defaultMode: isServerThread ? "heartbeat" : "standalone",
-                  nowIso,
-                })
-                .catch(() => null)
-            : null;
-        const automationResolution = resolveChatAutomationIntent({
-          deterministicIntent: deterministicAutomationIntent,
-          generatedIntent: generatedAutomationIntent,
-          isServerThread,
-        });
-        if (!automationResolution) {
+      const automationRequest = await resolveComposerAutomationRequest({
+        message: trimmed,
+        cwd: activeProject.cwd,
+        generateIntent: (request) => api.server.generateAutomationIntent(request),
+      });
+      if (automationRequest.type !== "normal-chat") {
+        if (automationRequest.type === "missing-schedule") {
           toastManager.add({
             type: "warning",
             title: "Automation schedule needed",
             description:
-              generatedAutomationIntent?.reason ??
+              automationRequest.reason ??
               "Try /automation every 6h check the page, or @automation daily at 9:00.",
           });
           return true;
         }
-        const { intent: automationIntent, mode: automationMode } = automationResolution;
-        const automationStopWhen = stopWhenFromCompletionPolicy(automationIntent.completionPolicy);
-        const baseForm = formFromDefinition(
-          null,
-          activeProject.id,
-          automationProjectModelSelection(automationProjects, activeProject.id),
-        );
-        // Chat-created automations should not inherit live Full access; escalating scheduled
-        // runs stays an explicit review step in the automation dialog.
-        const chatAutomationRuntimeMode: RuntimeMode = "approval-required";
-        const nextForm = applyScheduleToForm(
-          {
-            ...baseForm,
-            name: automationIntent.name,
-            prompt: automationIntent.prompt,
-            projectId: activeProject.id,
-            modelSelection: selectedModelSelectionForSend,
-            runtimeMode: chatAutomationRuntimeMode,
-            worktreeMode: "auto",
-            mode: automationMode,
-            targetThreadId: automationMode === "heartbeat" && isServerThread ? activeThread.id : "",
-            maxIterations: "",
-            stopOnError: true,
-            stopWhen: automationMode === "heartbeat" ? automationStopWhen : "",
-          },
-          automationIntent.schedule,
-        );
-        const warnings = buildAutomationDraftWarnings({
-          schedule: automationIntent.schedule,
-          mode: nextForm.mode,
-          runtimeMode: nextForm.runtimeMode,
-          worktreeMode: nextForm.worktreeMode,
+
+        const automationIntent = automationRequest.resolution.intent;
+        const automationTargetThreadId =
+          automationIntent.executionScope === "thread" ? activeThread.id : null;
+        const automationDraft = buildComposerAutomationDraft({
+          resolution: automationRequest.resolution,
+          projectId: activeProject.id,
+          projectModelSelection: automationProjectModelSelection(
+            automationProjects,
+            activeProject.id,
+          ),
+          selectedModelSelection: selectedModelSelectionForSend,
+          targetThreadId: automationTargetThreadId,
           hasEphemeralContext: !hasPromptOnlySendableContent,
-          generatedConfidence: automationResolution.generatedConfidence,
-          generatedNeedsConfirmation: automationResolution.generatedNeedsConfirmation,
-          prompt: automationIntent.prompt,
         });
-        const warningContext = {
-          hasEphemeralContext: !hasPromptOnlySendableContent,
-          generatedConfidence: automationResolution.generatedConfidence,
-          generatedNeedsConfirmation: automationResolution.generatedNeedsConfirmation,
-        };
-        const acknowledgedWarningIds = new Set<AutomationDraftWarningId>();
-        const needsDraftReview =
-          automationResolution.requiresReview ||
-          automationResolution.generatedNeedsConfirmation ||
-          !isFormSubmittable(nextForm) ||
-          hasBlockingAutomationDraftWarnings(warnings, acknowledgedWarningIds);
-        if (needsDraftReview) {
+        if (automationDraft.needsDraftReview) {
           setAutomationEditingDefinition(null);
-          setAutomationDraftWarningContext(warningContext);
-          setAutomationDraftForm(nextForm);
-          setAutomationDraftWarnings(warnings);
-          setAcknowledgedAutomationWarnings(acknowledgedWarningIds);
+          setAutomationDraftWarningContext(automationDraft.warningContext);
+          setAutomationDraftForm(automationDraft.form);
+          setAutomationDraftWarnings(automationDraft.warnings);
+          setAcknowledgedAutomationWarnings(automationDraft.acknowledgedWarningIds);
           setAutomationDraftOpen(true);
           return true;
         }
+        const preparedAutomation = await prepareAutomationFormForCreate(automationDraft.form);
+        if (!preparedAutomation) {
+          return true;
+        }
         await createAutomationFromForm({
-          form: nextForm,
-          warnings,
-          acknowledgedWarningIds,
+          form: preparedAutomation.form,
+          warnings: automationDraft.warnings,
+          acknowledgedWarningIds: automationDraft.acknowledgedWarningIds,
+          activityThreadId: preparedAutomation.activityThreadId,
           ...(providerOptionsForDispatchForSend
             ? { providerOptions: providerOptionsForDispatchForSend }
             : {}),
@@ -8845,13 +8922,10 @@ export default function ChatView({
       </div>
     ) : null;
 
-  const threadAutomationItems = automationData.definitions
-    .filter(
-      (definition) =>
-        definition.mode === "heartbeat" && definition.targetThreadId === activeThread.id,
-    )
-    .sort((left, right) => left.name.localeCompare(right.name))
-    .map((definition) => ({ definition }));
+  const threadAutomationItems = heartbeatAutomationsForThread(
+    automationData.definitions,
+    activeThread.id,
+  ).map((definition) => ({ definition }));
 
   // Shared inputs for both Environment panel surfaces (the header Popover when the dock is
   // open, and the docked right column when it is closed) so the two never drift.

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -65,6 +65,7 @@ import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-
 import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
 import {
+  type AutomationDefinition,
   type AutomationListResult,
   MAX_PINNED_PROJECTS,
   type DesktopUpdateState,
@@ -144,6 +145,8 @@ import {
   applyAutomationEvent,
   automationAttentionCount,
   automationQueryKey,
+  formatCadence,
+  groupHeartbeatAutomationsByTargetThread,
 } from "../routes/-automations.shared";
 import { shouldRenderTerminalWorkspace } from "./ChatView.logic";
 import { CHAT_SURFACE_HEADER_HEIGHT_CLASS } from "./chat/chatHeaderControls";
@@ -155,7 +158,7 @@ import { SidebarLeadingIcon } from "./SidebarLeadingIcon";
 import { SidebarMetaChipStack } from "./SidebarMetaChip";
 import { SidebarRowHoverActions } from "./SidebarRowHoverActions";
 import { SidebarSectionToolbar } from "./SidebarSectionToolbar";
-import { SidebarGlyph, sidebarGlyphClass } from "./sidebarGlyphs";
+import { SidebarGlyph, sidebarGlyphClass, SIDEBAR_TRAILING_ICON_CLASS } from "./sidebarGlyphs";
 import { ThreadPinToggleButton } from "./ThreadPinToggleButton";
 import { ThreadRunningSpinner } from "./ThreadRunningSpinner";
 import { RenameDialog } from "./RenameDialog";
@@ -546,7 +549,9 @@ function threadRowTimestampSlotClassName(
     "mr-1 flex shrink-0 items-center justify-end leading-none tabular-nums transition-opacity group-hover/thread-row:opacity-0 group-focus-within/thread-row:opacity-0",
     isSubagentThread
       ? "w-[1.2rem] text-[10px]"
-      : "w-[1.625rem] text-[length:var(--app-font-size-ui-meta,11px)]",
+      : // Nudge the timestamp a hair above the meta scale while still tracking the user's
+        // typography setting (the CSS var is always set; the 11px is just an SSR fallback).
+        "w-[1.625rem] text-[length:calc(var(--app-font-size-ui-meta,11px)+0.5px)]",
     toneClassName ?? (isSubagentThread ? "text-muted-foreground/26" : "text-muted-foreground/38"),
   );
 }
@@ -561,7 +566,7 @@ function resolveWorktreeBadgeLabel(
 }
 
 type ThreadMetaChip = {
-  id: "handoff" | "fork" | "worktree";
+  id: "automation" | "handoff" | "fork" | "worktree";
   tooltip: string;
   icon: ReactNode;
 };
@@ -582,9 +587,34 @@ function resolveThreadRowMetaChips(input: {
    * pair, the trailing handoff chip is a redundant double icon and is dropped.
    */
   handoffShownInAvatar?: boolean;
+  /** Heartbeat automations targeting this thread; surfaced as an at-a-glance clock chip. */
+  threadAutomations?: readonly AutomationDefinition[] | undefined;
 }): ThreadMetaChip[] {
   const chips: ThreadMetaChip[] = [];
   const isSidechatThread = Boolean(input.thread.sidechatSourceThreadId);
+
+  const threadAutomations = input.threadAutomations;
+  if (threadAutomations && threadAutomations.length > 0) {
+    const anyEnabled = threadAutomations.some((automation) => automation.enabled);
+    const firstAutomation = threadAutomations[0]!;
+    const tooltip =
+      threadAutomations.length === 1
+        ? `${firstAutomation.name} · ${
+            firstAutomation.enabled ? formatCadence(firstAutomation.schedule) : "Paused"
+          }`
+        : `${threadAutomations.length} automations`;
+    chips.push({
+      id: "automation",
+      tooltip,
+      icon: (
+        <SidebarGlyph
+          icon={ClockIcon}
+          variant="meta"
+          className={anyEnabled ? "text-muted-foreground/55" : "text-muted-foreground/40"}
+        />
+      ),
+    });
+  }
 
   const handoffBadgeLabel = resolveThreadHandoffBadgeLabel(input.thread);
   if (input.includeHandoffBadge && !input.handoffShownInAvatar && handoffBadgeLabel) {
@@ -1258,6 +1288,12 @@ export default function Sidebar() {
     if (!data) return 0;
     return automationAttentionCount(data.runs);
   }, [automationListQuery.data]);
+  // Heartbeat automations grouped by their target thread, so each thread row can show a
+  // clock chip indicating an automation is attached (mirrors the Environment panel section).
+  const automationsByThreadId = useMemo(
+    () => groupHeartbeatAutomationsByTargetThread(automationListQuery.data?.definitions ?? []),
+    [automationListQuery.data],
+  );
   const { settings: appSettings, updateSettings } = useAppSettings();
   // The Threads/Projects tab is always available; only the optional Workspace tab
   // and the standalone Chats footer list can be hidden from Settings.
@@ -3113,8 +3149,7 @@ export default function Sidebar() {
 
       void reconcileDeletedThreadsFromClient({
         threadIds: successfullyDeletedIds,
-        removeDeletedThreadFromClientState:
-          useStore.getState().removeDeletedThreadFromClientState,
+        removeDeletedThreadFromClientState: useStore.getState().removeDeletedThreadFromClientState,
       });
       removeFromSelection([...deletedIds]);
 
@@ -4531,7 +4566,9 @@ export default function Sidebar() {
         title="Archive thread"
         data-testid={`thread-archive-${threadId}`}
         size={compact ? "sm" : "md"}
-        glyph={compact ? "compact" : "meta"}
+        // Match the pin and the right-side meta chips (shared trailing-icon size); subagent
+        // rows stay on the denser "compact" scale.
+        iconClassName={compact ? sidebarGlyphClass("compact") : SIDEBAR_TRAILING_ICON_CLASS}
         className={cn("hover:text-foreground/89", toneClassName)}
         onMouseDown={(event) => {
           event.preventDefault();
@@ -4583,7 +4620,7 @@ export default function Sidebar() {
             <span>Confirm</span>
           </button>
         ) : (
-          <div className="pointer-events-auto inline-flex items-center gap-1">
+          <div className="pointer-events-auto inline-flex items-center gap-2">
             {includePinToggle ? (
               <ThreadPinToggleButton
                 pinned={input.isPinned}
@@ -4675,6 +4712,7 @@ export default function Sidebar() {
         threadEntryPoint !== "terminal" &&
         !isGenericChatThreadTitle(thread.title) &&
         Boolean(thread.handoff?.sourceProvider),
+      threadAutomations: automationsByThreadId.get(thread.id),
     });
     const threadStatus = resolveThreadStatusForSidebar(thread);
     const isSubagentThread = Boolean(thread.parentThreadId);
@@ -4856,6 +4894,7 @@ export default function Sidebar() {
         threadEntryPoint !== "terminal" &&
         !isGenericChatThreadTitle(thread.title) &&
         Boolean(thread.handoff?.sourceProvider),
+      threadAutomations: automationsByThreadId.get(thread.id),
     });
     const isSubagentThread = Boolean(thread.parentThreadId);
     const leadingPrStatus =

--- a/apps/web/src/components/SidebarMetaChip.tsx
+++ b/apps/web/src/components/SidebarMetaChip.tsx
@@ -4,9 +4,17 @@
 // Exports: SidebarMetaChip, SidebarMetaChipStack, SidebarMetaChipPlaceholder
 
 import type { ReactNode } from "react";
+import { SIDEBAR_TRAILING_ICON_FORCE_CLASS } from "./sidebarGlyphs";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
-const CHIP_SLOT = "inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center";
+// Right-aligned thread-row meta chips (automation clock, worktree, fork, handoff). Their
+// icons are forced to the shared trailing size at the slot so they match the pin/archive
+// buttons and the whole right-side cluster reads as one uniform set — including the worktree
+// Central icon, which the shared force class covers via its [data-slot=central-icon] selector.
+// CHIP_SLOT_PX drives the overlapping-stack layout math below (Tailwind can only scan literal
+// class strings, so keep it in step with the slot's h-[15px]/w-[15px]).
+const CHIP_SLOT_PX = 15;
+const CHIP_SLOT = `inline-flex h-[15px] w-[15px] shrink-0 items-center justify-center ${SIDEBAR_TRAILING_ICON_FORCE_CLASS}`;
 
 export function SidebarMetaChip({ tooltip, children }: { tooltip: string; children: ReactNode }) {
   return (
@@ -31,7 +39,7 @@ export function SidebarMetaChipStack({
   }
 
   const tooltipText = chips.map((chip) => chip.tooltip).join(" · ");
-  const chipSize = 14;
+  const chipSize = CHIP_SLOT_PX;
   const step = 8;
   const width = chipSize + step * (chips.length - 1);
 
@@ -40,14 +48,14 @@ export function SidebarMetaChipStack({
       <TooltipTrigger
         render={
           <div
-            className="relative h-3.5 shrink-0"
+            className="relative h-[15px] shrink-0"
             style={{ width: `${width}px` }}
             aria-label={tooltipText}
           >
             {chips.map((chip, index) => (
               <span
                 key={chip.id}
-                className="sidebar-icon-chip absolute top-1/2 inline-flex size-3.5 -translate-y-1/2 items-center justify-center rounded-full"
+                className={`sidebar-icon-chip absolute top-1/2 inline-flex size-[15px] -translate-y-1/2 items-center justify-center rounded-full ${SIDEBAR_TRAILING_ICON_FORCE_CLASS}`}
                 style={{ left: `${index * step}px`, zIndex: index + 1 }}
               >
                 {chip.icon}

--- a/apps/web/src/components/ThreadPinToggleButton.tsx
+++ b/apps/web/src/components/ThreadPinToggleButton.tsx
@@ -10,6 +10,7 @@ import type React from "react";
 import { PinIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { IconButton } from "./ui/icon-button";
+import { SIDEBAR_TRAILING_ICON_CLASS } from "./sidebarGlyphs";
 
 export function ThreadPinToggleButton({
   pinned,
@@ -53,7 +54,7 @@ export function ThreadPinToggleButton({
       }}
       onClick={onToggle}
     >
-      <PinIcon className="size-3.5" />
+      <PinIcon className={SIDEBAR_TRAILING_ICON_CLASS} />
     </IconButton>
   );
 }

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -781,14 +781,13 @@ export const ChatHeader = memo(function ChatHeader({
             </ComposerPickerMenuPopup>
           </Menu>
         ) : null}
-        {/* Keep the shared project-action dialog mounted for the Open-in picker,
-            but do not render the header play/chevron runner. */}
+        {/* Keep the shared project-action dialog mounted for the Open-in picker while
+            preserving the header's quick run button for saved project scripts. */}
         {!isDisposableThread && activeProjectScripts ? (
           <ProjectScriptsControl
             scripts={activeProjectScripts}
             keybindings={keybindings}
             preferredScriptId={preferredScriptId}
-            showInlineControls={false}
             openAddActionNonce={openAddActionNonce}
             onRunScript={onRunProjectScript}
             onAddScript={onAddProjectScript}

--- a/apps/web/src/components/chat/environment/EnvironmentAutomationsSection.browser.tsx
+++ b/apps/web/src/components/chat/environment/EnvironmentAutomationsSection.browser.tsx
@@ -4,12 +4,7 @@
 
 import "../../../index.css";
 
-import {
-  AutomationId,
-  ProjectId,
-  ThreadId,
-  type AutomationDefinition,
-} from "@t3tools/contracts";
+import { AutomationId, ProjectId, ThreadId, type AutomationDefinition } from "@t3tools/contracts";
 import { page } from "vitest/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";

--- a/apps/web/src/components/kanban/useKanbanCardContextMenu.tsx
+++ b/apps/web/src/components/kanban/useKanbanCardContextMenu.tsx
@@ -155,8 +155,7 @@ export function useKanbanCardContextMenu(): KanbanCardContextMenuController {
       });
       void reconcileDeletedThreadFromClient({
         threadId: card.threadId,
-        removeDeletedThreadFromClientState:
-          useStore.getState().removeDeletedThreadFromClientState,
+        removeDeletedThreadFromClientState: useStore.getState().removeDeletedThreadFromClientState,
       });
       clearDraftThread(card.threadId);
       clearProjectDraftThreadById(thread.projectId, thread.id);

--- a/apps/web/src/components/sidebarGlyphs.tsx
+++ b/apps/web/src/components/sidebarGlyphs.tsx
@@ -29,6 +29,18 @@ export const SIDEBAR_GLYPH = {
 
 export type SidebarGlyphVariant = keyof typeof SIDEBAR_GLYPH;
 
+// Trailing thread-row icons (meta chips, pin, archive) share one optical size so the
+// right-side cluster reads as a uniform set. Tailwind can only scan literal class strings,
+// so the plain and slot-forced forms are spelled out here; keep their px values in step —
+// this is the single place to retune the trailing-icon size.
+//
+// The forced form targets BOTH `<svg>` glyphs (lucide / react-icons) and Central icons,
+// which render as a masked `<span data-slot=central-icon>` rather than an svg — without the
+// second selector those (e.g. the worktree glyph) keep their smaller base size and look off.
+export const SIDEBAR_TRAILING_ICON_CLASS = "size-[15px] shrink-0";
+export const SIDEBAR_TRAILING_ICON_FORCE_CLASS =
+  "[&_svg]:size-[15px] [&_[data-slot=central-icon]]:size-[15px]";
+
 export function sidebarGlyphClass(variant: SidebarGlyphVariant, className?: string) {
   return cn(SIDEBAR_GLYPH[variant], className);
 }

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  acknowledgedWarningIdsForAutomaticChatAutomation,
   acknowledgedRiskIdsForDraft,
   buildAutomationDraftWarnings,
   hasBlockingAutomationDraftWarnings,
@@ -124,6 +125,54 @@ describe("automation draft warnings", () => {
         new Set(["fast-recurring-interval", "full-access", "local-checkout"]),
       ),
     ).toBe(false);
+  });
+
+  it("auto-acknowledges bounded thread fast loops without hiding standalone risks", () => {
+    const threadWarnings = buildAutomationDraftWarnings({
+      schedule: { type: "interval", everySeconds: 15 },
+      mode: "heartbeat",
+      runtimeMode: "approval-required",
+      worktreeMode: "auto",
+      hasEphemeralContext: false,
+      generatedConfidence: null,
+      generatedNeedsConfirmation: false,
+      prompt: "Say hi.",
+    });
+
+    const boundedIds = acknowledgedWarningIdsForAutomaticChatAutomation({
+      warnings: threadWarnings,
+      maxIterations: 3,
+      executionScope: "thread",
+    });
+    expect(Array.from(boundedIds)).toEqual(["fast-recurring-interval"]);
+    expect(hasBlockingAutomationDraftWarnings(threadWarnings, boundedIds)).toBe(false);
+    expect(acknowledgedRiskIdsForDraft(threadWarnings, boundedIds)).toEqual(["fast-interval"]);
+
+    const unboundedIds = acknowledgedWarningIdsForAutomaticChatAutomation({
+      warnings: threadWarnings,
+      maxIterations: null,
+      executionScope: "thread",
+    });
+    expect(Array.from(unboundedIds)).toEqual([]);
+    expect(hasBlockingAutomationDraftWarnings(threadWarnings, unboundedIds)).toBe(true);
+
+    const standaloneWarnings = buildAutomationDraftWarnings({
+      schedule: { type: "interval", everySeconds: 15 },
+      mode: "standalone",
+      runtimeMode: "approval-required",
+      worktreeMode: "auto",
+      hasEphemeralContext: false,
+      generatedConfidence: null,
+      generatedNeedsConfirmation: false,
+      prompt: "Say hi.",
+    });
+    const standaloneIds = acknowledgedWarningIdsForAutomaticChatAutomation({
+      warnings: standaloneWarnings,
+      maxIterations: 3,
+      executionScope: "standalone",
+    });
+    expect(Array.from(standaloneIds)).toEqual([]);
+    expect(hasBlockingAutomationDraftWarnings(standaloneWarnings, standaloneIds)).toBe(true);
   });
 
   it("does not show worktree cleanup risk for heartbeat runs", () => {

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -4,6 +4,7 @@
 // Exports: AutomationCreationDraft plus pure warning/skill helpers.
 // Depends on: automation contracts shared with the native API.
 
+import { DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS } from "@t3tools/contracts";
 import type {
   AutomationMode,
   AutomationSchedule,
@@ -14,6 +15,8 @@ import type {
   RuntimeMode,
   ThreadId,
 } from "@t3tools/contracts";
+
+import type { ChatAutomationExecutionScope } from "./automationIntent";
 
 export type AutomationCreationDraftSource = "slash" | "mention" | "dialog" | "generated";
 
@@ -187,4 +190,26 @@ export function hasBlockingAutomationDraftWarnings(
       warning.id === "missing-schedule" ||
       (warning.requiresAcknowledgement && !acknowledgedWarningIds.has(warning.id)),
   );
+}
+
+// Thread-bound chat creation can accept bounded fast loops without reopening the form.
+export function acknowledgedWarningIdsForAutomaticChatAutomation(input: {
+  readonly warnings: readonly AutomationDraftWarning[];
+  readonly maxIterations: number | null;
+  readonly executionScope: ChatAutomationExecutionScope;
+}): ReadonlySet<AutomationDraftWarningId> {
+  const ids = new Set<AutomationDraftWarningId>();
+  if (input.executionScope !== "thread") {
+    return ids;
+  }
+  for (const warning of input.warnings) {
+    if (
+      warning.id === "fast-recurring-interval" &&
+      input.maxIterations !== null &&
+      input.maxIterations <= DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS
+    ) {
+      ids.add(warning.id);
+    }
+  }
+  return ids;
 }

--- a/apps/web/src/lib/automationForm.ts
+++ b/apps/web/src/lib/automationForm.ts
@@ -1,0 +1,633 @@
+// FILE: automationForm.ts
+// Purpose: Owns automation form state, schedule conversion, and API payload helpers.
+// Layer: Web lib (pure form/domain helpers)
+// Exports: form builders, schedule formatters, warning adapters, and payload mappers.
+
+import {
+  DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS,
+  DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS,
+} from "@t3tools/contracts";
+import type {
+  AutomationCreateInput,
+  AutomationDefinition,
+  AutomationMode,
+  AutomationSchedule,
+  AutomationUpdateInput,
+  AutomationWorktreeMode,
+  ModelSelection,
+  ProjectId,
+  ProviderStartOptions,
+  RuntimeMode,
+  ThreadId,
+} from "@t3tools/contracts";
+
+import {
+  completionPolicyFromStopWhen,
+  stopWhenFromCompletionPolicy,
+} from "./automationCompletionPolicy";
+import {
+  acknowledgedRiskIdsForDraft,
+  buildAutomationDraftWarnings,
+  type AutomationDraftWarning,
+  type AutomationDraftWarningId,
+} from "./automationDraft";
+
+export const defaultModelSelection: ModelSelection = {
+  provider: "codex",
+  model: "gpt-5-codex",
+};
+
+export const TIME_OF_DAY_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+const LEGACY_WALL_CLOCK_TIMEZONE = "UTC";
+
+// --- Schedule form shape ----------------------------------------------------
+
+/** UI-level cadence options shown in the schedule picker (each maps onto an AutomationSchedule). */
+export type ScheduleKind =
+  | "manual"
+  | "once"
+  | "hourly"
+  | "daily"
+  | "weekdays"
+  | "weekly"
+  | "custom"
+  | "cron";
+
+export type IntervalUnit = "seconds" | "minutes";
+
+export const SCHEDULE_KIND_OPTIONS: readonly { value: ScheduleKind; label: string }[] = [
+  { value: "manual", label: "Manual" },
+  { value: "once", label: "Once" },
+  { value: "hourly", label: "Hourly" },
+  { value: "daily", label: "Daily" },
+  { value: "weekdays", label: "Weekdays" },
+  { value: "weekly", label: "Weekly" },
+  { value: "custom", label: "Custom" },
+  { value: "cron", label: "Cron" },
+];
+
+export type AutomationFormState = {
+  readonly name: string;
+  readonly projectId: string;
+  readonly prompt: string;
+  readonly enabled: boolean;
+  readonly scheduleKind: ScheduleKind;
+  readonly intervalAmount: string;
+  readonly intervalUnit: IntervalUnit;
+  readonly timeOfDay: string;
+  readonly dayOfWeek: string;
+  readonly onceRunAt: string;
+  readonly cronExpression: string;
+  readonly timezone: string;
+  readonly runtimeMode: RuntimeMode;
+  readonly worktreeMode: AutomationWorktreeMode;
+  readonly modelSelection: ModelSelection;
+  readonly mode: AutomationMode;
+  readonly targetThreadId: string;
+  readonly maxIterations: string;
+  readonly stopOnError: boolean;
+  readonly stopWhen: string;
+};
+
+export type AutomationProjectModelSelectionSource = {
+  readonly id: string;
+  readonly defaultModelSelection?: ModelSelection | null;
+};
+
+function localTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+function scheduleTimezone(schedule: AutomationSchedule, fallbackTimezone: string): string {
+  return (
+    (schedule.type === "daily" ||
+    schedule.type === "weekly" ||
+    schedule.type === "weekdays" ||
+    schedule.type === "cron"
+      ? schedule.timezone
+      : undefined) ?? fallbackTimezone
+  );
+}
+
+// --- Schedule conversion and labels ----------------------------------------
+
+/** Pick the schedule option that represents a stored schedule (interval 1h reads as "Hourly"). */
+export function scheduleKindFromSchedule(schedule: AutomationSchedule): ScheduleKind {
+  switch (schedule.type) {
+    case "daily":
+      return "daily";
+    case "weekdays":
+      return "weekdays";
+    case "weekly":
+      return "weekly";
+    case "interval":
+      return schedule.everySeconds === 3600 ? "hourly" : "custom";
+    case "manual":
+      return "manual";
+    case "once":
+      return "once";
+    case "cron":
+      return "cron";
+  }
+}
+
+/** Build a schedule for the chosen kind, reusing time/day/interval from `current` where it applies. */
+export function scheduleFromKind(
+  kind: ScheduleKind,
+  current: AutomationSchedule,
+  fallbackTimezone: string = localTimezone(),
+): AutomationSchedule {
+  const timeOfDay =
+    current.type === "daily" || current.type === "weekly" || current.type === "weekdays"
+      ? current.timeOfDay
+      : "09:00";
+  const timezone = scheduleTimezone(current, fallbackTimezone);
+  switch (kind) {
+    case "manual":
+      return { type: "manual" };
+    case "once":
+      return { type: "once", runAt: new Date(Date.now() + 15 * 60_000).toISOString() };
+    case "hourly":
+      return { type: "interval", everySeconds: 3600 };
+    case "custom":
+      return {
+        type: "interval",
+        everySeconds:
+          current.type === "interval" && current.everySeconds !== 3600
+            ? current.everySeconds
+            : 1800,
+      };
+    case "daily":
+      return { type: "daily", timeOfDay, timezone };
+    case "weekdays":
+      return { type: "weekdays", timeOfDay, timezone };
+    case "weekly":
+      return {
+        type: "weekly",
+        dayOfWeek: current.type === "weekly" ? current.dayOfWeek : 1,
+        timeOfDay,
+        timezone,
+      };
+    case "cron":
+      return {
+        type: "cron",
+        expression: current.type === "cron" ? current.expression : "0 9 * * *",
+        timezone,
+      };
+  }
+}
+
+export function datetimeLocalFromIso(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  const localIso = new Date(date.getTime() - offsetMs).toISOString();
+  return localIso.slice(0, date.getSeconds() === 0 && date.getMilliseconds() === 0 ? 16 : 19);
+}
+
+export function isoFromDatetimeLocal(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? new Date(Date.now() + 15 * 60_000).toISOString()
+    : date.toISOString();
+}
+
+export function updateWeeklyScheduleDay(
+  schedule: Extract<AutomationSchedule, { type: "weekly" }>,
+  dayOfWeek: number,
+): AutomationSchedule {
+  return { ...schedule, dayOfWeek };
+}
+
+export function updateWeeklyScheduleTime(
+  schedule: Extract<AutomationSchedule, { type: "weekly" }>,
+  timeOfDay: string,
+): AutomationSchedule {
+  return { ...schedule, timeOfDay };
+}
+
+export function formatDateTime(value: string | null): string {
+  if (!value) return "Not scheduled";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return `${new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date)}`;
+}
+
+function timezoneSuffix(schedule: AutomationSchedule): string {
+  if (
+    (schedule.type === "daily" ||
+      schedule.type === "weekdays" ||
+      schedule.type === "weekly" ||
+      schedule.type === "cron") &&
+    schedule.timezone
+  ) {
+    return ` ${schedule.timezone}`;
+  }
+  return " UTC";
+}
+
+function formatIntervalSchedule(seconds: number): string {
+  return seconds % 60 === 0 ? `Every ${seconds / 60} min` : `Every ${seconds} sec`;
+}
+
+function formatIntervalCadence(seconds: number): string {
+  if (seconds === 3600) return "Hourly";
+  if (seconds % 3600 === 0) return `Every ${seconds / 3600}h`;
+  if (seconds % 60 === 0) return `Every ${seconds / 60}m`;
+  return `Every ${seconds}s`;
+}
+
+export function formatSchedule(schedule: AutomationSchedule): string {
+  switch (schedule.type) {
+    case "manual":
+      return "Manual";
+    case "once":
+      return `Once ${formatDateTime(schedule.runAt)}`;
+    case "interval":
+      return formatIntervalSchedule(schedule.everySeconds);
+    case "daily":
+      return `Daily ${schedule.timeOfDay}${timezoneSuffix(schedule)}`;
+    case "weekdays":
+      return `Weekdays ${schedule.timeOfDay}${timezoneSuffix(schedule)}`;
+    case "weekly":
+      return `Weekly ${weekdayLabel(schedule.dayOfWeek)} ${schedule.timeOfDay}${timezoneSuffix(schedule)}`;
+    case "cron":
+      return `Cron ${schedule.expression} ${schedule.timezone}`;
+  }
+}
+
+/** "09:00" -> "9:00": drops the leading zero on the hour for friendlier cadence labels. */
+export function formatClockTime(timeOfDay: string): string {
+  const [hours, minutes] = timeOfDay.split(":");
+  const hour = Number.parseInt(hours ?? "", 10);
+  if (Number.isNaN(hour)) return timeOfDay;
+  return `${hour}:${minutes ?? "00"}`;
+}
+
+export function formatCadence(schedule: AutomationSchedule): string {
+  switch (schedule.type) {
+    case "manual":
+      return "Manual";
+    case "once":
+      return formatDateTime(schedule.runAt);
+    case "interval":
+      return formatIntervalCadence(schedule.everySeconds);
+    case "daily":
+      return `Daily at ${formatClockTime(schedule.timeOfDay)}`;
+    case "weekdays":
+      return `Weekdays at ${formatClockTime(schedule.timeOfDay)}`;
+    case "weekly":
+      return `${weekdayLabel(schedule.dayOfWeek)} at ${formatClockTime(schedule.timeOfDay)}`;
+    case "cron":
+      return `Cron ${schedule.expression}`;
+  }
+}
+
+export function weekdayLabel(value: number): string {
+  return ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][value] ?? "Sun";
+}
+
+// --- Thread automation lookups ---------------------------------------------
+// Heartbeat automations are the only kind bound to a specific thread; both the
+// Environment panel and the sidebar surface them keyed by their target thread.
+
+const byAutomationName = (left: AutomationDefinition, right: AutomationDefinition): number =>
+  left.name.localeCompare(right.name);
+
+/** Heartbeat automations targeting a single thread, sorted by name. */
+export function heartbeatAutomationsForThread(
+  definitions: readonly AutomationDefinition[],
+  threadId: ThreadId,
+): AutomationDefinition[] {
+  return definitions
+    .filter(
+      (definition) => definition.mode === "heartbeat" && definition.targetThreadId === threadId,
+    )
+    .toSorted(byAutomationName);
+}
+
+/** All heartbeat automations grouped by the thread they target (each list sorted by name). */
+export function groupHeartbeatAutomationsByTargetThread(
+  definitions: readonly AutomationDefinition[],
+): Map<ThreadId, AutomationDefinition[]> {
+  const byThreadId = new Map<ThreadId, AutomationDefinition[]>();
+  for (const definition of definitions) {
+    if (definition.mode !== "heartbeat" || !definition.targetThreadId) {
+      continue;
+    }
+    const existing = byThreadId.get(definition.targetThreadId);
+    if (existing) {
+      existing.push(definition);
+    } else {
+      byThreadId.set(definition.targetThreadId, [definition]);
+    }
+  }
+  for (const [threadId, automations] of byThreadId) {
+    byThreadId.set(threadId, automations.toSorted(byAutomationName));
+  }
+  return byThreadId;
+}
+
+// --- Form state and API payloads -------------------------------------------
+
+function intervalFormPartsFromSeconds(everySeconds: number): {
+  readonly amount: string;
+  readonly unit: IntervalUnit;
+} {
+  return everySeconds >= 60 && everySeconds % 60 === 0
+    ? { amount: String(everySeconds / 60), unit: "minutes" }
+    : { amount: String(everySeconds), unit: "seconds" };
+}
+
+export function formFromDefinition(
+  definition: AutomationDefinition | null,
+  fallbackProjectId: string,
+  fallbackModelSelection: ModelSelection = defaultModelSelection,
+): AutomationFormState {
+  // New automations default to a daily schedule; existing definitions keep their saved cadence.
+  const schedule = definition?.schedule ?? { type: "daily" as const, timeOfDay: "09:00" };
+  const timezone = scheduleTimezone(
+    schedule,
+    definition ? LEGACY_WALL_CLOCK_TIMEZONE : localTimezone(),
+  );
+  return {
+    name: definition?.name ?? "",
+    projectId: definition?.projectId ?? fallbackProjectId,
+    prompt: definition?.prompt ?? "",
+    enabled: definition?.enabled ?? true,
+    scheduleKind: scheduleKindFromSchedule(schedule),
+    intervalAmount:
+      schedule.type === "interval" && schedule.everySeconds !== 3600
+        ? intervalFormPartsFromSeconds(schedule.everySeconds).amount
+        : "30",
+    intervalUnit:
+      schedule.type === "interval" && schedule.everySeconds !== 3600
+        ? intervalFormPartsFromSeconds(schedule.everySeconds).unit
+        : "minutes",
+    timeOfDay:
+      schedule.type === "daily" || schedule.type === "weekly" || schedule.type === "weekdays"
+        ? schedule.timeOfDay
+        : "09:00",
+    dayOfWeek: schedule.type === "weekly" ? String(schedule.dayOfWeek) : "1",
+    onceRunAt:
+      schedule.type === "once"
+        ? datetimeLocalFromIso(schedule.runAt)
+        : datetimeLocalFromIso(new Date(Date.now() + 15 * 60_000).toISOString()),
+    cronExpression: schedule.type === "cron" ? schedule.expression : "0 9 * * *",
+    timezone,
+    runtimeMode: definition?.runtimeMode ?? "approval-required",
+    worktreeMode: definition?.worktreeMode ?? "auto",
+    modelSelection: definition?.modelSelection ?? fallbackModelSelection,
+    mode: definition?.mode ?? "standalone",
+    targetThreadId: definition?.targetThreadId ?? "",
+    maxIterations: definition?.maxIterations != null ? String(definition.maxIterations) : "",
+    stopOnError: definition?.stopOnError ?? true,
+    stopWhen: definition
+      ? stopWhenFromCompletionPolicy(definition.completionPolicy ?? { type: "none" })
+      : "",
+  };
+}
+
+export function applyScheduleToForm(
+  form: AutomationFormState,
+  schedule: AutomationSchedule,
+  fallbackTimezone: string = localTimezone(),
+): AutomationFormState {
+  const timezone = scheduleTimezone(schedule, fallbackTimezone);
+  return {
+    ...form,
+    scheduleKind: scheduleKindFromSchedule(schedule),
+    intervalAmount:
+      schedule.type === "interval" && schedule.everySeconds !== 3600
+        ? intervalFormPartsFromSeconds(schedule.everySeconds).amount
+        : form.intervalAmount,
+    intervalUnit:
+      schedule.type === "interval" && schedule.everySeconds !== 3600
+        ? intervalFormPartsFromSeconds(schedule.everySeconds).unit
+        : form.intervalUnit,
+    timeOfDay:
+      schedule.type === "daily" || schedule.type === "weekly" || schedule.type === "weekdays"
+        ? schedule.timeOfDay
+        : form.timeOfDay,
+    dayOfWeek: schedule.type === "weekly" ? String(schedule.dayOfWeek) : form.dayOfWeek,
+    onceRunAt: schedule.type === "once" ? datetimeLocalFromIso(schedule.runAt) : form.onceRunAt,
+    cronExpression: schedule.type === "cron" ? schedule.expression : form.cronExpression,
+    timezone,
+  };
+}
+
+export function scheduleFromForm(form: AutomationFormState): AutomationSchedule {
+  const timezone = form.timezone.trim();
+  switch (form.scheduleKind) {
+    case "hourly":
+      return { type: "interval", everySeconds: 3600 };
+    case "manual":
+      return { type: "manual" };
+    case "once":
+      return { type: "once", runAt: isoFromDatetimeLocal(form.onceRunAt) };
+    case "custom": {
+      const amount = Math.max(1, Number.parseInt(form.intervalAmount, 10) || 1);
+      return {
+        type: "interval",
+        everySeconds: form.intervalUnit === "seconds" ? amount : amount * 60,
+      };
+    }
+    case "daily":
+      return { type: "daily", timeOfDay: form.timeOfDay, timezone };
+    case "weekdays":
+      return { type: "weekdays", timeOfDay: form.timeOfDay, timezone };
+    case "weekly": {
+      const dayOfWeek = Math.min(6, Math.max(0, Number.parseInt(form.dayOfWeek, 10) || 0));
+      return { type: "weekly", dayOfWeek, timeOfDay: form.timeOfDay, timezone };
+    }
+    case "cron":
+      return {
+        type: "cron",
+        expression: form.cronExpression.trim() || "0 9 * * *",
+        timezone,
+      };
+  }
+}
+
+function maxIterationsFromForm(form: Pick<AutomationFormState, "maxIterations">): number | null {
+  const trimmed = form.maxIterations.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  return parsed > 0 ? parsed : null;
+}
+
+export function automationFastIntervalLimitMessage(form: AutomationFormState): string | null {
+  const schedule = scheduleFromForm(form);
+  const maxIterations = maxIterationsFromForm(form);
+  if (
+    schedule.type === "interval" &&
+    schedule.everySeconds < DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS &&
+    (maxIterations === null || maxIterations > DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS)
+  ) {
+    return `Intervals under one minute need max iterations set to ${DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS} runs or fewer.`;
+  }
+  return null;
+}
+
+export function projectModelSelection(
+  projects: readonly AutomationProjectModelSelectionSource[],
+  projectId: string,
+): ModelSelection {
+  return (
+    projects.find((project) => project.id === projectId)?.defaultModelSelection ??
+    defaultModelSelection
+  );
+}
+
+function modelSelectionsMatch(left: ModelSelection, right: ModelSelection): boolean {
+  const leftOptions = "options" in left ? left.options : undefined;
+  const rightOptions = "options" in right ? right.options : undefined;
+  return (
+    left.provider === right.provider &&
+    left.model === right.model &&
+    JSON.stringify(leftOptions ?? null) === JSON.stringify(rightOptions ?? null)
+  );
+}
+
+function modelIdentityMatches(left: ModelSelection, right: ModelSelection): boolean {
+  return left.provider === right.provider && left.model === right.model;
+}
+
+// Automation edits keep saved provider start options unless the provider/model identity changes.
+export function providerOptionsForAutomationModelSelection(
+  definition: Pick<AutomationDefinition, "modelSelection" | "providerOptions">,
+  nextModelSelection: ModelSelection,
+  currentProviderOptions?: ProviderStartOptions,
+): ProviderStartOptions | undefined {
+  return modelIdentityMatches(definition.modelSelection, nextModelSelection)
+    ? definition.providerOptions
+    : (currentProviderOptions ?? {});
+}
+
+export function providerOptionsForAutomationEdit(
+  definition: Pick<AutomationDefinition, "modelSelection" | "providerOptions">,
+  form: Pick<AutomationFormState, "modelSelection">,
+  currentProviderOptions?: ProviderStartOptions,
+): ProviderStartOptions | undefined {
+  return providerOptionsForAutomationModelSelection(
+    definition,
+    form.modelSelection,
+    currentProviderOptions,
+  );
+}
+
+export function modelSelectionForProjectChange(
+  projects: readonly AutomationProjectModelSelectionSource[],
+  currentProjectId: string,
+  nextProjectId: string,
+  currentModelSelection: ModelSelection,
+): ModelSelection {
+  const currentDefaultModelSelection = projectModelSelection(projects, currentProjectId);
+  const nextDefaultModelSelection = projectModelSelection(projects, nextProjectId);
+  return modelSelectionsMatch(currentModelSelection, currentDefaultModelSelection)
+    ? nextDefaultModelSelection
+    : currentModelSelection;
+}
+
+export function createInputFromForm(
+  form: AutomationFormState,
+  providerOptions?: ProviderStartOptions,
+  acknowledgedRisks?: AutomationCreateInput["acknowledgedRisks"],
+  sourceThreadId?: ThreadId | null,
+): AutomationCreateInput {
+  const maxIterations = maxIterationsFromForm(form);
+  const stopWhen = form.stopWhen.trim();
+  return {
+    name: form.name.trim(),
+    projectId: form.projectId as ProjectId,
+    ...(sourceThreadId !== undefined ? { sourceThreadId } : {}),
+    prompt: form.prompt.trim(),
+    schedule: scheduleFromForm(form),
+    enabled: form.enabled,
+    modelSelection: form.modelSelection,
+    runtimeMode: form.runtimeMode,
+    interactionMode: "default",
+    worktreeMode: form.worktreeMode,
+    ...(providerOptions ? { providerOptions } : {}),
+    mode: form.mode,
+    targetThreadId: form.mode === "heartbeat" ? (form.targetThreadId as ThreadId) : null,
+    maxIterations,
+    ...(form.mode === "heartbeat"
+      ? {
+          stopOnError: form.stopOnError,
+          completionPolicy: completionPolicyFromStopWhen(stopWhen),
+        }
+      : { completionPolicy: { type: "none" as const } }),
+    ...(acknowledgedRisks ? { acknowledgedRisks } : {}),
+  };
+}
+
+export function updateInputFromForm(
+  definition: AutomationDefinition,
+  form: AutomationFormState,
+  providerOptions?: ProviderStartOptions,
+  acknowledgedRisks?: AutomationCreateInput["acknowledgedRisks"],
+): AutomationUpdateInput {
+  return {
+    id: definition.id,
+    ...createInputFromForm(form, providerOptions, acknowledgedRisks),
+  };
+}
+
+export function buildAutomationFormWarnings(form: AutomationFormState) {
+  return buildAutomationDraftWarnings({
+    schedule: scheduleFromForm(form),
+    mode: form.mode,
+    runtimeMode: form.runtimeMode,
+    worktreeMode: form.worktreeMode,
+    hasEphemeralContext: false,
+    generatedConfidence: null,
+    generatedNeedsConfirmation: false,
+    prompt: form.prompt,
+  });
+}
+
+export function acknowledgedRiskIdsForFormWarnings(
+  warnings: readonly AutomationDraftWarning[],
+  acknowledgedWarningIds: ReadonlySet<AutomationDraftWarningId>,
+) {
+  return acknowledgedRiskIdsForDraft(warnings, acknowledgedWarningIds);
+}
+
+export function isFormSubmittable(form: AutomationFormState): boolean {
+  if (!form.name.trim() || !form.prompt.trim() || !form.projectId) return false;
+  if (form.mode === "heartbeat" && !form.targetThreadId) return false;
+  if (automationFastIntervalLimitMessage(form)) return false;
+  if (
+    form.scheduleKind === "custom" &&
+    (!form.intervalAmount.trim() || Number.parseInt(form.intervalAmount, 10) <= 0)
+  ) {
+    return false;
+  }
+  if (form.scheduleKind === "cron" && !form.cronExpression.trim()) return false;
+  if (form.scheduleKind === "once" && !form.onceRunAt.trim()) return false;
+  if (
+    (form.scheduleKind === "daily" ||
+      form.scheduleKind === "weekdays" ||
+      form.scheduleKind === "cron" ||
+      form.scheduleKind === "weekly") &&
+    !form.timezone.trim()
+  ) {
+    return false;
+  }
+  if (
+    (form.scheduleKind === "daily" ||
+      form.scheduleKind === "weekdays" ||
+      form.scheduleKind === "weekly") &&
+    !TIME_OF_DAY_PATTERN.test(form.timeOfDay)
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/apps/web/src/lib/automationIntent.test.ts
+++ b/apps/web/src/lib/automationIntent.test.ts
@@ -190,6 +190,24 @@ describe("parseChatAutomationIntent", () => {
       schedule: { type: "interval", everySeconds: 300 },
       executionScope: "worktree",
     });
+
+    expect(
+      parseChatAutomationIntent("/automation every 5m check whether the new run finished"),
+    ).toMatchObject({
+      cadenceLabel: "Every 5m",
+      prompt: "check whether the new run finished",
+      schedule: { type: "interval", everySeconds: 300 },
+      executionScope: "thread",
+    });
+
+    expect(
+      parseChatAutomationIntent("/automation every 5m check CI as a new run"),
+    ).toMatchObject({
+      cadenceLabel: "Every 5m",
+      prompt: "check CI",
+      schedule: { type: "interval", everySeconds: 300 },
+      executionScope: "standalone",
+    });
   });
 
   it("extracts English stop clauses into first-class completion policies", () => {

--- a/apps/web/src/lib/automationIntent.test.ts
+++ b/apps/web/src/lib/automationIntent.test.ts
@@ -11,7 +11,9 @@ import {
   formatAutomationIntentCadence,
   parseChatAutomationInvocation,
   parseChatAutomationIntent,
+  parsePlainChatAutomationInvocation,
   resolveChatAutomationIntent,
+  shouldGenerateAutomationIntent,
 } from "./automationIntent";
 
 describe("parseChatAutomationIntent", () => {
@@ -55,14 +57,148 @@ describe("parseChatAutomationIntent", () => {
     });
   });
 
+  it("extracts bounded run counts from fast recurring chat automation prompts", () => {
+    const intent = parseChatAutomationIntent("/automation say hi every 15 seconds for 3 times");
+
+    expect(intent).toMatchObject({
+      cadenceLabel: "Every 15s",
+      prompt: "say hi",
+      schedule: { type: "interval", everySeconds: 15 },
+      maxIterations: 3,
+      completionPolicy: { type: "none" },
+      executionScope: "thread",
+    });
+
+    expect(
+      parseChatAutomationIntent("/automation say hi every 15 seconds 3 times total"),
+    ).toMatchObject({
+      cadenceLabel: "Every 15s",
+      prompt: "say hi",
+      schedule: { type: "interval", everySeconds: 15 },
+      maxIterations: 3,
+      executionScope: "thread",
+    });
+
+    expect(
+      parseChatAutomationIntent("/automation say hi every 15 seconds per un totale di 3 volte"),
+    ).toMatchObject({
+      cadenceLabel: "Every 15s",
+      prompt: "say hi",
+      schedule: { type: "interval", everySeconds: 15 },
+      maxIterations: 3,
+      executionScope: "thread",
+    });
+  });
+
+  it("keeps bare scheduled statements in normal chat while explicit prompts can still be bounded", () => {
+    expect(parsePlainChatAutomationInvocation("say hi every 15 seconds for 3 times")).toBeNull();
+
+    const deterministicIntent = parseChatAutomationIntent(
+      "/automation say hi every 15 seconds for 3 times",
+    );
+    const resolved = resolveChatAutomationIntent({
+      deterministicIntent,
+      generatedIntent: null,
+      defaultMode: "heartbeat",
+      executionScope: deterministicIntent?.executionScope ?? "thread",
+    });
+
+    expect(resolved).toMatchObject({
+      mode: "heartbeat",
+      requiresReview: false,
+      intent: {
+        prompt: "say hi",
+        schedule: { type: "interval", everySeconds: 15 },
+        maxIterations: 3,
+        executionScope: "thread",
+      },
+    });
+    expect(parseChatAutomationInvocation("what is standalone?")).toBeNull();
+  });
+
+  it("keeps unmarked automation questions in normal chat", () => {
+    expect(parsePlainChatAutomationInvocation("how do automations work every day?")).toBeNull();
+    expect(parsePlainChatAutomationInvocation("what is standalone?")).toBeNull();
+    expect(
+      parsePlainChatAutomationInvocation("come funzionano le automazioni ogni giorno?"),
+    ).toBeNull();
+    expect(parsePlainChatAutomationInvocation("can automations run every day?")).toBeNull();
+    expect(
+      parsePlainChatAutomationInvocation("can you write a script that runs every 5 minutes?"),
+    ).toBeNull();
+    expect(
+      parsePlainChatAutomationInvocation("could you tell me how automations work every day?"),
+    ).toBeNull();
+    expect(parsePlainChatAutomationInvocation("tell me how automations work every day")).toBeNull();
+
+    expect(
+      parseChatAutomationIntent("/automation how do automations work every day?"),
+    ).toMatchObject({
+      cadenceLabel: "Daily at 09:00",
+      prompt: "how do automations work ?",
+    });
+  });
+
+  it("accepts polite unmarked automation requests", () => {
+    expect(
+      parsePlainChatAutomationInvocation("can you remind me every day to stretch?"),
+    ).toMatchObject({
+      cadenceLabel: "Daily at 09:00",
+      prompt: "remind me stretch",
+      schedule: { type: "daily", timeOfDay: "09:00" },
+      executionScope: "thread",
+    });
+
+    expect(
+      parsePlainChatAutomationInvocation(
+        "could you check the website every 15 seconds for 3 times",
+      ),
+    ).toMatchObject({
+      cadenceLabel: "Every 15s",
+      prompt: "check the website",
+      schedule: { type: "interval", everySeconds: 15 },
+      maxIterations: 3,
+      executionScope: "thread",
+    });
+
+    expect(
+      parsePlainChatAutomationInvocation("could you say hi every 15 seconds for 3 times"),
+    ).toMatchObject({
+      cadenceLabel: "Every 15s",
+      prompt: "say hi",
+      schedule: { type: "interval", everySeconds: 15 },
+      maxIterations: 3,
+      executionScope: "thread",
+    });
+  });
+
+  it("detects explicit standalone and worktree scopes without saving scope scaffolding", () => {
+    expect(parseChatAutomationIntent("/automation run standalone every 5m check CI")).toMatchObject(
+      {
+        cadenceLabel: "Every 5m",
+        prompt: "check CI",
+        schedule: { type: "interval", everySeconds: 300 },
+        executionScope: "standalone",
+      },
+    );
+
+    expect(
+      parseChatAutomationIntent("/automation in a new worktree every 5m check CI"),
+    ).toMatchObject({
+      cadenceLabel: "Every 5m",
+      prompt: "check CI",
+      schedule: { type: "interval", everySeconds: 300 },
+      executionScope: "worktree",
+    });
+  });
+
   it("extracts English stop clauses into first-class completion policies", () => {
     expect(
       parseChatAutomationInvocation(
         "every 3 min watch codex-bot. Stop when codex-bot says the PR is ready to merge. If there are actionable issues, fix them and keep monitoring.",
       ),
     ).toMatchObject({
-      prompt:
-        "watch codex-bot. If there are actionable issues, fix them and keep monitoring.",
+      prompt: "watch codex-bot. If there are actionable issues, fix them and keep monitoring.",
       completionPolicy: {
         type: "ai-evaluated",
         stopWhen: "codex-bot says the PR is ready to merge",
@@ -70,40 +206,44 @@ describe("parseChatAutomationIntent", () => {
       },
     });
 
-    expect(parseChatAutomationInvocation("every 5 min keep monitoring until CI is green"))
-      .toMatchObject({
-        prompt: "keep monitoring",
-        completionPolicy: {
-          type: "ai-evaluated",
-          stopWhen: "CI is green",
-        },
-      });
+    expect(
+      parseChatAutomationInvocation("every 5 min keep monitoring until CI is green"),
+    ).toMatchObject({
+      prompt: "keep monitoring",
+      completionPolicy: {
+        type: "ai-evaluated",
+        stopWhen: "CI is green",
+      },
+    });
 
-    expect(parseChatAutomationInvocation("every 10 min check the PR; if there are no issues, stop"))
-      .toMatchObject({
-        completionPolicy: {
-          type: "ai-evaluated",
-          stopWhen: "there are no issues",
-        },
-      });
+    expect(
+      parseChatAutomationInvocation("every 10 min check the PR; if there are no issues, stop"),
+    ).toMatchObject({
+      completionPolicy: {
+        type: "ai-evaluated",
+        stopWhen: "there are no issues",
+      },
+    });
   });
 
   it("extracts Italian stop clauses into first-class completion policies", () => {
-    expect(parseChatAutomationInvocation("ogni 5 minuti controlla la PR finché è pronta"))
-      .toMatchObject({
-        completionPolicy: {
-          type: "ai-evaluated",
-          stopWhen: "è pronta",
-        },
-      });
+    expect(
+      parseChatAutomationInvocation("ogni 5 minuti controlla la PR finché è pronta"),
+    ).toMatchObject({
+      completionPolicy: {
+        type: "ai-evaluated",
+        stopWhen: "è pronta",
+      },
+    });
 
-    expect(parseChatAutomationInvocation("ogni 5 minuti controlla la PR. Quando è pronta, fermati"))
-      .toMatchObject({
-        completionPolicy: {
-          type: "ai-evaluated",
-          stopWhen: "è pronta",
-        },
-      });
+    expect(
+      parseChatAutomationInvocation("ogni 5 minuti controlla la PR. Quando è pronta, fermati"),
+    ).toMatchObject({
+      completionPolicy: {
+        type: "ai-evaluated",
+        stopWhen: "è pronta",
+      },
+    });
   });
 
   it("parses English and Italian one-shot timers from a deterministic now", () => {
@@ -269,7 +409,34 @@ describe("parseChatAutomationIntent", () => {
     );
   });
 
-  it("prefers deterministic intent so obvious requests do not need AI generation", () => {
+  it("only asks for generation when a deterministic prompt is too terse", () => {
+    const terseIntent = parseChatAutomationIntent("/automation every 6h check the website");
+    const detailedIntent = parseChatAutomationIntent(
+      "/automation every 6h check the staging website, inspect the checkout diff, run npm test, and report only confirmed deployment blockers",
+    );
+
+    expect(
+      shouldGenerateAutomationIntent({
+        deterministicIntent: null,
+        automationMessage: "tomorrow morning check the queue",
+      }),
+    ).toBe(true);
+    expect(
+      shouldGenerateAutomationIntent({
+        deterministicIntent: terseIntent,
+        automationMessage: "every 6h check the website",
+      }),
+    ).toBe(true);
+    expect(
+      shouldGenerateAutomationIntent({
+        deterministicIntent: detailedIntent,
+        automationMessage:
+          "every 6h check the staging website, inspect the checkout diff, run npm test, and report only confirmed deployment blockers",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps deterministic scheduling while accepting generated prompt enrichment", () => {
     const deterministicIntent = parseChatAutomationIntent("/automation every 6h check the website");
 
     const resolved = resolveChatAutomationIntent({
@@ -281,34 +448,110 @@ describe("parseChatAutomationIntent", () => {
         name: "Generated",
         taskPrompt: "Generated prompt",
         schedule: { type: "daily", timeOfDay: "09:00" },
-        mode: "standalone",
+        mode: "heartbeat",
         completionPolicy: { type: "none" },
         missingFields: [],
         needsConfirmation: false,
         reason: null,
       },
-      isServerThread: true,
+      defaultMode: "heartbeat",
+      executionScope: "thread",
     });
 
     expect(resolved).toMatchObject({
       source: "deterministic",
       mode: "heartbeat",
       intent: {
-        prompt: "check the website",
+        name: "Generated",
+        prompt: "Generated prompt",
         schedule: { type: "interval", everySeconds: 21_600 },
       },
     });
   });
 
-  it("requires review instead of auto-submitting stop clauses from standalone contexts", () => {
+  it("strips generated scaffolding before merging deterministic prompt enrichment", () => {
     const deterministicIntent = parseChatAutomationIntent(
-      "/automation every 5m check CI until it is green",
+      "/automation say hi every 15 seconds for 3 times",
+    );
+
+    const resolved = resolveChatAutomationIntent({
+      deterministicIntent,
+      generatedIntent: {
+        isAutomation: true,
+        confidence: 0.96,
+        language: "en",
+        name: "Say hi",
+        taskPrompt: "Every 15 seconds, say hi in this thread for 3 times.",
+        schedule: { type: "interval", everySeconds: 15 },
+        mode: "heartbeat",
+        completionPolicy: { type: "none" },
+        missingFields: [],
+        needsConfirmation: true,
+        reason: "Fast interval",
+      },
+      defaultMode: "heartbeat",
+      executionScope: "thread",
+    });
+
+    expect(resolved).toMatchObject({
+      source: "deterministic",
+      mode: "heartbeat",
+      requiresReview: true,
+      generatedNeedsConfirmation: true,
+      reason: "Fast interval",
+      intent: {
+        prompt: "say hi in this thread.",
+        schedule: { type: "interval", everySeconds: 15 },
+        maxIterations: 3,
+      },
+    });
+  });
+
+  it("preserves generated standalone mode when deterministic scope parsing misses the phrasing", () => {
+    const deterministicIntent = parseChatAutomationInvocation(
+      "independently check CI every 5 minutes",
+    );
+
+    const resolved = resolveChatAutomationIntent({
+      deterministicIntent,
+      generatedIntent: {
+        isAutomation: true,
+        confidence: 0.93,
+        language: "en",
+        name: "Check CI",
+        taskPrompt: "Check CI.",
+        schedule: { type: "interval", everySeconds: 300 },
+        mode: "standalone",
+        completionPolicy: { type: "none" },
+        missingFields: [],
+        needsConfirmation: false,
+        reason: null,
+      },
+      defaultMode: "heartbeat",
+      executionScope: deterministicIntent?.executionScope ?? "thread",
+    });
+
+    expect(resolved).toMatchObject({
+      source: "deterministic",
+      mode: "standalone",
+      requiresReview: true,
+      intent: {
+        prompt: "Check CI.",
+        executionScope: "standalone",
+      },
+    });
+  });
+
+  it("requires review instead of auto-submitting explicit standalone stop clauses", () => {
+    const deterministicIntent = parseChatAutomationIntent(
+      "/automation standalone every 5m check CI until it is green",
     );
 
     const resolved = resolveChatAutomationIntent({
       deterministicIntent,
       generatedIntent: null,
-      isServerThread: false,
+      defaultMode: "heartbeat",
+      executionScope: deterministicIntent?.executionScope ?? "thread",
     });
 
     expect(resolved).toMatchObject({
@@ -323,7 +566,7 @@ describe("parseChatAutomationIntent", () => {
     });
   });
 
-  it("converts generated standalone stop clauses to heartbeat drafts", () => {
+  it("keeps generated standalone stop clauses behind review", () => {
     const resolved = resolveChatAutomationIntent({
       deterministicIntent: null,
       generatedIntent: {
@@ -343,7 +586,8 @@ describe("parseChatAutomationIntent", () => {
         needsConfirmation: false,
         reason: null,
       },
-      isServerThread: true,
+      defaultMode: "heartbeat",
+      executionScope: "thread",
     });
 
     expect(resolved).toMatchObject({
@@ -351,6 +595,7 @@ describe("parseChatAutomationIntent", () => {
       mode: "heartbeat",
       requiresReview: true,
       intent: {
+        executionScope: "standalone",
         completionPolicy: {
           type: "ai-evaluated",
           stopWhen: "CI is green",
@@ -375,7 +620,8 @@ describe("parseChatAutomationIntent", () => {
         needsConfirmation: false,
         reason: null,
       },
-      isServerThread: true,
+      defaultMode: "heartbeat",
+      executionScope: "thread",
     });
 
     expect(resolved).toMatchObject({
@@ -384,6 +630,40 @@ describe("parseChatAutomationIntent", () => {
       intent: {
         name: "Controlla disponibilita",
         cadenceLabel: "Every 6h",
+      },
+    });
+  });
+
+  it("strips scaffold from generated-only task prompts before saving them", () => {
+    const resolved = resolveChatAutomationIntent({
+      deterministicIntent: null,
+      generatedIntent: {
+        isAutomation: true,
+        confidence: 0.93,
+        language: "en",
+        name: "Check website",
+        taskPrompt: "Every 6h, check the website for 3 times. Stop when it succeeds.",
+        schedule: { type: "interval", everySeconds: 21_600 },
+        mode: "heartbeat",
+        completionPolicy: {
+          type: "ai-evaluated",
+          stopWhen: "it succeeds",
+          confidenceThreshold: DEFAULT_AUTOMATION_STOP_CONFIDENCE_THRESHOLD,
+        },
+        missingFields: [],
+        needsConfirmation: false,
+        reason: null,
+      },
+      defaultMode: "heartbeat",
+      executionScope: "thread",
+    });
+
+    expect(resolved).toMatchObject({
+      source: "generated",
+      intent: {
+        prompt: "check the website.",
+        schedule: { type: "interval", everySeconds: 21_600 },
+        maxIterations: 3,
       },
     });
   });
@@ -404,7 +684,8 @@ describe("parseChatAutomationIntent", () => {
         needsConfirmation: true,
         reason: "Missing schedule",
       },
-      isServerThread: true,
+      defaultMode: "heartbeat",
+      executionScope: "thread",
     });
 
     expect(resolved).toMatchObject({
@@ -430,7 +711,8 @@ describe("parseChatAutomationIntent", () => {
         needsConfirmation: false,
         reason: null,
       },
-      isServerThread: true,
+      defaultMode: "heartbeat",
+      executionScope: "thread",
     });
 
     expect(resolved).toMatchObject({
@@ -457,7 +739,8 @@ describe("parseChatAutomationIntent", () => {
           needsConfirmation: false,
           reason: "Ambiguous",
         },
-        isServerThread: true,
+        defaultMode: "heartbeat",
+        executionScope: "thread",
       }),
     ).toBeNull();
   });

--- a/apps/web/src/lib/automationIntent.ts
+++ b/apps/web/src/lib/automationIntent.ts
@@ -193,7 +193,10 @@ function extractExecutionScope(value: string): ParsedExecutionScope | null {
     },
     { executionScope: "standalone", pattern: /\bstandalone(?:\s+automation)?\b/i },
     { executionScope: "standalone", pattern: /\bseparate\s+(?:run|automation|task)\b/i },
-    { executionScope: "standalone", pattern: /\b(?:new|separate)\s+run\b/i },
+    {
+      executionScope: "standalone",
+      pattern: /\b(?:as|in|into|inside|within)\s+(?:a\s+)?(?:new|separate)\s+run\b/i,
+    },
     {
       executionScope: "standalone",
       pattern: /\bfor\s+(?:every|each|all)\s+(?:new\s+)?chats?\b/i,

--- a/apps/web/src/lib/automationIntent.ts
+++ b/apps/web/src/lib/automationIntent.ts
@@ -22,8 +22,12 @@ export interface ChatAutomationIntent {
   readonly prompt: string;
   readonly schedule: AutomationSchedule;
   readonly cadenceLabel: string;
+  readonly maxIterations: number | null;
   readonly completionPolicy: AutomationCompletionPolicy;
+  readonly executionScope: ChatAutomationExecutionScope;
 }
+
+export type ChatAutomationExecutionScope = "thread" | "standalone" | "worktree";
 
 export interface ResolvedChatAutomationIntent {
   readonly intent: ChatAutomationIntent;
@@ -40,10 +44,30 @@ interface ParsedSchedule {
   readonly cadenceLabel: string;
 }
 
+interface ParsedIterationLimit {
+  readonly maxIterations: number;
+  readonly textWithoutIterationLimit: string;
+}
+
+interface ParsedExecutionScope {
+  readonly executionScope: ChatAutomationExecutionScope;
+  readonly textWithoutExecutionScope: string;
+}
+
 const DEFAULT_DAILY_TIME = "09:00";
 const GENERATED_INTENT_CONFIDENCE_THRESHOLD = 0.75;
+const PROMPT_ENRICHMENT_MAX_WORDS = 10;
+const PROMPT_ENRICHMENT_MAX_LENGTH = 80;
 const MAX_NAME_LENGTH = 120;
 const CRON_FIELD_PATTERN = "[*/0-9,-]+";
+const PLAIN_INVOCATION_QUESTION_PREFIX_PATTERN =
+  /^(?:what|why|how|who|when|where|which|can|could|would|should|do|does|did|is|are|am|will|qual|quale|quali|cosa|come|perche|dove|quando|chi|posso|puoi|potresti|dovrei)\b/;
+const PLAIN_INVOCATION_POLITE_REQUEST_PATTERN =
+  /^(?:(?:can|could|would|will|should)\s+you(?:\s+please)?|(?:puoi|potresti)(?:\s+per favore)?)\s+/i;
+const PLAIN_INVOCATION_ACTION_PREFIX_PATTERN =
+  /^(?:check|verify|monitor|watch|remind(?:\s+me)?|notify(?:\s+me)?|alert(?:\s+me)?|tell\s+me|controlla|verifica|monitora|avvisami|ricordami)\b/i;
+const PLAIN_INVOCATION_POLITE_ACTION_PREFIX_PATTERN =
+  /^(?:check|verify|monitor|watch|say|remind(?:\s+me)?|notify(?:\s+me)?|alert(?:\s+me)?|tell\s+me|controlla|verifica|monitora|avvisami|ricordami)\b/i;
 
 const WEEKDAY_BY_TOKEN: Record<string, number> = {
   sunday: 0,
@@ -98,6 +122,106 @@ function normalizeSearchText(value: string): string {
     .toLowerCase();
 }
 
+// Plain composer text is intentionally conservative so questions keep reaching the model.
+function isLikelyPlainAutomationQuestion(value: string): boolean {
+  const text = normalizeInlineText(value);
+  if (!text) {
+    return false;
+  }
+  if (/[?？]\s*$/.test(text)) {
+    return true;
+  }
+  return PLAIN_INVOCATION_QUESTION_PREFIX_PATTERN.test(normalizeSearchText(text));
+}
+
+function isLikelyAutomationQuestionCandidate(value: string): boolean {
+  if (isLikelyPlainAutomationQuestion(value)) {
+    return true;
+  }
+  return /^tell me\s+(?:what|why|how|who|when|where|which|qual|quale|quali|cosa|come|perche|dove|quando|chi)\b/.test(
+    normalizeSearchText(value),
+  );
+}
+
+// Allows natural requests like "could you remind me every day" without reopening broad questions.
+function stripPlainAutomationPoliteRequest(value: string): string | null {
+  const normalized = normalizeInlineText(value);
+  const match = PLAIN_INVOCATION_POLITE_REQUEST_PATTERN.exec(normalized);
+  if (!match) {
+    return null;
+  }
+  return normalizeInlineText(normalized.slice(match[0].length))
+    .replace(/[?？]+$/g, "")
+    .replace(/^(?:to|di|che)\s+/i, "");
+}
+
+function wordCount(value: string): number {
+  return normalizeInlineText(value).split(/\s+/).filter(Boolean).length;
+}
+
+// Bare composer text must start like an automation task, not just contain a schedule phrase.
+function isLikelyPlainAutomationAction(value: string, politeRequest: boolean): boolean {
+  const pattern = politeRequest
+    ? PLAIN_INVOCATION_POLITE_ACTION_PREFIX_PATTERN
+    : PLAIN_INVOCATION_ACTION_PREFIX_PATTERN;
+  return pattern.test(normalizeInlineText(value));
+}
+
+function removeMatchedText(value: string, match: RegExpExecArray): string {
+  return normalizeInlineText(
+    `${value.slice(0, match.index)} ${value.slice(match.index + match[0].length)}`,
+  )
+    .replace(/\s+([,.!?;:])/g, "$1")
+    .replace(/^(?:and|then|to|e|poi|che|di|per)\s+/i, "");
+}
+
+// Composer automations are thread-bound by default; these phrases intentionally opt out.
+function extractExecutionScope(value: string): ParsedExecutionScope | null {
+  const patterns: ReadonlyArray<{
+    readonly executionScope: ChatAutomationExecutionScope;
+    readonly pattern: RegExp;
+  }> = [
+    {
+      executionScope: "worktree",
+      pattern: /\b(?:in|on|with|using|su|con)\s+(?:a\s+|un\s+)?(?:new\s+|nuovo\s+)?worktree\b/i,
+    },
+    { executionScope: "worktree", pattern: /\b(?:new|nuovo)\s+worktree\b/i },
+    {
+      executionScope: "standalone",
+      pattern:
+        /\b(?:run|create|make|start|save|crea|fai|avvia)\s+(?:it\s+)?(?:as\s+)?(?:a\s+|un\s+)?standalone(?:\s+automation)?\b/i,
+    },
+    { executionScope: "standalone", pattern: /\bstandalone(?:\s+automation)?\b/i },
+    { executionScope: "standalone", pattern: /\bseparate\s+(?:run|automation|task)\b/i },
+    { executionScope: "standalone", pattern: /\b(?:new|separate)\s+run\b/i },
+    {
+      executionScope: "standalone",
+      pattern: /\bfor\s+(?:every|each|all)\s+(?:new\s+)?chats?\b/i,
+    },
+    {
+      executionScope: "standalone",
+      pattern: /\b(?:per|in)\s+ogni\s+(?:nuova\s+)?chat\b/i,
+    },
+  ];
+
+  for (const { executionScope, pattern } of patterns) {
+    const match = pattern.exec(value);
+    if (!match) {
+      continue;
+    }
+    return {
+      executionScope,
+      textWithoutExecutionScope: removeMatchedText(value, match),
+    };
+  }
+
+  return null;
+}
+
+export function detectChatAutomationExecutionScope(value: string): ChatAutomationExecutionScope {
+  return extractExecutionScope(value)?.executionScope ?? "thread";
+}
+
 interface ParsedStopClause {
   readonly stopWhen: string;
   readonly textWithoutStopClause: string;
@@ -115,7 +239,10 @@ function extractStopClause(value: string): ParsedStopClause | null {
   ];
   for (const pattern of patterns) {
     const match = pattern.exec(value);
-    const stopWhen = match?.[1]?.trim().replace(/[.!?]+$/g, "").trim();
+    const stopWhen = match?.[1]
+      ?.trim()
+      .replace(/[.!?]+$/g, "")
+      .trim();
     if (!match || !stopWhen) {
       continue;
     }
@@ -127,6 +254,31 @@ function extractStopClause(value: string): ParsedStopClause | null {
     return {
       stopWhen,
       textWithoutStopClause,
+    };
+  }
+  return null;
+}
+
+// Pulls bounded-loop language out of the saved prompt so the scheduler can stop itself.
+function extractIterationLimit(value: string): ParsedIterationLimit | null {
+  const patterns: readonly RegExp[] = [
+    /\bfor\s+(\d{1,4})\s+(?:times?|runs?|iterations?|turns?)(?:\s+(?:in\s+)?total)?\b/i,
+    /\b(?:a\s+)?total\s+of\s+(\d{1,4})\s+(?:times?|runs?|iterations?|turns?)\b/i,
+    /\b(\d{1,4})\s+(?:times?|runs?|iterations?|turns?)\s+(?:(?:in\s+)?total|overall)\b/i,
+    /\bper\s+(\d{1,4})\s+(?:volte|iterazioni|run|giri)(?:\s+in\s+totale)?\b/i,
+    /\b(?:per\s+)?un\s+totale\s+di\s+(\d{1,4})\s+(?:volte|iterazioni|run|giri)\b/i,
+    /\b(\d{1,4})\s+(?:volte|iterazioni|run|giri)\s+in\s+totale\b/i,
+  ];
+  for (const pattern of patterns) {
+    const match = pattern.exec(value);
+    const amount = Number.parseInt(match?.[1] ?? "", 10);
+    if (!match || !Number.isFinite(amount) || amount <= 0) {
+      continue;
+    }
+    const textWithoutIterationLimit = removeMatchedText(value, match).replace(/(?:,\s*)$/g, "");
+    return {
+      maxIterations: amount,
+      textWithoutIterationLimit,
     };
   }
   return null;
@@ -589,13 +741,18 @@ export function parseChatAutomationInvocation(
     return null;
   }
 
-  const searchText = normalizeSearchText(normalizedInvocation);
+  const executionScope = extractExecutionScope(normalizedInvocation);
+  const scopedInvocation = executionScope?.textWithoutExecutionScope ?? normalizedInvocation;
+  const searchText = normalizeSearchText(scopedInvocation);
   const parsedSchedule = parseSchedule(searchText, options.nowIso ?? new Date().toISOString());
   if (!parsedSchedule) {
     return null;
   }
 
-  const prompt = stripAutomationScaffold(normalizedInvocation);
+  const iterationLimit = extractIterationLimit(scopedInvocation);
+  const prompt = stripAutomationScaffold(
+    iterationLimit?.textWithoutIterationLimit ?? scopedInvocation,
+  );
   if (!prompt) {
     return null;
   }
@@ -611,8 +768,34 @@ export function parseChatAutomationInvocation(
     prompt: taskPrompt,
     schedule: parsedSchedule.schedule,
     cadenceLabel: parsedSchedule.cadenceLabel,
+    maxIterations: iterationLimit?.maxIterations ?? null,
     completionPolicy: completionPolicyFromStopWhen(stopClause?.stopWhen ?? ""),
+    executionScope: executionScope?.executionScope ?? "thread",
   };
+}
+
+// Parses unmarked composer text only when it looks like an instruction, not a question.
+export function parsePlainChatAutomationInvocation(
+  invocation: string,
+  options: { readonly nowIso?: string } = {},
+): ChatAutomationIntent | null {
+  const normalizedInvocation = normalizeInlineText(invocation);
+  if (!normalizedInvocation) {
+    return null;
+  }
+  const politeInvocation = stripPlainAutomationPoliteRequest(normalizedInvocation);
+  const candidate = politeInvocation ?? normalizedInvocation;
+  if (!isLikelyPlainAutomationAction(candidate, politeInvocation !== null)) {
+    return null;
+  }
+  const candidateIsQuestion =
+    politeInvocation === null
+      ? isLikelyAutomationQuestionCandidate(normalizedInvocation)
+      : isLikelyAutomationQuestionCandidate(candidate);
+  if (candidateIsQuestion) {
+    return null;
+  }
+  return parseChatAutomationInvocation(candidate, options);
 }
 
 // Parses only explicit scheduled intents so regular automation questions keep going to the model.
@@ -627,8 +810,75 @@ export function parseChatAutomationIntent(
   return parseChatAutomationInvocation(invocation, options);
 }
 
+export function shouldGenerateAutomationIntent(input: {
+  readonly deterministicIntent: ChatAutomationIntent | null;
+  readonly automationMessage: string;
+}): boolean {
+  const message = normalizeInlineText(input.automationMessage);
+  if (!message) {
+    return false;
+  }
+  if (!input.deterministicIntent) {
+    return true;
+  }
+  const prompt = normalizeInlineText(input.deterministicIntent.prompt);
+  return (
+    prompt.length > 0 &&
+    (prompt.length <= PROMPT_ENRICHMENT_MAX_LENGTH ||
+      wordCount(prompt) <= PROMPT_ENRICHMENT_MAX_WORDS)
+  );
+}
+
+function stripGeneratedPromptScaffolding(value: string): string {
+  const withoutExecutionScope = extractExecutionScope(value)?.textWithoutExecutionScope ?? value;
+  const withoutIterationLimit =
+    extractIterationLimit(withoutExecutionScope)?.textWithoutIterationLimit ??
+    withoutExecutionScope;
+  const withoutSchedule = stripAutomationScaffold(withoutIterationLimit);
+  const stopClause = extractStopClause(withoutSchedule);
+  return normalizeInlineText(
+    stopClause?.textWithoutStopClause
+      ? stripAutomationScaffold(stopClause.textWithoutStopClause)
+      : withoutSchedule,
+  );
+}
+
+// Prefer the model's structured run cap, but recover old/generated prompt scaffolding too.
+function maxIterationsFromGeneratedIntent(
+  generatedIntent: ServerGenerateAutomationIntentResult,
+): number | null {
+  return (
+    generatedIntent.maxIterations ??
+    (generatedIntent.taskPrompt
+      ? (extractIterationLimit(generatedIntent.taskPrompt)?.maxIterations ?? null)
+      : null)
+  );
+}
+
+function generatedAutomationPromptEnrichment(
+  generatedIntent: ServerGenerateAutomationIntentResult | null,
+): Pick<ChatAutomationIntent, "name" | "prompt" | "maxIterations"> | null {
+  if (
+    generatedIntent?.isAutomation !== true ||
+    generatedIntent.taskPrompt === null ||
+    generatedIntent.confidence < GENERATED_INTENT_CONFIDENCE_THRESHOLD
+  ) {
+    return null;
+  }
+  const prompt = stripGeneratedPromptScaffolding(generatedIntent.taskPrompt);
+  if (!prompt) {
+    return null;
+  }
+  return {
+    name: generatedIntent.name ?? deriveAutomationIntentName(prompt),
+    prompt,
+    maxIterations: maxIterationsFromGeneratedIntent(generatedIntent),
+  };
+}
+
 function generatedAutomationIntentToChatIntent(
   generatedIntent: ServerGenerateAutomationIntentResult | null,
+  executionScope: ChatAutomationExecutionScope,
 ): ChatAutomationIntent | null {
   if (generatedIntent?.isAutomation !== true || generatedIntent.taskPrompt === null) {
     return null;
@@ -642,38 +892,85 @@ function generatedAutomationIntentToChatIntent(
   }
 
   const schedule = generatedIntent.schedule ?? { type: "manual" as const };
+  const prompt = stripGeneratedPromptScaffolding(generatedIntent.taskPrompt);
+  if (!prompt) {
+    return null;
+  }
+  const resolvedExecutionScope = executionScopeForGeneratedMode(
+    generatedIntent.mode,
+    executionScope,
+  );
   return {
-    name: generatedIntent.name ?? deriveAutomationIntentName(generatedIntent.taskPrompt),
-    prompt: generatedIntent.taskPrompt,
+    name: generatedIntent.name ?? deriveAutomationIntentName(prompt),
+    prompt,
     schedule,
     cadenceLabel: formatAutomationIntentCadence(schedule),
+    maxIterations: maxIterationsFromGeneratedIntent(generatedIntent),
     completionPolicy: generatedIntent.completionPolicy ?? { type: "none" },
+    executionScope: resolvedExecutionScope,
   };
+}
+
+// Generated mode can recover standalone phrasing the deterministic regexes do not know.
+function executionScopeForGeneratedMode(
+  mode: AutomationMode | null,
+  fallback: ChatAutomationExecutionScope,
+): ChatAutomationExecutionScope {
+  if (mode === "heartbeat") {
+    return "thread";
+  }
+  if (mode === "standalone") {
+    return fallback === "worktree" ? "worktree" : "standalone";
+  }
+  return fallback;
 }
 
 export function resolveChatAutomationIntent(input: {
   readonly deterministicIntent: ChatAutomationIntent | null;
   readonly generatedIntent: ServerGenerateAutomationIntentResult | null;
-  readonly isServerThread: boolean;
+  readonly defaultMode: AutomationMode;
+  readonly executionScope: ChatAutomationExecutionScope;
 }): ResolvedChatAutomationIntent | null {
-  const defaultMode: AutomationMode = input.isServerThread ? "heartbeat" : "standalone";
   if (input.deterministicIntent) {
-    const mode = modeForCompletionPolicy(defaultMode, input.deterministicIntent.completionPolicy);
+    const resolvedExecutionScope =
+      input.deterministicIntent.executionScope === "thread"
+        ? executionScopeForGeneratedMode(input.generatedIntent?.mode ?? null, input.executionScope)
+        : input.deterministicIntent.executionScope;
+    const requestedMode = resolvedExecutionScope === "thread" ? input.defaultMode : "standalone";
+    const mode = modeForCompletionPolicy(requestedMode, input.deterministicIntent.completionPolicy);
+    const enrichment = generatedAutomationPromptEnrichment(input.generatedIntent);
+    const enrichmentNeedsConfirmation =
+      enrichment !== null && (input.generatedIntent?.needsConfirmation ?? false);
+    const deterministicIntent =
+      resolvedExecutionScope === input.deterministicIntent.executionScope
+        ? input.deterministicIntent
+        : { ...input.deterministicIntent, executionScope: resolvedExecutionScope };
+    const intent = enrichment
+      ? {
+          ...deterministicIntent,
+          name: enrichment.name,
+          prompt: enrichment.prompt,
+          maxIterations: enrichment.maxIterations ?? deterministicIntent.maxIterations,
+        }
+      : deterministicIntent;
     return {
-      intent: input.deterministicIntent,
+      intent,
       mode,
       source: "deterministic",
-      requiresReview: requiresCompletionPolicyReview(
-        defaultMode,
-        input.deterministicIntent.completionPolicy,
-      ),
-      generatedConfidence: null,
-      generatedNeedsConfirmation: false,
-      reason: null,
+      requiresReview:
+        resolvedExecutionScope !== "thread" ||
+        enrichmentNeedsConfirmation ||
+        requiresCompletionPolicyReview(requestedMode, input.deterministicIntent.completionPolicy),
+      generatedConfidence: enrichment ? (input.generatedIntent?.confidence ?? null) : null,
+      generatedNeedsConfirmation: enrichmentNeedsConfirmation,
+      reason: enrichmentNeedsConfirmation ? (input.generatedIntent?.reason ?? null) : null,
     };
   }
 
-  const generatedIntent = generatedAutomationIntentToChatIntent(input.generatedIntent);
+  const generatedIntent = generatedAutomationIntentToChatIntent(
+    input.generatedIntent,
+    input.executionScope,
+  );
   if (!generatedIntent) {
     return null;
   }
@@ -682,18 +979,16 @@ export function resolveChatAutomationIntent(input: {
   const fastRecurringInterval =
     generatedSchedule?.type === "interval" && generatedSchedule.everySeconds < 60;
 
-  const requestedMode = input.isServerThread
-    ? (input.generatedIntent?.mode ?? "heartbeat")
-    : "standalone";
+  const requestedMode =
+    generatedIntent.executionScope === "thread" ? input.defaultMode : "standalone";
   const mode = modeForCompletionPolicy(requestedMode, generatedIntent.completionPolicy);
   return {
     intent: generatedIntent,
     mode,
     source: "generated",
-    requiresReview: requiresCompletionPolicyReview(
-      requestedMode,
-      generatedIntent.completionPolicy,
-    ),
+    requiresReview:
+      generatedIntent.executionScope !== "thread" ||
+      requiresCompletionPolicyReview(requestedMode, generatedIntent.completionPolicy),
     generatedConfidence: input.generatedIntent?.confidence ?? null,
     generatedNeedsConfirmation:
       (input.generatedIntent?.needsConfirmation ?? false) || fastRecurringInterval,

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -1,0 +1,366 @@
+// FILE: composerAutomation.test.ts
+// Purpose: Locks down composer-to-automation orchestration outside ChatView.
+// Layer: Web lib test
+// Depends on: composerAutomation resolver and automation form helpers.
+
+import type { ModelSelection, ProjectId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildComposerAutomationDraft,
+  resolveComposerAutomationRequest,
+} from "./composerAutomation";
+
+const PROJECT_ID = "project-composer-automation" as ProjectId;
+const THREAD_ID = "thread-composer-automation" as ThreadId;
+const MODEL_SELECTION: ModelSelection = {
+  provider: "codex",
+  model: "gpt-5",
+};
+const NOW_ISO = "2026-06-22T08:00:00.000Z";
+
+describe("composerAutomation", () => {
+  it("keeps unmarked automation questions as normal chat", async () => {
+    const generateIntent = vi.fn(async () => {
+      throw new Error("should not generate");
+    });
+
+    const decision = await resolveComposerAutomationRequest({
+      message: "how do automations work every day?",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+
+    expect(decision).toEqual({ type: "normal-chat" });
+    expect(generateIntent).not.toHaveBeenCalled();
+
+    const scriptDecision = await resolveComposerAutomationRequest({
+      message: "can you write a script that runs every 5 minutes?",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+
+    expect(scriptDecision).toEqual({ type: "normal-chat" });
+    expect(generateIntent).not.toHaveBeenCalled();
+  });
+
+  it("accepts polite unmarked automation requests", async () => {
+    const generateIntent = vi.fn(async () => {
+      throw new Error("offline generation falls back to deterministic intent");
+    });
+
+    const decision = await resolveComposerAutomationRequest({
+      message: "could you remind me every day to stretch?",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+
+    expect(decision).toMatchObject({
+      type: "automation",
+      resolution: {
+        mode: "heartbeat",
+        intent: {
+          prompt: "remind me stretch",
+          executionScope: "thread",
+          schedule: { type: "daily", timeOfDay: "09:00" },
+        },
+      },
+    });
+  });
+
+  it("accepts polite say requests as bounded thread automations", async () => {
+    const generateIntent = vi.fn(async () => {
+      throw new Error("bounded fast loops should not need generation");
+    });
+
+    const decision = await resolveComposerAutomationRequest({
+      message: "could you say hi every 15 seconds for 3 times",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+
+    expect(decision).toMatchObject({
+      type: "automation",
+      resolution: {
+        mode: "heartbeat",
+        intent: {
+          prompt: "say hi",
+          maxIterations: 3,
+          executionScope: "thread",
+          schedule: { type: "interval", everySeconds: 15 },
+        },
+      },
+    });
+    expect(generateIntent).not.toHaveBeenCalled();
+  });
+
+  it("keeps generated standalone mode when regex scope parsing misses it", async () => {
+    const generateIntent = vi.fn(async () => ({
+      isAutomation: true,
+      confidence: 0.93,
+      language: "en",
+      name: "Check CI",
+      taskPrompt: "Check CI.",
+      schedule: { type: "interval" as const, everySeconds: 300 },
+      mode: "standalone" as const,
+      completionPolicy: { type: "none" as const },
+      missingFields: [],
+      needsConfirmation: false,
+      reason: null,
+    }));
+
+    const decision = await resolveComposerAutomationRequest({
+      message: "/automation independently check CI every 5 minutes",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+
+    expect(decision).toMatchObject({
+      type: "automation",
+      resolution: {
+        mode: "standalone",
+        requiresReview: true,
+        intent: {
+          prompt: "Check CI.",
+          executionScope: "standalone",
+        },
+      },
+    });
+  });
+
+  it("falls back to deterministic automation parsing when AI enrichment is slow", async () => {
+    const generateIntent = vi.fn(() => new Promise<never>(() => undefined));
+
+    const decision = await resolveComposerAutomationRequest({
+      message: "/automation ogni domenica alle 9 controlla CI",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+      generateIntentTimeoutMs: 1,
+    });
+
+    expect(generateIntent).toHaveBeenCalledTimes(1);
+    expect(decision).toMatchObject({
+      type: "automation",
+      resolution: {
+        source: "deterministic",
+        mode: "heartbeat",
+        intent: {
+          prompt: "controlla CI",
+          executionScope: "thread",
+          schedule: { type: "weekly", dayOfWeek: 0, timeOfDay: "09:00" },
+        },
+      },
+    });
+  });
+
+  it("opens review when AI prompt enrichment needs confirmation", async () => {
+    const generateIntent = vi.fn(async () => ({
+      isAutomation: true,
+      confidence: 0.94,
+      language: "en",
+      name: "Check deployment",
+      taskPrompt: "Check the deployment status and report any ambiguous result.",
+      schedule: { type: "interval" as const, everySeconds: 21_600 },
+      mode: "heartbeat" as const,
+      completionPolicy: { type: "none" as const },
+      missingFields: [],
+      needsConfirmation: true,
+      reason: "The target is vague.",
+    }));
+
+    const decision = await resolveComposerAutomationRequest({
+      message: "check it every 6h",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+
+    expect(decision).toMatchObject({
+      type: "automation",
+      resolution: {
+        generatedNeedsConfirmation: true,
+        reason: "The target is vague.",
+        intent: {
+          prompt: "Check the deployment status and report any ambiguous result.",
+        },
+      },
+    });
+    if (decision.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    const draft = buildComposerAutomationDraft({
+      resolution: decision.resolution,
+      projectId: PROJECT_ID,
+      projectModelSelection: MODEL_SELECTION,
+      selectedModelSelection: MODEL_SELECTION,
+      targetThreadId: THREAD_ID,
+      hasEphemeralContext: false,
+    });
+
+    expect(draft.needsDraftReview).toBe(true);
+    expect(draft.warnings.map((warning) => warning.id)).toContain("generated-low-confidence");
+  });
+
+  it("builds an auto-submittable thread heartbeat draft for bounded fast loops", async () => {
+    const generateIntent = vi.fn(async () => ({
+      isAutomation: true,
+      confidence: 0.96,
+      language: "en",
+      name: "Say hi",
+      taskPrompt: "Every 15 seconds, say hi in this thread for 3 times.",
+      schedule: { type: "interval" as const, everySeconds: 15 },
+      mode: "heartbeat" as const,
+      completionPolicy: { type: "none" as const },
+      missingFields: [],
+      needsConfirmation: true,
+      reason: "Fast interval",
+    }));
+
+    const decision = await resolveComposerAutomationRequest({
+      message: "/automation say hi every 15 seconds for 3 times",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+    expect(decision).toMatchObject({
+      type: "automation",
+      automationMessage: "say hi every 15 seconds for 3 times",
+      resolution: {
+        mode: "heartbeat",
+        intent: {
+          prompt: "say hi",
+          maxIterations: 3,
+          executionScope: "thread",
+          schedule: { type: "interval", everySeconds: 15 },
+        },
+      },
+    });
+    expect(generateIntent).not.toHaveBeenCalled();
+
+    if (decision.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    const draft = buildComposerAutomationDraft({
+      resolution: decision.resolution,
+      projectId: PROJECT_ID,
+      projectModelSelection: MODEL_SELECTION,
+      selectedModelSelection: MODEL_SELECTION,
+      targetThreadId: THREAD_ID,
+      hasEphemeralContext: false,
+    });
+
+    expect(draft.needsDraftReview).toBe(false);
+    expect(draft.form).toMatchObject({
+      mode: "heartbeat",
+      targetThreadId: THREAD_ID,
+      runtimeMode: "approval-required",
+      maxIterations: "3",
+      prompt: "say hi",
+    });
+    expect(draft.warnings.map((warning) => warning.id)).toEqual(["fast-recurring-interval"]);
+    expect(Array.from(draft.acknowledgedWarningIds)).toEqual(["fast-recurring-interval"]);
+  });
+
+  it("auto-submits fast loops when the run cap is written as a total", async () => {
+    const generateIntent = vi.fn(async () => {
+      throw new Error("bounded fast loops should not need generation");
+    });
+
+    const decision = await resolveComposerAutomationRequest({
+      message: "/automation say hi every 15 seconds 3 times total",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+    expect(decision).toMatchObject({
+      type: "automation",
+      resolution: {
+        mode: "heartbeat",
+        intent: {
+          prompt: "say hi",
+          maxIterations: 3,
+          executionScope: "thread",
+          schedule: { type: "interval", everySeconds: 15 },
+        },
+      },
+    });
+    expect(generateIntent).not.toHaveBeenCalled();
+
+    if (decision.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    const draft = buildComposerAutomationDraft({
+      resolution: decision.resolution,
+      projectId: PROJECT_ID,
+      projectModelSelection: MODEL_SELECTION,
+      selectedModelSelection: MODEL_SELECTION,
+      targetThreadId: THREAD_ID,
+      hasEphemeralContext: false,
+    });
+
+    expect(draft.needsDraftReview).toBe(false);
+    expect(draft.form).toMatchObject({
+      mode: "heartbeat",
+      targetThreadId: THREAD_ID,
+      maxIterations: "3",
+      prompt: "say hi",
+    });
+    expect(Array.from(draft.acknowledgedWarningIds)).toEqual(["fast-recurring-interval"]);
+  });
+
+  it("keeps explicit standalone drafts behind review with risks unacknowledged", async () => {
+    const generateIntent = vi.fn(async () => {
+      throw new Error("offline generation falls back to deterministic intent");
+    });
+
+    const decision = await resolveComposerAutomationRequest({
+      message: "/automation run standalone say hi every 15 seconds for 3 times",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+    expect(decision).toMatchObject({
+      type: "automation",
+      resolution: {
+        mode: "standalone",
+        intent: {
+          prompt: "say hi",
+          maxIterations: 3,
+          executionScope: "standalone",
+        },
+      },
+    });
+
+    if (decision.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    const draft = buildComposerAutomationDraft({
+      resolution: decision.resolution,
+      projectId: PROJECT_ID,
+      projectModelSelection: MODEL_SELECTION,
+      selectedModelSelection: MODEL_SELECTION,
+      targetThreadId: null,
+      hasEphemeralContext: false,
+    });
+
+    expect(draft.needsDraftReview).toBe(true);
+    expect(draft.form).toMatchObject({
+      mode: "standalone",
+      targetThreadId: "",
+      worktreeMode: "auto",
+      maxIterations: "3",
+    });
+    expect(draft.warnings.map((warning) => warning.id)).toEqual([
+      "fast-recurring-interval",
+      "local-checkout",
+      "worktree-cleanup",
+    ]);
+    expect(Array.from(draft.acknowledgedWarningIds)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/composerAutomation.ts
+++ b/apps/web/src/lib/composerAutomation.ts
@@ -1,0 +1,246 @@
+// FILE: composerAutomation.ts
+// Purpose: Turns composer text into automation decisions and drafts while keeping ChatView thin.
+// Layer: Web composer orchestration helper
+// Exports: composer automation resolver plus draft builder for ChatView.
+// Depends on: automationIntent parsing and automation form helpers.
+
+import { DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS } from "@t3tools/contracts";
+import type {
+  AutomationMode,
+  ModelSelection,
+  ProjectId,
+  ServerGenerateAutomationIntentInput,
+  ServerGenerateAutomationIntentResult,
+  ThreadId,
+} from "@t3tools/contracts";
+
+import {
+  applyScheduleToForm,
+  formFromDefinition,
+  isFormSubmittable,
+  type AutomationFormState,
+} from "./automationForm";
+import { stopWhenFromCompletionPolicy } from "./automationCompletionPolicy";
+import {
+  acknowledgedWarningIdsForAutomaticChatAutomation,
+  buildAutomationDraftWarnings,
+  hasBlockingAutomationDraftWarnings,
+  type AutomationDraftWarning,
+  type AutomationDraftWarningId,
+} from "./automationDraft";
+import {
+  detectChatAutomationExecutionScope,
+  extractChatAutomationInvocation,
+  parseChatAutomationInvocation,
+  parsePlainChatAutomationInvocation,
+  resolveChatAutomationIntent,
+  shouldGenerateAutomationIntent,
+  type ChatAutomationIntent,
+  type ResolvedChatAutomationIntent,
+} from "./automationIntent";
+
+type GenerateComposerAutomationIntent = (
+  input: ServerGenerateAutomationIntentInput,
+) => Promise<ServerGenerateAutomationIntentResult>;
+
+const DEFAULT_GENERATE_INTENT_TIMEOUT_MS = 1_500;
+
+export type ComposerAutomationRequestDecision =
+  | { readonly type: "normal-chat" }
+  | {
+      readonly type: "missing-schedule";
+      readonly reason: string | null;
+    }
+  | {
+      readonly type: "automation";
+      readonly automationMessage: string;
+      readonly resolution: ResolvedChatAutomationIntent;
+    };
+
+export interface ComposerAutomationDraftDecision {
+  readonly form: AutomationFormState;
+  readonly warnings: readonly AutomationDraftWarning[];
+  readonly warningContext: {
+    readonly hasEphemeralContext: boolean;
+    readonly generatedConfidence: number | null;
+    readonly generatedNeedsConfirmation: boolean;
+  };
+  readonly acknowledgedWarningIds: ReadonlySet<AutomationDraftWarningId>;
+  readonly needsDraftReview: boolean;
+}
+
+// ─── ENTRY POINT ─────────────────────────────────────────────
+
+async function generateIntentWithTimeout(input: {
+  readonly generateIntent: GenerateComposerAutomationIntent;
+  readonly request: ServerGenerateAutomationIntentInput;
+  readonly timeoutMs: number;
+}): Promise<ServerGenerateAutomationIntentResult | null> {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      input.generateIntent(input.request).catch(() => null),
+      new Promise<null>((resolve) => {
+        timeoutId = setTimeout(() => resolve(null), Math.max(0, input.timeoutMs));
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function isAutoSubmittableBoundedFastLoop(intent: ChatAutomationIntent | null): boolean {
+  if (!intent || intent.executionScope !== "thread") {
+    return false;
+  }
+  return (
+    intent.schedule.type === "interval" &&
+    intent.schedule.everySeconds < 60 &&
+    intent.maxIterations !== null &&
+    intent.maxIterations <= DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS
+  );
+}
+
+// Resolves whether a composer submission should stay chat or become an automation.
+export async function resolveComposerAutomationRequest(input: {
+  readonly message: string;
+  readonly cwd: string;
+  readonly nowIso?: string;
+  readonly generateIntent: GenerateComposerAutomationIntent;
+  readonly generateIntentTimeoutMs?: number;
+}): Promise<ComposerAutomationRequestDecision> {
+  const trimmed = input.message.trim();
+  if (!trimmed) {
+    return { type: "normal-chat" };
+  }
+
+  const explicitAutomationInvocation = extractChatAutomationInvocation(trimmed);
+  const nowIso = input.nowIso ?? new Date().toISOString();
+  const automaticAutomationIntent =
+    explicitAutomationInvocation === null
+      ? parsePlainChatAutomationInvocation(trimmed, { nowIso })
+      : null;
+  const automationInvocation =
+    explicitAutomationInvocation ?? (automaticAutomationIntent ? trimmed : null);
+  if (automationInvocation === null) {
+    return { type: "normal-chat" };
+  }
+
+  const automationMessage = automationInvocation.trim();
+  const deterministicAutomationIntent =
+    automaticAutomationIntent ??
+    parseChatAutomationInvocation(automationInvocation, {
+      nowIso,
+    });
+  const automationExecutionScope =
+    deterministicAutomationIntent?.executionScope ??
+    detectChatAutomationExecutionScope(automationMessage);
+  const automationDefaultMode: AutomationMode =
+    automationExecutionScope === "thread" ? "heartbeat" : "standalone";
+  const shouldGenerateIntent =
+    !isAutoSubmittableBoundedFastLoop(deterministicAutomationIntent) &&
+    shouldGenerateAutomationIntent({
+      deterministicIntent: deterministicAutomationIntent,
+      automationMessage,
+    });
+  const generatedAutomationIntent = shouldGenerateIntent
+    ? await generateIntentWithTimeout({
+        generateIntent: input.generateIntent,
+        timeoutMs: input.generateIntentTimeoutMs ?? DEFAULT_GENERATE_INTENT_TIMEOUT_MS,
+        request: {
+          cwd: input.cwd,
+          message: automationMessage,
+          defaultMode: automationDefaultMode,
+          nowIso,
+        },
+      })
+    : null;
+  const automationResolution = resolveChatAutomationIntent({
+    deterministicIntent: deterministicAutomationIntent,
+    generatedIntent: generatedAutomationIntent,
+    defaultMode: automationDefaultMode,
+    executionScope: automationExecutionScope,
+  });
+  if (!automationResolution) {
+    return {
+      type: "missing-schedule",
+      reason: generatedAutomationIntent?.reason ?? null,
+    };
+  }
+
+  return {
+    type: "automation",
+    automationMessage,
+    resolution: automationResolution,
+  };
+}
+
+// Builds the draft form and review state once ChatView has resolved any thread target.
+export function buildComposerAutomationDraft(input: {
+  readonly resolution: ResolvedChatAutomationIntent;
+  readonly projectId: ProjectId;
+  readonly projectModelSelection: ModelSelection;
+  readonly selectedModelSelection: ModelSelection;
+  readonly targetThreadId: ThreadId | null;
+  readonly hasEphemeralContext: boolean;
+}): ComposerAutomationDraftDecision {
+  const { intent: automationIntent, mode: automationMode } = input.resolution;
+  const automationStopWhen = stopWhenFromCompletionPolicy(automationIntent.completionPolicy);
+  const baseForm = formFromDefinition(null, input.projectId, input.projectModelSelection);
+  // Chat-created automations should not inherit live Full access; escalating scheduled
+  // runs stays an explicit review step in the automation dialog.
+  const nextForm = applyScheduleToForm(
+    {
+      ...baseForm,
+      name: automationIntent.name,
+      prompt: automationIntent.prompt,
+      projectId: input.projectId,
+      modelSelection: input.selectedModelSelection,
+      runtimeMode: "approval-required",
+      worktreeMode: automationIntent.executionScope === "worktree" ? "worktree" : "auto",
+      mode: automationMode,
+      targetThreadId:
+        automationMode === "heartbeat" && input.targetThreadId ? input.targetThreadId : "",
+      maxIterations:
+        automationIntent.maxIterations === null ? "" : String(automationIntent.maxIterations),
+      stopOnError: true,
+      stopWhen: automationMode === "heartbeat" ? automationStopWhen : "",
+    },
+    automationIntent.schedule,
+  );
+  const warnings = buildAutomationDraftWarnings({
+    schedule: automationIntent.schedule,
+    mode: nextForm.mode,
+    runtimeMode: nextForm.runtimeMode,
+    worktreeMode: nextForm.worktreeMode,
+    hasEphemeralContext: input.hasEphemeralContext,
+    generatedConfidence: input.resolution.generatedConfidence,
+    generatedNeedsConfirmation: input.resolution.generatedNeedsConfirmation,
+    prompt: automationIntent.prompt,
+  });
+  const warningContext = {
+    hasEphemeralContext: input.hasEphemeralContext,
+    generatedConfidence: input.resolution.generatedConfidence,
+    generatedNeedsConfirmation: input.resolution.generatedNeedsConfirmation,
+  };
+  const acknowledgedWarningIds = acknowledgedWarningIdsForAutomaticChatAutomation({
+    warnings,
+    maxIterations: automationIntent.maxIterations,
+    executionScope: automationIntent.executionScope,
+  });
+  const needsDraftReview =
+    input.resolution.requiresReview ||
+    input.resolution.generatedNeedsConfirmation ||
+    !isFormSubmittable(nextForm) ||
+    hasBlockingAutomationDraftWarnings(warnings, acknowledgedWarningIds);
+
+  return {
+    form: nextForm,
+    warnings,
+    warningContext,
+    acknowledgedWarningIds,
+    needsDraftReview,
+  };
+}

--- a/apps/web/src/lib/deletedThreadClientReconciliation.ts
+++ b/apps/web/src/lib/deletedThreadClientReconciliation.ts
@@ -10,8 +10,10 @@ interface DeletedThreadClientReconciliationInput {
   removeDeletedThreadFromClientState: (threadId: ThreadId) => void;
 }
 
-interface DeletedThreadClientReconciliationSingleInput
-  extends Omit<DeletedThreadClientReconciliationInput, "threadIds"> {
+interface DeletedThreadClientReconciliationSingleInput extends Omit<
+  DeletedThreadClientReconciliationInput,
+  "threadIds"
+> {
   threadId: ThreadId;
 }
 

--- a/apps/web/src/lib/threadBootstrap.ts
+++ b/apps/web/src/lib/threadBootstrap.ts
@@ -271,8 +271,7 @@ export function resolveTerminalThreadCreationState(
     interactionMode:
       // Plan mode is an explicit composer/thread choice. Do not copy it from
       // the previously active thread into a fresh session bootstrap.
-      input.draftThread?.interactionMode ??
-      DEFAULT_INTERACTION_MODE,
+      input.draftThread?.interactionMode ?? DEFAULT_INTERACTION_MODE,
     lastKnownPr:
       input.draftThread?.lastKnownPr ??
       (input.activeThread?.projectId === input.projectId

--- a/apps/web/src/lib/threadCreatePromotion.ts
+++ b/apps/web/src/lib/threadCreatePromotion.ts
@@ -12,6 +12,10 @@ import { getThreadFromState } from "../threadDerivation";
 type ThreadCreateCommand = Extract<ClientOrchestrationCommand, { type: "thread.create" }>;
 
 type PromoteThreadCreateResult = "created" | "exists" | "unavailable";
+interface PromoteThreadCreateOptions {
+  // Draft-aware callers use this when React knows the route is still local.
+  readonly force?: boolean;
+}
 
 const inFlightThreadCreateById = new Map<ThreadId, Promise<PromoteThreadCreateResult>>();
 
@@ -43,8 +47,9 @@ async function recoverPromotedThreadFromShellSnapshot(
 async function dispatchPromoteThreadCreate(
   api: NativeApi,
   command: ThreadCreateCommand,
+  options: PromoteThreadCreateOptions = {},
 ): Promise<PromoteThreadCreateResult> {
-  if (getThreadFromState(useStore.getState(), command.threadId)) {
+  if (!options.force && getThreadFromState(useStore.getState(), command.threadId)) {
     markPromotedDraftThreads(new Set([command.threadId]));
     return "exists";
   }
@@ -71,6 +76,7 @@ async function dispatchPromoteThreadCreate(
 export async function promoteThreadCreate(
   command: ThreadCreateCommand,
   api: NativeApi | undefined = readNativeApi(),
+  options: PromoteThreadCreateOptions = {},
 ): Promise<PromoteThreadCreateResult> {
   if (!api) {
     return "unavailable";
@@ -81,7 +87,7 @@ export async function promoteThreadCreate(
     return "exists";
   }
 
-  const promise = dispatchPromoteThreadCreate(api, command).finally(() => {
+  const promise = dispatchPromoteThreadCreate(api, command, options).finally(() => {
     inFlightThreadCreateById.delete(command.threadId);
   });
   inFlightThreadCreateById.set(command.threadId, promise);

--- a/apps/web/src/routes/-automations.shared.test.tsx
+++ b/apps/web/src/routes/-automations.shared.test.tsx
@@ -22,6 +22,7 @@ import {
   allVisibleTriageRuns,
   applyAutomationEvent,
   automationAttentionCount,
+  automationFastIntervalLimitMessage,
   canCancelAutomationRun,
   createInputFromForm,
   datetimeLocalFromIso,
@@ -30,6 +31,7 @@ import {
   formFromDefinition,
   isoFromDatetimeLocal,
   isFormSubmittable,
+  maxIterationOptions,
   modelSelectionForProjectChange,
   providerOptionsForAutomationEdit,
   providerOptionsForAutomationModelSelection,
@@ -233,6 +235,30 @@ describe("automation shared route helpers", () => {
     expect(formatCadence(schedule)).toBe("Every 90s");
   });
 
+  it("requires a hard iteration cap for sub-minute interval forms", () => {
+    const form = {
+      ...applyScheduleToForm(formFromDefinition(null, "project-1"), {
+        type: "interval",
+        everySeconds: 15,
+      }),
+      name: "Say hi",
+      prompt: "Say hi.",
+    };
+    const cappedForm = { ...form, maxIterations: "10" };
+
+    expect(automationFastIntervalLimitMessage(form)).toBe(
+      "Intervals under one minute need max iterations set to 10 runs or fewer.",
+    );
+    expect(isFormSubmittable(form)).toBe(false);
+    expect(automationFastIntervalLimitMessage(cappedForm)).toBeNull();
+    expect(isFormSubmittable(cappedForm)).toBe(true);
+  });
+
+  it("keeps custom max-iteration caps visible in picker options", () => {
+    expect(maxIterationOptions("3")[0]).toEqual({ value: "3", label: "3 runs" });
+    expect(maxIterationOptions(10)[0]).toEqual({ value: "", label: "Unlimited" });
+  });
+
   it("refreshes the default model when the current model came from the old project", () => {
     const projects = [
       {
@@ -340,6 +366,36 @@ describe("automation shared route helpers", () => {
     });
   });
 
+  it("serializes standalone max iterations when chat parsing supplies a run limit", () => {
+    const form = {
+      ...formFromDefinition(null, "project-1"),
+      name: "Say hi",
+      prompt: "Say hi.",
+      mode: "standalone" as const,
+      maxIterations: "3",
+    };
+
+    expect(createInputFromForm(form)).toMatchObject({
+      mode: "standalone",
+      maxIterations: 3,
+      completionPolicy: { type: "none" },
+    });
+  });
+
+  it("serializes composer source thread provenance on create inputs", () => {
+    const form = {
+      ...formFromDefinition(null, "project-1"),
+      name: "Say hi",
+      prompt: "Say hi.",
+    };
+
+    expect(
+      createInputFromForm(form, undefined, undefined, threadId("thread-source")),
+    ).toMatchObject({
+      sourceThreadId: "thread-source",
+    });
+  });
+
   it("preserves saved provider options when editing without changing models", () => {
     const savedProviderOptions: ProviderStartOptions = {
       opencode: { binaryPath: "/old/opencode", serverUrl: "http://old.example" },
@@ -378,6 +434,35 @@ describe("automation shared route helpers", () => {
         currentProviderOptions,
       ),
     ).toEqual(currentProviderOptions);
+  });
+
+  it("preserves saved provider options when only model capability options change", () => {
+    const savedProviderOptions: ProviderStartOptions = {
+      codex: { binaryPath: "/old/codex", homePath: "/old/home" },
+    };
+    const currentProviderOptions: ProviderStartOptions = {
+      codex: { binaryPath: "/new/codex", homePath: "/new/home" },
+    };
+    const definition = definitionWith({
+      modelSelection: {
+        provider: "codex",
+        model: "gpt-5-codex",
+        options: { reasoningEffort: "medium" },
+      },
+      providerOptions: savedProviderOptions,
+    });
+
+    expect(
+      providerOptionsForAutomationModelSelection(
+        definition,
+        {
+          provider: "codex",
+          model: "gpt-5-codex",
+          options: { reasoningEffort: "high" },
+        },
+        currentProviderOptions,
+      ),
+    ).toEqual(savedProviderOptions);
   });
 
   it("clears stale provider options when an automation edit changes models without current options", () => {

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -6,14 +6,11 @@ import {
   type AutomationMode,
   type AutomationRun,
   type AutomationRunResult,
-  type AutomationSchedule,
   type AutomationStreamEvent,
   type AutomationUpdateInput,
   type AutomationWorktreeMode,
   type ModelSelection,
-  type ProjectId,
   type ProviderKind,
-  type ProviderStartOptions,
   type RuntimeMode,
   type ThreadId,
 } from "@t3tools/contracts";
@@ -44,27 +41,48 @@ import {
 import { TimePicker } from "~/components/ui/time-picker";
 import { toastManager } from "~/components/ui/toast";
 import {
-  acknowledgedRiskIdsForDraft,
-  buildAutomationDraftWarnings,
   hasBlockingAutomationDraftWarnings,
   type AutomationDraftWarning,
   type AutomationDraftWarningId,
 } from "~/lib/automationDraft";
 import {
-  completionPolicyFromStopWhen,
-  stopWhenFromCompletionPolicy,
-} from "~/lib/automationCompletionPolicy";
-import {
-  BrainIcon,
-  ChevronDownIcon,
-  ClockIcon,
-  FolderIcon,
-  InfoIcon,
-  SkillCubeIcon,
-  WorktreeIcon,
-  XIcon,
-} from "~/lib/icons";
+  acknowledgedRiskIdsForFormWarnings,
+  applyScheduleToForm,
+  automationFastIntervalLimitMessage,
+  buildAutomationFormWarnings,
+  createInputFromForm,
+  datetimeLocalFromIso,
+  defaultModelSelection,
+  formatCadence,
+  formatClockTime,
+  formatDateTime,
+  formatSchedule,
+  formFromDefinition,
+  groupHeartbeatAutomationsByTargetThread,
+  heartbeatAutomationsForThread,
+  isFormSubmittable,
+  isoFromDatetimeLocal,
+  modelSelectionForProjectChange,
+  projectModelSelection,
+  providerOptionsForAutomationEdit,
+  providerOptionsForAutomationModelSelection,
+  scheduleFromForm,
+  scheduleFromKind,
+  scheduleKindFromSchedule,
+  SCHEDULE_KIND_OPTIONS,
+  TIME_OF_DAY_PATTERN,
+  updateInputFromForm,
+  updateWeeklyScheduleDay,
+  updateWeeklyScheduleTime,
+  weekdayLabel,
+  type AutomationFormState,
+  type IntervalUnit,
+  type ScheduleKind,
+} from "~/lib/automationForm";
+import { SkillCubeIcon, WorktreeIcon } from "~/lib/icons";
+import { CentralIcon } from "~/lib/central-icons";
 import { resolveProviderDiscoveryCwd } from "~/lib/providerDiscovery";
+import { cn } from "~/lib/utils";
 import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
 import { ensureNativeApi } from "~/nativeApi";
 import { buildModelSelection } from "~/providerModelOptions";
@@ -74,13 +92,42 @@ import { useStore } from "~/store";
 import { resolveThreadPickerTitle } from "./-chatThreadRoute.logic";
 
 export const automationQueryKey = ["automations"] as const;
-export const defaultModelSelection: ModelSelection = {
-  provider: "codex",
-  model: "gpt-5-codex",
-};
 export const EMPTY_AUTOMATION_LIST: AutomationListResult = { definitions: [], runs: [] };
-export const TIME_OF_DAY_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
-const LEGACY_WALL_CLOCK_TIMEZONE = "UTC";
+
+export {
+  acknowledgedRiskIdsForFormWarnings,
+  applyScheduleToForm,
+  automationFastIntervalLimitMessage,
+  buildAutomationFormWarnings,
+  createInputFromForm,
+  datetimeLocalFromIso,
+  defaultModelSelection,
+  formatCadence,
+  formatClockTime,
+  formatDateTime,
+  formatSchedule,
+  formFromDefinition,
+  groupHeartbeatAutomationsByTargetThread,
+  heartbeatAutomationsForThread,
+  isFormSubmittable,
+  isoFromDatetimeLocal,
+  modelSelectionForProjectChange,
+  projectModelSelection,
+  providerOptionsForAutomationEdit,
+  providerOptionsForAutomationModelSelection,
+  scheduleFromForm,
+  scheduleFromKind,
+  scheduleKindFromSchedule,
+  SCHEDULE_KIND_OPTIONS,
+  TIME_OF_DAY_PATTERN,
+  updateInputFromForm,
+  updateWeeklyScheduleDay,
+  updateWeeklyScheduleTime,
+  weekdayLabel,
+  type AutomationFormState,
+  type IntervalUnit,
+  type ScheduleKind,
+};
 
 /** Starter prompts surfaced behind the composer's "Use template" button. */
 export const AUTOMATION_TEMPLATES: readonly {
@@ -107,245 +154,6 @@ export const AUTOMATION_TEMPLATES: readonly {
   },
 ];
 
-/** UI-level cadence options shown in the schedule picker (each maps onto an AutomationSchedule). */
-export type ScheduleKind =
-  | "manual"
-  | "once"
-  | "hourly"
-  | "daily"
-  | "weekdays"
-  | "weekly"
-  | "custom"
-  | "cron";
-
-export const SCHEDULE_KIND_OPTIONS: readonly { value: ScheduleKind; label: string }[] = [
-  { value: "manual", label: "Manual" },
-  { value: "once", label: "Once" },
-  { value: "hourly", label: "Hourly" },
-  { value: "daily", label: "Daily" },
-  { value: "weekdays", label: "Weekdays" },
-  { value: "weekly", label: "Weekly" },
-  { value: "custom", label: "Custom" },
-  { value: "cron", label: "Cron" },
-];
-
-/** Pick the schedule option that represents a stored schedule (interval 1h reads as "Hourly"). */
-export function scheduleKindFromSchedule(schedule: AutomationSchedule): ScheduleKind {
-  switch (schedule.type) {
-    case "daily":
-      return "daily";
-    case "weekdays":
-      return "weekdays";
-    case "weekly":
-      return "weekly";
-    case "interval":
-      return schedule.everySeconds === 3600 ? "hourly" : "custom";
-    case "manual":
-      return "manual";
-    case "once":
-      return "once";
-    case "cron":
-      return "cron";
-  }
-}
-
-/** Build a schedule for the chosen kind, reusing time/day/interval from `current` where it applies. */
-export function scheduleFromKind(
-  kind: ScheduleKind,
-  current: AutomationSchedule,
-  fallbackTimezone: string = localTimezone(),
-): AutomationSchedule {
-  const timeOfDay =
-    current.type === "daily" || current.type === "weekly" || current.type === "weekdays"
-      ? current.timeOfDay
-      : "09:00";
-  const timezone = scheduleTimezone(current, fallbackTimezone);
-  switch (kind) {
-    case "manual":
-      return { type: "manual" };
-    case "once":
-      return { type: "once", runAt: new Date(Date.now() + 15 * 60_000).toISOString() };
-    case "hourly":
-      return { type: "interval", everySeconds: 3600 };
-    case "custom":
-      return {
-        type: "interval",
-        everySeconds:
-          current.type === "interval" && current.everySeconds !== 3600
-            ? current.everySeconds
-            : 1800,
-      };
-    case "daily":
-      return { type: "daily", timeOfDay, timezone };
-    case "weekdays":
-      return { type: "weekdays", timeOfDay, timezone };
-    case "weekly":
-      return {
-        type: "weekly",
-        dayOfWeek: current.type === "weekly" ? current.dayOfWeek : 1,
-        timeOfDay,
-        timezone,
-      };
-    case "cron":
-      return {
-        type: "cron",
-        expression: current.type === "cron" ? current.expression : "0 9 * * *",
-        timezone,
-      };
-  }
-}
-
-export type AutomationFormState = {
-  readonly name: string;
-  readonly projectId: string;
-  readonly prompt: string;
-  readonly enabled: boolean;
-  readonly scheduleKind: ScheduleKind;
-  readonly intervalAmount: string;
-  readonly intervalUnit: IntervalUnit;
-  readonly timeOfDay: string;
-  readonly dayOfWeek: string;
-  readonly onceRunAt: string;
-  readonly cronExpression: string;
-  readonly timezone: string;
-  readonly runtimeMode: RuntimeMode;
-  readonly worktreeMode: AutomationWorktreeMode;
-  readonly modelSelection: ModelSelection;
-  readonly mode: AutomationMode;
-  readonly targetThreadId: string;
-  readonly maxIterations: string;
-  readonly stopOnError: boolean;
-  readonly stopWhen: string;
-};
-
-type IntervalUnit = "seconds" | "minutes";
-
-function localTimezone(): string {
-  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
-}
-
-function scheduleTimezone(schedule: AutomationSchedule, fallbackTimezone: string): string {
-  return (
-    (schedule.type === "daily" ||
-    schedule.type === "weekly" ||
-    schedule.type === "weekdays" ||
-    schedule.type === "cron"
-      ? schedule.timezone
-      : undefined) ?? fallbackTimezone
-  );
-}
-
-export function datetimeLocalFromIso(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  const offsetMs = date.getTimezoneOffset() * 60_000;
-  const localIso = new Date(date.getTime() - offsetMs).toISOString();
-  return localIso.slice(0, date.getSeconds() === 0 && date.getMilliseconds() === 0 ? 16 : 19);
-}
-
-export function isoFromDatetimeLocal(value: string): string {
-  const date = new Date(value);
-  return Number.isNaN(date.getTime())
-    ? new Date(Date.now() + 15 * 60_000).toISOString()
-    : date.toISOString();
-}
-
-export function updateWeeklyScheduleDay(
-  schedule: Extract<AutomationSchedule, { type: "weekly" }>,
-  dayOfWeek: number,
-): AutomationSchedule {
-  return { ...schedule, dayOfWeek };
-}
-
-export function updateWeeklyScheduleTime(
-  schedule: Extract<AutomationSchedule, { type: "weekly" }>,
-  timeOfDay: string,
-): AutomationSchedule {
-  return { ...schedule, timeOfDay };
-}
-
-export function formatDateTime(value: string | null): string {
-  if (!value) return "Not scheduled";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return `${new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(date)}`;
-}
-
-function timezoneSuffix(schedule: AutomationSchedule): string {
-  if (
-    (schedule.type === "daily" ||
-      schedule.type === "weekdays" ||
-      schedule.type === "weekly" ||
-      schedule.type === "cron") &&
-    schedule.timezone
-  ) {
-    return ` ${schedule.timezone}`;
-  }
-  return " UTC";
-}
-
-function formatIntervalSchedule(seconds: number): string {
-  return seconds % 60 === 0 ? `Every ${seconds / 60} min` : `Every ${seconds} sec`;
-}
-
-function formatIntervalCadence(seconds: number): string {
-  if (seconds === 3600) return "Hourly";
-  if (seconds % 3600 === 0) return `Every ${seconds / 3600}h`;
-  if (seconds % 60 === 0) return `Every ${seconds / 60}m`;
-  return `Every ${seconds}s`;
-}
-
-export function formatSchedule(schedule: AutomationSchedule): string {
-  switch (schedule.type) {
-    case "manual":
-      return "Manual";
-    case "once":
-      return `Once ${formatDateTime(schedule.runAt)}`;
-    case "interval":
-      return formatIntervalSchedule(schedule.everySeconds);
-    case "daily":
-      return `Daily ${schedule.timeOfDay}${timezoneSuffix(schedule)}`;
-    case "weekdays":
-      return `Weekdays ${schedule.timeOfDay}${timezoneSuffix(schedule)}`;
-    case "weekly":
-      return `Weekly ${weekdayLabel(schedule.dayOfWeek)} ${schedule.timeOfDay}${timezoneSuffix(schedule)}`;
-    case "cron":
-      return `Cron ${schedule.expression} ${schedule.timezone}`;
-  }
-}
-
-/** "09:00" -> "9:00": drops the leading zero on the hour for friendlier cadence labels. */
-export function formatClockTime(timeOfDay: string): string {
-  const [hours, minutes] = timeOfDay.split(":");
-  const hour = Number.parseInt(hours ?? "", 10);
-  if (Number.isNaN(hour)) return timeOfDay;
-  return `${hour}:${minutes ?? "00"}`;
-}
-
-export function formatCadence(schedule: AutomationSchedule): string {
-  switch (schedule.type) {
-    case "manual":
-      return "Manual";
-    case "once":
-      return formatDateTime(schedule.runAt);
-    case "interval":
-      return formatIntervalCadence(schedule.everySeconds);
-    case "daily":
-      return `Daily at ${formatClockTime(schedule.timeOfDay)}`;
-    case "weekdays":
-      return `Weekdays at ${formatClockTime(schedule.timeOfDay)}`;
-    case "weekly":
-      return `${weekdayLabel(schedule.dayOfWeek)} at ${formatClockTime(schedule.timeOfDay)}`;
-    case "cron":
-      return `Cron ${schedule.expression}`;
-  }
-}
-
 export function formatRelativeTime(iso: string | null): string {
   if (!iso) return "";
   const date = new Date(iso);
@@ -361,10 +169,6 @@ export function formatRelativeTime(iso: string | null): string {
   const weeks = Math.floor(days / 7);
   if (weeks < 4) return `${weeks}w`;
   return `${Math.floor(days / 30)}mo`;
-}
-
-export function weekdayLabel(value: number): string {
-  return ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][value] ?? "Sun";
 }
 
 export function runStatusVariant(
@@ -385,6 +189,55 @@ export function runStatusVariant(
     case "pending":
       return "info";
   }
+}
+
+/** Status-colored dot/icon class for a single run, shared by the detail history and triage rows. */
+export function runStatusDotClassName(status: AutomationRun["status"]): string {
+  switch (runStatusVariant(status)) {
+    case "success":
+      return "text-emerald-500";
+    case "error":
+      return "text-destructive";
+    case "warning":
+      return "text-amber-500";
+    case "info":
+      return "text-blue-500";
+    case "outline":
+      return "text-muted-foreground/50";
+  }
+}
+
+/**
+ * Leading status glyph for a single run row: a quiet check for success, otherwise a
+ * status-colored dot. Shared by the detail history and the list triage rows so both
+ * surfaces read identically.
+ */
+export function RunStatusIndicator({
+  status,
+  className,
+}: {
+  readonly status: AutomationRun["status"];
+  readonly className?: string;
+}) {
+  if (runStatusVariant(status) === "success") {
+    return (
+      <CentralIcon
+        name="circle-check"
+        className={cn("size-3.5 shrink-0 text-muted-foreground/70", className)}
+      />
+    );
+  }
+  return (
+    <span
+      className={cn(
+        "flex size-3.5 shrink-0 items-center justify-center",
+        runStatusDotClassName(status),
+        className,
+      )}
+    >
+      <span className="block size-1.5 rounded-full bg-current" />
+    </span>
+  );
 }
 
 export function isTriageRun(run: AutomationRun): boolean {
@@ -485,275 +338,6 @@ export function automationStatusDotClass(
   }
   if (latestRun && isTriageRun(latestRun)) return "text-destructive";
   return "text-emerald-500";
-}
-
-function intervalFormPartsFromSeconds(everySeconds: number): {
-  readonly amount: string;
-  readonly unit: IntervalUnit;
-} {
-  return everySeconds >= 60 && everySeconds % 60 === 0
-    ? { amount: String(everySeconds / 60), unit: "minutes" }
-    : { amount: String(everySeconds), unit: "seconds" };
-}
-
-export function formFromDefinition(
-  definition: AutomationDefinition | null,
-  fallbackProjectId: string,
-  fallbackModelSelection: ModelSelection = defaultModelSelection,
-): AutomationFormState {
-  // New automations default to a daily schedule (the most common automation cadence);
-  // existing definitions keep whatever schedule they were saved with.
-  const schedule = definition?.schedule ?? { type: "daily" as const, timeOfDay: "09:00" };
-  const timezone = scheduleTimezone(
-    schedule,
-    definition ? LEGACY_WALL_CLOCK_TIMEZONE : localTimezone(),
-  );
-  return {
-    name: definition?.name ?? "",
-    projectId: definition?.projectId ?? fallbackProjectId,
-    prompt: definition?.prompt ?? "",
-    enabled: definition?.enabled ?? true,
-    scheduleKind: scheduleKindFromSchedule(schedule),
-    intervalAmount:
-      schedule.type === "interval" && schedule.everySeconds !== 3600
-        ? intervalFormPartsFromSeconds(schedule.everySeconds).amount
-        : "30",
-    intervalUnit:
-      schedule.type === "interval" && schedule.everySeconds !== 3600
-        ? intervalFormPartsFromSeconds(schedule.everySeconds).unit
-        : "minutes",
-    timeOfDay:
-      schedule.type === "daily" || schedule.type === "weekly" || schedule.type === "weekdays"
-        ? schedule.timeOfDay
-        : "09:00",
-    dayOfWeek: schedule.type === "weekly" ? String(schedule.dayOfWeek) : "1",
-    onceRunAt:
-      schedule.type === "once"
-        ? datetimeLocalFromIso(schedule.runAt)
-        : datetimeLocalFromIso(new Date(Date.now() + 15 * 60_000).toISOString()),
-    cronExpression: schedule.type === "cron" ? schedule.expression : "0 9 * * *",
-    timezone,
-    runtimeMode: definition?.runtimeMode ?? "approval-required",
-    worktreeMode: definition?.worktreeMode ?? "auto",
-    modelSelection: definition?.modelSelection ?? fallbackModelSelection,
-    mode: definition?.mode ?? "standalone",
-    targetThreadId: definition?.targetThreadId ?? "",
-    maxIterations: definition?.maxIterations != null ? String(definition.maxIterations) : "",
-    stopOnError: definition?.stopOnError ?? true,
-    stopWhen: definition ? stopWhenFromCompletionPolicy(definition.completionPolicy) : "",
-  };
-}
-
-export function applyScheduleToForm(
-  form: AutomationFormState,
-  schedule: AutomationSchedule,
-  fallbackTimezone: string = localTimezone(),
-): AutomationFormState {
-  const timezone = scheduleTimezone(schedule, fallbackTimezone);
-  return {
-    ...form,
-    scheduleKind: scheduleKindFromSchedule(schedule),
-    intervalAmount:
-      schedule.type === "interval" && schedule.everySeconds !== 3600
-        ? intervalFormPartsFromSeconds(schedule.everySeconds).amount
-        : form.intervalAmount,
-    intervalUnit:
-      schedule.type === "interval" && schedule.everySeconds !== 3600
-        ? intervalFormPartsFromSeconds(schedule.everySeconds).unit
-        : form.intervalUnit,
-    timeOfDay:
-      schedule.type === "daily" || schedule.type === "weekly" || schedule.type === "weekdays"
-        ? schedule.timeOfDay
-        : form.timeOfDay,
-    dayOfWeek: schedule.type === "weekly" ? String(schedule.dayOfWeek) : form.dayOfWeek,
-    onceRunAt: schedule.type === "once" ? datetimeLocalFromIso(schedule.runAt) : form.onceRunAt,
-    cronExpression: schedule.type === "cron" ? schedule.expression : form.cronExpression,
-    timezone,
-  };
-}
-
-export function scheduleFromForm(form: AutomationFormState): AutomationSchedule {
-  const timezone = form.timezone.trim();
-  switch (form.scheduleKind) {
-    case "hourly":
-      return { type: "interval", everySeconds: 3600 };
-    case "manual":
-      return { type: "manual" };
-    case "once":
-      return { type: "once", runAt: isoFromDatetimeLocal(form.onceRunAt) };
-    case "custom": {
-      const amount = Math.max(1, Number.parseInt(form.intervalAmount, 10) || 1);
-      return {
-        type: "interval",
-        everySeconds: form.intervalUnit === "seconds" ? amount : amount * 60,
-      };
-    }
-    case "daily":
-      return { type: "daily", timeOfDay: form.timeOfDay, timezone };
-    case "weekdays":
-      return { type: "weekdays", timeOfDay: form.timeOfDay, timezone };
-    case "weekly": {
-      const dayOfWeek = Math.min(6, Math.max(0, Number.parseInt(form.dayOfWeek, 10) || 0));
-      return { type: "weekly", dayOfWeek, timeOfDay: form.timeOfDay, timezone };
-    }
-    case "cron":
-      return {
-        type: "cron",
-        expression: form.cronExpression.trim() || "0 9 * * *",
-        timezone,
-      };
-  }
-}
-
-export function projectModelSelection(
-  projects: ReturnType<typeof useStore.getState>["projects"],
-  projectId: string,
-) {
-  return (
-    projects.find((project) => project.id === projectId)?.defaultModelSelection ??
-    defaultModelSelection
-  );
-}
-
-function modelSelectionsMatch(left: ModelSelection, right: ModelSelection): boolean {
-  const leftOptions = "options" in left ? left.options : undefined;
-  const rightOptions = "options" in right ? right.options : undefined;
-  return (
-    left.provider === right.provider &&
-    left.model === right.model &&
-    JSON.stringify(leftOptions ?? null) === JSON.stringify(rightOptions ?? null)
-  );
-}
-
-// Automation edits keep their saved provider options unless the user changes models.
-// On model changes, an empty object intentionally clears stale provider-specific options.
-export function providerOptionsForAutomationModelSelection(
-  definition: Pick<AutomationDefinition, "modelSelection" | "providerOptions">,
-  nextModelSelection: ModelSelection,
-  currentProviderOptions?: ProviderStartOptions,
-): ProviderStartOptions | undefined {
-  return modelSelectionsMatch(definition.modelSelection, nextModelSelection)
-    ? definition.providerOptions
-    : (currentProviderOptions ?? {});
-}
-
-export function providerOptionsForAutomationEdit(
-  definition: Pick<AutomationDefinition, "modelSelection" | "providerOptions">,
-  form: Pick<AutomationFormState, "modelSelection">,
-  currentProviderOptions?: ProviderStartOptions,
-): ProviderStartOptions | undefined {
-  return providerOptionsForAutomationModelSelection(
-    definition,
-    form.modelSelection,
-    currentProviderOptions,
-  );
-}
-
-export function modelSelectionForProjectChange(
-  projects: ReturnType<typeof useStore.getState>["projects"],
-  currentProjectId: string,
-  nextProjectId: string,
-  currentModelSelection: ModelSelection,
-): ModelSelection {
-  const currentDefaultModelSelection = projectModelSelection(projects, currentProjectId);
-  const nextDefaultModelSelection = projectModelSelection(projects, nextProjectId);
-  return modelSelectionsMatch(currentModelSelection, currentDefaultModelSelection)
-    ? nextDefaultModelSelection
-    : currentModelSelection;
-}
-
-export function createInputFromForm(
-  form: AutomationFormState,
-  providerOptions?: ProviderStartOptions,
-  acknowledgedRisks?: AutomationCreateInput["acknowledgedRisks"],
-): AutomationCreateInput {
-  const maxIterations = form.maxIterations.trim() ? Number.parseInt(form.maxIterations, 10) : null;
-  const stopWhen = form.stopWhen.trim();
-  return {
-    name: form.name.trim(),
-    projectId: form.projectId as ProjectId,
-    prompt: form.prompt.trim(),
-    schedule: scheduleFromForm(form),
-    enabled: form.enabled,
-    modelSelection: form.modelSelection,
-    runtimeMode: form.runtimeMode,
-    interactionMode: "default",
-    worktreeMode: form.worktreeMode,
-    ...(providerOptions ? { providerOptions } : {}),
-    mode: form.mode,
-    targetThreadId: form.mode === "heartbeat" ? (form.targetThreadId as ThreadId) : null,
-    ...(form.mode === "heartbeat"
-      ? {
-          maxIterations,
-          stopOnError: form.stopOnError,
-          completionPolicy: completionPolicyFromStopWhen(stopWhen),
-        }
-      : { completionPolicy: { type: "none" as const } }),
-    ...(acknowledgedRisks ? { acknowledgedRisks } : {}),
-  };
-}
-
-export function updateInputFromForm(
-  definition: AutomationDefinition,
-  form: AutomationFormState,
-  providerOptions?: ProviderStartOptions,
-  acknowledgedRisks?: AutomationCreateInput["acknowledgedRisks"],
-): AutomationUpdateInput {
-  return {
-    id: definition.id,
-    ...createInputFromForm(form, providerOptions, acknowledgedRisks),
-  };
-}
-
-export function buildAutomationFormWarnings(form: AutomationFormState) {
-  return buildAutomationDraftWarnings({
-    schedule: scheduleFromForm(form),
-    mode: form.mode,
-    runtimeMode: form.runtimeMode,
-    worktreeMode: form.worktreeMode,
-    hasEphemeralContext: false,
-    generatedConfidence: null,
-    generatedNeedsConfirmation: false,
-    prompt: form.prompt,
-  });
-}
-
-export function acknowledgedRiskIdsForFormWarnings(
-  warnings: readonly AutomationDraftWarning[],
-  acknowledgedWarningIds: ReadonlySet<AutomationDraftWarningId>,
-) {
-  return acknowledgedRiskIdsForDraft(warnings, acknowledgedWarningIds);
-}
-
-export function isFormSubmittable(form: AutomationFormState): boolean {
-  if (!form.name.trim() || !form.prompt.trim() || !form.projectId) return false;
-  if (form.mode === "heartbeat" && !form.targetThreadId) return false;
-  if (
-    form.scheduleKind === "custom" &&
-    (!form.intervalAmount.trim() || Number.parseInt(form.intervalAmount, 10) <= 0)
-  ) {
-    return false;
-  }
-  if (form.scheduleKind === "cron" && !form.cronExpression.trim()) return false;
-  if (form.scheduleKind === "once" && !form.onceRunAt.trim()) return false;
-  if (
-    (form.scheduleKind === "daily" ||
-      form.scheduleKind === "weekdays" ||
-      form.scheduleKind === "cron" ||
-      form.scheduleKind === "weekly") &&
-    !form.timezone.trim()
-  ) {
-    return false;
-  }
-  if (
-    (form.scheduleKind === "daily" ||
-      form.scheduleKind === "weekdays" ||
-      form.scheduleKind === "weekly") &&
-    !TIME_OF_DAY_PATTERN.test(form.timeOfDay)
-  ) {
-    return false;
-  }
-  return true;
 }
 
 const deletedAutomationIdsInCache = new Set<string>();
@@ -1005,6 +589,20 @@ const MAX_ITERATION_PRESETS: readonly CadenceOption[] = [
   { value: "250", label: "250 runs" },
 ];
 
+function maxIterationLabel(value: string): string {
+  return value === "1" ? "1 run" : `${value} runs`;
+}
+
+export function maxIterationOptions(
+  currentValue: string | number | null | undefined,
+): readonly { readonly value: string; readonly label: string }[] {
+  const value = currentValue == null ? "" : String(currentValue).trim();
+  if (!/^\d+$/.test(value) || MAX_ITERATION_PRESETS.some((preset) => preset.value === value)) {
+    return MAX_ITERATION_PRESETS;
+  }
+  return [{ value, label: maxIterationLabel(value) }, ...MAX_ITERATION_PRESETS];
+}
+
 export function AutomationModelPicker({
   value,
   projectCwd,
@@ -1084,12 +682,14 @@ export function AutomationDialog({
   const projectThreads = threads.filter((thread) => thread.projectId === form.projectId);
   const selectedProject = projects.find((project) => project.id === form.projectId);
   const schedule = scheduleFromForm(form);
+  const fastIntervalLimitMessage = automationFastIntervalLimitMessage(form);
   const hasBlockingWarning = hasBlockingAutomationDraftWarnings(warnings, acknowledgedWarningIds);
   const submittable = isFormSubmittable(form) && !hasBlockingWarning;
   const intervalValue = intervalOptionValue({
     amount: form.intervalAmount,
     unit: form.intervalUnit,
   });
+  const maxIterationPresets = maxIterationOptions(form.maxIterations);
   const intervalPresets = INTERVAL_PRESETS.some(
     (preset) => intervalOptionValue(preset) === intervalValue,
   )
@@ -1160,7 +760,7 @@ export function AutomationDialog({
               aria-label="About automations"
               title="Automations run this prompt on a schedule and open the result as a thread."
             >
-              <InfoIcon className="size-4" />
+              <CentralIcon name="info-simple" className="size-4" />
             </Button>
             <Menu>
               <MenuTrigger render={<Button variant="outline" size="sm" />}>
@@ -1182,12 +782,12 @@ export function AutomationDialog({
               disabled={busy}
               onClick={() => onOpenChange(false)}
             >
-              <XIcon className="size-4" />
+              <CentralIcon name="cross-small" className="size-4" />
             </Button>
           </div>
         </div>
 
-        <div className="min-h-0 flex-1 px-5 py-3">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-3">
           <textarea
             value={form.prompt}
             onChange={(event) => setField("prompt", event.target.value)}
@@ -1199,35 +799,40 @@ export function AutomationDialog({
             }}
             placeholder="Add prompt e.g. look for crashes in $sentry"
             aria-label="Automation prompt"
-            className="max-h-[42vh] min-h-[15rem] w-full resize-none overflow-y-auto bg-transparent font-system-ui text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/50"
+            className="min-h-[15rem] w-full flex-1 resize-none overflow-y-auto bg-transparent font-system-ui text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/50"
           />
-        </div>
 
-        {warnings.length > 0 ? (
-          <div className="mx-5 mb-2 flex flex-col gap-1.5 rounded-lg border border-border/70 bg-[var(--color-background-elevated-secondary)] p-3">
-            {warnings.map((warning) => (
-              <label
-                key={warning.id}
-                className="flex items-start gap-2 text-xs text-muted-foreground"
-              >
-                {warning.requiresAcknowledgement ? (
-                  <input
-                    type="checkbox"
-                    checked={acknowledgedWarningIds.has(warning.id)}
-                    onChange={(event) => onToggleWarning?.(warning.id, event.target.checked)}
-                    className="mt-0.5"
-                  />
-                ) : (
-                  <span className="mt-1 size-1.5 shrink-0 rounded-full bg-amber-500" />
-                )}
-                <span className="min-w-0">
-                  <span className="font-medium text-foreground">{warning.title}</span>
-                  <span className="block">{warning.detail}</span>
-                </span>
-              </label>
-            ))}
-          </div>
-        ) : null}
+          {warnings.length > 0 ? (
+            <div className="mt-2 flex flex-col gap-1.5 border-t border-border/50 pt-3">
+              {warnings.map((warning) => (
+                <label
+                  key={warning.id}
+                  className="flex items-start gap-2 text-xs text-muted-foreground"
+                >
+                  {warning.requiresAcknowledgement ? (
+                    <input
+                      type="checkbox"
+                      checked={acknowledgedWarningIds.has(warning.id)}
+                      onChange={(event) => onToggleWarning?.(warning.id, event.target.checked)}
+                      className="mt-0.5"
+                    />
+                  ) : (
+                    <span className="mt-1 size-1.5 shrink-0 rounded-full bg-amber-500" />
+                  )}
+                  <span className="min-w-0">
+                    <span className="font-medium text-foreground">{warning.title}</span>
+                    <span className="block">{warning.detail}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          ) : null}
+          {fastIntervalLimitMessage ? (
+            <div className="mt-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-2 text-xs text-amber-700 dark:text-amber-300">
+              {fastIntervalLimitMessage}
+            </div>
+          ) : null}
+        </div>
 
         <div className="flex flex-wrap items-center gap-2 px-4 pb-4 pt-1">
           <div className="flex flex-1 flex-wrap items-center gap-0.5">
@@ -1236,7 +841,7 @@ export function AutomationDialog({
                 <MenuTrigger render={<Button variant="ghost" size="sm" className={CHIP_CLASS} />}>
                   <WorktreeIcon className="size-4" />
                   <span className="capitalize">{form.worktreeMode}</span>
-                  <ChevronDownIcon className="size-3.5 opacity-60" />
+                  <CentralIcon name="chevron-down-small" className="size-3.5 opacity-60" />
                 </MenuTrigger>
                 <ComposerPickerMenuPopup align="start" className="w-40">
                   <MenuRadioGroup
@@ -1257,11 +862,11 @@ export function AutomationDialog({
 
             <Menu>
               <MenuTrigger render={<Button variant="ghost" size="sm" className={CHIP_CLASS} />}>
-                <FolderIcon className="size-4" />
+                <CentralIcon name="folder-2" className="size-4" />
                 <span className="max-w-[10rem] truncate">
                   {selectedProject?.name ?? "Select project"}
                 </span>
-                <ChevronDownIcon className="size-3.5 opacity-60" />
+                <CentralIcon name="chevron-down-small" className="size-3.5 opacity-60" />
               </MenuTrigger>
               <ComposerPickerMenuPopup align="start" className="w-56">
                 <MenuRadioGroup value={form.projectId} onValueChange={chooseProject}>
@@ -1282,9 +887,9 @@ export function AutomationDialog({
 
             <Menu>
               <MenuTrigger render={<Button variant="ghost" size="sm" className={CHIP_CLASS} />}>
-                <ClockIcon className="size-4" />
+                <CentralIcon name="clock" className="size-4" />
                 <span>{formatCadence(schedule)}</span>
-                <ChevronDownIcon className="size-3.5 opacity-60" />
+                <CentralIcon name="chevron-down-small" className="size-3.5 opacity-60" />
               </MenuTrigger>
               <ComposerPickerMenuPopup align="start" className="w-56">
                 <MenuGroup>
@@ -1487,20 +1092,6 @@ export function AutomationDialog({
                       </div>
                     </MenuGroup>
                     <MenuSeparator />
-                    <MenuGroup>
-                      <MenuGroupLabel>Max iterations</MenuGroupLabel>
-                      <MenuRadioGroup
-                        value={form.maxIterations}
-                        onValueChange={(value) => setField("maxIterations", value)}
-                      >
-                        {MAX_ITERATION_PRESETS.map((preset) => (
-                          <MenuRadioItem key={preset.value || "unlimited"} value={preset.value}>
-                            {preset.label}
-                          </MenuRadioItem>
-                        ))}
-                      </MenuRadioGroup>
-                    </MenuGroup>
-                    <MenuSeparator />
                     <MenuCheckboxItem
                       checked={form.stopOnError}
                       onCheckedChange={(checked) => setField("stopOnError", checked)}
@@ -1509,6 +1100,20 @@ export function AutomationDialog({
                     </MenuCheckboxItem>
                   </>
                 ) : null}
+                <MenuSeparator />
+                <MenuGroup>
+                  <MenuGroupLabel>Max iterations</MenuGroupLabel>
+                  <MenuRadioGroup
+                    value={form.maxIterations}
+                    onValueChange={(value) => setField("maxIterations", value)}
+                  >
+                    {maxIterationPresets.map((preset) => (
+                      <MenuRadioItem key={preset.value || "unlimited"} value={preset.value}>
+                        {preset.label}
+                      </MenuRadioItem>
+                    ))}
+                  </MenuRadioGroup>
+                </MenuGroup>
               </ComposerPickerMenuPopup>
             </Menu>
 
@@ -1524,7 +1129,7 @@ export function AutomationDialog({
                   />
                 }
               >
-                <BrainIcon className="size-4" />
+                <CentralIcon name="brain" className="size-4" />
               </MenuTrigger>
               <ComposerPickerMenuPopup align="start" className="w-48">
                 <MenuRadioGroup

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -3,13 +3,19 @@ import {
   type AutomationRun,
   type AutomationUpdateInput,
   type AutomationWorktreeMode,
+  type ModelSelection,
+  type ProviderOptionDescriptor,
 } from "@t3tools/contracts";
+import {
+  getModelCapabilities,
+  getProviderOptionCurrentValue,
+  getProviderOptionDescriptors,
+} from "@t3tools/shared/model";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
 
 import { getProviderStartOptions, useAppSettings } from "~/appSettings";
 import {
-  CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME,
   CHAT_SURFACE_HEADER_HEIGHT_CLASS,
   CHAT_SURFACE_HEADER_PADDING_X_CLASS,
 } from "~/components/chat/chatHeaderControls";
@@ -35,8 +41,15 @@ import {
   useDesktopTopBarTrafficLightGutterClassName,
   useDesktopTopBarWindowControlsGutterClassName,
 } from "~/hooks/useDesktopTopBarGutter";
-import { ChevronDownIcon, PencilIcon, PlayIcon, StopFilledIcon, Trash2 } from "~/lib/icons";
+import { CentralIcon } from "~/lib/central-icons";
+import { PencilIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
+import {
+  buildModelSelection,
+  buildNextProviderOptions,
+  buildProviderOptionPatch,
+  type ProviderOptions,
+} from "~/providerModelOptions";
 import { ensureNativeApi } from "~/nativeApi";
 import { useStore } from "~/store";
 import {
@@ -47,17 +60,17 @@ import {
   buildAutomationFormWarnings,
   canCancelAutomationRun,
   datetimeLocalFromIso,
-  formatDateTime,
   formatRelativeTime,
   formFromDefinition,
   isoFromDatetimeLocal,
   isTriageRun,
   isFormSubmittable,
+  maxIterationOptions,
   providerOptionsForAutomationEdit,
   providerOptionsForAutomationModelSelection,
-  runStatusVariant,
   runResultSummary,
   runStatusLabel,
+  RunStatusIndicator,
   SCHEDULE_KIND_OPTIONS,
   scheduleFromKind,
   scheduleKindFromSchedule,
@@ -75,6 +88,32 @@ export const Route = createFileRoute("/_chat/automations/$automationId")({
 
 function lastFinishedRun(runs: readonly AutomationRun[]): AutomationRun | null {
   return runs.find((run) => run.finishedAt != null || run.startedAt != null) ?? null;
+}
+
+function startOfDay(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+// Reference-style absolute timestamp: "Today at 09:00", "Tomorrow at 12:30", "5 May 2026, 09:05".
+function formatRunTimestamp(value: string | null): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+  const dayDelta = Math.round((startOfDay(date) - startOfDay(new Date())) / 86_400_000);
+  if (dayDelta === 0) return `Today at ${time}`;
+  if (dayDelta === 1) return `Tomorrow at ${time}`;
+  if (dayDelta === -1) return `Yesterday at ${time}`;
+  return new Intl.DateTimeFormat(undefined, {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
 }
 
 type SelectOption = { readonly value: string; readonly label: string };
@@ -95,21 +134,13 @@ const INTERVAL_PRESETS: readonly SelectOption[] = [
   { value: "86400", label: "Every 24 hours" },
 ];
 
-const MAX_ITERATION_OPTIONS: readonly SelectOption[] = [
-  { value: "", label: "Unlimited" },
-  { value: "10", label: "10 runs" },
-  { value: "25", label: "25 runs" },
-  { value: "50", label: "50 runs" },
-  { value: "100", label: "100 runs" },
-  { value: "250", label: "250 runs" },
-];
-
 function intervalOptions(current: number): readonly SelectOption[] {
   if (INTERVAL_PRESETS.some((option) => option.value === String(current))) {
     return INTERVAL_PRESETS;
   }
-  const minutes = Math.max(1, Math.round(current / 60));
-  return [{ value: String(current), label: `Every ${minutes} min` }, ...INTERVAL_PRESETS];
+  const label =
+    current >= 60 && current % 60 === 0 ? `Every ${current / 60} min` : `Every ${current} sec`;
+  return [{ value: String(current), label }, ...INTERVAL_PRESETS];
 }
 
 function AutomationDetailView() {
@@ -137,7 +168,9 @@ function AutomationDetailView() {
     markRunReadMutation,
     archiveRunMutation,
     runsByAutomationId,
-  } = useAutomations((threadId) => void navigate({ to: "/$threadId", params: { threadId } }));
+    // Running an automation keeps the user on this info page; the live run surfaces in
+    // "Previous runs" (click a run there to open its thread), matching the reference UX.
+  } = useAutomations();
 
   const definition = data.definitions.find((candidate) => candidate.id === automationId) ?? null;
   const runs = useMemo(
@@ -160,7 +193,6 @@ function AutomationDetailView() {
         >
           <header
             className={cn(
-              CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME,
               CHAT_SURFACE_HEADER_PADDING_X_CLASS,
               "drag-region",
               desktopTopBarTrafficLightGutterClassName,
@@ -171,7 +203,7 @@ function AutomationDetailView() {
               className={cn("flex items-center gap-2 sm:gap-3", CHAT_SURFACE_HEADER_HEIGHT_CLASS)}
             >
               <SidebarHeaderNavigationControls />
-              <h1 className="truncate font-heading text-sm font-semibold">Automations</h1>
+              <h1 className="truncate font-heading text-sm font-medium">Automations</h1>
             </div>
           </header>
           <main className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
@@ -192,12 +224,29 @@ function AutomationDetailView() {
 
   const project = projects.find((candidate) => candidate.id === definition.projectId);
   const targetThread = threads.find((candidate) => candidate.id === definition.targetThreadId);
+  const sourceThread = definition.sourceThreadId
+    ? threads.find((candidate) => candidate.id === definition.sourceThreadId)
+    : null;
   const lastRun = lastFinishedRun(runs);
   const schedule = definition.schedule;
-  const stopWhen = stopWhenFromCompletionPolicy(definition.completionPolicy);
+  const stopWhen = stopWhenFromCompletionPolicy(definition.completionPolicy ?? { type: "none" });
 
   const patch = (input: Omit<AutomationUpdateInput, "id">) =>
     updateMutation.mutate({ id: definition.id, ...input });
+
+  // Applying a new model selection (model swap or a capability tweak) refreshes the saved
+  // provider start options the same way the model picker does, then patches both at once.
+  const applyModelSelection = (nextModelSelection: ModelSelection) => {
+    const providerOptions = providerOptionsForAutomationModelSelection(
+      definition,
+      nextModelSelection,
+      providerOptionsForDispatch,
+    );
+    patch({
+      modelSelection: nextModelSelection,
+      ...(providerOptions ? { providerOptions } : {}),
+    });
+  };
 
   const openEditDialog = (overrides: Partial<AutomationFormState> = {}) => {
     const nextForm = {
@@ -266,94 +315,141 @@ function AutomationDetailView() {
     >
       <div
         className={cn(
-          "flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden",
+          "flex min-h-0 min-w-0 flex-1 flex-row overflow-hidden",
           CHAT_BACKGROUND_CLASS_NAME,
         )}
       >
-        <header
-          className={cn(
-            CHAT_SURFACE_HEADER_DIVIDER_CLASS_NAME,
-            CHAT_SURFACE_HEADER_PADDING_X_CLASS,
-            "drag-region",
-            desktopTopBarTrafficLightGutterClassName,
-            desktopTopBarWindowControlsGutterClassName,
-          )}
-        >
-          <div className={cn("flex items-center gap-2 sm:gap-3", CHAT_SURFACE_HEADER_HEIGHT_CLASS)}>
-            <SidebarHeaderNavigationControls />
-            <div className="flex min-w-0 flex-1 items-center gap-1.5 text-sm [-webkit-app-region:no-drag]">
-              <button
-                type="button"
-                onClick={() => void navigate({ to: "/automations" })}
-                className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-              >
-                Automations
-              </button>
-              <span className="shrink-0 text-muted-foreground">/</span>
-              <span className="truncate font-heading font-semibold">{definition.name}</span>
+        {/* Left column: breadcrumb header + the prompt. */}
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          <header
+            className={cn(
+              CHAT_SURFACE_HEADER_PADDING_X_CLASS,
+              "drag-region",
+              desktopTopBarTrafficLightGutterClassName,
+            )}
+          >
+            <div
+              className={cn("flex items-center gap-2 sm:gap-3", CHAT_SURFACE_HEADER_HEIGHT_CLASS)}
+            >
+              <SidebarHeaderNavigationControls />
+              <div className="flex min-w-0 flex-1 items-center gap-1.5 text-sm [-webkit-app-region:no-drag]">
+                <button
+                  type="button"
+                  onClick={() => void navigate({ to: "/automations" })}
+                  className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  Automations
+                </button>
+                <span className="shrink-0 text-muted-foreground">/</span>
+                <span className="truncate font-heading font-medium">{definition.name}</span>
+              </div>
             </div>
-            <div className="flex shrink-0 items-center gap-2 [-webkit-app-region:no-drag]">
-              <Button type="button" size="sm" variant="ghost" onClick={togglePause}>
-                {definition.enabled ? "Pause" : "Resume"}
-              </Button>
-              <Button
-                type="button"
-                size="icon-sm"
-                variant="ghost"
-                aria-label="Edit"
-                onClick={() => openEditDialog()}
-              >
-                <PencilIcon className="size-4" />
-              </Button>
-              <Button
-                type="button"
-                size="icon-sm"
-                variant="ghost"
-                aria-label="Delete"
-                onClick={() => void deleteDefinition()}
-              >
-                <Trash2 className="size-4" />
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                disabled={runNowMutation.isPending}
-                onClick={() => runNowMutation.mutate(definition)}
-              >
-                <PlayIcon className="size-4" />
-                Run now
-              </Button>
-            </div>
-          </div>
-        </header>
+          </header>
 
-        <main className="min-h-0 flex-1 overflow-y-auto">
-          <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-8 md:flex-row">
-            <div className="min-w-0 flex-1 space-y-3">
-              <h1 className="font-heading text-xl font-semibold tracking-tight">
+          <main className="min-h-0 flex-1 overflow-y-auto px-6 py-8 sm:px-8">
+            <div className="max-w-3xl space-y-4">
+              <h1 className="font-heading text-2xl font-normal text-foreground">
                 {definition.name}
               </h1>
-              <p className="max-w-2xl whitespace-pre-wrap text-sm leading-relaxed text-foreground/80">
+              <p className="whitespace-pre-wrap text-[0.9375rem] leading-relaxed text-muted-foreground">
                 {definition.prompt}
               </p>
             </div>
+          </main>
+        </div>
 
-            <aside className="flex w-full shrink-0 flex-col gap-6 md:w-72">
+        {/* Right column: action header + details panel. The left border is the divider, so the
+            line runs continuously down through both the header and the panel below. */}
+        <div className="flex min-h-0 w-72 shrink-0 flex-col overflow-hidden border-l border-[var(--app-surface-divider)]">
+          <header
+            className={cn(
+              CHAT_SURFACE_HEADER_PADDING_X_CLASS,
+              "drag-region",
+              desktopTopBarWindowControlsGutterClassName,
+            )}
+          >
+            <div
+              className={cn(
+                "flex items-center justify-end gap-2 sm:gap-3",
+                CHAT_SURFACE_HEADER_HEIGHT_CLASS,
+              )}
+            >
+              <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label={definition.enabled ? "Pause" : "Resume"}
+                  title={definition.enabled ? "Pause" : "Resume"}
+                  onClick={togglePause}
+                >
+                  <CentralIcon name={definition.enabled ? "pause" : "play"} className="size-4" />
+                </Button>
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label="Edit"
+                  title="Edit"
+                  onClick={() => openEditDialog()}
+                >
+                  <PencilIcon className="size-4" />
+                </Button>
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  aria-label="Delete"
+                  title="Delete"
+                  onClick={() => void deleteDefinition()}
+                >
+                  <CentralIcon name="trash-can-simple" className="size-4" />
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  className="ml-1.5"
+                  disabled={runNowMutation.isPending}
+                  onClick={() => runNowMutation.mutate(definition)}
+                >
+                  <CentralIcon name="play" className="size-4" />
+                  Run now
+                </Button>
+              </div>
+            </div>
+          </header>
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="flex flex-col gap-6 py-8 pl-4">
               <DetailGroup title="Status">
                 <DetailRow label="Status">
-                  <span className="inline-flex items-center gap-1.5">
+                  <StatusValue>
                     <span
                       className={cn(
-                        "size-2 rounded-full",
-                        definition.enabled ? "bg-emerald-500" : "bg-muted-foreground/40",
+                        "size-1.5 rounded-full",
+                        definition.enabled ? "bg-emerald-500" : "bg-amber-500",
                       )}
                     />
                     {definition.enabled ? "Active" : "Paused"}
-                  </span>
+                  </StatusValue>
                 </DetailRow>
-                <DetailRow label="Next run">{formatDateTime(definition.nextRunAt)}</DetailRow>
+                <DetailRow label="Next run">
+                  {definition.enabled && definition.nextRunAt ? (
+                    <StatusValue tone="muted">
+                      {formatRunTimestamp(definition.nextRunAt)}
+                    </StatusValue>
+                  ) : (
+                    "—"
+                  )}
+                </DetailRow>
                 <DetailRow label="Last ran">
-                  {lastRun ? formatDateTime(lastRun.finishedAt ?? lastRun.startedAt) : "Never"}
+                  {lastRun ? (
+                    <StatusValue tone="muted">
+                      {formatRunTimestamp(lastRun.finishedAt ?? lastRun.startedAt)}
+                    </StatusValue>
+                  ) : (
+                    "—"
+                  )}
                 </DetailRow>
               </DetailGroup>
 
@@ -361,7 +457,18 @@ function AutomationDetailView() {
                 {definition.mode === "heartbeat" ? (
                   <DetailRow label="Runs in">Thread</DetailRow>
                 ) : (
-                  <EditRow label="Runs in">
+                  <EditRow
+                    label={
+                      <>
+                        Runs in
+                        <CentralIcon
+                          name="info-simple"
+                          className="size-3 text-muted-foreground/60"
+                          aria-label="Where the automation runs: a worktree, a local checkout, or auto"
+                        />
+                      </>
+                    }
+                  >
                     <InlineSelect
                       value={definition.worktreeMode}
                       options={WORKTREE_OPTIONS}
@@ -391,6 +498,26 @@ function AutomationDetailView() {
                     />
                   </EditRow>
                 )}
+                {definition.sourceThreadId ? (
+                  <DetailRow label="Created from">
+                    {sourceThread ? (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          void navigate({
+                            to: "/$threadId",
+                            params: { threadId: sourceThread.id },
+                          })
+                        }
+                        className="min-w-0 truncate text-right text-foreground transition-colors hover:text-primary"
+                      >
+                        {resolveThreadPickerTitle(sourceThread.title)}
+                      </button>
+                    ) : (
+                      "Thread unavailable"
+                    )}
+                  </DetailRow>
+                ) : null}
                 <EditRow label="Repeats">
                   <InlineSelect
                     value={scheduleKindFromSchedule(schedule)}
@@ -510,19 +637,13 @@ function AutomationDetailView() {
                   <AutomationModelPicker
                     value={definition.modelSelection}
                     projectCwd={project?.cwd ?? null}
-                    onChange={(value) => {
-                      const providerOptions = providerOptionsForAutomationModelSelection(
-                        definition,
-                        value,
-                        providerOptionsForDispatch,
-                      );
-                      patch({
-                        modelSelection: value,
-                        ...(providerOptions ? { providerOptions } : {}),
-                      });
-                    }}
+                    onChange={applyModelSelection}
                   />
                 </EditRow>
+                <ModelOptionRows
+                  modelSelection={definition.modelSelection}
+                  onChange={applyModelSelection}
+                />
                 <DetailRow label="Mode">
                   {definition.mode === "heartbeat" ? "Heartbeat" : "Standalone"}
                 </DetailRow>
@@ -539,31 +660,29 @@ function AutomationDetailView() {
                     />
                   </EditRow>
                 ) : null}
+                <EditRow label="Max iterations">
+                  <InlineSelect
+                    value={definition.maxIterations == null ? "" : String(definition.maxIterations)}
+                    options={maxIterationOptions(definition.maxIterations)}
+                    onChange={(value) =>
+                      patch({ maxIterations: value === "" ? null : Number.parseInt(value, 10) })
+                    }
+                  />
+                </EditRow>
                 {definition.mode === "heartbeat" ? (
-                  <EditRow label="Max iterations">
-                    <InlineSelect
-                      value={
-                        definition.maxIterations == null ? "" : String(definition.maxIterations)
-                      }
-                      options={MAX_ITERATION_OPTIONS}
-                      onChange={(value) =>
-                        patch({ maxIterations: value === "" ? null : Number.parseInt(value, 10) })
-                      }
-                    />
-                  </EditRow>
-                ) : null}
-                {definition.mode === "heartbeat" && targetThread ? (
                   <DetailRow label="Thread">
-                    {resolveThreadPickerTitle(targetThread.title)}
+                    {targetThread
+                      ? resolveThreadPickerTitle(targetThread.title)
+                      : "Thread unavailable"}
                   </DetailRow>
                 ) : null}
               </DetailGroup>
 
               <DetailGroup title="Previous runs">
                 {runs.length === 0 ? (
-                  <div className="px-1 text-xs text-muted-foreground">No runs yet.</div>
+                  <div className="px-1.5 py-1 text-xs text-muted-foreground">No runs yet.</div>
                 ) : (
-                  <div className="flex flex-col gap-1">
+                  <div className="flex flex-col gap-0.5">
                     {runs.map((run) => (
                       <RunRow
                         key={run.id}
@@ -579,9 +698,9 @@ function AutomationDetailView() {
                   </div>
                 )}
               </DetailGroup>
-            </aside>
+            </div>
           </div>
-        </main>
+        </div>
       </div>
 
       {form ? (
@@ -612,11 +731,9 @@ function DetailGroup({
   readonly children: React.ReactNode;
 }) {
   return (
-    <section className="space-y-1.5">
-      <h2 className="px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        {title}
-      </h2>
-      <div className="rounded-lg border border-border">{children}</div>
+    <section className="space-y-0.5">
+      <h2 className="px-1.5 pb-1 text-xs font-medium text-muted-foreground/70">{title}</h2>
+      <div className="flex flex-col">{children}</div>
     </section>
   );
 }
@@ -625,14 +742,35 @@ function DetailRow({
   label,
   children,
 }: {
-  readonly label: string;
+  readonly label: React.ReactNode;
   readonly children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 border-b border-border/60 px-3 py-2 text-xs last:border-b-0">
-      <span className="shrink-0 text-muted-foreground">{label}</span>
-      <span className="min-w-0 truncate text-right font-medium text-foreground">{children}</span>
+    <div className="flex items-center justify-between gap-3 rounded-md px-1.5 py-1.5 text-xs">
+      <span className="flex shrink-0 items-center gap-1 text-muted-foreground">{label}</span>
+      <span className="min-w-0 truncate text-right text-foreground">{children}</span>
     </div>
+  );
+}
+
+// Subtle pill used by the read-only Status group values (Active/Next run/Last ran), echoing
+// the reference layout where those values sit in quiet rounded chips flush to the right.
+function StatusValue({
+  tone = "default",
+  children,
+}: {
+  readonly tone?: "default" | "muted";
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md bg-foreground/[0.05] px-2 py-0.5",
+        tone === "muted" ? "text-muted-foreground" : "text-foreground",
+      )}
+    >
+      {children}
+    </span>
   );
 }
 
@@ -640,19 +778,19 @@ function EditRow({
   label,
   children,
 }: {
-  readonly label: string;
+  readonly label: React.ReactNode;
   readonly children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between gap-2 border-b border-border/60 py-px pl-3 pr-1.5 text-xs transition-colors last:border-b-0 hover:bg-foreground/[0.03]">
-      <span className="shrink-0 text-muted-foreground">{label}</span>
+    <div className="flex items-center justify-between gap-2 rounded-md py-px pl-1.5 pr-0.5 text-xs transition-colors hover:bg-foreground/[0.04]">
+      <span className="flex shrink-0 items-center gap-1 text-muted-foreground">{label}</span>
       {children}
     </div>
   );
 }
 
 const INLINE_CONTROL_CLASS =
-  "cursor-pointer rounded-md bg-transparent px-2 py-1.5 text-right text-xs font-medium text-foreground outline-none transition-colors focus-visible:ring-1 focus-visible:ring-ring";
+  "cursor-pointer rounded-md bg-transparent px-2 py-1.5 text-right text-xs text-foreground outline-none transition-colors focus-visible:ring-1 focus-visible:ring-ring";
 
 function InlineSelect({
   value,
@@ -668,7 +806,7 @@ function InlineSelect({
       <select
         value={value}
         onChange={(event) => onChange(event.target.value)}
-        className={cn(INLINE_CONTROL_CLASS, "max-w-[12rem] appearance-none truncate pr-6")}
+        className={cn(INLINE_CONTROL_CLASS, "max-w-[11rem] appearance-none truncate pr-5")}
       >
         {options.map((option) => (
           <option key={option.value} value={option.value}>
@@ -676,8 +814,95 @@ function InlineSelect({
           </option>
         ))}
       </select>
-      <ChevronDownIcon className="pointer-events-none absolute right-1.5 size-3 text-muted-foreground" />
+      <CentralIcon
+        name="chevron-down-small"
+        className="pointer-events-none absolute right-1 size-3 text-muted-foreground"
+      />
     </div>
+  );
+}
+
+function InlineToggle({
+  value,
+  onChange,
+}: {
+  readonly value: boolean;
+  readonly onChange: (value: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!value)}
+      className={cn(INLINE_CONTROL_CLASS, "min-w-[3rem]")}
+    >
+      {value ? "On" : "Off"}
+    </button>
+  );
+}
+
+/**
+ * Inline edit rows for the selected model's capabilities — reasoning effort, fast mode,
+ * thinking, context window, etc. The knobs are derived from the provider's capability
+ * descriptors, so each provider surfaces exactly the controls it supports (and none when it
+ * supports nothing). Changing a value reuses the same model-selection patch path as the
+ * model picker, keeping provider start options in sync.
+ */
+function ModelOptionRows({
+  modelSelection,
+  onChange,
+}: {
+  readonly modelSelection: ModelSelection;
+  readonly onChange: (next: ModelSelection) => void;
+}) {
+  const { provider, model } = modelSelection;
+  const caps = getModelCapabilities(provider, model);
+  const descriptors = getProviderOptionDescriptors({
+    provider,
+    caps,
+    selections: modelSelection.options as Record<string, unknown> | undefined,
+  });
+  if (descriptors.length === 0) {
+    return null;
+  }
+
+  const setOption = (descriptor: ProviderOptionDescriptor, value: string | boolean) => {
+    const optionPatch = buildProviderOptionPatch(provider, descriptor.id, value);
+    const nextOptions = buildNextProviderOptions(
+      provider,
+      modelSelection.options as ProviderOptions | undefined,
+      optionPatch,
+    );
+    onChange(buildModelSelection(provider, model, nextOptions));
+  };
+
+  return (
+    <>
+      {descriptors.map((descriptor) => {
+        if (descriptor.type === "boolean") {
+          return (
+            <EditRow key={descriptor.id} label={descriptor.label}>
+              <InlineToggle
+                value={getProviderOptionCurrentValue(descriptor) === true}
+                onChange={(checked) => setOption(descriptor, checked)}
+              />
+            </EditRow>
+          );
+        }
+        const current = getProviderOptionCurrentValue(descriptor);
+        return (
+          <EditRow key={descriptor.id} label={descriptor.label}>
+            <InlineSelect
+              value={typeof current === "string" ? current : ""}
+              options={descriptor.options.map((option) => ({
+                value: option.id,
+                label: option.label,
+              }))}
+              onChange={(value) => setOption(descriptor, value)}
+            />
+          </EditRow>
+        );
+      })}
+    </>
   );
 }
 
@@ -741,6 +966,13 @@ function InlineCommitTextInput({
   );
 }
 
+function isInlineRunActionEventTarget(target: EventTarget | null, currentTarget: HTMLElement) {
+  if (!(target instanceof HTMLElement) || target === currentTarget) {
+    return false;
+  }
+  return Boolean(target.closest("button,a,input,textarea,select,[contenteditable='true']"));
+}
+
 function RunRow({
   run,
   onOpen,
@@ -754,53 +986,74 @@ function RunRow({
   readonly onMarkRead: (unread: boolean) => void;
   readonly onArchive: (archived: boolean) => void;
 }) {
-  const variant = runStatusVariant(run.status);
-  const dotClass =
-    variant === "success"
-      ? "text-emerald-500"
-      : variant === "error"
-        ? "text-destructive"
-        : variant === "warning"
-          ? "text-amber-500"
-          : variant === "info"
-            ? "text-blue-500"
-            : "text-muted-foreground/50";
   const active = canCancelAutomationRun(run);
   const archived = run.result?.archivedAt !== null && run.result?.archivedAt !== undefined;
   const triageActionable = run.result !== null || isTriageRun(run);
   const unread = run.result ? run.result.unread : triageActionable;
-  const worktreeLabel =
-    run.permissionSnapshot.worktreeMode === "worktree"
-      ? "Worktree kept"
-      : run.permissionSnapshot.worktreeMode === "auto"
-        ? "Auto worktree"
-        : null;
+  const openable = run.threadId != null;
+  const open = () => {
+    if (run.threadId) {
+      onOpen(run.threadId as NonNullable<AutomationRun["threadId"]>);
+    }
+  };
   return (
-    <div className="flex items-center gap-2 rounded-md px-1 py-1.5 text-xs">
-      <span className={cn("shrink-0", dotClass)}>
-        <span className="block size-2 rounded-full bg-current" />
-      </span>
+    // The whole row opens its thread (the run's chat history); inline actions stop
+    // propagation so they don't also navigate.
+    <div
+      role={openable ? "button" : undefined}
+      tabIndex={openable ? 0 : undefined}
+      onClick={openable ? open : undefined}
+      onKeyDown={
+        openable
+          ? (event) => {
+              if (isInlineRunActionEventTarget(event.target, event.currentTarget)) {
+                return;
+              }
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                open();
+              }
+            }
+          : undefined
+      }
+      className={cn(
+        "group flex items-center gap-2 rounded-md px-1.5 py-1.5 text-xs transition-colors",
+        openable ? "cursor-pointer hover:bg-foreground/[0.03]" : undefined,
+      )}
+    >
+      <RunStatusIndicator status={run.status} />
       <div className="min-w-0 flex-1 truncate">
-        <span className="font-medium text-foreground">{runStatusLabel(run.status)}</span>
-        <span className="text-muted-foreground"> • {run.trigger.type}</span>
-        <span className="text-muted-foreground"> • {runResultSummary(run)}</span>
+        <span className="text-foreground/90">{runStatusLabel(run.status)}</span>
+        <span className="text-muted-foreground"> · {runResultSummary(run)}</span>
       </div>
-      {worktreeLabel ? (
-        <span
-          className="shrink-0 text-muted-foreground"
-          title="Archiving keeps generated worktrees and branches."
-        >
-          {worktreeLabel}
-        </span>
-      ) : null}
-      {run.threadId ? (
-        <button
-          type="button"
-          onClick={() => onOpen(run.threadId as NonNullable<AutomationRun["threadId"]>)}
-          className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-        >
-          Open
-        </button>
+      {triageActionable ? (
+        <div className="flex shrink-0 items-center gap-1.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onMarkRead(!unread);
+            }}
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {unread ? "Read" : "Unread"}
+          </button>
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onArchive(!archived);
+            }}
+            title={
+              run.permissionSnapshot.worktreeMode === "local"
+                ? undefined
+                : "Archiving does not remove generated worktrees or branches."
+            }
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {archived ? "Unarchive" : "Archive"}
+          </button>
+        </div>
       ) : null}
       {active ? (
         <Button
@@ -808,35 +1061,15 @@ function RunRow({
           size="icon-chip"
           variant="ghost"
           aria-label="Cancel run"
-          onClick={onCancel}
+          onClick={(event) => {
+            event.stopPropagation();
+            onCancel();
+          }}
         >
-          <StopFilledIcon className="size-3.5" />
+          <CentralIcon name="stop" className="size-3.5" />
         </Button>
       ) : null}
-      {triageActionable ? (
-        <>
-          <button
-            type="button"
-            onClick={() => onMarkRead(!unread)}
-            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            {unread ? "Read" : "Unread"}
-          </button>
-          <button
-            type="button"
-            onClick={() => onArchive(!archived)}
-            title={
-              run.permissionSnapshot.worktreeMode === "local"
-                ? undefined
-                : "Archiving does not remove generated worktrees or branches."
-            }
-            className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            {archived ? "Unarchive" : "Archive"}
-          </button>
-        </>
-      ) : null}
-      <span className="shrink-0 text-muted-foreground">
+      <span className="shrink-0 tabular-nums text-muted-foreground">
         {formatRelativeTime(run.finishedAt ?? run.startedAt ?? run.scheduledFor)}
       </span>
     </div>

--- a/apps/web/src/routes/_chat.automations.index.tsx
+++ b/apps/web/src/routes/_chat.automations.index.tsx
@@ -1,6 +1,6 @@
 import { type AutomationDefinition, type AutomationRun } from "@t3tools/contracts";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { type ReactNode, useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 
 import { getProviderStartOptions, useAppSettings } from "~/appSettings";
 import {
@@ -25,17 +25,7 @@ import {
   useDesktopTopBarTrafficLightGutterClassName,
   useDesktopTopBarWindowControlsGutterClassName,
 } from "~/hooks/useDesktopTopBarGutter";
-import {
-  CircleAlertIcon,
-  CircleCheckIcon,
-  ClockIcon,
-  ExternalLinkIcon,
-  FolderIcon,
-  MessageCircleIcon,
-  PlayIcon,
-  PlusIcon,
-  RefreshCwIcon,
-} from "~/lib/icons";
+import { CentralIcon } from "~/lib/central-icons";
 import { cn } from "~/lib/utils";
 import { useStore } from "~/store";
 import {
@@ -43,10 +33,9 @@ import {
   AutomationDialog,
   acknowledgedRiskIdsForFormWarnings,
   allVisibleTriageRuns,
-  automationAttentionCount,
+  automationStatusDotClass,
   buildAutomationFormWarnings,
   createInputFromForm,
-  formatDateTime,
   formatCadence,
   formatRelativeTime,
   formFromDefinition,
@@ -56,7 +45,7 @@ import {
   projectModelSelection,
   runResultSummary,
   runStatusLabel,
-  runStatusVariant,
+  RunStatusIndicator,
   updateInputFromForm,
   unresolvedTriageRuns,
   useAutomations,
@@ -67,7 +56,6 @@ export const Route = createFileRoute("/_chat/automations/")({
   component: AutomationsRouteView,
 });
 
-type RowTone = "default" | "info" | "success" | "warning" | "danger" | "muted";
 type LiveAutomationRun = AutomationRun & {
   readonly status: "pending" | "claimed" | "running" | "waiting-for-approval";
 };
@@ -81,112 +69,58 @@ function isLiveRun(run: AutomationRun | null): run is LiveAutomationRun {
   );
 }
 
-function toneClasses(tone: RowTone): {
-  readonly chip: string;
-  readonly icon: string;
-  readonly dot: string;
-} {
-  switch (tone) {
-    case "info":
-      return {
-        chip: "border-blue-500/20 bg-blue-500/10 text-blue-700 dark:text-blue-300",
-        icon: "bg-blue-500/10 text-blue-600 dark:text-blue-300",
-        dot: "text-blue-500",
-      };
-    case "success":
-      return {
-        chip: "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-        icon: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-300",
-        dot: "text-emerald-500",
-      };
-    case "warning":
-      return {
-        chip: "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300",
-        icon: "bg-amber-500/10 text-amber-600 dark:text-amber-300",
-        dot: "text-amber-500",
-      };
-    case "danger":
-      return {
-        chip: "border-destructive/25 bg-destructive/10 text-destructive",
-        icon: "bg-destructive/10 text-destructive",
-        dot: "text-destructive",
-      };
-    case "muted":
-      return {
-        chip: "border-border bg-[var(--color-background-elevated-secondary)] text-muted-foreground",
-        icon: "bg-[var(--color-background-elevated-secondary)] text-muted-foreground",
-        dot: "text-muted-foreground/45",
-      };
-    case "default":
-      return {
-        chip: "border-border bg-background text-foreground",
-        icon: "bg-[var(--color-background-elevated-secondary)] text-foreground",
-        dot: "text-foreground/70",
-      };
-  }
-}
-
-function runTone(run: AutomationRun): RowTone {
-  const variant = runStatusVariant(run.status);
-  if (variant === "error") return "danger";
-  if (variant === "warning") return "warning";
-  if (variant === "info") return "info";
-  if (variant === "success") return "success";
-  return "muted";
-}
-
 function triageRunLabel(run: AutomationRun): string {
   if (run.status === "succeeded" && run.result?.unread) return "New result";
   return runStatusLabel(run.status);
 }
 
-function automationState(
-  definition: AutomationDefinition,
-  latestRun: AutomationRun | null,
-): { readonly label: string; readonly detail: string; readonly tone: RowTone } {
-  if (isLiveRun(latestRun)) {
-    return {
-      label: runStatusLabel(latestRun.status),
-      detail: `Run started ${formatRelativeTime(latestRun.startedAt ?? latestRun.scheduledFor)}`,
-      tone: latestRun.status === "waiting-for-approval" ? "warning" : "info",
-    };
-  }
-  if (latestRun && isTriageRun(latestRun)) {
-    return {
-      label: latestRun.status === "succeeded" ? "New result" : runStatusLabel(latestRun.status),
-      detail: runResultSummary(latestRun),
-      tone: runTone(latestRun),
-    };
-  }
-  if (
-    !definition.enabled &&
-    definition.schedule.type === "once" &&
-    latestRun?.status === "succeeded"
-  ) {
-    return {
-      label: "Finished",
-      detail: "One-time automation completed",
-      tone: "success",
-    };
-  }
-  if (!definition.enabled) {
-    return {
-      label: "Paused",
-      detail: "Will not run again until resumed",
-      tone: "muted",
-    };
-  }
-  return {
-    label: "Scheduled",
-    detail: definition.nextRunAt
-      ? `Next ${formatDateTime(definition.nextRunAt)}`
-      : "Waiting for schedule",
-    tone: "default",
-  };
+/**
+ * Minimal list row shared by the automation sections and the triage list: a leading
+ * status glyph, a title, a muted detail that fills the row, and optional right-aligned
+ * meta plus a trailing affordance.
+ */
+function AutomationListRow({
+  onClick,
+  leading,
+  title,
+  detail,
+  meta,
+  trailing,
+}: {
+  readonly onClick: () => void;
+  readonly leading: ReactNode;
+  readonly title: string;
+  readonly detail: string;
+  readonly meta?: ReactNode;
+  readonly trailing?: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors hover:bg-[var(--color-background-elevated-secondary)]"
+    >
+      {leading}
+      <span className="min-w-0 max-w-[45%] truncate text-[0.8125rem] text-foreground">{title}</span>
+      <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">{detail}</span>
+      {meta == null ? null : (
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">{meta}</span>
+      )}
+      {trailing}
+    </button>
+  );
 }
 
-function joinedParts(parts: readonly (string | null | undefined)[]): string {
-  return parts.filter((part): part is string => Boolean(part)).join(" • ");
+/** Right-aligned meta for an automation row: live status, triage outcome, cadence, or "Paused". */
+function rowMeta(definition: AutomationDefinition, latestRun: AutomationRun | null): string {
+  if (isLiveRun(latestRun)) return runStatusLabel(latestRun.status);
+  if (latestRun && isTriageRun(latestRun)) return triageRunLabel(latestRun);
+  if (!definition.enabled) {
+    return definition.schedule.type === "once" && latestRun?.status === "succeeded"
+      ? "Done"
+      : "Paused";
+  }
+  return formatCadence(definition.schedule);
 }
 
 function AutomationsRouteView() {
@@ -273,112 +207,111 @@ function AutomationsRouteView() {
   const inactive = data.definitions.filter((definition) => !definition.enabled);
   const allTriageRuns = allVisibleTriageRuns(data.runs);
   const triageRuns = triageFilter === "unread" ? unresolvedTriageRuns(data.runs) : allTriageRuns;
-  const unreadTriageCount = automationAttentionCount(data.runs);
+  const unreadTriageCount = unresolvedTriageRuns(data.runs).length;
 
   const projectName = (definition: AutomationDefinition) =>
     projects.find((project) => project.id === definition.projectId)?.name ?? "Unknown project";
 
+  const sourceSuffix = (definition: AutomationDefinition) => {
+    if (!definition.sourceThreadId || definition.sourceThreadId === definition.targetThreadId) {
+      return "";
+    }
+    const sourceThread = threads.find((candidate) => candidate.id === definition.sourceThreadId);
+    return sourceThread ? ` · From ${resolveThreadPickerTitle(sourceThread.title)}` : "";
+  };
+
   const subtitle = (definition: AutomationDefinition) => {
+    const suffix = sourceSuffix(definition);
     if (definition.mode === "heartbeat") {
       const thread = threads.find((candidate) => candidate.id === definition.targetThreadId);
       const target = thread ? resolveThreadPickerTitle(thread.title) : projectName(definition);
-      return `Heartbeat • ${target}`;
+      return `Heartbeat · ${target}${suffix}`;
     }
-    return projectName(definition);
+    return `${projectName(definition)}${suffix}`;
   };
 
   const renderRow = (definition: AutomationDefinition) => {
     const latestRun: AutomationRun | null = runsByAutomationId.get(definition.id)?.[0] ?? null;
-    const state = automationState(definition, latestRun);
-    const classes = toneClasses(state.tone);
-    const lastRunTime = latestRun
-      ? formatRelativeTime(latestRun.finishedAt ?? latestRun.startedAt ?? latestRun.scheduledFor)
-      : null;
-    const detailLine = joinedParts([
-      subtitle(definition),
-      state.detail,
-      latestRun ? `Last result: ${runResultSummary(latestRun)}` : null,
-    ]);
     return (
-      <button
+      <AutomationListRow
         key={definition.id}
-        type="button"
         onClick={() =>
           void navigate({
             to: "/automations/$automationId",
             params: { automationId: definition.id },
           })
         }
-        className="group flex w-full items-center gap-3 rounded-lg px-3 py-3 text-left transition-colors hover:bg-[var(--color-background-elevated-secondary)]"
-      >
-        <span
-          className={cn(
-            "flex size-8 shrink-0 items-center justify-center rounded-md",
-            classes.icon,
-          )}
-        >
-          {isLiveRun(latestRun) ? (
-            <PlayIcon className="size-4" />
-          ) : state.label === "Finished" ? (
-            <CircleCheckIcon className="size-4" />
-          ) : state.tone === "danger" || state.tone === "warning" ? (
-            <CircleAlertIcon className="size-4" />
-          ) : definition.mode === "heartbeat" ? (
-            <MessageCircleIcon className="size-4" />
-          ) : (
-            <ClockIcon className="size-4" />
-          )}
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 items-center gap-2">
-            <span className="truncate text-sm font-medium text-foreground">{definition.name}</span>
-            <span
-              className={cn(
-                "inline-flex shrink-0 items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] font-medium",
-                classes.chip,
-              )}
-            >
-              <span className={cn("size-1.5 rounded-full bg-current", classes.dot)} />
-              {state.label}
-            </span>
-          </div>
-          <div className="mt-1 truncate text-xs text-muted-foreground">{detailLine}</div>
-        </div>
-        <div className="flex shrink-0 flex-col items-end gap-1 text-right">
-          <span className="text-xs font-medium text-foreground">
-            {definition.enabled ? formatCadence(definition.schedule) : state.label}
+        leading={
+          <span
+            className={cn(
+              "flex size-3.5 shrink-0 items-center justify-center",
+              automationStatusDotClass(definition, latestRun),
+            )}
+          >
+            <span className="block size-1.5 rounded-full bg-current" />
           </span>
-          <span className="text-[11px] text-muted-foreground tabular-nums">
-            {lastRunTime ?? "No runs"}
-          </span>
-        </div>
-      </button>
+        }
+        title={definition.name}
+        detail={subtitle(definition)}
+        meta={rowMeta(definition, latestRun)}
+      />
     );
   };
 
   const renderSection = (title: string, defs: readonly AutomationDefinition[]) =>
     defs.length > 0 ? (
-      <section className="flex flex-col gap-2">
-        <div className="border-b border-border/60 px-3 pb-2">
-          <SectionHeading count={defs.length}>{title}</SectionHeading>
-        </div>
-        <div className="flex flex-col divide-y divide-border/50">{defs.map(renderRow)}</div>
+      <section className="flex flex-col gap-0.5">
+        <h2 className="px-2 pb-1 text-sm font-medium text-foreground">{title}</h2>
+        <div className="flex flex-col">{defs.map(renderRow)}</div>
       </section>
     ) : null;
 
+  const renderTriageRow = (run: AutomationRun) => {
+    const definition = data.definitions.find((entry) => entry.id === run.automationId);
+    const summary = runResultSummary(run);
+    const target = definition ? subtitle(definition) : "Saved run";
+    return (
+      <AutomationListRow
+        key={run.id}
+        // A run row opens its automation; the run's thread is opened from inside the
+        // automation detail's "Previous runs" sidebar (orphan runs fall back to the thread).
+        onClick={() =>
+          definition
+            ? void navigate({
+                to: "/automations/$automationId",
+                params: { automationId: definition.id },
+              })
+            : run.threadId
+              ? void navigate({ to: "/$threadId", params: { threadId: run.threadId } })
+              : undefined
+        }
+        leading={<RunStatusIndicator status={run.status} />}
+        title={definition?.name ?? "Automation run"}
+        detail={summary || target}
+        meta={formatRelativeTime(run.finishedAt ?? run.startedAt ?? run.scheduledFor)}
+        trailing={
+          <CentralIcon
+            name="chevron-right-small"
+            className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+          />
+        }
+      />
+    );
+  };
+
   const renderTriage = () =>
     allTriageRuns.length > 0 ? (
-      <section className="flex flex-col gap-2">
-        <div className="flex items-center justify-between gap-3 border-b border-border/60 px-3 pb-2">
-          <SectionHeading count={triageRuns.length}>Needs review</SectionHeading>
-          <div className="flex items-center gap-1 rounded-md bg-[var(--color-background-elevated-secondary)] p-0.5 text-xs">
+      <section className="flex flex-col gap-0.5">
+        <div className="flex items-center justify-between gap-3 px-2 pb-1">
+          <h2 className="text-sm font-medium text-foreground">Needs review</h2>
+          <div className="flex items-center gap-0.5 rounded-md bg-[var(--color-background-elevated-secondary)] p-0.5 text-xs">
             {(["unread", "all"] as const).map((value) => (
               <button
                 key={value}
                 type="button"
                 onClick={() => setTriageFilter(value)}
                 className={cn(
-                  "rounded px-2 py-1 capitalize transition-colors",
+                  "rounded px-2 py-0.5 transition-colors",
                   triageFilter === value
                     ? "bg-background text-foreground"
                     : "text-muted-foreground hover:text-foreground",
@@ -390,77 +323,9 @@ function AutomationsRouteView() {
           </div>
         </div>
         {triageRuns.length === 0 ? (
-          <div className="px-3 py-6 text-sm text-muted-foreground">No unread runs.</div>
+          <div className="px-2 py-4 text-xs text-muted-foreground">No unread runs.</div>
         ) : (
-          <div className="flex flex-col divide-y divide-border/50">
-            {triageRuns.map((run) => {
-              const definition = data.definitions.find((entry) => entry.id === run.automationId);
-              const tone = runTone(run);
-              const classes = toneClasses(tone);
-              const destination = run.threadId ? "Open thread" : "View automation";
-              const target = definition ? subtitle(definition) : "Saved run";
-              const summary = runResultSummary(run);
-              return (
-                <button
-                  key={run.id}
-                  type="button"
-                  onClick={() =>
-                    run.threadId
-                      ? void navigate({ to: "/$threadId", params: { threadId: run.threadId } })
-                      : definition
-                        ? void navigate({
-                            to: "/automations/$automationId",
-                            params: { automationId: definition.id },
-                          })
-                        : undefined
-                  }
-                  className="group flex w-full items-center gap-3 rounded-lg px-3 py-3.5 text-left transition-colors hover:bg-[var(--color-background-elevated-secondary)]"
-                >
-                  <span
-                    className={cn(
-                      "flex size-8 shrink-0 items-center justify-center rounded-md",
-                      classes.icon,
-                    )}
-                  >
-                    {tone === "success" ? (
-                      <CircleCheckIcon className="size-4" />
-                    ) : tone === "danger" || tone === "warning" ? (
-                      <CircleAlertIcon className="size-4" />
-                    ) : (
-                      <ClockIcon className="size-4" />
-                    )}
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <span className="truncate text-sm font-medium text-foreground">
-                        {definition?.name ?? "Automation run"}
-                      </span>
-                      <span
-                        className={cn(
-                          "inline-flex shrink-0 rounded-md border px-1.5 py-0.5 text-[11px] font-medium",
-                          classes.chip,
-                        )}
-                      >
-                        {triageRunLabel(run)}
-                      </span>
-                    </div>
-                    <div className="mt-1 truncate text-xs text-muted-foreground">
-                      {joinedParts([summary, target])}
-                    </div>
-                  </div>
-                  <div className="flex shrink-0 flex-col items-end gap-1 text-right">
-                    <span className="text-xs text-muted-foreground tabular-nums">
-                      {formatRelativeTime(run.finishedAt ?? run.startedAt ?? run.scheduledFor)}
-                    </span>
-                    <span className="inline-flex items-center gap-1 text-[11px] font-medium text-foreground opacity-80 transition-opacity group-hover:opacity-100">
-                      {destination}
-                      <ExternalLinkIcon className="size-3" />
-                    </span>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
+          <div className="flex flex-col">{triageRuns.map(renderTriageRow)}</div>
         )}
       </section>
     ) : null;
@@ -488,18 +353,24 @@ function AutomationsRouteView() {
           <div className={cn("flex items-center gap-2 sm:gap-3", CHAT_SURFACE_HEADER_HEIGHT_CLASS)}>
             <SidebarHeaderNavigationControls />
             <div className="min-w-0 flex-1" />
-            <div className="flex shrink-0 items-center gap-1.5 [-webkit-app-region:no-drag]">
+            <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
               <Button
                 type="button"
                 size="icon-sm"
                 variant="ghost"
                 aria-label="Refresh"
+                title="Refresh"
                 onClick={() => void refetch()}
               >
-                <RefreshCwIcon className="size-4" />
+                <CentralIcon name="arrow-rotate-clockwise" className="size-4" />
               </Button>
-              <Button type="button" onClick={openCreateDialog} disabled={projects.length === 0}>
-                <PlusIcon className="size-4" />
+              <Button
+                type="button"
+                size="sm"
+                onClick={openCreateDialog}
+                disabled={projects.length === 0}
+              >
+                <CentralIcon name="plus-small" className="size-4" />
                 New automation
               </Button>
             </div>
@@ -507,27 +378,10 @@ function AutomationsRouteView() {
         </header>
 
         <main className="min-h-0 flex-1 overflow-y-auto">
-          <div className="mx-auto flex w-full max-w-5xl flex-col gap-7 px-6 pb-12 pt-6">
-            <div className="flex flex-col gap-3 px-3 sm:flex-row sm:items-end sm:justify-between">
-              <div className="min-w-0">
-                <h1 className="font-heading text-[1.75rem] font-semibold leading-tight tracking-tight text-foreground">
-                  Automations
-                </h1>
-              </div>
-              {!isLoading && data.definitions.length > 0 ? (
-                <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-                  <SummaryPill icon={<CircleAlertIcon className="size-3.5" />}>
-                    {unreadTriageCount} to review
-                  </SummaryPill>
-                  <SummaryPill icon={<ClockIcon className="size-3.5" />}>
-                    {active.length} scheduled
-                  </SummaryPill>
-                  <SummaryPill icon={<FolderIcon className="size-3.5" />}>
-                    {inactive.length} not running
-                  </SummaryPill>
-                </div>
-              ) : null}
-            </div>
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 pb-12 pt-8">
+            <h1 className="px-2 font-heading text-2xl font-semibold tracking-tight text-foreground">
+              Automations
+            </h1>
             {isLoading ? (
               <div className="py-16 text-center text-sm text-muted-foreground">
                 Loading automations...
@@ -540,10 +394,10 @@ function AutomationsRouteView() {
                 </p>
               </div>
             ) : (
-              <div className="flex flex-col gap-8">
+              <div className="flex flex-col gap-6">
                 {renderTriage()}
-                {renderSection("Scheduled", active)}
-                {renderSection("Not running", inactive)}
+                {renderSection("Current", active)}
+                {renderSection("Paused", inactive)}
               </div>
             )}
           </div>
@@ -565,35 +419,5 @@ function AutomationsRouteView() {
         busy={createMutation.isPending || updateMutation.isPending}
       />
     </SidebarInset>
-  );
-}
-
-function SectionHeading({
-  children,
-  count,
-}: {
-  readonly children: ReactNode;
-  readonly count: number;
-}) {
-  return (
-    <div className="flex min-w-0 items-baseline gap-2">
-      <h2 className="truncate text-base font-semibold text-foreground">{children}</h2>
-      <span className="shrink-0 text-xs font-medium text-muted-foreground">{count}</span>
-    </div>
-  );
-}
-
-function SummaryPill({
-  icon,
-  children,
-}: {
-  readonly icon: ReactNode;
-  readonly children: ReactNode;
-}) {
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded-md border border-border/70 bg-[var(--color-background-elevated-secondary)] px-2 py-1 font-medium text-muted-foreground">
-      {icon}
-      {children}
-    </span>
   );
 }

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -2916,9 +2916,6 @@ describe("store read model sync", () => {
         updatedAt: "2026-02-27T00:00:30.000Z",
         handoff: null,
         session: null,
-        activities: [],
-        proposedPlans: [],
-        checkpoints: [],
       }),
     );
     expect(afterStaleSnapshot.threads).toHaveLength(0);
@@ -2980,9 +2977,6 @@ describe("store read model sync", () => {
         updatedAt: "2026-02-27T00:00:30.000Z",
         handoff: null,
         session: null,
-        activities: [],
-        proposedPlans: [],
-        checkpoints: [],
       }),
     );
 
@@ -3032,9 +3026,6 @@ describe("store read model sync", () => {
         updatedAt: "2026-02-27T00:00:30.000Z",
         handoff: null,
         session: null,
-        activities: [],
-        proposedPlans: [],
-        checkpoints: [],
       }),
     );
 

--- a/apps/web/src/storeSelectors.test.ts
+++ b/apps/web/src/storeSelectors.test.ts
@@ -126,7 +126,7 @@ describe("thread shell route selectors", () => {
     const threadShellById = {
       [threadIdA]: {
         ...shellA,
-        envMode: "worktree",
+        envMode: "worktree" as const,
         worktreePath: "/repo/.worktrees/feature",
       },
     };

--- a/packages/contracts/src/automation.test.ts
+++ b/packages/contracts/src/automation.test.ts
@@ -96,6 +96,9 @@ it.effect("accepts AI-evaluated automation completion policies", () =>
     });
 
     assert.strictEqual(parsed.type, "ai-evaluated");
+    if (parsed.type !== "ai-evaluated") {
+      assert.fail("Expected AI-evaluated completion policy.");
+    }
     assert.strictEqual(parsed.confidenceThreshold, DEFAULT_AUTOMATION_STOP_CONFIDENCE_THRESHOLD);
   }),
 );

--- a/packages/contracts/src/automation.ts
+++ b/packages/contracts/src/automation.ts
@@ -167,6 +167,7 @@ export const AutomationMisfirePolicy = Schema.Literals(["skip", "coalesce", "run
 export type AutomationMisfirePolicy = typeof AutomationMisfirePolicy.Type;
 
 export const DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS = 60;
+export const DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS = 10;
 export const DEFAULT_AUTOMATION_MAX_RUNTIME_SECONDS = 60 * 60;
 export const DEFAULT_AUTOMATION_RETRY_POLICY: AutomationRetryPolicy = { type: "none" };
 export const DEFAULT_AUTOMATION_MISFIRE_POLICY: AutomationMisfirePolicy = "coalesce";
@@ -211,7 +212,9 @@ export const AutomationDefinition = Schema.Struct({
     Schema.withDecodingDefault(() => DEFAULT_AUTOMATION_COMPLETION_POLICY),
   ),
   /** Increments whenever the persisted stop policy changes; run snapshots use it for stale checks. */
-  completionPolicyVersion: Schema.optional(NonNegativeInt).pipe(Schema.withDecodingDefault(() => 0)),
+  completionPolicyVersion: Schema.optional(NonNegativeInt).pipe(
+    Schema.withDecodingDefault(() => 0),
+  ),
   /** Save time for the current completion policy; used only for legacy run snapshots. */
   completionPolicyUpdatedAt: Schema.optional(AutomationIsoDateTime).pipe(
     Schema.withDecodingDefault(() => "1970-01-01T00:00:00.000Z"),

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -315,6 +315,9 @@ export const ServerGenerateAutomationIntentResult = Schema.Struct({
   taskPrompt: Schema.NullOr(TrimmedNonEmptyString.check(Schema.isMaxLength(64_000))),
   schedule: Schema.NullOr(AutomationSchedule),
   mode: Schema.NullOr(AutomationMode),
+  maxIterations: Schema.optional(Schema.NullOr(PositiveInt)).pipe(
+    Schema.withDecodingDefault(() => null),
+  ),
   completionPolicy: Schema.optional(AutomationCompletionPolicy).pipe(
     Schema.withDecodingDefault(() => ({ type: "none" as const })),
   ),


### PR DESCRIPTION
## Summary
- harden composer automation creation so review dialogs do not promote draft threads until submission and promoted draft threads preserve their environment
- keep saved provider start options when only model capability options change
- tighten fast-interval safety, AI stop policy defaults, rerun/source-thread handling, and automation triage/detail interactions
- extract shared automation form/composer helpers and add focused coverage for parsing, draft review, scheduler/service behavior, and browser flows

## Validation
- `bun run --cwd apps/web test src/lib/automationIntent.test.ts src/lib/composerAutomation.test.ts src/lib/automationDraft.test.ts src/routes/-automations.shared.test.tsx`
- `bun run --cwd apps/web test --config vitest.browser.config.ts src/components/ChatView.browser.tsx`
- `bun run --cwd apps/server test src/automation/Layers/AutomationService.test.ts src/automation/schedule.test.ts src/git/textGenerationShared.test.ts src/git/Layers/ProviderTextGeneration.test.ts`
- `bun run --cwd apps/web test src/lib/threadCreatePromotion.test.ts src/projectScripts.test.ts src/components/Sidebar.logic.test.ts`
- `bun run --cwd apps/web test --config vitest.browser.config.ts src/components/chat/environment/EnvironmentAutomationsSection.browser.tsx`
- `bun fmt && bun lint && bun typecheck`
- `git diff --check`