### PR TITLE
fix(automations): don't let stop-evaluation clobber a run's archive/read state

### DIFF
--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -1074,7 +1074,7 @@ export const AutomationServiceLive = Layer.effect(
         const latestRun = yield* latestRunForCompletionResult(input.run);
         const updatedAt = isoNow();
         const updated = yield* automationRepository
-          .markRunResult({
+          .markRunCompletionResult({
             id: latestRun.id,
             result: automationCompletionRunResult({
               baseResult: latestRun.result,

--- a/apps/server/src/persistence/Layers/AutomationRepository.test.ts
+++ b/apps/server/src/persistence/Layers/AutomationRepository.test.ts
@@ -870,6 +870,128 @@ layer("AutomationRepository", (it) => {
     }),
   );
 
+  it.effect("markRunCompletionResult preserves archive/read state from the current row", () =>
+    Effect.gen(function* () {
+      const repository = yield* AutomationRepository;
+      yield* runMigrations();
+
+      yield* repository.createDefinition({
+        id: AutomationId.makeUnsafe("automation-completion-merge"),
+        input: createInputForProject("project-completion-merge"),
+        now: "2026-06-16T10:00:00.000Z",
+      });
+      yield* repository.createRun({
+        id: AutomationRunId.makeUnsafe("run-completion-merge"),
+        automationId: AutomationId.makeUnsafe("automation-completion-merge"),
+        projectId: ProjectId.makeUnsafe("project-completion-merge"),
+        threadId: ThreadId.makeUnsafe("thread-completion-merge"),
+        trigger: { type: "manual" },
+        scheduledFor: "2026-06-16T10:05:00.000Z",
+        permissionSnapshot,
+        now: "2026-06-16T10:00:00.000Z",
+      });
+      yield* repository.markRunSucceeded({
+        id: AutomationRunId.makeUnsafe("run-completion-merge"),
+        turnId: TurnId.makeUnsafe("turn-completion-merge"),
+        result: null,
+        finishedAt: "2026-06-16T10:10:00.000Z",
+      });
+
+      // A user archives the run (which also marks it read).
+      const archivedAt = "2026-06-16T10:11:00.000Z";
+      yield* repository.archiveRun({
+        runId: AutomationRunId.makeUnsafe("run-completion-merge"),
+        archived: true,
+        now: archivedAt,
+      });
+
+      // A background completion evaluation lands afterwards, carrying stale triage
+      // fields (unarchived / unread) in its result payload.
+      const merged = yield* repository.markRunCompletionResult({
+        id: AutomationRunId.makeUnsafe("run-completion-merge"),
+        result: {
+          outcome: "no-findings",
+          summary: "Stop condition not met.",
+          unread: true,
+          archivedAt: null,
+          completionEvaluation: {
+            stopMatched: false,
+            confidence: 0.4,
+            reason: "Still working through the review.",
+          },
+        },
+        updatedAt: "2026-06-16T10:12:00.000Z",
+      });
+
+      // Archive/read state survives; the completion fields are updated.
+      assert.strictEqual(merged.result?.archivedAt, archivedAt);
+      assert.strictEqual(merged.result?.unread, false);
+      assert.strictEqual(merged.result?.outcome, "no-findings");
+      assert.strictEqual(
+        merged.result?.completionEvaluation?.reason,
+        "Still working through the review.",
+      );
+    }),
+  );
+
+  it.effect("markRunCompletionResult preserves a read run that was not archived", () =>
+    Effect.gen(function* () {
+      const repository = yield* AutomationRepository;
+      yield* runMigrations();
+
+      yield* repository.createDefinition({
+        id: AutomationId.makeUnsafe("automation-read-merge"),
+        input: createInputForProject("project-read-merge"),
+        now: "2026-06-16T10:00:00.000Z",
+      });
+      yield* repository.createRun({
+        id: AutomationRunId.makeUnsafe("run-read-merge"),
+        automationId: AutomationId.makeUnsafe("automation-read-merge"),
+        projectId: ProjectId.makeUnsafe("project-read-merge"),
+        threadId: ThreadId.makeUnsafe("thread-read-merge"),
+        trigger: { type: "manual" },
+        scheduledFor: "2026-06-16T10:05:00.000Z",
+        permissionSnapshot,
+        now: "2026-06-16T10:00:00.000Z",
+      });
+      yield* repository.markRunSucceeded({
+        id: AutomationRunId.makeUnsafe("run-read-merge"),
+        turnId: TurnId.makeUnsafe("turn-read-merge"),
+        result: null,
+        finishedAt: "2026-06-16T10:10:00.000Z",
+      });
+
+      // User marks the run read WITHOUT archiving it.
+      yield* repository.markRunRead({
+        runId: AutomationRunId.makeUnsafe("run-read-merge"),
+        unread: false,
+        now: "2026-06-16T10:11:00.000Z",
+      });
+
+      // A background completion eval lands with stale triage fields (unread: true).
+      const merged = yield* repository.markRunCompletionResult({
+        id: AutomationRunId.makeUnsafe("run-read-merge"),
+        result: {
+          outcome: "no-findings",
+          summary: "Stop condition not met.",
+          unread: true,
+          archivedAt: null,
+          completionEvaluation: {
+            stopMatched: false,
+            confidence: 0.4,
+            reason: "Still working through the review.",
+          },
+        },
+        updatedAt: "2026-06-16T10:12:00.000Z",
+      });
+
+      // Read state is preserved in isolation; archive stays null; completion fields update.
+      assert.strictEqual(merged.result?.unread, false);
+      assert.strictEqual(merged.result?.archivedAt, null);
+      assert.strictEqual(merged.result?.outcome, "no-findings");
+    }),
+  );
+
   it.effect("returns the earliest enabled next run, including overdue rows", () =>
     Effect.gen(function* () {
       const repository = yield* AutomationRepository;

--- a/apps/server/src/persistence/Layers/AutomationRepository.ts
+++ b/apps/server/src/persistence/Layers/AutomationRepository.ts
@@ -720,6 +720,49 @@ const makeAutomationRepository = Effect.gen(function* () {
       `,
   });
 
+  // Writes a new result but carries the triage fields (archivedAt/unread) over from the
+  // existing row atomically, so a background completion evaluation can never clobber a
+  // concurrent user archive/mark-read landing between the run reload and this write.
+  // unread is round-tripped through json() so it stays a JSON boolean rather than the
+  // 0/1 that json_extract yields.
+  const markRunCompletionResultRow = SqlSchema.void({
+    Request: MarkAutomationRunResultInput,
+    execute: ({ id, result, updatedAt }) =>
+      result === null
+        ? sql`
+            UPDATE automation_runs
+            SET result_json = NULL, updated_at = ${updatedAt}
+            WHERE run_id = ${id}
+          `
+        : sql`
+            UPDATE automation_runs
+            SET result_json = CASE
+                  WHEN result_json IS NULL THEN ${JSON.stringify(result)}
+                  ELSE json_set(
+                    json_set(
+                      ${JSON.stringify(result)},
+                      '$.archivedAt',
+                      json_extract(result_json, '$.archivedAt')
+                    ),
+                    '$.unread',
+                    json(
+                      CASE
+                        -- Existing row has no boolean unread (legacy/null): fall back to the
+                        -- incoming result's value rather than implicitly defaulting to unread.
+                        WHEN json_extract(result_json, '$.unread') IS NULL THEN
+                          CASE WHEN json_extract(${JSON.stringify(result)}, '$.unread') = 0
+                            THEN 'false' ELSE 'true' END
+                        WHEN json_extract(result_json, '$.unread') = 0 THEN 'false'
+                        ELSE 'true'
+                      END
+                    )
+                  )
+                END,
+                updated_at = ${updatedAt}
+            WHERE run_id = ${id}
+          `,
+  });
+
   const markRunInterruptedRow = SqlSchema.void({
     Request: MarkAutomationRunInterruptedInput,
     execute: ({ id, turnId, finishedAt }) =>
@@ -1349,6 +1392,12 @@ const makeAutomationRepository = Effect.gen(function* () {
       Effect.flatMap(() => requireRunById(input.id, "AutomationRepository.markRunResult")),
     );
 
+  const markRunCompletionResult: AutomationRepositoryShape["markRunCompletionResult"] = (input) =>
+    markRunCompletionResultRow(input).pipe(
+      Effect.mapError(toPersistenceSqlError("AutomationRepository.markRunCompletionResult:update")),
+      Effect.flatMap(() => requireRunById(input.id, "AutomationRepository.markRunCompletionResult")),
+    );
+
   const markRunInterrupted: AutomationRepositoryShape["markRunInterrupted"] = (input) =>
     markRunInterruptedRow(input).pipe(
       Effect.mapError(toPersistenceSqlError("AutomationRepository.markRunInterrupted:update")),
@@ -1522,6 +1571,7 @@ const makeAutomationRepository = Effect.gen(function* () {
     markRunSkipped,
     markRunSucceeded,
     markRunResult,
+    markRunCompletionResult,
     markRunInterrupted,
     markRunWaitingForApproval,
     cancelRun,

--- a/apps/server/src/persistence/Services/AutomationRepository.ts
+++ b/apps/server/src/persistence/Services/AutomationRepository.ts
@@ -257,6 +257,15 @@ export interface AutomationRepositoryShape {
   readonly markRunResult: (
     input: MarkAutomationRunResultInput,
   ) => Effect.Effect<AutomationRun, AutomationRepositoryError>;
+  /**
+   * Like {@link markRunResult}, but preserves the run's triage fields
+   * (`archivedAt`/`unread`) from the current row instead of from the supplied
+   * result. Background completion-evaluation must not clobber a concurrent user
+   * archive/mark-read; this write merges those fields atomically, SQL-side.
+   */
+  readonly markRunCompletionResult: (
+    input: MarkAutomationRunResultInput,
+  ) => Effect.Effect<AutomationRun, AutomationRepositoryError>;
   readonly markRunInterrupted: (
     input: MarkAutomationRunInterruptedInput,
   ) => Effect.Effect<AutomationRun, AutomationRepositoryError>;


### PR DESCRIPTION
**Race (most data-corrupting of the lifecycle bugs):** `recordCompletionEvaluation` reloads the run, then writes the whole `result_json` blob via `markRunResult`. `automationCompletionRunResult` spreads `...baseResult`, so `archivedAt`/`unread` come from the *reloaded* run. A user archive or mark-read landing between the reload and the write is silently reverted - a background heartbeat can un-archive a run the user just filed away.

**Fix:** add `markRunCompletionResult` to the repository. It writes the new result but `json_set()`s `$.archivedAt` and `$.unread` from the **current row**, closing the window atomically SQL-side. `unread` round-trips through `json()` so it stays a JSON boolean (not the 0/1 `json_extract` yields); a legacy/null `unread` falls back to the incoming value rather than defaulting to unread. `recordCompletionEvaluation` now calls it instead of `markRunResult`.

**Tests:** a completion eval landing after an archive keeps `archivedAt`/`unread`; a read-but-not-archived run keeps `unread=false` with `archivedAt` staying null. 24/24 repository + 76/76 service tests pass.