### PR TITLE
[codex] fix automation audit findings

### DIFF
--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -19,7 +19,11 @@ import {
 } from "@t3tools/contracts";
 import { Effect, Layer, Option, Stream } from "effect";
 
-import { GitCore, type GitCoreShape } from "../../git/Services/GitCore.ts";
+import {
+  GitCore,
+  type GitCoreShape,
+  type GitDeleteBranchInput,
+} from "../../git/Services/GitCore.ts";
 import { TextGeneration, type TextGenerationShape } from "../../git/Services/TextGeneration.ts";
 import { OrchestrationCommandInternalError } from "../../orchestration/Errors.ts";
 import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
@@ -55,6 +59,7 @@ const project: OrchestrationProjectShell = {
 const dispatchedCommands: OrchestrationCommand[] = [];
 const createdWorktrees: GitCreateWorktreeInput[] = [];
 const removedWorktrees: GitRemoveWorktreeInput[] = [];
+const deletedBranches: GitDeleteBranchInput[] = [];
 type CompletionEvaluationInputForTest = Parameters<
   TextGenerationShape["evaluateAutomationCompletion"]
 >[0];
@@ -91,6 +96,7 @@ function resetHarness() {
   dispatchedCommands.length = 0;
   createdWorktrees.length = 0;
   removedWorktrees.length = 0;
+  deletedBranches.length = 0;
   gitMode = "nonRepo";
   gitStatusHook = null;
   createWorktreeHook = null;
@@ -466,6 +472,10 @@ const gitCore = {
     Effect.sync(() => {
       removedWorktrees.push(input);
     }),
+  deleteBranch: (input: GitDeleteBranchInput) =>
+    Effect.sync(() => {
+      deletedBranches.push(input);
+    }),
 } as unknown as GitCoreShape;
 
 const layer = it.layer(
@@ -587,6 +597,13 @@ layer("AutomationService", (it) => {
           force: true,
         },
       ]);
+      assert.deepStrictEqual(deletedBranches, [
+        {
+          cwd: project.workspaceRoot,
+          branch: createdWorktrees[0]?.newBranch,
+          force: true,
+        },
+      ]);
 
       const reloaded = yield* service.list({ projectId });
       const run = reloaded.runs.find((entry) => entry.automationId === created.id);
@@ -642,6 +659,13 @@ layer("AutomationService", (it) => {
           force: true,
         },
       ]);
+      assert.deepStrictEqual(deletedBranches, [
+        {
+          cwd: project.workspaceRoot,
+          branch: createdWorktrees[0]?.newBranch,
+          force: true,
+        },
+      ]);
       assert.strictEqual(
         results.find((entry) => entry.run.automationId === automationId)?.run.status,
         "cancelled",
@@ -666,6 +690,7 @@ layer("AutomationService", (it) => {
       assert.match(error.message, /Failed to start automation turn/);
       assert.strictEqual(createdWorktrees.length, 1);
       assert.strictEqual(removedWorktrees.length, 0);
+      assert.strictEqual(deletedBranches.length, 0);
       assert.strictEqual(dispatchedCommands[0]?.type, "thread.create");
     }),
   );

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -12,6 +12,7 @@ import {
   type AutomationCreateInput,
   type AutomationRun,
   type GitCreateWorktreeInput,
+  type GitRemoveWorktreeInput,
   type OrchestrationCommand,
   type OrchestrationProjectShell,
   type OrchestrationThreadShell,
@@ -53,11 +54,13 @@ const project: OrchestrationProjectShell = {
 
 const dispatchedCommands: OrchestrationCommand[] = [];
 const createdWorktrees: GitCreateWorktreeInput[] = [];
+const removedWorktrees: GitRemoveWorktreeInput[] = [];
 type CompletionEvaluationInputForTest = Parameters<
   TextGenerationShape["evaluateAutomationCompletion"]
 >[0];
 let gitMode: "nonRepo" | "worktree" = "nonRepo";
 let gitStatusHook: ((cwd: string) => Effect.Effect<void>) | null = null;
+let createWorktreeHook: ((input: GitCreateWorktreeInput) => Effect.Effect<void>) | null = null;
 // Configurable thread shell returned by the ProjectionSnapshotQuery mock; reconcile
 // tests set it to drive the run's latest-turn outcome.
 let threadShell: Option.Option<OrchestrationThreadShell> = Option.none();
@@ -87,8 +90,10 @@ let dispatchHook:
 function resetHarness() {
   dispatchedCommands.length = 0;
   createdWorktrees.length = 0;
+  removedWorktrees.length = 0;
   gitMode = "nonRepo";
   gitStatusHook = null;
+  createWorktreeHook = null;
   threadShell = Option.none();
   threadDetail = Option.none();
   completionEvaluation = {
@@ -445,14 +450,21 @@ const gitCore = {
       };
     }),
   createWorktree: (input: GitCreateWorktreeInput) =>
-    Effect.sync(() => {
+    Effect.gen(function* () {
       createdWorktrees.push(input);
+      if (createWorktreeHook) {
+        yield* createWorktreeHook(input);
+      }
       return {
         worktree: {
           path: "/tmp/automation-worktree",
           branch: input.newBranch ?? input.branch,
         },
       };
+    }),
+  removeWorktree: (input: GitRemoveWorktreeInput) =>
+    Effect.sync(() => {
+      removedWorktrees.push(input);
     }),
 } as unknown as GitCoreShape;
 
@@ -553,6 +565,108 @@ layer("AutomationService", (it) => {
       assert.strictEqual(threadCreate.envMode, "worktree");
       assert.strictEqual(threadCreate.worktreePath, "/tmp/automation-worktree");
       assert.strictEqual(threadCreate.associatedWorktreeBranch, createdWorktrees[0]?.newBranch);
+    }),
+  );
+
+  it.effect("cleans up a new worktree when standalone thread creation fails", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      gitMode = "worktree";
+      failDispatchType = "thread.create";
+      const service = yield* AutomationService;
+      const created = yield* service.create(createInput("worktree"));
+
+      const error = yield* service.runNow({ automationId: created.id }).pipe(Effect.flip);
+
+      assert.match(error.message, /Failed to create automation thread/);
+      assert.strictEqual(createdWorktrees.length, 1);
+      assert.deepStrictEqual(removedWorktrees, [
+        {
+          cwd: project.workspaceRoot,
+          path: "/tmp/automation-worktree",
+          force: true,
+        },
+      ]);
+
+      const reloaded = yield* service.list({ projectId });
+      const run = reloaded.runs.find((entry) => entry.automationId === created.id);
+      assert.strictEqual(run?.status, "failed");
+    }),
+  );
+
+  it.effect("cleans up a new worktree when cancellation wins before thread creation", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      gitMode = "worktree";
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-cancel-after-worktree");
+
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("worktree"),
+          schedule: { type: "interval", everySeconds: 300 },
+          stopOnError: true,
+        },
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      createWorktreeHook = () =>
+        Effect.gen(function* () {
+          const runs = yield* repository
+            .listActiveRunsForDefinition({ automationId })
+            .pipe(Effect.orDie);
+          const run = runs.find((entry) => entry.automationId === automationId);
+          if (run) {
+            yield* repository
+              .cancelRun({
+                runId: run.id,
+                now: "2026-06-16T10:00:30.000Z",
+              })
+              .pipe(Effect.orDie);
+          }
+        });
+
+      const results = yield* service.runDueOnce({
+        now: "2026-06-16T10:00:00.000Z",
+        limit: 10,
+        leaseOwnerId: "test-scheduler",
+      });
+
+      assert.strictEqual(createdWorktrees.length, 1);
+      assert.deepStrictEqual(removedWorktrees, [
+        {
+          cwd: project.workspaceRoot,
+          path: "/tmp/automation-worktree",
+          force: true,
+        },
+      ]);
+      assert.strictEqual(
+        results.find((entry) => entry.run.automationId === automationId)?.run.status,
+        "cancelled",
+      );
+      assert.strictEqual(
+        dispatchedCommands.some((command) => command.type === "thread.create"),
+        false,
+      );
+    }),
+  );
+
+  it.effect("keeps a worktree once standalone thread creation succeeds", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      gitMode = "worktree";
+      failDispatchType = "thread.turn.start";
+      const service = yield* AutomationService;
+      const created = yield* service.create(createInput("worktree"));
+
+      const error = yield* service.runNow({ automationId: created.id }).pipe(Effect.flip);
+
+      assert.match(error.message, /Failed to start automation turn/);
+      assert.strictEqual(createdWorktrees.length, 1);
+      assert.strictEqual(removedWorktrees.length, 0);
+      assert.strictEqual(dispatchedCommands[0]?.type, "thread.create");
     }),
   );
 

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -467,7 +467,11 @@ export const AutomationServiceLive = Layer.effect(
       if (input.environment.envMode !== "worktree" || !path) {
         return Effect.void;
       }
-      return git
+      const expectedBranch = makeAutomationBranchName(input.definition, input.run.id);
+      // Only delete the branch minted for this not-yet-owned automation worktree.
+      const branch =
+        input.environment.associatedWorktreeBranch === expectedBranch ? expectedBranch : null;
+      const removeWorktree = git
         .removeWorktree({
           cwd: input.project.workspaceRoot,
           path,
@@ -485,6 +489,28 @@ export const AutomationServiceLive = Layer.effect(
           ),
           Effect.asVoid,
         );
+      const deleteBranch = branch
+        ? git
+            .deleteBranch({
+              cwd: input.project.workspaceRoot,
+              branch,
+              force: true,
+            })
+            .pipe(
+              Effect.catch((error) =>
+                Effect.logWarning("automation unattached branch cleanup failed", {
+                  automationId: input.definition.id,
+                  runId: input.run.id,
+                  branch,
+                  reason: input.reason,
+                  error: errorMessage(error),
+                }),
+              ),
+              Effect.asVoid,
+            )
+        : Effect.void;
+
+      return removeWorktree.pipe(Effect.flatMap(() => deleteBranch));
     };
 
     const requireDefinition = (id: AutomationId) =>

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -50,6 +50,7 @@ import {
 const AUTOMATION_ERROR_MAX_CHARS = 4_000;
 const FAST_INTERVAL_ACKNOWLEDGED_MINIMUM_SECONDS = 1;
 const AUTOMATION_COMPLETION_EVALUATION_WORKERS = 2;
+const AUTOMATION_COMPLETION_EVALUATION_QUEUE_CAPACITY = 100;
 
 interface AutomationCompletionEvaluationJob {
   readonly definition: AutomationDefinition;
@@ -445,12 +446,46 @@ export const AutomationServiceLive = Layer.effect(
     // Unbounded so we never silently drop run/definition updates under a burst, matching
     // the rest of the server's PubSub usage.
     const events = yield* PubSub.unbounded<AutomationStreamEvent>();
-    // Stop-condition AI calls can be slow; a dedicated queue keeps reconciliation responsive.
-    const completionEvaluationQueue = yield* Queue.unbounded<AutomationCompletionEvaluationJob>();
+    // Stop-condition AI calls can be slow; cap queued+active jobs and let DB
+    // reconciliation rediscover excess pending rows when worker capacity frees up.
+    const completionEvaluationQueue = yield* Queue.bounded<AutomationCompletionEvaluationJob>(
+      AUTOMATION_COMPLETION_EVALUATION_QUEUE_CAPACITY,
+    );
     const queuedCompletionEvaluationRunIds = new Set<string>();
 
     const publish = (event: AutomationStreamEvent) =>
       PubSub.publish(events, event).pipe(Effect.asVoid);
+
+    const cleanupUnattachedWorktree = (input: {
+      readonly definition: AutomationDefinition;
+      readonly run: AutomationRun;
+      readonly project: OrchestrationProjectShell;
+      readonly environment: ThreadEnvironment;
+      readonly reason: string;
+    }) => {
+      const path = input.environment.associatedWorktreePath;
+      if (input.environment.envMode !== "worktree" || !path) {
+        return Effect.void;
+      }
+      return git
+        .removeWorktree({
+          cwd: input.project.workspaceRoot,
+          path,
+          force: true,
+        })
+        .pipe(
+          Effect.catch((error) =>
+            Effect.logWarning("automation unattached worktree cleanup failed", {
+              automationId: input.definition.id,
+              runId: input.run.id,
+              path,
+              reason: input.reason,
+              error: errorMessage(error),
+            }),
+          ),
+          Effect.asVoid,
+        );
+    };
 
     const requireDefinition = (id: AutomationId) =>
       automationRepository.getDefinitionById({ id }).pipe(
@@ -850,6 +885,16 @@ export const AutomationServiceLive = Layer.effect(
         );
         yield* requireRunStillDispatching(
           "Automation run was cancelled before creating the automation thread.",
+        ).pipe(
+          Effect.catch((error) =>
+            cleanupUnattachedWorktree({
+              definition,
+              run,
+              project,
+              environment,
+              reason: "cancelled-before-thread-create",
+            }).pipe(Effect.flatMap(() => Effect.fail(error))),
+          ),
         );
 
         yield* orchestrationEngine
@@ -870,7 +915,18 @@ export const AutomationServiceLive = Layer.effect(
             associatedWorktreeRef: environment.associatedWorktreeRef,
             createdAt: now,
           })
-          .pipe(Effect.mapError(toServiceError("Failed to create automation thread.")));
+          .pipe(
+            Effect.mapError(toServiceError("Failed to create automation thread.")),
+            Effect.catch((error) =>
+              cleanupUnattachedWorktree({
+                definition,
+                run,
+                project,
+                environment,
+                reason: "thread-create-failed",
+              }).pipe(Effect.flatMap(() => Effect.fail(error))),
+            ),
+          );
 
         yield* requireRunStillDispatching(
           "Automation run was cancelled before starting the automation turn.",
@@ -1272,16 +1328,30 @@ export const AutomationServiceLive = Layer.effect(
     const enqueueCompletionEvaluationJob = (job: AutomationCompletionEvaluationJob) =>
       Effect.sync(() => {
         if (queuedCompletionEvaluationRunIds.has(job.run.id)) {
-          return false;
+          return "duplicate" as const;
+        }
+        if (
+          queuedCompletionEvaluationRunIds.size >= AUTOMATION_COMPLETION_EVALUATION_QUEUE_CAPACITY
+        ) {
+          return "full" as const;
         }
         queuedCompletionEvaluationRunIds.add(job.run.id);
-        return true;
+        return "queued" as const;
       }).pipe(
-        Effect.flatMap((shouldEnqueue) =>
-          shouldEnqueue
-            ? Queue.offer(completionEvaluationQueue, job).pipe(Effect.asVoid)
-            : Effect.void,
-        ),
+        Effect.flatMap((state) => {
+          switch (state) {
+            case "duplicate":
+              return Effect.void;
+            case "full":
+              return Effect.logWarning("automation completion evaluation queue at capacity", {
+                automationId: job.definition.id,
+                runId: job.run.id,
+                capacity: AUTOMATION_COMPLETION_EVALUATION_QUEUE_CAPACITY,
+              });
+            case "queued":
+              return Queue.offer(completionEvaluationQueue, job).pipe(Effect.asVoid);
+          }
+        }),
       );
 
     const enqueueCompletionEvaluationForRun = (run: AutomationRun) => {
@@ -1342,7 +1412,18 @@ export const AutomationServiceLive = Layer.effect(
       );
 
     const completionEvaluationWorker = Effect.forever(
-      Queue.take(completionEvaluationQueue).pipe(Effect.flatMap(processCompletionEvaluationJob)),
+      Queue.take(completionEvaluationQueue).pipe(
+        Effect.flatMap(processCompletionEvaluationJob),
+        Effect.flatMap(() =>
+          enqueuePendingCompletionEvaluations().pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("automation pending stop evaluations could not be requeued", {
+                error: errorMessage(error),
+              }),
+            ),
+          ),
+        ),
+      ),
     );
 
     yield* Effect.forEach(

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -976,6 +976,22 @@ it.layer(TestLayer)("git integration", (it) => {
         expect(result._tag).toBe("Failure");
       }),
     );
+
+    it.effect("deletes an existing local branch", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const core = yield* GitCore;
+        yield* initRepoWithCommit(tmp);
+        yield* core.createBranch({ cwd: tmp, branch: "feature/delete-me" });
+
+        yield* core.deleteBranch({ cwd: tmp, branch: "feature/delete-me", force: true });
+
+        const branches = yield* core.listBranches({ cwd: tmp });
+        expect(branches.branches.some((branch) => branch.name === "feature/delete-me")).toBe(
+          false,
+        );
+      }),
+    );
   });
 
   // ── renameGitBranch ──

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -2220,6 +2220,25 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
         );
       });
 
+    const deleteBranch: GitCoreShape["deleteBranch"] = (input) =>
+      Effect.gen(function* () {
+        const args = ["branch", input.force ? "-D" : "-d", "--", input.branch];
+        yield* executeGit("GitCore.deleteBranch", input.cwd, args, {
+          timeoutMs: 10_000,
+          fallbackErrorMessage: "git branch delete failed",
+        }).pipe(
+          Effect.mapError((error) =>
+            createGitCommandError(
+              "GitCore.deleteBranch",
+              input.cwd,
+              args,
+              `${commandLabel(args)} failed (cwd: ${input.cwd}): ${error instanceof Error ? error.message : String(error)}`,
+              error,
+            ),
+          ),
+        );
+      });
+
     const renameBranch: GitCoreShape["renameBranch"] = (input) =>
       Effect.gen(function* () {
         if (input.oldBranch === input.newBranch) {
@@ -2625,6 +2644,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
       fetchRemoteBranch,
       setBranchUpstream,
       removeWorktree,
+      deleteBranch,
       renameBranch,
       createBranch,
       publishBranch,

--- a/apps/server/src/git/Services/GitCore.ts
+++ b/apps/server/src/git/Services/GitCore.ts
@@ -116,6 +116,12 @@ export interface GitRenameBranchResult {
   branch: string;
 }
 
+export interface GitDeleteBranchInput {
+  cwd: string;
+  branch: string;
+  force?: boolean | undefined;
+}
+
 export interface GitFetchPullRequestBranchInput {
   cwd: string;
   prNumber: number;
@@ -286,6 +292,11 @@ export interface GitCoreShape {
    * Remove an existing worktree.
    */
   readonly removeWorktree: (input: GitRemoveWorktreeInput) => Effect.Effect<void, GitCommandError>;
+
+  /**
+   * Delete an existing local branch.
+   */
+  readonly deleteBranch: (input: GitDeleteBranchInput) => Effect.Effect<void, GitCommandError>;
 
   /**
    * Rename an existing local branch.

--- a/apps/server/src/persistence/Layers/AutomationRepository.ts
+++ b/apps/server/src/persistence/Layers/AutomationRepository.ts
@@ -393,42 +393,8 @@ const makeAutomationRepository = Effect.gen(function* () {
             AND definitions.target_thread_id IS NOT NULL
             AND EXISTS (
               SELECT 1
-              FROM automation_runs runs
-              INNER JOIN automation_definitions pending_definitions
-                ON pending_definitions.automation_id = runs.automation_id
-              WHERE runs.thread_id = definitions.target_thread_id
-                AND runs.status = 'succeeded'
-                AND pending_definitions.enabled = 1
-                AND pending_definitions.archived_at IS NULL
-                AND pending_definitions.mode = 'heartbeat'
-                AND json_extract(
-                  pending_definitions.completion_policy_json,
-                  '$.type'
-                ) = 'ai-evaluated'
-                AND runs.finished_at IS NOT NULL
-                AND (
-                  json_extract(
-                    runs.permission_snapshot_json,
-                    '$.completionPolicyVersion'
-                  ) = pending_definitions.completion_policy_version
-                  OR (
-                    json_type(
-                      runs.permission_snapshot_json,
-                      '$.completionPolicyVersion'
-                    ) IS NULL
-                    AND COALESCE(runs.started_at, runs.created_at) >
-                      COALESCE(
-                        pending_definitions.completion_policy_updated_at,
-                        pending_definitions.updated_at,
-                        pending_definitions.created_at,
-                        '1970-01-01T00:00:00.000Z'
-                      )
-                  )
-                )
-                AND (
-                  runs.result_json IS NULL
-                  OR json_type(runs.result_json, '$.completionEvaluation') IS NULL
-                )
+              FROM automation_pending_completion_evaluations pending
+              WHERE pending.thread_id = definitions.target_thread_id
             )
           )
         ORDER BY definitions.next_run_at ASC, definitions.automation_id ASC
@@ -846,33 +812,9 @@ const makeAutomationRepository = Effect.gen(function* () {
           runs.created_at AS "createdAt",
           runs.updated_at AS "updatedAt"
         FROM automation_runs runs
-        INNER JOIN automation_definitions definitions
-          ON definitions.automation_id = runs.automation_id
-        WHERE runs.status = 'succeeded'
-          AND definitions.enabled = 1
-          AND definitions.archived_at IS NULL
-          AND definitions.mode = 'heartbeat'
-          AND json_extract(definitions.completion_policy_json, '$.type') = 'ai-evaluated'
-          AND runs.finished_at IS NOT NULL
-          AND (
-            json_extract(runs.permission_snapshot_json, '$.completionPolicyVersion') =
-              definitions.completion_policy_version
-            OR (
-              json_type(runs.permission_snapshot_json, '$.completionPolicyVersion') IS NULL
-              AND COALESCE(runs.started_at, runs.created_at) >
-                COALESCE(
-                  definitions.completion_policy_updated_at,
-                  definitions.updated_at,
-                  definitions.created_at,
-                  '1970-01-01T00:00:00.000Z'
-                )
-            )
-          )
-          AND (
-            runs.result_json IS NULL
-            OR json_type(runs.result_json, '$.completionEvaluation') IS NULL
-          )
-        ORDER BY runs.finished_at ASC, runs.run_id ASC
+        INNER JOIN automation_pending_completion_evaluations pending
+          ON pending.run_id = runs.run_id
+        ORDER BY pending.finished_at ASC, pending.run_id ASC
         LIMIT ${limit}
       `,
   });
@@ -907,34 +849,8 @@ const makeAutomationRepository = Effect.gen(function* () {
     execute: ({ threadId }) =>
       sql`
         SELECT COUNT(*) AS "count"
-        FROM automation_runs runs
-        INNER JOIN automation_definitions definitions
-          ON definitions.automation_id = runs.automation_id
-        WHERE runs.thread_id = ${threadId}
-          AND runs.status = 'succeeded'
-          AND definitions.enabled = 1
-          AND definitions.archived_at IS NULL
-          AND definitions.mode = 'heartbeat'
-          AND json_extract(definitions.completion_policy_json, '$.type') = 'ai-evaluated'
-          AND runs.finished_at IS NOT NULL
-          AND (
-            json_extract(runs.permission_snapshot_json, '$.completionPolicyVersion') =
-              definitions.completion_policy_version
-            OR (
-              json_type(runs.permission_snapshot_json, '$.completionPolicyVersion') IS NULL
-              AND COALESCE(runs.started_at, runs.created_at) >
-                COALESCE(
-                  definitions.completion_policy_updated_at,
-                  definitions.updated_at,
-                  definitions.created_at,
-                  '1970-01-01T00:00:00.000Z'
-                )
-            )
-          )
-          AND (
-            runs.result_json IS NULL
-            OR json_type(runs.result_json, '$.completionEvaluation') IS NULL
-          )
+        FROM automation_pending_completion_evaluations pending
+        WHERE pending.thread_id = ${threadId}
       `,
   });
 
@@ -987,42 +903,8 @@ const makeAutomationRepository = Effect.gen(function* () {
             AND definitions.target_thread_id IS NOT NULL
             AND EXISTS (
               SELECT 1
-              FROM automation_runs runs
-              INNER JOIN automation_definitions pending_definitions
-                ON pending_definitions.automation_id = runs.automation_id
-              WHERE runs.thread_id = definitions.target_thread_id
-                AND runs.status = 'succeeded'
-                AND pending_definitions.enabled = 1
-                AND pending_definitions.archived_at IS NULL
-                AND pending_definitions.mode = 'heartbeat'
-                AND json_extract(
-                  pending_definitions.completion_policy_json,
-                  '$.type'
-                ) = 'ai-evaluated'
-                AND runs.finished_at IS NOT NULL
-                AND (
-                  json_extract(
-                    runs.permission_snapshot_json,
-                    '$.completionPolicyVersion'
-                  ) = pending_definitions.completion_policy_version
-                  OR (
-                    json_type(
-                      runs.permission_snapshot_json,
-                      '$.completionPolicyVersion'
-                    ) IS NULL
-                    AND COALESCE(runs.started_at, runs.created_at) >
-                      COALESCE(
-                        pending_definitions.completion_policy_updated_at,
-                        pending_definitions.updated_at,
-                        pending_definitions.created_at,
-                        '1970-01-01T00:00:00.000Z'
-                      )
-                  )
-                )
-                AND (
-                  runs.result_json IS NULL
-                  OR json_type(runs.result_json, '$.completionEvaluation') IS NULL
-                )
+              FROM automation_pending_completion_evaluations pending
+              WHERE pending.thread_id = definitions.target_thread_id
             )
           )
         ORDER BY definitions.next_run_at ASC, definitions.automation_id ASC

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -63,6 +63,7 @@ import Migration0044 from "./Migrations/044_Automations.ts";
 import Migration0045 from "./Migrations/045_AutomationPolicies.ts";
 import Migration0046 from "./Migrations/046_AutomationCompletionPolicy.ts";
 import Migration0047 from "./Migrations/047_AutomationCompletionPolicyVersion.ts";
+import Migration0048 from "./Migrations/048_AutomationCompletionEvaluationBacklog.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -122,6 +123,7 @@ export const migrationEntries = [
   [45, "AutomationPolicies", Migration0045],
   [46, "AutomationCompletionPolicy", Migration0046],
   [47, "AutomationCompletionPolicyVersion", Migration0047],
+  [48, "AutomationCompletionEvaluationBacklog", Migration0048],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/044_Automations.test.ts
+++ b/apps/server/src/persistence/Migrations/044_Automations.test.ts
@@ -21,12 +21,19 @@ const indexNames = (sql: SqlClient.SqlClient) =>
     ORDER BY name ASC
   `.pipe(Effect.map((rows) => rows.map((row) => row.name)));
 
+const viewNames = (sql: SqlClient.SqlClient) =>
+  sql<{ readonly name: string }>`
+    SELECT name FROM sqlite_master
+    WHERE type = 'view' AND name LIKE 'automation_%'
+    ORDER BY name ASC
+  `.pipe(Effect.map((rows) => rows.map((row) => row.name)));
+
 layer("automation migration", (it) => {
-  it.effect("registers automation policy migration in the Synara lineage", () =>
+  it.effect("registers automation backlog migration in the Synara lineage", () =>
     Effect.sync(() => {
       assert.deepStrictEqual(migrationEntries[migrationEntries.length - 1]?.slice(0, 2), [
-        47,
-        "AutomationCompletionPolicyVersion",
+        48,
+        "AutomationCompletionEvaluationBacklog",
       ]);
     }),
   );
@@ -48,6 +55,10 @@ layer("automation migration", (it) => {
         "idx_automation_runs_recovery",
         "idx_automation_runs_project",
         "idx_automation_runs_thread",
+        "idx_automation_runs_completion_eval",
+      ]);
+      assert.includeMembers(yield* viewNames(sql), [
+        "automation_pending_completion_evaluations",
       ]);
       const policyColumns = yield* sql<{ readonly name: string }>`
         SELECT name FROM pragma_table_info('automation_definitions')

--- a/apps/server/src/persistence/Migrations/048_AutomationCompletionEvaluationBacklog.ts
+++ b/apps/server/src/persistence/Migrations/048_AutomationCompletionEvaluationBacklog.ts
@@ -1,0 +1,49 @@
+import { Effect } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  // Backs the pending stop-check scan, which reads oldest succeeded runs first.
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_automation_runs_completion_eval
+    ON automation_runs (finished_at, run_id)
+    WHERE status = 'succeeded' AND finished_at IS NOT NULL
+  `;
+
+  yield* sql`
+    CREATE VIEW IF NOT EXISTS automation_pending_completion_evaluations AS
+    SELECT
+      runs.run_id,
+      runs.automation_id,
+      runs.thread_id,
+      runs.finished_at
+    FROM automation_runs runs
+    INNER JOIN automation_definitions definitions
+      ON definitions.automation_id = runs.automation_id
+    WHERE runs.status = 'succeeded'
+      AND definitions.enabled = 1
+      AND definitions.archived_at IS NULL
+      AND definitions.mode = 'heartbeat'
+      AND json_extract(definitions.completion_policy_json, '$.type') = 'ai-evaluated'
+      AND runs.finished_at IS NOT NULL
+      AND (
+        json_extract(runs.permission_snapshot_json, '$.completionPolicyVersion') =
+          definitions.completion_policy_version
+        OR (
+          json_type(runs.permission_snapshot_json, '$.completionPolicyVersion') IS NULL
+          AND COALESCE(runs.started_at, runs.created_at) >
+            COALESCE(
+              definitions.completion_policy_updated_at,
+              definitions.updated_at,
+              definitions.created_at,
+              '1970-01-01T00:00:00.000Z'
+            )
+        )
+      )
+      AND (
+        runs.result_json IS NULL
+        OR json_type(runs.result_json, '$.completionEvaluation') IS NULL
+      )
+  `;
+});

--- a/apps/web/src/routes/-automations.shared.test.tsx
+++ b/apps/web/src/routes/-automations.shared.test.tsx
@@ -552,7 +552,7 @@ describe("automation shared route helpers", () => {
     });
   });
 
-  it("applies equal-timestamp snapshot run updates", () => {
+  it("keeps cached run state when an equal-timestamp snapshot arrives later", () => {
     const firstRun = runWith({
       id: runId("run-snapshot-cache-equal"),
       result: { ...baseRun.result!, unread: true, archivedAt: null },
@@ -569,8 +569,8 @@ describe("automation shared route helpers", () => {
     );
 
     expect(afterSnapshot.runs.find((run) => run.id === snapshotRun.id)?.result).toMatchObject({
-      unread: false,
-      archivedAt: "2026-06-19T10:02:00.000Z",
+      unread: true,
+      archivedAt: null,
     });
   });
 
@@ -595,6 +595,27 @@ describe("automation shared route helpers", () => {
       afterLateLiveEvent.definitions.find((definition) => definition.id === newerDefinition.id)
         ?.name,
     ).toBe("New name");
+  });
+
+  it("keeps cached definition state when an equal-timestamp snapshot arrives later", () => {
+    const cachedDefinition = definitionWith({
+      id: automationId("automation-snapshot-cache-equal"),
+      name: "Updated name",
+      updatedAt: "2026-06-19T10:02:00.000Z",
+    });
+    const snapshotDefinition = definitionWith({
+      ...cachedDefinition,
+      name: "Older snapshot name",
+    });
+
+    const afterSnapshot = applyAutomationEvent(
+      { definitions: [cachedDefinition], runs: [] },
+      { type: "snapshot", definitions: [snapshotDefinition], runs: [] },
+    );
+
+    expect(
+      afterSnapshot.definitions.find((definition) => definition.id === cachedDefinition.id)?.name,
+    ).toBe("Updated name");
   });
 
   it("does not resurrect a deleted automation from a late snapshot", () => {

--- a/apps/web/src/routes/-automations.shared.test.tsx
+++ b/apps/web/src/routes/-automations.shared.test.tsx
@@ -530,6 +530,50 @@ describe("automation shared route helpers", () => {
     );
   });
 
+  it("applies equal-timestamp live run updates", () => {
+    const firstRun = runWith({
+      id: runId("run-live-cache-equal"),
+      result: { ...baseRun.result!, unread: true, archivedAt: null },
+      updatedAt: "2026-06-19T10:02:00.000Z",
+    });
+    const followUpRun = runWith({
+      ...firstRun,
+      result: { ...baseRun.result!, unread: false, archivedAt: "2026-06-19T10:02:00.000Z" },
+    });
+
+    const afterLiveEvent = applyAutomationEvent(
+      { definitions: [baseDefinition], runs: [firstRun] },
+      { type: "run-upserted", run: followUpRun },
+    );
+
+    expect(afterLiveEvent.runs.find((run) => run.id === followUpRun.id)?.result).toMatchObject({
+      unread: false,
+      archivedAt: "2026-06-19T10:02:00.000Z",
+    });
+  });
+
+  it("applies equal-timestamp snapshot run updates", () => {
+    const firstRun = runWith({
+      id: runId("run-snapshot-cache-equal"),
+      result: { ...baseRun.result!, unread: true, archivedAt: null },
+      updatedAt: "2026-06-19T10:02:00.000Z",
+    });
+    const snapshotRun = runWith({
+      ...firstRun,
+      result: { ...baseRun.result!, unread: false, archivedAt: "2026-06-19T10:02:00.000Z" },
+    });
+
+    const afterSnapshot = applyAutomationEvent(
+      { definitions: [baseDefinition], runs: [firstRun] },
+      { type: "snapshot", definitions: [baseDefinition], runs: [snapshotRun] },
+    );
+
+    expect(afterSnapshot.runs.find((run) => run.id === snapshotRun.id)?.result).toMatchObject({
+      unread: false,
+      archivedAt: "2026-06-19T10:02:00.000Z",
+    });
+  });
+
   it("keeps a newer definition update when an older live event arrives later", () => {
     const staleDefinition = definitionWith({
       id: automationId("automation-live-cache-race"),

--- a/apps/web/src/routes/-automations.shared.test.tsx
+++ b/apps/web/src/routes/-automations.shared.test.tsx
@@ -508,6 +508,51 @@ describe("automation shared route helpers", () => {
     );
   });
 
+  it("keeps a newer run update when an older live event arrives later", () => {
+    const staleRun = runWith({
+      id: runId("run-live-cache-race"),
+      result: { ...baseRun.result!, unread: true },
+      updatedAt: "2026-06-19T10:01:00.000Z",
+    });
+    const newerRun = runWith({
+      ...staleRun,
+      result: { ...baseRun.result!, unread: false },
+      updatedAt: "2026-06-19T10:02:00.000Z",
+    });
+
+    const afterLateLiveEvent = applyAutomationEvent(
+      { definitions: [baseDefinition], runs: [newerRun] },
+      { type: "run-upserted", run: staleRun },
+    );
+
+    expect(afterLateLiveEvent.runs.find((run) => run.id === newerRun.id)?.result?.unread).toBe(
+      false,
+    );
+  });
+
+  it("keeps a newer definition update when an older live event arrives later", () => {
+    const staleDefinition = definitionWith({
+      id: automationId("automation-live-cache-race"),
+      name: "Old name",
+      updatedAt: "2026-06-19T10:01:00.000Z",
+    });
+    const newerDefinition = definitionWith({
+      ...staleDefinition,
+      name: "New name",
+      updatedAt: "2026-06-19T10:02:00.000Z",
+    });
+
+    const afterLateLiveEvent = applyAutomationEvent(
+      { definitions: [newerDefinition], runs: [] },
+      { type: "definition-upserted", definition: staleDefinition },
+    );
+
+    expect(
+      afterLateLiveEvent.definitions.find((definition) => definition.id === newerDefinition.id)
+        ?.name,
+    ).toBe("New name");
+  });
+
   it("does not resurrect a deleted automation from a late snapshot", () => {
     const deletedDefinition = definitionWith({
       id: automationId("automation-deleted-cache-race"),

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -357,8 +357,8 @@ export function automationStatusDotClass(
 
 const deletedAutomationIdsInCache = new Set<string>();
 
-function isNewerOrEqualTimestamp(candidate: string, existing: string): boolean {
-  return candidate.localeCompare(existing) >= 0;
+function isNewerTimestamp(candidate: string, existing: string): boolean {
+  return candidate.localeCompare(existing) > 0;
 }
 
 function mergeDefinitionsByUpdatedAt(
@@ -378,7 +378,7 @@ function mergeDefinitionsByUpdatedAt(
     const previousDefinition = previousById.get(snapshotDefinition.id);
     definitions.push(
       previousDefinition &&
-        isNewerOrEqualTimestamp(previousDefinition.updatedAt, snapshotDefinition.updatedAt)
+        isNewerTimestamp(previousDefinition.updatedAt, snapshotDefinition.updatedAt)
         ? previousDefinition
         : snapshotDefinition,
     );
@@ -391,7 +391,7 @@ function upsertDefinitionByUpdatedAt(
   incoming: AutomationDefinition,
 ): AutomationDefinition[] {
   const existing = definitions.find((definition) => definition.id === incoming.id);
-  if (existing && isNewerOrEqualTimestamp(existing.updatedAt, incoming.updatedAt)) {
+  if (existing && isNewerTimestamp(existing.updatedAt, incoming.updatedAt)) {
     return [...definitions];
   }
   return existing
@@ -415,7 +415,7 @@ function mergeRunsByUpdatedAt(
     }
     const previousRun = previousById.get(snapshotRun.id);
     runs.push(
-      previousRun && isNewerOrEqualTimestamp(previousRun.updatedAt, snapshotRun.updatedAt)
+      previousRun && isNewerTimestamp(previousRun.updatedAt, snapshotRun.updatedAt)
         ? previousRun
         : snapshotRun,
     );
@@ -428,7 +428,7 @@ function upsertRunByUpdatedAt(
   incoming: AutomationRun,
 ): AutomationRun[] {
   const existing = runs.find((run) => run.id === incoming.id);
-  if (existing && isNewerOrEqualTimestamp(existing.updatedAt, incoming.updatedAt)) {
+  if (existing && isNewerTimestamp(existing.updatedAt, incoming.updatedAt)) {
     return [...runs];
   }
   return existing

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -361,6 +361,11 @@ function isNewerTimestamp(candidate: string, existing: string): boolean {
   return candidate.localeCompare(existing) > 0;
 }
 
+// Snapshots are reconciliation data, so equal timestamps keep the live cache winner.
+function isSameOrNewerTimestamp(candidate: string, existing: string): boolean {
+  return candidate.localeCompare(existing) >= 0;
+}
+
 function mergeDefinitionsByUpdatedAt(
   snapshotDefinitions: readonly AutomationDefinition[],
   previousDefinitions: readonly AutomationDefinition[],
@@ -378,7 +383,7 @@ function mergeDefinitionsByUpdatedAt(
     const previousDefinition = previousById.get(snapshotDefinition.id);
     definitions.push(
       previousDefinition &&
-        isNewerTimestamp(previousDefinition.updatedAt, snapshotDefinition.updatedAt)
+        isSameOrNewerTimestamp(previousDefinition.updatedAt, snapshotDefinition.updatedAt)
         ? previousDefinition
         : snapshotDefinition,
     );
@@ -415,7 +420,7 @@ function mergeRunsByUpdatedAt(
     }
     const previousRun = previousById.get(snapshotRun.id);
     runs.push(
-      previousRun && isNewerTimestamp(previousRun.updatedAt, snapshotRun.updatedAt)
+      previousRun && isSameOrNewerTimestamp(previousRun.updatedAt, snapshotRun.updatedAt)
         ? previousRun
         : snapshotRun,
     );

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -386,6 +386,19 @@ function mergeDefinitionsByUpdatedAt(
   return definitions;
 }
 
+function upsertDefinitionByUpdatedAt(
+  definitions: readonly AutomationDefinition[],
+  incoming: AutomationDefinition,
+): AutomationDefinition[] {
+  const existing = definitions.find((definition) => definition.id === incoming.id);
+  if (existing && isNewerOrEqualTimestamp(existing.updatedAt, incoming.updatedAt)) {
+    return [...definitions];
+  }
+  return existing
+    ? definitions.map((definition) => (definition.id === incoming.id ? incoming : definition))
+    : [incoming, ...definitions];
+}
+
 function mergeRunsByUpdatedAt(
   snapshotRuns: readonly AutomationRun[],
   previousRuns: readonly AutomationRun[],
@@ -410,6 +423,19 @@ function mergeRunsByUpdatedAt(
   return runs;
 }
 
+function upsertRunByUpdatedAt(
+  runs: readonly AutomationRun[],
+  incoming: AutomationRun,
+): AutomationRun[] {
+  const existing = runs.find((run) => run.id === incoming.id);
+  if (existing && isNewerOrEqualTimestamp(existing.updatedAt, incoming.updatedAt)) {
+    return [...runs];
+  }
+  return existing
+    ? runs.map((run) => (run.id === incoming.id ? incoming : run))
+    : [incoming, ...runs];
+}
+
 export function applyAutomationEvent(
   prev: AutomationListResult | undefined,
   event: AutomationStreamEvent,
@@ -425,13 +451,11 @@ export function applyAutomationEvent(
       };
     }
     case "definition-upserted": {
+      if (deletedAutomationIdsInCache.has(event.definition.id)) {
+        return base;
+      }
       deletedAutomationIdsInCache.delete(event.definition.id);
-      const exists = base.definitions.some((definition) => definition.id === event.definition.id);
-      const definitions = exists
-        ? base.definitions.map((definition) =>
-            definition.id === event.definition.id ? event.definition : definition,
-          )
-        : [event.definition, ...base.definitions];
+      const definitions = upsertDefinitionByUpdatedAt(base.definitions, event.definition);
       return { definitions, runs: base.runs };
     }
     case "definition-deleted":
@@ -444,10 +468,7 @@ export function applyAutomationEvent(
       if (deletedAutomationIdsInCache.has(event.run.automationId)) {
         return base;
       }
-      const exists = base.runs.some((run) => run.id === event.run.id);
-      const runs = exists
-        ? base.runs.map((run) => (run.id === event.run.id ? event.run : run))
-        : [event.run, ...base.runs];
+      const runs = upsertRunByUpdatedAt(base.runs, event.run);
       return { definitions: base.definitions, runs };
     }
   }


### PR DESCRIPTION
## Summary

- cleans up newly created standalone automation worktrees when cancellation or `thread.create` failure happens before durable thread ownership exists
- guards live automation definition/run upserts by `updatedAt` so stale stream events cannot roll back newer cache rows
- adds a focused pending completion-evaluation migration/index and consolidates duplicated scheduler-critical SQL through a shared view
- bounds the completion-evaluation queue while preserving DB reconciliation for pending rows

## Validation

- `cd apps/server && bun run test src/automation/Layers/AutomationService.test.ts src/persistence/Layers/AutomationRepository.test.ts src/persistence/Migrations.test.ts src/persistence/Migrations/044_Automations.test.ts`
- `cd apps/web && bun run test src/routes/-automations.shared.test.tsx`
- `git diff --check`

## Notes

I did not run `bun fmt`, `bun lint`, or `bun typecheck` because this thread explicitly limited verification to focused tests unless those heavyweight checks are requested.
