### PR TITLE
refactor(shared): tighten deriveAssociatedWorktreeMetadata param types to match its undefined handling

### DIFF
--- a/packages/shared/src/threadWorkspace.ts
+++ b/packages/shared/src/threadWorkspace.ts
@@ -114,9 +114,13 @@ export function isScratchWorkspacePath(filePath: string): boolean {
 export function deriveAssociatedWorktreeMetadata(input: {
   branch?: string | null;
   worktreePath?: string | null;
-  associatedWorktreePath?: string | null;
-  associatedWorktreeBranch?: string | null;
-  associatedWorktreeRef?: string | null;
+  // Checked with `!== undefined` below to distinguish "derive from worktreePath"
+  // (undefined) from "explicitly none" (null). The thread schema marks these
+  // Schema.optional, so the param type must admit an explicit undefined under
+  // exactOptionalPropertyTypes.
+  associatedWorktreePath?: string | null | undefined;
+  associatedWorktreeBranch?: string | null | undefined;
+  associatedWorktreeRef?: string | null | undefined;
 }): AssociatedWorktreeMetadata {
   return {
     associatedWorktreePath:
@@ -143,9 +147,10 @@ export function deriveAssociatedWorktreeMetadata(input: {
 export function deriveAssociatedWorktreeMetadataPatch(input: {
   branch?: string | null;
   worktreePath?: string | null;
-  associatedWorktreePath?: string | null;
-  associatedWorktreeBranch?: string | null;
-  associatedWorktreeRef?: string | null;
+  // Same undefined-aware semantics as deriveAssociatedWorktreeMetadata above.
+  associatedWorktreePath?: string | null | undefined;
+  associatedWorktreeBranch?: string | null | undefined;
+  associatedWorktreeRef?: string | null | undefined;
 }): AssociatedWorktreeMetadataPatch {
   const patch: AssociatedWorktreeMetadataPatch = {};
 


### PR DESCRIPTION
Widens the three `associated*` params of `deriveAssociatedWorktreeMetadata` (and its sibling `deriveAssociatedWorktreeMetadataPatch`) from `string | null` to `string | null | undefined`, matching the `x !== undefined` branching the functions already perform and the `Schema.optional` thread fields they consume under `exactOptionalPropertyTypes`. Behavior-preserving (a call-site `?? null` would have erased the worktreePath-derivation path).

Context: I branched this before your #225/#226 merges, where it fixed a `tsc` failure at `ChatView.tsx:1423`. Your attachment merge has since reworked that call site, so this is now a standalone type-hygiene improvement rather than a compile fix.

Heads-up unrelated to this PR: on current `main`, `bun typecheck` fails in `apps/server/src/automation/Layers/AutomationService.test.ts` lines 603 and 665 (`createdWorktrees[0]?.newBranch` is `string | undefined` where a `string` is expected) from the cleanupUnattachedWorktree test in #225 - flagging in case CI did not catch it.