### PR TITLE
[codex] fix OpenCode model discovery fallback

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -105,6 +105,9 @@ function makeModel(input: Omit<TestModelInput, "providerID"> & Pick<Model, "prov
 
 function createMockOpenCodeRuntime(options?: {
   readonly inventory?: OpenCodeInventory;
+  readonly inventoryError?: OpenCodeRuntimeError;
+  readonly connectError?: OpenCodeRuntimeError;
+  readonly cliModelsError?: OpenCodeRuntimeError;
   readonly cliModels?: ReadonlyArray<OpenCodeCliModelDescriptor>;
   readonly events?: AsyncIterable<unknown>;
   readonly prompt?: (input: Record<string, unknown>) => Promise<unknown>;
@@ -202,8 +205,11 @@ function createMockOpenCodeRuntime(options?: {
   const runtime: OpenCodeRuntimeShape = {
     startOpenCodeServerProcess: () => unexpectedOperation("startOpenCodeServerProcess"),
     connectToOpenCodeServer: (input) =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         connectCalls.push(input);
+        if (options?.connectError) {
+          return yield* options.connectError;
+        }
         return {
           url: input.serverUrl ?? "http://127.0.0.1:4099",
           exitCode: null,
@@ -213,16 +219,21 @@ function createMockOpenCodeRuntime(options?: {
     runOpenCodeCommand: () => unexpectedOperation("runOpenCodeCommand"),
     createOpenCodeSdkClient,
     loadOpenCodeInventory: () =>
-      Effect.succeed(
-        options?.inventory ?? {
-          providerList: { connected: [], all: [], default: {} },
-          agents: [],
-          consoleState: null,
-        },
-      ),
+      options?.inventoryError
+        ? Effect.fail(options.inventoryError)
+        : Effect.succeed(
+            options?.inventory ?? {
+              providerList: { connected: [], all: [], default: {} },
+              agents: [],
+              consoleState: null,
+            },
+          ),
     listOpenCodeCliModels: (input) =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         cliModelCalls.push(input);
+        if (options?.cliModelsError) {
+          return yield* options.cliModelsError;
+        }
         return options?.cliModels ?? [];
       }),
     loadOpenCodeCredentialProviderIDs: () => Effect.succeed([]),
@@ -1096,6 +1107,59 @@ describe("OpenCodeAdapter runtime lifecycle", () => {
     expect(runtime.connectCalls[0]).toMatchObject({ cwd: "/repo/model-discovery-config" });
     expect(runtime.cliModelCalls).toHaveLength(1);
     expect(runtime.cliModelCalls[0]).toMatchObject({ cwd: "/repo/model-discovery-config" });
+  });
+
+  it("lists OpenCode CLI models when server inventory discovery fails", async () => {
+    const runtime = createMockOpenCodeRuntime({
+      connectError: new OpenCodeRuntimeError({
+        operation: "connectToOpenCodeServer",
+        detail: "OpenCode server failed to start.",
+      }),
+      cliModels: [
+        {
+          slug: "opencode/nemotron-3-ultra-free",
+          providerID: "opencode",
+          modelID: "nemotron-3-ultra-free",
+          name: "Nemotron 3 Ultra Free",
+          variants: [],
+          supportedReasoningEfforts: [],
+        },
+      ],
+    });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        const listModels = adapter.listModels;
+        if (!listModels) {
+          throw new Error("Expected OpenCode adapter to support runtime model listing.");
+        }
+        return yield* listModels({
+          provider: "opencode",
+          binaryPath: "opencode",
+          cwd: "/repo/server-startup-fails",
+        });
+      }).pipe(
+        Effect.provide(
+          makeOpenCodeAdapterLive({ runtime: runtime.runtime }).pipe(
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), { prefix: "opencode-adapter-test-" }),
+            ),
+            Layer.provideMerge(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(result).toMatchObject({
+      source: "opencode-cli",
+      cached: false,
+    });
+    expect(result?.models.map((model) => model.slug)).toEqual(["opencode/nemotron-3-ultra-free"]);
+    expect(runtime.connectCalls).toHaveLength(1);
+    expect(runtime.connectCalls[0]).toMatchObject({ cwd: "/repo/server-startup-fails" });
+    expect(runtime.cliModelCalls).toHaveLength(1);
+    expect(runtime.cliModelCalls[0]).toMatchObject({ cwd: "/repo/server-startup-fails" });
   });
 
   it("lists OpenCode agents from the active discovery cwd", async () => {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1628,6 +1628,16 @@ function mergeOpenCodeCliModelDescriptors(input: {
   return [...mergedBySlug.values()].toSorted(compareOpenCodeModelDescriptors);
 }
 
+function emptyOpenCodeModelInventory(): OpenCodeModelInventory {
+  return {
+    providerList: {
+      connected: [],
+      all: [],
+    },
+    consoleState: null,
+  };
+}
+
 function flattenOpenCodeAgents(agents: ReadonlyArray<Agent>): ProviderListAgentsResult["agents"] {
   return agents
     .filter((agent) => !agent.hidden && (agent.mode === "primary" || agent.mode === "all"))
@@ -4303,67 +4313,106 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
       const listModels: NonNullable<OpenCodeAdapterShape["listModels"]> = (input) => {
         const binaryPath = input.binaryPath?.trim() || adapterConfig.defaultBinaryPath;
         const freeOnlyProviderID = adapterConfig.provider === "kilo" ? "kilo" : undefined;
-        return withDiscoveryInventory(
-          { binaryPath, ...(input.cwd ? { cwd: input.cwd } : {}) },
-          ({ inventory, credentialProviderIDs }) =>
-            Effect.gen(function* () {
-              const preferredProviderIDs = new Set(
-                resolvePreferredOpenCodeModelProviders({
-                  inventory,
-                  credentialProviderIDs,
-                }).map((provider) => provider.id),
-              );
-              const inventoryModels = flattenOpenCodeModels({
+        return Effect.gen(function* () {
+          const cliModelsEffect = openCodeRuntime
+            .listOpenCodeCliModels({
+              binaryPath,
+              cliSpec: adapterConfig.cliSpec,
+              ...(input.cwd ? { cwd: input.cwd } : {}),
+            })
+            .pipe(
+              Effect.catch((error) =>
+                Effect.logDebug(`${adapterConfig.displayName} CLI model discovery failed`, {
+                  binaryPath,
+                  detail: openCodeRuntimeErrorDetail(error),
+                }).pipe(Effect.as([] as ReadonlyArray<OpenCodeCliModelDescriptor>)),
+              ),
+            );
+          const inventoryEffect = withDiscoveryInventory(
+            { binaryPath, ...(input.cwd ? { cwd: input.cwd } : {}) },
+            ({ inventory, credentialProviderIDs }) =>
+              Effect.succeed({
                 inventory,
                 credentialProviderIDs,
-                ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
-              });
-              const cliModels = yield* openCodeRuntime
-                .listOpenCodeCliModels({
-                  binaryPath,
-                  cliSpec: adapterConfig.cliSpec,
-                  ...(input.cwd ? { cwd: input.cwd } : {}),
-                })
-                .pipe(Effect.catch(() => Effect.succeed([])));
-              const preferredCliModels = cliModels.filter((model) =>
-                preferredProviderIDs.has(model.providerID),
-              );
-              const models = mergeOpenCodeCliModelDescriptors({
+              }),
+          ).pipe(Effect.exit);
+          const [cliModels, inventoryExit] = yield* Effect.all([cliModelsEffect, inventoryEffect], {
+            concurrency: "unbounded",
+          });
+
+          if (Exit.isSuccess(inventoryExit)) {
+            const { inventory, credentialProviderIDs } = inventoryExit.value;
+            const preferredProviderIDs = new Set(
+              resolvePreferredOpenCodeModelProviders({
                 inventory,
-                models: inventoryModels,
-                cliModels: preferredCliModels.length > 0 ? preferredCliModels : cliModels,
-                ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
-              });
-              yield* Effect.logDebug(`${adapterConfig.displayName} model discovery resolved`, {
+                credentialProviderIDs,
+              }).map((provider) => provider.id),
+            );
+            const inventoryModels = flattenOpenCodeModels({
+              inventory,
+              credentialProviderIDs,
+              ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
+            });
+            const preferredCliModels = cliModels.filter((model) =>
+              preferredProviderIDs.has(model.providerID),
+            );
+            const models = mergeOpenCodeCliModelDescriptors({
+              inventory,
+              models: inventoryModels,
+              cliModels: preferredCliModels.length > 0 ? preferredCliModels : cliModels,
+              ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
+            });
+            yield* Effect.logDebug(`${adapterConfig.displayName} model discovery resolved`, {
+              binaryPath,
+              connectedProviders: inventory.providerList.connected,
+              inventoryModelCount: inventoryModels.length,
+              cliModelCount: cliModels.length,
+              modelCount: models.length,
+              sampleModels: models.slice(0, 12).map((model) => model.slug),
+            });
+            return {
+              models,
+              source:
+                cliModels.length > 0
+                  ? adapterConfig.cliModelSource
+                  : adapterConfig.fallbackModelSource,
+              cached: false,
+            };
+          }
+
+          // Keep OpenCode's authoritative CLI list usable even if the local server
+          // cannot start; otherwise the web picker falls back to one static model.
+          if (cliModels.length > 0) {
+            const models = mergeOpenCodeCliModelDescriptors({
+              inventory: emptyOpenCodeModelInventory(),
+              models: [],
+              cliModels,
+              ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
+            });
+            yield* Effect.logDebug(
+              `${adapterConfig.displayName} model discovery resolved from CLI only`,
+              {
                 binaryPath,
-                connectedProviders: inventory.providerList.connected,
-                inventoryModelCount: inventoryModels.length,
                 cliModelCount: cliModels.length,
                 modelCount: models.length,
                 sampleModels: models.slice(0, 12).map((model) => model.slug),
-              });
-              return {
-                models,
-                source:
-                  cliModels.length > 0
-                    ? adapterConfig.cliModelSource
-                    : adapterConfig.fallbackModelSource,
-                cached: false,
-              };
-            }).pipe(
-              Effect.catch(() =>
-                Effect.succeed({
-                  models: flattenOpenCodeModels({
-                    inventory,
-                    credentialProviderIDs,
-                    ...(freeOnlyProviderID ? { freeOnlyProviderID } : {}),
-                  }),
-                  source: adapterConfig.fallbackModelSource,
-                  cached: false,
-                }),
-              ),
-            ),
-        );
+              },
+            );
+            return {
+              models,
+              source: adapterConfig.cliModelSource,
+              cached: false,
+            };
+          }
+
+          const inventoryFailure = Cause.squash(inventoryExit.cause);
+          return yield* new ProviderAdapterRequestError({
+            provider,
+            method: "listModels",
+            detail: openCodeRuntimeErrorDetail(inventoryFailure),
+            cause: inventoryFailure,
+          });
+        });
       };
 
       const listAgents: NonNullable<OpenCodeAdapterShape["listAgents"]> = (input) => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1423,9 +1423,15 @@ export default function ChatView({
       deriveAssociatedWorktreeMetadata({
         branch: activeThread?.branch ?? null,
         worktreePath: activeThread?.worktreePath ?? null,
-        associatedWorktreePath: activeThread?.associatedWorktreePath,
-        associatedWorktreeBranch: activeThread?.associatedWorktreeBranch,
-        associatedWorktreeRef: activeThread?.associatedWorktreeRef,
+        ...(activeThread?.associatedWorktreePath !== undefined
+          ? { associatedWorktreePath: activeThread.associatedWorktreePath }
+          : {}),
+        ...(activeThread?.associatedWorktreeBranch !== undefined
+          ? { associatedWorktreeBranch: activeThread.associatedWorktreeBranch }
+          : {}),
+        ...(activeThread?.associatedWorktreeRef !== undefined
+          ? { associatedWorktreeRef: activeThread.associatedWorktreeRef }
+          : {}),
       }),
     [
       activeThread?.associatedWorktreeBranch,
@@ -1716,6 +1722,14 @@ export default function ChatView({
     kiloModelDiscoveryEnabled &&
     !hasResolvedKiloModelDiscovery &&
     (kiloDynamicModelsQuery.isLoading || kiloDynamicModelsQuery.isFetching);
+  const hasResolvedOpenCodeModelDiscovery =
+    (openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
+      openCodeDynamicModelsQuery.data?.source === "opencode") &&
+    (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0;
+  const openCodeModelDiscoveryPending =
+    openCodeModelDiscoveryEnabled &&
+    !hasResolvedOpenCodeModelDiscovery &&
+    (openCodeDynamicModelsQuery.isLoading || openCodeDynamicModelsQuery.isFetching);
   const hasResolvedPiModelDiscovery =
     piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
     (piDynamicModelsQuery.data.models.length ?? 0) > 0;
@@ -1917,22 +1931,29 @@ export default function ChatView({
       ? cursorModelDiscoveryPending
       : selectedProvider === "kilo"
         ? kiloModelDiscoveryPending
-        : selectedProvider === "pi"
-          ? piModelDiscoveryPending
-          : selectedProviderModelsQuery !== undefined &&
-            (selectedProviderModelsQuery.isLoading ||
-              (selectedProviderModelsQuery.isFetching &&
-                selectedProviderModelsQuery.data === undefined));
+        : selectedProvider === "opencode"
+          ? openCodeModelDiscoveryPending
+          : selectedProvider === "pi"
+            ? piModelDiscoveryPending
+            : selectedProviderModelsQuery !== undefined &&
+              (selectedProviderModelsQuery.isLoading ||
+                (selectedProviderModelsQuery.isFetching &&
+                  selectedProviderModelsQuery.data === undefined));
   const selectedProviderRequiresRuntimeModels =
-    selectedProvider === "cursor" || selectedProvider === "kilo" || selectedProvider === "pi";
+    selectedProvider === "cursor" ||
+    selectedProvider === "kilo" ||
+    selectedProvider === "opencode" ||
+    selectedProvider === "pi";
   const selectedProviderRuntimeModelDiscoveryPending =
     selectedProvider === "cursor"
       ? cursorModelDiscoveryPending
       : selectedProvider === "kilo"
         ? kiloModelDiscoveryPending
-        : selectedProvider === "pi"
-          ? piModelDiscoveryPending
-          : false;
+        : selectedProvider === "opencode"
+          ? openCodeModelDiscoveryPending
+          : selectedProvider === "pi"
+            ? piModelDiscoveryPending
+            : false;
   const showComposerModelBootstrapSkeleton = shouldShowComposerModelBootstrapSkeleton({
     selectedProvider,
     selectedModel,
@@ -7885,6 +7906,7 @@ export default function ChatView({
         loadingModelProviders={{
           cursor: cursorModelDiscoveryPending,
           kilo: kiloModelDiscoveryPending,
+          opencode: openCodeModelDiscoveryPending,
           pi: piModelDiscoveryPending,
         }}
         hiddenProviders={settings.hiddenProviders}
@@ -7925,6 +7947,7 @@ export default function ChatView({
       loadingModelProviders={{
         cursor: cursorModelDiscoveryPending,
         kilo: kiloModelDiscoveryPending,
+        opencode: openCodeModelDiscoveryPending,
         pi: piModelDiscoveryPending,
       }}
       hiddenProviders={settings.hiddenProviders}

--- a/apps/web/src/hooks/useProviderModelCatalog.ts
+++ b/apps/web/src/hooks/useProviderModelCatalog.ts
@@ -169,6 +169,15 @@ export function useProviderModelCatalog(input: {
     kiloModelDiscoveryEnabled &&
     !hasResolvedKiloModelDiscovery &&
     (kiloDynamicModelsQuery.isLoading || kiloDynamicModelsQuery.isFetching);
+  const openCodeModelDiscoveryEnabled = selectedProvider === "opencode" || discoveryEnabled;
+  const hasResolvedOpenCodeModelDiscovery =
+    (openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
+      openCodeDynamicModelsQuery.data?.source === "opencode") &&
+    (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0;
+  const openCodeModelDiscoveryPending =
+    openCodeModelDiscoveryEnabled &&
+    !hasResolvedOpenCodeModelDiscovery &&
+    (openCodeDynamicModelsQuery.isLoading || openCodeDynamicModelsQuery.isFetching);
   const piModelDiscoveryEnabled = selectedProvider === "pi" || discoveryEnabled;
   const hasResolvedPiModelDiscovery =
     piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
@@ -263,9 +272,15 @@ export function useProviderModelCatalog(input: {
     () => ({
       cursor: cursorModelDiscoveryPending,
       kilo: kiloModelDiscoveryPending,
+      opencode: openCodeModelDiscoveryPending,
       pi: piModelDiscoveryPending,
     }),
-    [cursorModelDiscoveryPending, kiloModelDiscoveryPending, piModelDiscoveryPending],
+    [
+      cursorModelDiscoveryPending,
+      kiloModelDiscoveryPending,
+      openCodeModelDiscoveryPending,
+      piModelDiscoveryPending,
+    ],
   );
 
   const runtimeModelsByProvider = useMemo<


### PR DESCRIPTION
## Summary

- make OpenCode model discovery resilient when the local OpenCode server/inventory path fails but `opencode models --verbose` still works
- show OpenCode model discovery as pending in the composer/model picker instead of presenting the one static GPT-5 fallback as final
- add a regression test for CLI-only OpenCode model discovery

## Root Cause

Synara's OpenCode picker has a static fallback of `openai/gpt-5`, and runtime discovery previously depended on connecting to the OpenCode server before the CLI model list could be used. If server startup or inventory loading failed, the dynamic query failed and the UI appeared to support only GPT-5 even when `opencode models --verbose` could list free OpenCode models.

## Verification

- `bun run --cwd apps/server test src/provider/Layers/OpenCodeAdapter.test.ts`
- `bun run --cwd apps/web test src/components/ChatView.logic.test.ts src/composerDraftStore.test.ts src/components/chat/composerProviderRegistry.test.tsx`
- `bun run fmt -- --check`
- `bun run lint` (151 warnings, 0 errors; warnings are existing repo-wide lint warnings)
- `bun run typecheck`
