### PR TITLE
[codex] fix attachment drag-drop audit issues

### DIFF
--- a/apps/server/src/orchestration/dispatchCommandNormalization.test.ts
+++ b/apps/server/src/orchestration/dispatchCommandNormalization.test.ts
@@ -1,9 +1,19 @@
 // FILE: dispatchCommandNormalization.test.ts
-// Purpose: Verifies client command normalization for managed chat workspace setup.
+// Purpose: Verifies client command normalization for managed workspaces and uploads.
 
-import { CommandId, type ClientOrchestrationCommand, ProjectId } from "@t3tools/contracts";
-import type { FileSystem, Path } from "effect";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  CommandId,
+  MessageId,
+  type ClientOrchestrationCommand,
+  ProjectId,
+  ThreadId,
+} from "@t3tools/contracts";
 import { Effect } from "effect";
+import type { FileSystem, Path } from "effect";
 import { describe, expect, it } from "vitest";
 
 import { makeDispatchCommandNormalizer } from "./dispatchCommandNormalization";
@@ -75,5 +85,71 @@ describe("makeDispatchCommandNormalizer", () => {
     );
 
     expect(preparedRoots).toEqual([]);
+  });
+
+  it("rolls back attachment files written before a later upload fails", async () => {
+    const attachmentsDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-dispatch-normalize-"));
+    const fileSystem = {
+      makeDirectory: (dir: string, options?: { readonly recursive?: boolean }) =>
+        Effect.sync(() => {
+          fs.mkdirSync(dir, { recursive: options?.recursive === true });
+        }),
+      writeFile: (filePath: string, bytes: Uint8Array) =>
+        Effect.sync(() => {
+          fs.writeFileSync(filePath, bytes);
+        }),
+      remove: (filePath: string, options?: { readonly force?: boolean }) =>
+        Effect.sync(() => {
+          fs.rmSync(filePath, { force: options?.force === true });
+        }),
+    } as unknown as FileSystem.FileSystem;
+    const normalizer = makeDispatchCommandNormalizer<Error>({
+      attachmentsDir,
+      fileSystem,
+      path: path as unknown as Path.Path,
+      canonicalizeProjectWorkspaceRoot: (workspaceRoot) => Effect.succeed(workspaceRoot),
+    });
+
+    try {
+      await expect(
+        Effect.runPromise(
+          normalizer({
+            command: {
+              type: "thread.turn.start",
+              commandId: CommandId.makeUnsafe("cmd-turn-attachments"),
+              threadId: ThreadId.makeUnsafe("thread-rollback-attachments"),
+              message: {
+                messageId: MessageId.makeUnsafe("msg-attachments"),
+                role: "user",
+                text: "send files",
+                attachments: [
+                  {
+                    type: "image",
+                    name: "ok.png",
+                    mimeType: "image/png",
+                    sizeBytes: 1,
+                    dataUrl: "data:image/png;base64,AQ==",
+                  },
+                  {
+                    type: "image",
+                    name: "bad.png",
+                    mimeType: "image/png",
+                    sizeBytes: 1,
+                    dataUrl: "data:text/plain;base64,AQ==",
+                  },
+                ],
+              },
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              createdAt: "2026-01-01T00:00:00.000Z",
+            } satisfies Extract<ClientOrchestrationCommand, { type: "thread.turn.start" }>,
+          }),
+        ),
+      ).rejects.toThrow("Invalid image attachment payload");
+
+      expect(fs.readdirSync(attachmentsDir)).toEqual([]);
+    } finally {
+      fs.rmSync(attachmentsDir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/server/src/orchestration/dispatchCommandNormalization.ts
+++ b/apps/server/src/orchestration/dispatchCommandNormalization.ts
@@ -49,6 +49,7 @@ function persistBinaryAttachment(input: {
   readonly path: Path.Path;
   readonly maxBytes: number;
   readonly requireImageMime: boolean;
+  readonly trackAttachmentPath?: ((path: string) => void) | undefined;
 }): Effect.Effect<ChatAttachment, Error, never> {
   return Effect.gen(function* () {
     const parsed = parseBinaryAttachmentDataUrl(input.attachment.dataUrl);
@@ -103,6 +104,7 @@ function persistBinaryAttachment(input: {
         new Error(`Failed to resolve persisted path for '${input.attachment.name}'.`),
       );
     }
+    input.trackAttachmentPath?.(attachmentPath);
 
     yield* input.fileSystem
       .makeDirectory(input.path.dirname(attachmentPath), { recursive: true })
@@ -121,6 +123,18 @@ function persistBinaryAttachment(input: {
 
     return persistedAttachment;
   });
+}
+
+function removePersistedAttachmentPaths(input: {
+  readonly paths: ReadonlyArray<string>;
+  readonly fileSystem: FileSystem.FileSystem;
+}): Effect.Effect<void> {
+  return Effect.forEach(
+    input.paths,
+    (attachmentPath) =>
+      input.fileSystem.remove(attachmentPath, { force: true }).pipe(Effect.ignore),
+    { discard: true, concurrency: 1 },
+  );
 }
 
 export interface DispatchCommandNormalizerOptions<E> {
@@ -192,6 +206,7 @@ export function makeDispatchCommandNormalizer<E>(options: DispatchCommandNormali
     }
     const turnStartCommand = input.command;
 
+    const writtenAttachmentPaths: string[] = [];
     const normalizedAttachments = yield* Effect.forEach(
       turnStartCommand.message.attachments,
       (attachment) =>
@@ -219,6 +234,7 @@ export function makeDispatchCommandNormalizer<E>(options: DispatchCommandNormali
               path: options.path,
               maxBytes: PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
               requireImageMime: true,
+              trackAttachmentPath: (attachmentPath) => writtenAttachmentPaths.push(attachmentPath),
             });
           }
 
@@ -230,9 +246,20 @@ export function makeDispatchCommandNormalizer<E>(options: DispatchCommandNormali
             path: options.path,
             maxBytes: PROVIDER_SEND_TURN_MAX_FILE_BYTES,
             requireImageMime: false,
+            trackAttachmentPath: (attachmentPath) => writtenAttachmentPaths.push(attachmentPath),
           });
         }),
       { concurrency: 1 },
+    ).pipe(
+      Effect.catch((error) =>
+        Effect.gen(function* () {
+          yield* removePersistedAttachmentPaths({
+            paths: writtenAttachmentPaths,
+            fileSystem: options.fileSystem,
+          });
+          return yield* Effect.fail(error);
+        }),
+      ),
     );
 
     return {

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -518,6 +518,9 @@ export function BrowserPanel({
   const composerDraftImageCount = useComposerDraftStore(
     (store) => store.draftsByThreadId[threadId]?.images.length ?? 0,
   );
+  const composerDraftFileCount = useComposerDraftStore(
+    (store) => store.draftsByThreadId[threadId]?.files.length ?? 0,
+  );
   const composerDraftAssistantSelectionCount = useComposerDraftStore(
     (store) => store.draftsByThreadId[threadId]?.assistantSelections.length ?? 0,
   );
@@ -1111,7 +1114,8 @@ export function BrowserPanel({
       return;
     }
 
-    const attachmentCount = composerDraftImageCount + composerDraftAssistantSelectionCount;
+    const attachmentCount =
+      composerDraftImageCount + composerDraftFileCount + composerDraftAssistantSelectionCount;
     if (attachmentCount >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
       setLocalError(
         `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} references per message.`,
@@ -1140,6 +1144,7 @@ export function BrowserPanel({
     addComposerDraftImage,
     api,
     composerDraftAssistantSelectionCount,
+    composerDraftFileCount,
     composerDraftImageCount,
     ensureLiveRuntime,
     runBrowserAction,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1423,9 +1423,9 @@ export default function ChatView({
       deriveAssociatedWorktreeMetadata({
         branch: activeThread?.branch ?? null,
         worktreePath: activeThread?.worktreePath ?? null,
-        associatedWorktreePath: activeThread?.associatedWorktreePath,
-        associatedWorktreeBranch: activeThread?.associatedWorktreeBranch,
-        associatedWorktreeRef: activeThread?.associatedWorktreeRef,
+        associatedWorktreePath: activeThread?.associatedWorktreePath ?? null,
+        associatedWorktreeBranch: activeThread?.associatedWorktreeBranch ?? null,
+        associatedWorktreeRef: activeThread?.associatedWorktreeRef ?? null,
       }),
     [
       activeThread?.associatedWorktreeBranch,
@@ -5695,7 +5695,10 @@ export default function ChatView({
     onComposerDrop,
   } = useComposerDropzone({
     addImages: addComposerImages,
-    addFiles: addComposerFiles,
+    fileSupport: {
+      genericFiles: "accept",
+      addFiles: addComposerFiles,
+    },
     appendReferenceText: (referenceText) => appendComposerPromptText(threadId, referenceText),
     dragDepthRef,
     focusComposer,
@@ -6309,8 +6312,7 @@ export default function ChatView({
     const queuedChatTurn = queuedTurn ?? null;
     const liveComposerSnapshot =
       queuedChatTurn === null ? (composerEditorRef.current?.readSnapshot() ?? null) : null;
-    const promptForSend =
-      queuedChatTurn?.prompt ?? liveComposerSnapshot?.value ?? promptRef.current;
+    let promptForSend = queuedChatTurn?.prompt ?? liveComposerSnapshot?.value ?? promptRef.current;
     let composerImagesForSend = queuedChatTurn?.images ?? composerImages;
     const composerFilesForSend = queuedChatTurn?.files ?? composerFiles;
     const composerAssistantSelectionsForSend =
@@ -6331,7 +6333,7 @@ export default function ChatView({
     const providerOptionsForDispatchForSend =
       queuedChatTurn?.providerOptionsForDispatch ?? providerOptionsForDispatch;
     const runtimeModeForSend = queuedChatTurn?.runtimeMode ?? runtimeMode;
-    const interactionModeForSend = queuedChatTurn?.interactionMode ?? interactionMode;
+    let interactionModeForSend = queuedChatTurn?.interactionMode ?? interactionMode;
     const envModeForSend = queuedChatTurn?.envMode ?? envMode;
     const {
       trimmedPrompt: trimmed,
@@ -6348,14 +6350,28 @@ export default function ChatView({
       terminalContexts: composerTerminalContextsForSend,
       pastedTexts: composerPastedTextsForSend,
     });
-    // Queued chat turns already captured their intended mode; only live composer
-    // submissions should be interpreted as plan refinement/implementation.
-    if (queuedChatTurn === null && showPlanFollowUpPrompt && activeProposedPlan) {
+    let trimmedPromptForSend = trimmed;
+    const isLivePlanFollowUpSubmission =
+      queuedChatTurn === null && showPlanFollowUpPrompt && activeProposedPlan !== null;
+    const hasStructuredPlanFollowUpContent =
+      composerImagesForSend.length > 0 ||
+      composerFilesForSend.length > 0 ||
+      composerAssistantSelectionsForSend.length > 0 ||
+      composerFileCommentsForSend.length > 0 ||
+      sendableComposerTerminalContexts.length > 0 ||
+      sendableComposerPastedTexts.length > 0;
+    // Queued chat turns already captured their intended mode. Live plan follow-ups
+    // with attachments must use the normal send path so references are preserved.
+    if (isLivePlanFollowUpSubmission) {
       const followUp = resolvePlanFollowUpSubmission({
         draftText: trimmed,
         planMarkdown: activeProposedPlan.planMarkdown,
       });
-      if (hasLiveTurn && dispatchMode === "queue" && queuedChatTurn === null) {
+      if (hasStructuredPlanFollowUpContent) {
+        promptForSend = followUp.text;
+        interactionModeForSend = followUp.interactionMode;
+        trimmedPromptForSend = followUp.text.trim();
+      } else if (hasLiveTurn && dispatchMode === "queue") {
         clearComposerInput(activeThread.id);
         enqueueQueuedComposerTurn(activeThread.id, {
           id: randomUUID(),
@@ -6391,11 +6407,19 @@ export default function ChatView({
       selectedComposerMentionsForSend.length === 0;
     const hasPromptOnlySendableContent = hasNoStructuredComposerContext;
     if (hasPromptOnlySendableContent) {
-      const handledSlashCommand = await handleStandaloneSlashCommand(trimmed);
+      const handledSlashCommand = await handleStandaloneSlashCommand(trimmedPromptForSend);
       if (handledSlashCommand) {
         return true;
       }
     }
+    const sourceProposedPlanForSend =
+      queuedChatTurn?.sourceProposedPlan ??
+      (isLivePlanFollowUpSubmission && activeProposedPlan && interactionModeForSend === "default"
+        ? buildSourceProposedPlanReference({
+            threadId: activeThread.id,
+            proposedPlan: activeProposedPlan,
+          })
+        : undefined);
     if (!hasSendableContent) {
       if (expiredTerminalContextCount > 0) {
         const toastCopy = buildExpiredTerminalContextToastCopy(
@@ -6411,9 +6435,9 @@ export default function ChatView({
       return false;
     }
     if (!activeProject) return false;
-    if (queuedChatTurn === null) {
+    if (queuedChatTurn === null && !isLivePlanFollowUpSubmission) {
       const automationRequest = await resolveComposerAutomationRequest({
-        message: trimmed,
+        message: trimmedPromptForSend,
         cwd: activeProject.cwd,
         generateIntent: (request) => api.server.generateAutomationIntent(request),
       });
@@ -6566,6 +6590,7 @@ export default function ChatView({
         ...(providerOptionsForDispatchForSend
           ? { providerOptionsForDispatch: providerOptionsForDispatchForSend }
           : {}),
+        ...(sourceProposedPlanForSend ? { sourceProposedPlan: sourceProposedPlanForSend } : {}),
         runtimeMode: runtimeModeForSend,
         interactionMode: interactionModeForSend,
         envMode: envModeForSend,
@@ -6579,7 +6604,7 @@ export default function ChatView({
     if (composerImagesForSend.length > 0) {
       firstComposerImageNameForTitle = composerImagesForSend[0]?.name ?? null;
     }
-    let titleSeed = trimmed;
+    let titleSeed = trimmedPromptForSend;
     if (!titleSeed) {
       if (firstComposerImageNameForTitle) {
         titleSeed = `Image: ${firstComposerImageNameForTitle}`;
@@ -6817,7 +6842,7 @@ export default function ChatView({
     // must not clear a separate live draft the user may already be editing.
     if (queuedChatTurn === null) {
       promptRef.current = "";
-      clearComposerDraftContent(threadIdForSend);
+      clearComposerDraftContent(threadIdForSend, { preservePreviewUrls: true });
       setComposerHighlightedItemId(null);
       setComposerCursor(0);
       setComposerTrigger(null);
@@ -6984,9 +7009,14 @@ export default function ChatView({
         dispatchMode,
         runtimeMode: nextRuntimeModeForSend,
         interactionMode: interactionModeForSend,
+        ...(sourceProposedPlanForSend ? { sourceProposedPlan: sourceProposedPlanForSend } : {}),
         createdAt: messageCreatedAt,
       });
       turnStartSucceeded = true;
+      if (sourceProposedPlanForSend) {
+        planSidebarDismissedForTurnRef.current = null;
+        setPlanSidebarOpen(true);
+      }
     })().catch(async (err: unknown) => {
       if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
         // This rollback cleans up a retryable draft promotion; do not tombstone the draft id.

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4607,6 +4607,7 @@ export default function ChatView({
       pendingUserInputs.length === 0 &&
       !isComposerApprovalState,
     composerImagesRef,
+    composerFilesRef,
     composerAssistantSelectionsRef,
     addComposerAssistantSelectionToDraft,
     scheduleComposerFocus,
@@ -6396,8 +6397,20 @@ export default function ChatView({
       pastedTexts: composerPastedTextsForSend,
     });
     let trimmedPromptForSend = trimmed;
+    const restoredQueuedPlanDraftSource =
+      queuedChatTurn === null &&
+      restoredQueuedSourceProposedPlanRef.current?.threadId === activeThread.id &&
+      composerPromptStillMatchesRestoredQueuedDraft(
+        restoredQueuedSourceProposedPlanRef.current.restoredPrompt,
+        promptForSend,
+      )
+        ? restoredQueuedSourceProposedPlanRef.current
+        : null;
     const isLivePlanFollowUpSubmission =
-      queuedChatTurn === null && showPlanFollowUpPrompt && activeProposedPlan !== null;
+      queuedChatTurn === null &&
+      restoredQueuedPlanDraftSource === null &&
+      showPlanFollowUpPrompt &&
+      activeProposedPlan !== null;
     const hasStructuredPlanFollowUpContent =
       composerImagesForSend.length > 0 ||
       composerFilesForSend.length > 0 ||
@@ -6461,9 +6474,7 @@ export default function ChatView({
     }
     const sourceProposedPlanForSend =
       queuedChatTurn?.sourceProposedPlan ??
-      (restoredQueuedSourceProposedPlanRef.current?.threadId === activeThread.id
-        ? restoredQueuedSourceProposedPlanRef.current.sourceProposedPlan
-        : undefined) ??
+      restoredQueuedPlanDraftSource?.sourceProposedPlan ??
       (isLivePlanFollowUpSubmission && activeProposedPlan && interactionModeForSend === "default"
         ? buildSourceProposedPlanReference({
             threadId: activeThread.id,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -303,6 +303,7 @@ import {
   type QueuedComposerChatTurn,
   type QueuedComposerPlanFollowUp,
   type QueuedComposerTurn,
+  type RestoredComposerSourceProposedPlan,
   useComposerDraftStore,
   useComposerThreadDraft,
   useEffectiveComposerModelState,
@@ -900,6 +901,7 @@ export default function ChatView({
   const composerSkills = composerDraft.skills;
   const composerMentions = composerDraft.mentions;
   const queuedComposerTurns = composerDraft.queuedTurns;
+  const restoredSourceProposedPlan = composerDraft.restoredSourceProposedPlan;
   const {
     isRecording: isVoiceRecording,
     durationMs: voiceRecordingDurationMs,
@@ -979,6 +981,9 @@ export default function ChatView({
   );
   const syncComposerDraftPersistedAttachments = useComposerDraftStore(
     (store) => store.syncPersistedAttachments,
+  );
+  const setComposerDraftRestoredSourceProposedPlan = useComposerDraftStore(
+    (store) => store.setRestoredSourceProposedPlan,
   );
   const clearComposerDraftContent = useComposerDraftStore((store) => store.clearComposerContent);
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
@@ -1159,11 +1164,9 @@ export default function ChatView({
   const composerMenuOpenRef = useRef(false);
   const composerMenuItemsRef = useRef<ComposerCommandItem[]>([]);
   const queuedComposerTurnsRef = useRef<QueuedComposerTurn[]>([]);
-  const restoredQueuedSourceProposedPlanRef = useRef<{
-    threadId: ThreadId;
-    restoredPrompt: string;
-    sourceProposedPlan: QueuedComposerChatTurn["sourceProposedPlan"];
-  } | null>(null);
+  const restoredQueuedSourceProposedPlanRef = useRef<RestoredComposerSourceProposedPlan | null>(
+    restoredSourceProposedPlan ?? null,
+  );
   const autoDispatchingQueuedTurnRef = useRef(false);
   const activeComposerMenuItemRef = useRef<ComposerCommandItem | null>(null);
   const localDirectoryMenuRef = useRef<ComposerLocalDirectoryMenuHandle | null>(null);
@@ -1173,6 +1176,16 @@ export default function ChatView({
   const dragDepthRef = useRef(0);
   const terminalOpenByThreadRef = useRef<Record<string, boolean>>({});
   const activatedThreadIdRef = useRef<ThreadId | null>(null);
+  const setRestoredQueuedSourceProposedPlan = useCallback(
+    (targetThreadId: ThreadId, source: RestoredComposerSourceProposedPlan | null) => {
+      restoredQueuedSourceProposedPlanRef.current = source;
+      setComposerDraftRestoredSourceProposedPlan(targetThreadId, source);
+    },
+    [setComposerDraftRestoredSourceProposedPlan],
+  );
+  useEffect(() => {
+    restoredQueuedSourceProposedPlanRef.current = restoredSourceProposedPlan ?? null;
+  }, [restoredSourceProposedPlan]);
 
   const terminalState = useTerminalStateStore((state) =>
     selectThreadTerminalState(state.terminalStateByThreadId, threadId),
@@ -5819,7 +5832,7 @@ export default function ChatView({
   const clearComposerInput = useCallback(
     (threadId: ThreadId) => {
       promptRef.current = "";
-      restoredQueuedSourceProposedPlanRef.current = null;
+      setRestoredQueuedSourceProposedPlan(threadId, null);
       clearComposerDraftContent(threadId);
       updateSelectedComposerSkills([]);
       updateSelectedComposerMentions([]);
@@ -5827,7 +5840,12 @@ export default function ChatView({
       setComposerCursor(0);
       setComposerTrigger(null);
     },
-    [clearComposerDraftContent, updateSelectedComposerMentions, updateSelectedComposerSkills],
+    [
+      clearComposerDraftContent,
+      setRestoredQueuedSourceProposedPlan,
+      updateSelectedComposerMentions,
+      updateSelectedComposerSkills,
+    ],
   );
 
   const toggleAutomationWarning = useCallback((id: AutomationDraftWarningId, checked: boolean) => {
@@ -6261,14 +6279,16 @@ export default function ChatView({
         updateSelectedComposerSkills([]);
         updateSelectedComposerMentions([]);
       }
-      restoredQueuedSourceProposedPlanRef.current =
+      setRestoredQueuedSourceProposedPlan(
+        activeThread.id,
         queuedTurn.kind === "chat" && queuedTurn.sourceProposedPlan
           ? {
               threadId: activeThread.id,
               restoredPrompt: nextPrompt,
               sourceProposedPlan: queuedTurn.sourceProposedPlan,
             }
-          : null;
+          : null,
+      );
       setComposerDraftModelSelection(activeThread.id, queuedTurn.modelSelection);
       setComposerDraftRuntimeMode(activeThread.id, queuedTurn.runtimeMode);
       setComposerDraftInteractionMode(activeThread.id, queuedTurn.interactionMode);
@@ -6287,6 +6307,7 @@ export default function ChatView({
       clearComposerDraftContent,
       scheduleComposerFocus,
       setDraftThreadContext,
+      setRestoredQueuedSourceProposedPlan,
       setComposerDraftInteractionMode,
       setComposerDraftModelSelection,
       setComposerDraftPrompt,
@@ -7082,7 +7103,7 @@ export default function ChatView({
         setPlanSidebarOpen(true);
       }
       if (queuedChatTurn === null) {
-        restoredQueuedSourceProposedPlanRef.current = null;
+        setRestoredQueuedSourceProposedPlan(threadIdForSend, null);
       }
     })().catch(async (err: unknown) => {
       if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
@@ -7116,6 +7137,13 @@ export default function ChatView({
         });
         promptRef.current = promptForSend;
         setPrompt(promptForSend);
+        if (sourceProposedPlanForSend) {
+          setRestoredQueuedSourceProposedPlan(threadIdForSend, {
+            threadId: threadIdForSend,
+            restoredPrompt: promptForSend,
+            sourceProposedPlan: sourceProposedPlanForSend,
+          });
+        }
         setComposerCursor(collapseExpandedComposerCursor(promptForSend, promptForSend.length));
         addComposerImagesToDraft(composerImagesSnapshot.map(cloneComposerImageAttachment));
         addComposerFilesToDraft(composerFilesSnapshot);
@@ -8337,7 +8365,7 @@ export default function ChatView({
 
   const setComposerPromptValue = useCallback(
     (nextPrompt: string) => {
-      restoredQueuedSourceProposedPlanRef.current = null;
+      setRestoredQueuedSourceProposedPlan(threadId, null);
       promptRef.current = nextPrompt;
       setPrompt(nextPrompt);
       const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
@@ -8348,18 +8376,23 @@ export default function ChatView({
         composerEditorRef.current?.focusAt(nextCursor);
       });
     },
-    [setPrompt],
+    [setPrompt, setRestoredQueuedSourceProposedPlan, threadId],
   );
 
   const clearComposerSlashDraft = useCallback(() => {
     promptRef.current = "";
-    restoredQueuedSourceProposedPlanRef.current = null;
+    setRestoredQueuedSourceProposedPlan(threadId, null);
     clearComposerDraftContent(threadId);
     setComposerHighlightedItemId(null);
     setComposerCursor(0);
     setComposerTrigger(null);
     scheduleComposerFocus();
-  }, [clearComposerDraftContent, scheduleComposerFocus, threadId]);
+  }, [
+    clearComposerDraftContent,
+    scheduleComposerFocus,
+    setRestoredQueuedSourceProposedPlan,
+    threadId,
+  ]);
 
   const slashEditorActions = useMemo(
     () => ({
@@ -8624,7 +8657,7 @@ export default function ChatView({
           nextPrompt,
         )
       ) {
-        restoredQueuedSourceProposedPlanRef.current = null;
+        setRestoredQueuedSourceProposedPlan(threadId, null);
       }
       promptRef.current = nextPrompt;
       setPrompt(nextPrompt);
@@ -8651,6 +8684,7 @@ export default function ChatView({
       setPrompt,
       setComposerDraftTerminalContexts,
       setComposerCommandPicker,
+      setRestoredQueuedSourceProposedPlan,
       threadId,
     ],
   );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1133,8 +1133,10 @@ export default function ChatView({
   const composerMenuOpenRef = useRef(false);
   const composerMenuItemsRef = useRef<ComposerCommandItem[]>([]);
   const queuedComposerTurnsRef = useRef<QueuedComposerTurn[]>([]);
-  const restoredQueuedSourceProposedPlanRef =
-    useRef<QueuedComposerChatTurn["sourceProposedPlan"]>(undefined);
+  const restoredQueuedSourceProposedPlanRef = useRef<{
+    threadId: ThreadId;
+    sourceProposedPlan: QueuedComposerChatTurn["sourceProposedPlan"];
+  } | null>(null);
   const autoDispatchingQueuedTurnRef = useRef(false);
   const activeComposerMenuItemRef = useRef<ComposerCommandItem | null>(null);
   const localDirectoryMenuRef = useRef<ComposerLocalDirectoryMenuHandle | null>(null);
@@ -5789,7 +5791,7 @@ export default function ChatView({
   const clearComposerInput = useCallback(
     (threadId: ThreadId) => {
       promptRef.current = "";
-      restoredQueuedSourceProposedPlanRef.current = undefined;
+      restoredQueuedSourceProposedPlanRef.current = null;
       clearComposerDraftContent(threadId);
       updateSelectedComposerSkills([]);
       updateSelectedComposerMentions([]);
@@ -6232,7 +6234,9 @@ export default function ChatView({
         updateSelectedComposerMentions([]);
       }
       restoredQueuedSourceProposedPlanRef.current =
-        queuedTurn.kind === "chat" ? queuedTurn.sourceProposedPlan : undefined;
+        queuedTurn.kind === "chat" && queuedTurn.sourceProposedPlan
+          ? { threadId: activeThread.id, sourceProposedPlan: queuedTurn.sourceProposedPlan }
+          : null;
       setComposerDraftModelSelection(activeThread.id, queuedTurn.modelSelection);
       setComposerDraftRuntimeMode(activeThread.id, queuedTurn.runtimeMode);
       setComposerDraftInteractionMode(activeThread.id, queuedTurn.interactionMode);
@@ -6424,7 +6428,9 @@ export default function ChatView({
     }
     const sourceProposedPlanForSend =
       queuedChatTurn?.sourceProposedPlan ??
-      restoredQueuedSourceProposedPlanRef.current ??
+      (restoredQueuedSourceProposedPlanRef.current?.threadId === activeThread.id
+        ? restoredQueuedSourceProposedPlanRef.current.sourceProposedPlan
+        : undefined) ??
       (isLivePlanFollowUpSubmission && activeProposedPlan && interactionModeForSend === "default"
         ? buildSourceProposedPlanReference({
             threadId: activeThread.id,
@@ -7032,7 +7038,7 @@ export default function ChatView({
         setPlanSidebarOpen(true);
       }
       if (queuedChatTurn === null) {
-        restoredQueuedSourceProposedPlanRef.current = undefined;
+        restoredQueuedSourceProposedPlanRef.current = null;
       }
     })().catch(async (err: unknown) => {
       if (createdServerThreadForLocalDraft && !turnStartSucceeded) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -821,6 +821,32 @@ interface ChatViewProps {
   onCloseThreadPane?: () => void;
 }
 
+function normalizeRestoredQueuedPrompt(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function composerPromptStillMatchesRestoredQueuedDraft(
+  restoredPrompt: string,
+  nextPrompt: string,
+): boolean {
+  const restored = normalizeRestoredQueuedPrompt(restoredPrompt);
+  const next = normalizeRestoredQueuedPrompt(nextPrompt);
+  if (next.length === 0) {
+    return false;
+  }
+  if (restored.length === 0) {
+    return true;
+  }
+  if (next.includes(restored)) {
+    return true;
+  }
+  if (next.length >= Math.min(16, restored.length) && restored.includes(next)) {
+    return true;
+  }
+  const probe = restored.slice(0, Math.min(48, restored.length));
+  return probe.length >= 16 && next.includes(probe);
+}
+
 export default function ChatView({
   threadId,
   paneScopeId = "single",
@@ -1135,6 +1161,7 @@ export default function ChatView({
   const queuedComposerTurnsRef = useRef<QueuedComposerTurn[]>([]);
   const restoredQueuedSourceProposedPlanRef = useRef<{
     threadId: ThreadId;
+    restoredPrompt: string;
     sourceProposedPlan: QueuedComposerChatTurn["sourceProposedPlan"];
   } | null>(null);
   const autoDispatchingQueuedTurnRef = useRef(false);
@@ -6235,7 +6262,11 @@ export default function ChatView({
       }
       restoredQueuedSourceProposedPlanRef.current =
         queuedTurn.kind === "chat" && queuedTurn.sourceProposedPlan
-          ? { threadId: activeThread.id, sourceProposedPlan: queuedTurn.sourceProposedPlan }
+          ? {
+              threadId: activeThread.id,
+              restoredPrompt: nextPrompt,
+              sourceProposedPlan: queuedTurn.sourceProposedPlan,
+            }
           : null;
       setComposerDraftModelSelection(activeThread.id, queuedTurn.modelSelection);
       setComposerDraftRuntimeMode(activeThread.id, queuedTurn.runtimeMode);
@@ -6385,30 +6416,32 @@ export default function ChatView({
         promptForSend = followUp.text;
         interactionModeForSend = followUp.interactionMode;
         trimmedPromptForSend = followUp.text.trim();
-      } else if (hasLiveTurn && dispatchMode === "queue") {
+      } else {
+        if (hasLiveTurn && dispatchMode === "queue") {
+          clearComposerInput(activeThread.id);
+          enqueueQueuedComposerTurn(activeThread.id, {
+            id: randomUUID(),
+            kind: "plan-follow-up",
+            createdAt: new Date().toISOString(),
+            previewText: followUp.text.trim(),
+            text: followUp.text,
+            interactionMode: followUp.interactionMode,
+            selectedProvider,
+            selectedModel,
+            selectedPromptEffort,
+            modelSelection: selectedModelSelection,
+            ...(providerOptionsForDispatch ? { providerOptionsForDispatch } : {}),
+            runtimeMode,
+          });
+          return true;
+        }
         clearComposerInput(activeThread.id);
-        enqueueQueuedComposerTurn(activeThread.id, {
-          id: randomUUID(),
-          kind: "plan-follow-up",
-          createdAt: new Date().toISOString(),
-          previewText: followUp.text.trim(),
+        return onSubmitPlanFollowUp({
           text: followUp.text,
           interactionMode: followUp.interactionMode,
-          selectedProvider,
-          selectedModel,
-          selectedPromptEffort,
-          modelSelection: selectedModelSelection,
-          ...(providerOptionsForDispatch ? { providerOptionsForDispatch } : {}),
-          runtimeMode,
+          dispatchMode,
         });
-        return true;
       }
-      clearComposerInput(activeThread.id);
-      return onSubmitPlanFollowUp({
-        text: followUp.text,
-        interactionMode: followUp.interactionMode,
-        dispatchMode,
-      });
     }
     const hasNoStructuredComposerContext =
       composerImagesForSend.length === 0 &&
@@ -8293,6 +8326,7 @@ export default function ChatView({
 
   const setComposerPromptValue = useCallback(
     (nextPrompt: string) => {
+      restoredQueuedSourceProposedPlanRef.current = null;
       promptRef.current = nextPrompt;
       setPrompt(nextPrompt);
       const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
@@ -8308,6 +8342,7 @@ export default function ChatView({
 
   const clearComposerSlashDraft = useCallback(() => {
     promptRef.current = "";
+    restoredQueuedSourceProposedPlanRef.current = null;
     clearComposerDraftContent(threadId);
     setComposerHighlightedItemId(null);
     setComposerCursor(0);
@@ -8569,6 +8604,16 @@ export default function ChatView({
           cursorAdjacentToMention,
         );
         return;
+      }
+      const restoredQueuedSource = restoredQueuedSourceProposedPlanRef.current;
+      if (
+        restoredQueuedSource?.threadId === threadId &&
+        !composerPromptStillMatchesRestoredQueuedDraft(
+          restoredQueuedSource.restoredPrompt,
+          nextPrompt,
+        )
+      ) {
+        restoredQueuedSourceProposedPlanRef.current = null;
       }
       promptRef.current = nextPrompt;
       setPrompt(nextPrompt);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1133,6 +1133,8 @@ export default function ChatView({
   const composerMenuOpenRef = useRef(false);
   const composerMenuItemsRef = useRef<ComposerCommandItem[]>([]);
   const queuedComposerTurnsRef = useRef<QueuedComposerTurn[]>([]);
+  const restoredQueuedSourceProposedPlanRef =
+    useRef<QueuedComposerChatTurn["sourceProposedPlan"]>(undefined);
   const autoDispatchingQueuedTurnRef = useRef(false);
   const activeComposerMenuItemRef = useRef<ComposerCommandItem | null>(null);
   const localDirectoryMenuRef = useRef<ComposerLocalDirectoryMenuHandle | null>(null);
@@ -1418,23 +1420,28 @@ export default function ChatView({
     isFocusedPane && latestTurnLive && !diffEnvironmentPending && !resolvedDiffOpen
       ? GIT_WORKING_TREE_DIFF_LIVE_REFETCH_INTERVAL_MS
       : false;
-  const activeThreadAssociatedWorktree = useMemo(
-    () =>
-      deriveAssociatedWorktreeMetadata({
-        branch: activeThread?.branch ?? null,
-        worktreePath: activeThread?.worktreePath ?? null,
-        associatedWorktreePath: activeThread?.associatedWorktreePath ?? null,
-        associatedWorktreeBranch: activeThread?.associatedWorktreeBranch ?? null,
-        associatedWorktreeRef: activeThread?.associatedWorktreeRef ?? null,
-      }),
-    [
-      activeThread?.associatedWorktreeBranch,
-      activeThread?.associatedWorktreePath,
-      activeThread?.associatedWorktreeRef,
-      activeThread?.branch,
-      activeThread?.worktreePath,
-    ],
-  );
+  const activeThreadAssociatedWorktree = useMemo(() => {
+    const associatedWorktreeInput = {
+      branch: activeThread?.branch ?? null,
+      worktreePath: activeThread?.worktreePath ?? null,
+      ...(activeThread?.associatedWorktreePath !== undefined
+        ? { associatedWorktreePath: activeThread.associatedWorktreePath }
+        : {}),
+      ...(activeThread?.associatedWorktreeBranch !== undefined
+        ? { associatedWorktreeBranch: activeThread.associatedWorktreeBranch }
+        : {}),
+      ...(activeThread?.associatedWorktreeRef !== undefined
+        ? { associatedWorktreeRef: activeThread.associatedWorktreeRef }
+        : {}),
+    };
+    return deriveAssociatedWorktreeMetadata(associatedWorktreeInput);
+  }, [
+    activeThread?.associatedWorktreeBranch,
+    activeThread?.associatedWorktreePath,
+    activeThread?.associatedWorktreeRef,
+    activeThread?.branch,
+    activeThread?.worktreePath,
+  ]);
 
   const openPullRequestDialog = useCallback(
     (reference?: string) => {
@@ -5782,6 +5789,7 @@ export default function ChatView({
   const clearComposerInput = useCallback(
     (threadId: ThreadId) => {
       promptRef.current = "";
+      restoredQueuedSourceProposedPlanRef.current = undefined;
       clearComposerDraftContent(threadId);
       updateSelectedComposerSkills([]);
       updateSelectedComposerMentions([]);
@@ -6223,6 +6231,8 @@ export default function ChatView({
         updateSelectedComposerSkills([]);
         updateSelectedComposerMentions([]);
       }
+      restoredQueuedSourceProposedPlanRef.current =
+        queuedTurn.kind === "chat" ? queuedTurn.sourceProposedPlan : undefined;
       setComposerDraftModelSelection(activeThread.id, queuedTurn.modelSelection);
       setComposerDraftRuntimeMode(activeThread.id, queuedTurn.runtimeMode);
       setComposerDraftInteractionMode(activeThread.id, queuedTurn.interactionMode);
@@ -6414,6 +6424,7 @@ export default function ChatView({
     }
     const sourceProposedPlanForSend =
       queuedChatTurn?.sourceProposedPlan ??
+      restoredQueuedSourceProposedPlanRef.current ??
       (isLivePlanFollowUpSubmission && activeProposedPlan && interactionModeForSend === "default"
         ? buildSourceProposedPlanReference({
             threadId: activeThread.id,
@@ -6843,6 +6854,9 @@ export default function ChatView({
     if (queuedChatTurn === null) {
       promptRef.current = "";
       clearComposerDraftContent(threadIdForSend, { preservePreviewUrls: true });
+      if (isLivePlanFollowUpSubmission) {
+        setComposerDraftInteractionMode(threadIdForSend, interactionModeForSend);
+      }
       setComposerHighlightedItemId(null);
       setComposerCursor(0);
       setComposerTrigger(null);
@@ -7016,6 +7030,9 @@ export default function ChatView({
       if (sourceProposedPlanForSend) {
         planSidebarDismissedForTurnRef.current = null;
         setPlanSidebarOpen(true);
+      }
+      if (queuedChatTurn === null) {
+        restoredQueuedSourceProposedPlanRef.current = undefined;
       }
     })().catch(async (err: unknown) => {
       if (createdServerThreadForLocalDraft && !turnStartSucceeded) {

--- a/apps/web/src/components/chat/ChatTranscriptPane.browser.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.browser.tsx
@@ -33,6 +33,7 @@ const TIMELINE_ENTRIES = [
 function TranscriptPerfHarness(props: { onTranscriptRender: () => void }) {
   const [composerValue, setComposerValue] = useState("");
   const composerImagesRef = useRef<readonly []>([]);
+  const composerFilesRef = useRef<readonly []>([]);
   const composerAssistantSelectionsRef = useRef<readonly []>([]);
   const listRef = useRef<LegendListRef | null>(null);
   const {
@@ -50,6 +51,7 @@ function TranscriptPerfHarness(props: { onTranscriptRender: () => void }) {
     threadId: "thread-transcript-perf",
     enabled: true,
     composerImagesRef,
+    composerFilesRef,
     composerAssistantSelectionsRef,
     addComposerAssistantSelectionToDraft: () => true,
     scheduleComposerFocus: NOOP,

--- a/apps/web/src/components/chat/useTranscriptAssistantSelectionAction.ts
+++ b/apps/web/src/components/chat/useTranscriptAssistantSelectionAction.ts
@@ -36,6 +36,7 @@ interface UseTranscriptAssistantSelectionActionOptions {
   threadId: string;
   enabled: boolean;
   composerImagesRef: MutableRefObject<ReadonlyArray<unknown>>;
+  composerFilesRef: MutableRefObject<ReadonlyArray<unknown>>;
   composerAssistantSelectionsRef: MutableRefObject<
     ReadonlyArray<ComposerAssistantSelectionAttachment>
   >;
@@ -61,6 +62,7 @@ export function useTranscriptAssistantSelectionAction(
     threadId,
     enabled,
     composerImagesRef,
+    composerFilesRef,
     composerAssistantSelectionsRef,
     addComposerAssistantSelectionToDraft,
     scheduleComposerFocus,
@@ -187,7 +189,9 @@ export function useTranscriptAssistantSelectionAction(
     }
 
     if (
-      composerImagesRef.current.length + composerAssistantSelectionsRef.current.length >=
+      composerImagesRef.current.length +
+        composerFilesRef.current.length +
+        composerAssistantSelectionsRef.current.length >=
       PROVIDER_SEND_TURN_MAX_ATTACHMENTS
     ) {
       setPendingTranscriptSelectionAction(null);
@@ -219,6 +223,7 @@ export function useTranscriptAssistantSelectionAction(
   }, [
     addComposerAssistantSelectionToDraft,
     composerAssistantSelectionsRef,
+    composerFilesRef,
     composerImagesRef,
     pendingTranscriptSelectionAction,
     scheduleComposerFocus,

--- a/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
+++ b/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
@@ -57,6 +57,7 @@ import { useProviderModelCatalog } from "~/hooks/useProviderModelCatalog";
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
 import { useProviderStatusesForLocalConfig } from "~/hooks/useProviderStatusesForLocalConfig";
 import { useComposerDropzone } from "~/hooks/useComposerDropzone";
+import { toastManager } from "~/components/ui/toast";
 import { useTheme } from "~/hooks/useTheme";
 import { ChevronRightIcon, PaperclipIcon } from "~/lib/icons";
 import { findProviderStatus } from "~/lib/providerAvailability";
@@ -334,6 +335,19 @@ export function KanbanNewTaskDialog({
     onComposerDrop,
   } = useComposerDropzone({
     addImages: addComposerImages,
+    fileSupport: {
+      genericFiles: "reject",
+      onUnsupportedFiles: (files) => {
+        toastManager.add({
+          type: "warning",
+          title: "Only images can be attached to new tasks.",
+          description:
+            files.length === 1
+              ? "That file was not added."
+              : `${files.length} files were not added.`,
+        });
+      },
+    },
     appendReferenceText: appendComposerPromptText,
     dragDepthRef,
     focusComposer: scheduleComposerFocus,

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -112,6 +112,10 @@ function makeQueuedChatTurn(id: string, image?: ComposerImageAttachment): Queued
       provider: "codex",
       model: "gpt-5",
     },
+    sourceProposedPlan: {
+      threadId: ThreadId.makeUnsafe("thread-source-plan"),
+      planId: "plan-1",
+    },
     runtimeMode: "full-access",
     interactionMode: "default",
     envMode: "local",
@@ -283,14 +287,28 @@ describe("composerDraftStore clearComposerContent", () => {
     URL.revokeObjectURL = originalRevokeObjectUrl;
   });
 
-  it("does not revoke blob preview URLs when clearing composer content", () => {
+  it("revokes blob preview URLs when clearing composer content", () => {
+    const first = makeImage({
+      id: "img-clear",
+      previewUrl: "blob:clear",
+    });
+    useComposerDraftStore.getState().addImage(threadId, first);
+
+    useComposerDraftStore.getState().clearComposerContent(threadId);
+
+    const draft = useComposerDraftStore.getState().draftsByThreadId[threadId];
+    expect(draft).toBeUndefined();
+    expect(revokeSpy).toHaveBeenCalledWith("blob:clear");
+  });
+
+  it("can preserve blob preview URLs for optimistic message handoff", () => {
     const first = makeImage({
       id: "img-optimistic",
       previewUrl: "blob:optimistic",
     });
     useComposerDraftStore.getState().addImage(threadId, first);
 
-    useComposerDraftStore.getState().clearComposerContent(threadId);
+    useComposerDraftStore.getState().clearComposerContent(threadId, { preservePreviewUrls: true });
 
     const draft = useComposerDraftStore.getState().draftsByThreadId[threadId];
     expect(draft).toBeUndefined();
@@ -1512,6 +1530,10 @@ describe("composerDraftStore queued follow-ups", () => {
         kind: "chat",
         prompt: "queued chat prompt",
         images: [{ name: "queued.png" }],
+        sourceProposedPlan: {
+          threadId: "thread-source-plan",
+          planId: "plan-1",
+        },
         terminalContexts: [{ text: "git status\nOn branch main" }],
       },
     ]);

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1,5 +1,6 @@
 import * as Schema from "effect/Schema";
 import {
+  OrchestrationProposedPlanId,
   ProjectId,
   ThreadId,
   type ModelSelection,
@@ -327,6 +328,59 @@ describe("composerDraftStore clearComposerContent", () => {
   });
 });
 
+describe("composerDraftStore restored source proposed plan", () => {
+  const threadId = ThreadId.makeUnsafe("thread-restored-source");
+
+  beforeEach(() => {
+    resetComposerDraftStore();
+  });
+
+  it("persists restored plan source metadata with composer drafts", () => {
+    const restoredSource = {
+      threadId,
+      restoredPrompt: "Implement the accepted plan",
+      sourceProposedPlan: {
+        threadId,
+        planId: OrchestrationProposedPlanId.makeUnsafe("plan-restored-source"),
+      },
+    };
+    const store = useComposerDraftStore.getState();
+
+    store.setPrompt(threadId, restoredSource.restoredPrompt);
+    store.setRestoredSourceProposedPlan(threadId, restoredSource);
+
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const persistedState = persistApi.getOptions().partialize(useComposerDraftStore.getState()) as {
+      draftsByThreadId?: Record<
+        string,
+        {
+          restoredSourceProposedPlan?: unknown;
+        }
+      >;
+    };
+
+    expect(persistedState.draftsByThreadId?.[threadId]?.restoredSourceProposedPlan).toEqual(
+      restoredSource,
+    );
+
+    const mergedState = persistApi
+      .getOptions()
+      .merge(persistedState, useComposerDraftStore.getInitialState());
+
+    expect(mergedState.draftsByThreadId[threadId]?.restoredSourceProposedPlan).toEqual(
+      restoredSource,
+    );
+  });
+});
+
 describe("composerDraftStore copyTransferableComposerState", () => {
   const sourceThreadId = ThreadId.makeUnsafe("thread-source");
   const targetThreadId = ThreadId.makeUnsafe("thread-target");
@@ -436,6 +490,24 @@ describe("composerDraftStore copyTransferableComposerState", () => {
       },
       activeProvider: "claudeAgent",
     });
+  });
+
+  it("does not transfer thread-bound restored plan source metadata", () => {
+    useComposerDraftStore.getState().setPrompt(sourceThreadId, "Implement the accepted plan");
+    useComposerDraftStore.getState().setRestoredSourceProposedPlan(sourceThreadId, {
+      threadId: sourceThreadId,
+      restoredPrompt: "Implement the accepted plan",
+      sourceProposedPlan: {
+        threadId: sourceThreadId,
+        planId: OrchestrationProposedPlanId.makeUnsafe("plan-source-transfer"),
+      },
+    });
+
+    useComposerDraftStore.getState().copyTransferableComposerState(sourceThreadId, targetThreadId);
+
+    expect(
+      useComposerDraftStore.getState().draftsByThreadId[targetThreadId]?.restoredSourceProposedPlan,
+    ).toBeNull();
   });
 });
 
@@ -1537,6 +1609,54 @@ describe("composerDraftStore queued follow-ups", () => {
         terminalContexts: [{ text: "git status\nOn branch main" }],
       },
     ]);
+  });
+
+  it("persists restored proposed-plan source for edited queued sends", () => {
+    const store = useComposerDraftStore.getState();
+    store.setPrompt(threadId, "implement the queued plan");
+    store.setRestoredSourceProposedPlan(threadId, {
+      threadId,
+      restoredPrompt: "implement the queued plan",
+      sourceProposedPlan: {
+        threadId: ThreadId.makeUnsafe("thread-source-plan"),
+        planId: "plan-1",
+      },
+    });
+
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const persistedState = persistApi.getOptions().partialize(useComposerDraftStore.getState()) as {
+      draftsByThreadId?: Record<string, { restoredSourceProposedPlan?: unknown }>;
+    };
+
+    expect(persistedState.draftsByThreadId?.[threadId]?.restoredSourceProposedPlan).toEqual({
+      threadId,
+      restoredPrompt: "implement the queued plan",
+      sourceProposedPlan: {
+        threadId: "thread-source-plan",
+        planId: "plan-1",
+      },
+    });
+
+    const mergedState = persistApi
+      .getOptions()
+      .merge(persistedState, useComposerDraftStore.getInitialState());
+
+    expect(mergedState.draftsByThreadId[threadId]?.restoredSourceProposedPlan).toEqual({
+      threadId,
+      restoredPrompt: "implement the queued plan",
+      sourceProposedPlan: {
+        threadId: "thread-source-plan",
+        planId: "plan-1",
+      },
+    });
   });
 
   it("revokes queued chat image blob URLs when a queued turn is removed", () => {

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -12,6 +12,8 @@ import {
   GROK_REASONING_EFFORT_OPTIONS,
   type GrokReasoningEffort,
   type ModelSlug,
+  OrchestrationProposedPlanId,
+  type OrchestrationLatestTurn,
   type PiThinkingLevel,
   ModelSelection,
   OrchestrationThreadPullRequest,
@@ -140,6 +142,7 @@ export interface QueuedComposerChatTurn {
   selectedPromptEffort: string | null;
   modelSelection: ModelSelection;
   providerOptionsForDispatch?: ProviderStartOptions | undefined;
+  sourceProposedPlan?: NonNullable<OrchestrationLatestTurn["sourceProposedPlan"]> | undefined;
   runtimeMode: RuntimeMode;
   interactionMode: ProviderInteractionMode;
   envMode: DraftThreadEnvMode;
@@ -206,6 +209,11 @@ const PersistedPastedTextDraft = Schema.Struct({
 });
 type PersistedPastedTextDraft = typeof PersistedPastedTextDraft.Type;
 
+const PersistedSourceProposedPlanReference = Schema.Struct({
+  threadId: ThreadId,
+  planId: OrchestrationProposedPlanId,
+});
+
 const PersistedQueuedComposerChatTurn = Schema.Struct({
   id: Schema.String,
   kind: Schema.Literal("chat"),
@@ -232,6 +240,7 @@ const PersistedQueuedComposerChatTurn = Schema.Struct({
   selectedPromptEffort: Schema.NullOr(Schema.String),
   modelSelection: ModelSelection,
   providerOptionsForDispatch: Schema.optionalKey(ProviderStartOptions),
+  sourceProposedPlan: Schema.optionalKey(PersistedSourceProposedPlanReference),
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode,
   envMode: DraftThreadEnvModeSchema,
@@ -525,7 +534,10 @@ export interface ComposerDraftStoreState {
     attachments: PersistedComposerImageAttachment[],
   ) => void;
   copyTransferableComposerState: (sourceThreadId: ThreadId, targetThreadId: ThreadId) => void;
-  clearComposerContent: (threadId: ThreadId) => void;
+  clearComposerContent: (
+    threadId: ThreadId,
+    options?: { readonly preservePreviewUrls?: boolean },
+  ) => void;
 }
 
 export interface EffectiveComposerModelState {
@@ -1475,6 +1487,15 @@ function revokeDraftPreviewUrls(draft: ComposerThreadDraftState | undefined): vo
   }
 }
 
+function revokeDraftComposerImagePreviewUrls(draft: ComposerThreadDraftState | undefined): void {
+  if (!draft) {
+    return;
+  }
+  for (const image of draft.images) {
+    revokeObjectPreviewUrl(image.previewUrl);
+  }
+}
+
 function normalizePersistedAttachment(value: unknown): PersistedComposerImageAttachment | null {
   if (!value || typeof value !== "object") {
     return null;
@@ -1694,6 +1715,11 @@ function normalizePersistedQueuedTurns(
     )
       ? candidate.providerOptionsForDispatch
       : undefined;
+    const sourceProposedPlan = Schema.is(PersistedSourceProposedPlanReference)(
+      candidate.sourceProposedPlan,
+    )
+      ? candidate.sourceProposedPlan
+      : undefined;
     const runtimeMode =
       candidate.runtimeMode === "approval-required" || candidate.runtimeMode === "full-access"
         ? candidate.runtimeMode
@@ -1776,6 +1802,7 @@ function normalizePersistedQueuedTurns(
         selectedPromptEffort,
         modelSelection,
         ...(providerOptionsForDispatch ? { providerOptionsForDispatch } : {}),
+        ...(sourceProposedPlan ? { sourceProposedPlan } : {}),
         runtimeMode,
         interactionMode,
         envMode,
@@ -2180,6 +2207,9 @@ function partializeComposerDraftStoreState(
           modelSelection: queuedTurn.modelSelection,
           ...(queuedTurn.providerOptionsForDispatch
             ? { providerOptionsForDispatch: queuedTurn.providerOptionsForDispatch }
+            : {}),
+          ...(queuedTurn.sourceProposedPlan
+            ? { sourceProposedPlan: queuedTurn.sourceProposedPlan }
             : {}),
           runtimeMode: queuedTurn.runtimeMode,
           interactionMode: queuedTurn.interactionMode,
@@ -3965,9 +3995,12 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           return { draftsByThreadId: nextDraftsByThreadId };
         });
       },
-      clearComposerContent: (threadId) => {
+      clearComposerContent: (threadId, options) => {
         if (threadId.length === 0) {
           return;
+        }
+        if (options?.preservePreviewUrls !== true) {
+          revokeDraftComposerImagePreviewUrls(get().draftsByThreadId[threadId]);
         }
         set((state) => {
           const current = state.draftsByThreadId[threadId];

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -148,6 +148,12 @@ export interface QueuedComposerChatTurn {
   envMode: DraftThreadEnvMode;
 }
 
+export interface RestoredComposerSourceProposedPlan {
+  threadId: ThreadId;
+  restoredPrompt: string;
+  sourceProposedPlan: NonNullable<OrchestrationLatestTurn["sourceProposedPlan"]>;
+}
+
 export interface QueuedComposerPlanFollowUp {
   id: string;
   kind: "plan-follow-up";
@@ -212,6 +218,12 @@ type PersistedPastedTextDraft = typeof PersistedPastedTextDraft.Type;
 const PersistedSourceProposedPlanReference = Schema.Struct({
   threadId: ThreadId,
   planId: OrchestrationProposedPlanId,
+});
+
+const PersistedRestoredSourceProposedPlan = Schema.Struct({
+  threadId: ThreadId,
+  restoredPrompt: Schema.String,
+  sourceProposedPlan: PersistedSourceProposedPlanReference,
 });
 
 const PersistedQueuedComposerChatTurn = Schema.Struct({
@@ -287,6 +299,7 @@ const PersistedComposerThreadDraftState = Schema.Struct({
   skills: Schema.optionalKey(Schema.Array(ProviderSkillReference)),
   mentions: Schema.optionalKey(Schema.Array(ProviderMentionReference)),
   queuedTurns: Schema.optionalKey(Schema.Array(PersistedQueuedComposerTurn)),
+  restoredSourceProposedPlan: Schema.optionalKey(PersistedRestoredSourceProposedPlan),
   modelSelectionByProvider: Schema.optionalKey(
     Schema.Record(ProviderKind, Schema.optionalKey(ModelSelection)),
   ),
@@ -380,6 +393,7 @@ export interface ComposerThreadDraftState {
   skills: ProviderSkillReference[];
   mentions: ProviderMentionReference[];
   queuedTurns: QueuedComposerTurn[];
+  restoredSourceProposedPlan?: RestoredComposerSourceProposedPlan | null;
   modelSelectionByProvider: Partial<Record<ProviderKind, ModelSelection>>;
   activeProvider: ProviderKind | null;
   runtimeMode: RuntimeMode | null;
@@ -534,6 +548,10 @@ export interface ComposerDraftStoreState {
     attachments: PersistedComposerImageAttachment[],
   ) => void;
   copyTransferableComposerState: (sourceThreadId: ThreadId, targetThreadId: ThreadId) => void;
+  setRestoredSourceProposedPlan: (
+    threadId: ThreadId,
+    source: RestoredComposerSourceProposedPlan | null,
+  ) => void;
   clearComposerContent: (
     threadId: ThreadId,
     options?: { readonly preservePreviewUrls?: boolean },
@@ -655,6 +673,7 @@ const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
   skills: EMPTY_SKILLS,
   mentions: EMPTY_MENTIONS,
   queuedTurns: EMPTY_QUEUED_TURNS,
+  restoredSourceProposedPlan: null,
   modelSelectionByProvider: EMPTY_MODEL_SELECTION_BY_PROVIDER,
   activeProvider: null,
   runtimeMode: null,
@@ -675,6 +694,7 @@ function createEmptyThreadDraft(): ComposerThreadDraftState {
     skills: [],
     mentions: [],
     queuedTurns: [],
+    restoredSourceProposedPlan: null,
     modelSelectionByProvider: {},
     activeProvider: null,
     runtimeMode: null,
@@ -889,6 +909,7 @@ function buildTransferredComposerDraft(input: {
     pastedTexts: normalizePastedTexts(sourceDraft.pastedTexts),
     skills: [...sourceDraft.skills],
     mentions: [...sourceDraft.mentions],
+    restoredSourceProposedPlan: null,
   };
 }
 
@@ -905,6 +926,7 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
     draft.skills.length === 0 &&
     draft.mentions.length === 0 &&
     draft.queuedTurns.length === 0 &&
+    draft.restoredSourceProposedPlan == null &&
     Object.keys(draft.modelSelectionByProvider).length === 0 &&
     draft.activeProvider === null &&
     draft.runtimeMode === null &&
@@ -2087,6 +2109,11 @@ function normalizePersistedDraftsByThreadId(
     }
 
     const normalizedQueuedTurns = queuedTurns ?? [];
+    const restoredSourceProposedPlan = Schema.is(PersistedRestoredSourceProposedPlan)(
+      draftCandidate.restoredSourceProposedPlan,
+    )
+      ? draftCandidate.restoredSourceProposedPlan
+      : null;
     const hasModelData =
       Object.keys(modelSelectionByProvider).length > 0 || activeProvider !== null;
     const hasQueuedTurns = normalizedQueuedTurns.length > 0;
@@ -2100,6 +2127,7 @@ function normalizePersistedDraftsByThreadId(
       pastedTexts.length === 0 &&
       !hasReferenceData &&
       !hasQueuedTurns &&
+      restoredSourceProposedPlan === null &&
       !hasModelData &&
       !runtimeMode &&
       !interactionMode
@@ -2116,6 +2144,7 @@ function normalizePersistedDraftsByThreadId(
       ...(skills.length > 0 ? { skills } : {}),
       ...(mentions.length > 0 ? { mentions } : {}),
       ...(hasQueuedTurns ? { queuedTurns: normalizedQueuedTurns } : {}),
+      ...(restoredSourceProposedPlan ? { restoredSourceProposedPlan } : {}),
       ...(hasModelData ? { modelSelectionByProvider, activeProvider } : {}),
       ...(runtimeMode ? { runtimeMode } : {}),
       ...(interactionMode ? { interactionMode } : {}),
@@ -2247,6 +2276,7 @@ function partializeComposerDraftStoreState(
       draft.pastedTexts.length === 0 &&
       !hasReferenceData &&
       !hasQueuedTurns &&
+      draft.restoredSourceProposedPlan == null &&
       !hasModelData &&
       draft.runtimeMode === null &&
       draft.interactionMode === null
@@ -2301,6 +2331,9 @@ function partializeComposerDraftStoreState(
       ...(draft.skills.length > 0 ? { skills: [...draft.skills] } : {}),
       ...(draft.mentions.length > 0 ? { mentions: [...draft.mentions] } : {}),
       ...(hasQueuedTurns ? { queuedTurns: persistedQueuedTurns } : {}),
+      ...(draft.restoredSourceProposedPlan
+        ? { restoredSourceProposedPlan: draft.restoredSourceProposedPlan }
+        : {}),
       ...(hasModelData
         ? {
             modelSelectionByProvider: draft.modelSelectionByProvider,
@@ -2553,6 +2586,7 @@ function toHydratedThreadDraft(
     skills: [...(persistedDraft.skills ?? [])],
     mentions: [...(persistedDraft.mentions ?? [])],
     queuedTurns: hydrateQueuedTurnsFromPersisted(threadId, persistedDraft.queuedTurns),
+    restoredSourceProposedPlan: persistedDraft.restoredSourceProposedPlan ?? null,
     modelSelectionByProvider,
     activeProvider,
     runtimeMode: persistedDraft.runtimeMode ?? null,
@@ -3995,6 +4029,25 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           return { draftsByThreadId: nextDraftsByThreadId };
         });
       },
+      setRestoredSourceProposedPlan: (threadId, source) => {
+        if (threadId.length === 0) {
+          return;
+        }
+        set((state) => {
+          const current = state.draftsByThreadId[threadId] ?? createEmptyThreadDraft();
+          const nextDraft: ComposerThreadDraftState = {
+            ...current,
+            restoredSourceProposedPlan: source,
+          };
+          const nextDraftsByThreadId = { ...state.draftsByThreadId };
+          if (shouldRemoveDraft(nextDraft)) {
+            delete nextDraftsByThreadId[threadId];
+          } else {
+            nextDraftsByThreadId[threadId] = nextDraft;
+          }
+          return { draftsByThreadId: nextDraftsByThreadId };
+        });
+      },
       clearComposerContent: (threadId, options) => {
         if (threadId.length === 0) {
           return;
@@ -4020,6 +4073,7 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
             pastedTexts: [],
             skills: [],
             mentions: [],
+            restoredSourceProposedPlan: null,
           };
           const nextDraftsByThreadId = { ...state.draftsByThreadId };
           if (shouldRemoveDraft(nextDraft)) {

--- a/apps/web/src/hooks/useComposerDropzone.test.ts
+++ b/apps/web/src/hooks/useComposerDropzone.test.ts
@@ -1,0 +1,36 @@
+// FILE: useComposerDropzone.test.ts
+// Purpose: Covers file capability decisions for shared composer paste/drop handling.
+// Layer: Web hook tests
+
+import { describe, expect, it } from "vitest";
+
+import {
+  shouldHandleComposerDropzoneFiles,
+  splitComposerDropzoneFiles,
+} from "./useComposerDropzone";
+
+describe("useComposerDropzone file capability helpers", () => {
+  it("splits image files from generic files", () => {
+    const image = new File(["image"], "image.png", { type: "image/png" });
+    const generic = new File(["text"], "notes.txt", { type: "text/plain" });
+
+    expect(splitComposerDropzoneFiles([image, generic])).toEqual({
+      imageFiles: [image],
+      genericFiles: [generic],
+    });
+  });
+
+  it("lets unsupported generic-only files fall through when requested", () => {
+    const generic = new File(["text"], "notes.txt", { type: "text/plain" });
+    const files = splitComposerDropzoneFiles([generic]);
+
+    expect(shouldHandleComposerDropzoneFiles(files, "fallthrough")).toBe(false);
+  });
+
+  it("handles generic-only files when the consumer rejects them visibly", () => {
+    const generic = new File(["text"], "notes.txt", { type: "text/plain" });
+    const files = splitComposerDropzoneFiles([generic]);
+
+    expect(shouldHandleComposerDropzoneFiles(files, "reject")).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/useComposerDropzone.test.ts
+++ b/apps/web/src/hooks/useComposerDropzone.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  shouldPreventDefaultForUnhandledFileDrop,
   shouldResetComposerDropzoneAfterUnhandledFileDrop,
   shouldHandleComposerDropzoneFiles,
   splitComposerDropzoneFiles,
@@ -39,5 +40,13 @@ describe("useComposerDropzone file capability helpers", () => {
     const files = splitComposerDropzoneFiles([]);
 
     expect(shouldResetComposerDropzoneAfterUnhandledFileDrop(files, "accept")).toBe(true);
+  });
+
+  it("prevents default for claimed unusable file drops", () => {
+    const files = splitComposerDropzoneFiles([]);
+
+    expect(shouldPreventDefaultForUnhandledFileDrop(files, "accept")).toBe(true);
+    expect(shouldPreventDefaultForUnhandledFileDrop(files, "reject")).toBe(true);
+    expect(shouldPreventDefaultForUnhandledFileDrop(files, "fallthrough")).toBe(false);
   });
 });

--- a/apps/web/src/hooks/useComposerDropzone.test.ts
+++ b/apps/web/src/hooks/useComposerDropzone.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  shouldResetComposerDropzoneAfterUnhandledFileDrop,
   shouldHandleComposerDropzoneFiles,
   splitComposerDropzoneFiles,
 } from "./useComposerDropzone";
@@ -32,5 +33,11 @@ describe("useComposerDropzone file capability helpers", () => {
     const files = splitComposerDropzoneFiles([generic]);
 
     expect(shouldHandleComposerDropzoneFiles(files, "reject")).toBe(true);
+  });
+
+  it("resets drag state for unusable file drops", () => {
+    const files = splitComposerDropzoneFiles([]);
+
+    expect(shouldResetComposerDropzoneAfterUnhandledFileDrop(files, "accept")).toBe(true);
   });
 });

--- a/apps/web/src/hooks/useComposerDropzone.ts
+++ b/apps/web/src/hooks/useComposerDropzone.ts
@@ -14,17 +14,102 @@ export function isComposerHandledDrag(dataTransfer: DataTransfer): boolean {
   );
 }
 
+export interface ComposerDropzoneFileSplit {
+  readonly imageFiles: File[];
+  readonly genericFiles: File[];
+}
+
+export function splitComposerDropzoneFiles(files: Iterable<File>): ComposerDropzoneFileSplit {
+  const imageFiles: File[] = [];
+  const genericFiles: File[] = [];
+  for (const file of files) {
+    if (file.type.startsWith("image/")) {
+      imageFiles.push(file);
+    } else {
+      genericFiles.push(file);
+    }
+  }
+  return { imageFiles, genericFiles };
+}
+
+export type ComposerDropzoneGenericFileMode = "accept" | "reject" | "fallthrough";
+
+export function shouldHandleComposerDropzoneFiles(
+  files: ComposerDropzoneFileSplit,
+  genericFiles: ComposerDropzoneGenericFileMode,
+): boolean {
+  if (files.imageFiles.length > 0) {
+    return true;
+  }
+  if (files.genericFiles.length > 0) {
+    return genericFiles !== "fallthrough";
+  }
+  return false;
+}
+
+function isComposerHandledDragForMode(
+  dataTransfer: DataTransfer,
+  genericFiles: ComposerDropzoneGenericFileMode,
+): boolean {
+  if (dataTransfer.types.includes(CHAT_FILE_REFERENCE_DRAG_TYPE)) {
+    return true;
+  }
+  if (!dataTransfer.types.includes("Files")) {
+    return false;
+  }
+  if (genericFiles !== "fallthrough") {
+    return true;
+  }
+  const items = Array.from(dataTransfer.items);
+  if (items.length === 0) {
+    return true;
+  }
+  return items.some((item) => item.kind === "file" && item.type.startsWith("image/"));
+}
+
 export function useComposerDropzone(input: {
   readonly addImages: (files: readonly File[]) => void;
-  readonly addFiles?: ((files: readonly File[]) => void) | undefined;
+  readonly fileSupport:
+    | {
+        readonly genericFiles: "accept";
+        readonly addFiles: (files: readonly File[]) => void;
+      }
+    | {
+        readonly genericFiles: "reject";
+        readonly onUnsupportedFiles: (files: readonly File[]) => void;
+      }
+    | {
+        readonly genericFiles: "fallthrough";
+      };
   readonly appendReferenceText?: ((text: string) => void) | undefined;
   readonly focusComposer?: (() => void) | undefined;
   readonly dragDepthRef?: { current: number } | undefined;
   readonly setIsDragOverComposer: (dragging: boolean) => void;
 }) {
-  const { addImages, addFiles, appendReferenceText, focusComposer, setIsDragOverComposer } = input;
+  const { addImages, fileSupport, appendReferenceText, focusComposer, setIsDragOverComposer } =
+    input;
   const internalDragDepthRef = useRef(0);
   const dragDepthRef = input.dragDepthRef ?? internalDragDepthRef;
+
+  const handleSplitFiles = useCallback(
+    (files: ComposerDropzoneFileSplit): boolean => {
+      if (!shouldHandleComposerDropzoneFiles(files, fileSupport.genericFiles)) {
+        return false;
+      }
+      if (files.imageFiles.length > 0) {
+        addImages(files.imageFiles);
+      }
+      if (files.genericFiles.length > 0) {
+        if (fileSupport.genericFiles === "accept") {
+          fileSupport.addFiles(files.genericFiles);
+        } else if (fileSupport.genericFiles === "reject") {
+          fileSupport.onUnsupportedFiles(files.genericFiles);
+        }
+      }
+      return true;
+    },
+    [addImages, fileSupport],
+  );
 
   const resetComposerDragState = useCallback(() => {
     dragDepthRef.current = 0;
@@ -33,42 +118,35 @@ export function useComposerDropzone(input: {
 
   const onComposerPaste = useCallback(
     (event: ClipboardEvent<HTMLElement>) => {
-      const pastedFiles = Array.from(event.clipboardData.files);
-      const imageFiles = pastedFiles.filter((file) => file.type.startsWith("image/"));
-      const genericFiles = pastedFiles.filter((file) => !file.type.startsWith("image/"));
-      if (imageFiles.length === 0 && genericFiles.length === 0) {
-        return;
-      }
-      event.preventDefault();
-      addImages(imageFiles);
-      addFiles?.(genericFiles);
+      const handled = handleSplitFiles(splitComposerDropzoneFiles(event.clipboardData.files));
+      if (handled) event.preventDefault();
     },
-    [addFiles, addImages],
+    [handleSplitFiles],
   );
 
   const onComposerDragEnter = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
-      if (!isComposerHandledDrag(event.dataTransfer)) return;
+      if (!isComposerHandledDragForMode(event.dataTransfer, fileSupport.genericFiles)) return;
       event.preventDefault();
       dragDepthRef.current += 1;
       setIsDragOverComposer(true);
     },
-    [dragDepthRef, setIsDragOverComposer],
+    [dragDepthRef, fileSupport.genericFiles, setIsDragOverComposer],
   );
 
   const onComposerDragOver = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
-      if (!isComposerHandledDrag(event.dataTransfer)) return;
+      if (!isComposerHandledDragForMode(event.dataTransfer, fileSupport.genericFiles)) return;
       event.preventDefault();
       event.dataTransfer.dropEffect = "copy";
       setIsDragOverComposer(true);
     },
-    [setIsDragOverComposer],
+    [fileSupport.genericFiles, setIsDragOverComposer],
   );
 
   const onComposerDragLeave = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
-      if (!isComposerHandledDrag(event.dataTransfer)) return;
+      if (!isComposerHandledDragForMode(event.dataTransfer, fileSupport.genericFiles)) return;
       event.preventDefault();
       const nextTarget = event.relatedTarget;
       if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) {
@@ -79,25 +157,37 @@ export function useComposerDropzone(input: {
         setIsDragOverComposer(false);
       }
     },
-    [dragDepthRef, setIsDragOverComposer],
+    [dragDepthRef, fileSupport.genericFiles, setIsDragOverComposer],
   );
 
   const onComposerDrop = useCallback(
     (event: DragEvent<HTMLDivElement>) => {
-      if (!isComposerHandledDrag(event.dataTransfer)) return;
-      event.preventDefault();
-      resetComposerDragState();
       const referenceText = event.dataTransfer.getData(CHAT_FILE_REFERENCE_DRAG_TYPE);
       if (referenceText) {
+        event.preventDefault();
+        resetComposerDragState();
         appendReferenceText?.(referenceText);
         return;
       }
-      const droppedFiles = Array.from(event.dataTransfer.files);
-      addImages(droppedFiles.filter((file) => file.type.startsWith("image/")));
-      addFiles?.(droppedFiles.filter((file) => !file.type.startsWith("image/")));
+      if (!event.dataTransfer.types.includes("Files")) {
+        return;
+      }
+      const splitFiles = splitComposerDropzoneFiles(event.dataTransfer.files);
+      if (!shouldHandleComposerDropzoneFiles(splitFiles, fileSupport.genericFiles)) {
+        return;
+      }
+      event.preventDefault();
+      resetComposerDragState();
+      handleSplitFiles(splitFiles);
       focusComposer?.();
     },
-    [addFiles, addImages, appendReferenceText, focusComposer, resetComposerDragState],
+    [
+      appendReferenceText,
+      fileSupport.genericFiles,
+      focusComposer,
+      handleSplitFiles,
+      resetComposerDragState,
+    ],
   );
 
   return {

--- a/apps/web/src/hooks/useComposerDropzone.ts
+++ b/apps/web/src/hooks/useComposerDropzone.ts
@@ -54,6 +54,16 @@ export function shouldResetComposerDropzoneAfterUnhandledFileDrop(
   return !shouldHandleComposerDropzoneFiles(files, genericFiles);
 }
 
+export function shouldPreventDefaultForUnhandledFileDrop(
+  files: ComposerDropzoneFileSplit,
+  genericFiles: ComposerDropzoneGenericFileMode,
+): boolean {
+  return (
+    shouldResetComposerDropzoneAfterUnhandledFileDrop(files, genericFiles) &&
+    genericFiles !== "fallthrough"
+  );
+}
+
 function isComposerHandledDragForMode(
   dataTransfer: DataTransfer,
   genericFiles: ComposerDropzoneGenericFileMode,
@@ -181,6 +191,9 @@ export function useComposerDropzone(input: {
       }
       const splitFiles = splitComposerDropzoneFiles(event.dataTransfer.files);
       if (shouldResetComposerDropzoneAfterUnhandledFileDrop(splitFiles, fileSupport.genericFiles)) {
+        if (shouldPreventDefaultForUnhandledFileDrop(splitFiles, fileSupport.genericFiles)) {
+          event.preventDefault();
+        }
         resetComposerDragState();
         return;
       }

--- a/apps/web/src/hooks/useComposerDropzone.ts
+++ b/apps/web/src/hooks/useComposerDropzone.ts
@@ -47,6 +47,13 @@ export function shouldHandleComposerDropzoneFiles(
   return false;
 }
 
+export function shouldResetComposerDropzoneAfterUnhandledFileDrop(
+  files: ComposerDropzoneFileSplit,
+  genericFiles: ComposerDropzoneGenericFileMode,
+): boolean {
+  return !shouldHandleComposerDropzoneFiles(files, genericFiles);
+}
+
 function isComposerHandledDragForMode(
   dataTransfer: DataTransfer,
   genericFiles: ComposerDropzoneGenericFileMode,
@@ -173,7 +180,8 @@ export function useComposerDropzone(input: {
         return;
       }
       const splitFiles = splitComposerDropzoneFiles(event.dataTransfer.files);
-      if (!shouldHandleComposerDropzoneFiles(splitFiles, fileSupport.genericFiles)) {
+      if (shouldResetComposerDropzoneAfterUnhandledFileDrop(splitFiles, fileSupport.genericFiles)) {
+        resetComposerDragState();
         return;
       }
       event.preventDefault();

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -17,6 +17,7 @@ import {
   ProjectMetaUpdatedPayload,
   OrchestrationProposedPlan,
   OrchestrationSession,
+  PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   ProjectCreateCommand,
   THREAD_NOTES_MAX_CHARS,
   THREAD_MARKER_LABEL_MAX_CHARS,
@@ -625,6 +626,66 @@ it.effect("accepts a source proposed plan reference in thread.turn.start", () =>
       threadId: "thread-1",
       planId: "plan-1",
     });
+  }),
+);
+
+it.effect("rejects normalized thread.turn.start commands with too many attachments", () =>
+  Effect.gen(function* () {
+    const failed = yield* decodeThreadTurnStartCommand({
+      type: "thread.turn.start",
+      commandId: "cmd-turn-too-many-attachments",
+      threadId: "thread-1",
+      message: {
+        messageId: "msg-too-many-attachments",
+        role: "user",
+        text: "hello",
+        attachments: Array.from({ length: PROVIDER_SEND_TURN_MAX_ATTACHMENTS + 1 }, (_, index) => ({
+          type: "image",
+          id: `attachment-${index}`,
+          name: `image-${index}.png`,
+          mimeType: "image/png",
+          sizeBytes: 1,
+        })),
+      },
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }).pipe(
+      Effect.match({
+        onFailure: () => true,
+        onSuccess: () => false,
+      }),
+    );
+    assert.strictEqual(failed, true);
+  }),
+);
+
+it.effect("rejects client thread.turn.start commands with too many upload attachments", () =>
+  Effect.gen(function* () {
+    const failed = yield* decodeClientOrchestrationCommand({
+      type: "thread.turn.start",
+      commandId: "cmd-client-turn-too-many-attachments",
+      threadId: "thread-1",
+      message: {
+        messageId: "msg-client-too-many-attachments",
+        role: "user",
+        text: "hello",
+        attachments: Array.from({ length: PROVIDER_SEND_TURN_MAX_ATTACHMENTS + 1 }, (_, index) => ({
+          type: "image",
+          name: `image-${index}.png`,
+          mimeType: "image/png",
+          sizeBytes: 1,
+          dataUrl: "data:image/png;base64,AQ==",
+        })),
+      },
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    }).pipe(
+      Effect.match({
+        onFailure: () => true,
+        onSuccess: () => false,
+      }),
+    );
+    assert.strictEqual(failed, true);
   }),
 );
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -335,12 +335,18 @@ export const ChatAttachment = Schema.Union([
   ChatAssistantSelectionAttachment,
 ]);
 export type ChatAttachment = typeof ChatAttachment.Type;
+const ChatAttachmentList = Schema.Array(ChatAttachment).check(
+  Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_ATTACHMENTS),
+);
 const UploadChatAttachment = Schema.Union([
   UploadChatImageAttachment,
   UploadChatFileAttachment,
   UploadChatAssistantSelectionAttachment,
 ]);
 export type UploadChatAttachment = typeof UploadChatAttachment.Type;
+const UploadChatAttachmentList = Schema.Array(UploadChatAttachment).check(
+  Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_ATTACHMENTS),
+);
 
 export const ProjectScriptIcon = Schema.Literals([
   "play",
@@ -1029,7 +1035,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
     messageId: MessageId,
     role: Schema.Literal("user"),
     text: Schema.String,
-    attachments: Schema.Array(ChatAttachment),
+    attachments: ChatAttachmentList,
     skills: Schema.optional(Schema.Array(ProviderSkillReference)),
     mentions: Schema.optional(Schema.Array(ProviderMentionReference)),
   }),
@@ -1056,7 +1062,7 @@ const ClientThreadTurnStartCommand = Schema.Struct({
     messageId: MessageId,
     role: Schema.Literal("user"),
     text: Schema.String,
-    attachments: Schema.Array(UploadChatAttachment),
+    attachments: UploadChatAttachmentList,
     skills: Schema.optional(Schema.Array(ProviderSkillReference)),
     mentions: Schema.optional(Schema.Array(ProviderMentionReference)),
   }),


### PR DESCRIPTION
## Summary
- preserve attachment-bearing plan follow-ups by routing them through the normal send path while keeping source plan metadata, including queued sends
- revoke composer image blob URLs on normal clears while preserving ownership for optimistic handoff
- cap client and normalized turn-start attachments, and roll back server attachment files if upload normalization fails
- make composer dropzone generic-file support explicit and reject unsupported Kanban task files visibly

## Verification
- bun run --cwd packages/contracts test src/orchestration.test.ts
- bun run --cwd apps/server test src/orchestration/dispatchCommandNormalization.test.ts
- bun run --cwd apps/web test src/composerDraftStore.test.ts src/hooks/useComposerDropzone.test.ts
- bun fmt
- bun lint (0 errors; existing warnings only)
- bun typecheck
- git diff --check

@codex review