### PR TITLE
fix(automations): re-check turn ownership before resuming an approval wait

### DIFF
--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -970,6 +970,72 @@ layer("AutomationService", (it) => {
     }),
   );
 
+  it.effect("does not resume a waiting-for-approval run from an unrelated newer turn", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const projectionTurns = yield* ProjectionTurnRepository;
+      const targetThreadId = ThreadId.makeUnsafe("heartbeat-approval-ownership");
+      const automationTurnId = TurnId.makeUnsafe("turn-approval-owned");
+      const unrelatedTurnId = TurnId.makeUnsafe("turn-approval-unrelated");
+      threadShell = Option.some(makeThreadShell({ id: targetThreadId }));
+
+      const created = yield* service.create({
+        ...createInput("local"),
+        mode: "heartbeat",
+        targetThreadId,
+      });
+      const { run } = yield* service.runNow({ automationId: created.id });
+      assert.isNotNull(run.messageId);
+
+      // The run's own turn is registered and running.
+      yield* projectionTurns.upsertByTurnId({
+        threadId: targetThreadId,
+        turnId: automationTurnId,
+        pendingMessageId: run.messageId,
+        sourceProposedPlanThreadId: null,
+        sourceProposedPlanId: null,
+        assistantMessageId: null,
+        state: "running",
+        requestedAt: now,
+        startedAt: now,
+        completedAt: null,
+        checkpointTurnCount: null,
+        checkpointRef: null,
+        checkpointStatus: null,
+        checkpointFiles: [],
+      });
+      // Pending approval on the run's own turn -> waiting-for-approval.
+      threadShell = Option.some(
+        makeThreadShell({
+          id: targetThreadId,
+          latestTurn: makeLatestTurn("running", automationTurnId),
+          hasPendingApprovals: true,
+        }),
+      );
+      yield* service.reconcileThread({ threadId: targetThreadId });
+      assert.strictEqual(
+        (yield* service.list({ projectId })).runs.find((entry) => entry.id === run.id)?.status,
+        "waiting-for-approval",
+      );
+
+      // An unrelated newer turn becomes the thread's latest and approvals clear. The run
+      // no longer owns the latest turn, so it must NOT be resumed back to running.
+      threadShell = Option.some(
+        makeThreadShell({
+          id: targetThreadId,
+          latestTurn: makeLatestTurn("running", unrelatedTurnId),
+        }),
+      );
+      yield* service.reconcileThread({ threadId: targetThreadId });
+
+      assert.strictEqual(
+        (yield* service.list({ projectId })).runs.find((entry) => entry.id === run.id)?.status,
+        "waiting-for-approval",
+      );
+    }),
+  );
+
   it.effect("leaves a still-running turn untouched on reconcile", () =>
     Effect.gen(function* () {
       resetHarness();

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -1457,7 +1457,11 @@ export const AutomationServiceLive = Layer.effect(
             run.status === "waiting-for-approval" &&
             run.threadId &&
             run.messageId &&
-            run.turnStartCommandId
+            run.turnStartCommandId &&
+            // Only resume *our* run: if a later, foreign turn now owns the thread's
+            // pending input, flipping back to running would resurrect a run that no
+            // longer owns the turn (mirrors the entry guard above).
+            runTurnOwnsPendingInput(run, shell, turn)
           ) {
             const running = yield* automationRepository
               .markRunStarted({


### PR DESCRIPTION
**Race:** entering `waiting-for-approval` already requires `runTurnOwnsPendingInput`, but the EXIT back to `running` checked only `run.status` + thread/message/turn ids. Once a later, foreign turn takes over the same heartbeat thread and the original approval clears, reconcile flips the run back to `running` even though it no longer owns the turn, resurrecting a run that should stay parked.

**Fix:** add `runTurnOwnsPendingInput(run, shell, turn)` to the exit condition, mirroring the entry guard. Standalone runs short-circuit to `true`, so their resume path is unchanged (covered by the existing "cleared approval wait back into running" test).

**Test:** a heartbeat run whose thread's latest turn becomes an unrelated turn stays `waiting-for-approval` instead of resuming. Complements the existing completion-path ownership test. 77/77 pass.