### PR TITLE
fix(automations): time out the AI stop-evaluation

### DIFF
--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -16,7 +16,8 @@ import {
   type OrchestrationProjectShell,
   type OrchestrationThreadShell,
 } from "@t3tools/contracts";
-import { Effect, Layer, Option, Stream } from "effect";
+import { Duration, Effect, Layer, Option, Stream } from "effect";
+import { TestClock } from "effect/testing";
 
 import { GitCore, type GitCoreShape } from "../../git/Services/GitCore.ts";
 import { TextGeneration, type TextGenerationShape } from "../../git/Services/TextGeneration.ts";
@@ -1260,6 +1261,70 @@ layer("AutomationService", (it) => {
       assert.strictEqual(updatedDefinition?.enabled, false);
       assert.strictEqual(updatedRun?.result?.completionEvaluation?.stopMatched, true);
       assert.include(updatedRun?.result?.summary ?? "", "Stopped:");
+    }),
+  );
+
+  it.effect("records a timed-out stop check and keeps the heartbeat alive", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const targetThreadId = ThreadId.makeUnsafe("heartbeat-stop-timeout");
+      const automationTurnId = TurnId.makeUnsafe("turn-stop-timeout");
+      threadShell = Option.some(makeThreadShell({ id: targetThreadId }));
+      completionEvaluation = {
+        stopMatched: true,
+        confidence: 0.99,
+        reason: "Should never be read because the evaluation hangs.",
+      };
+      // Hold the AI evaluation open so the only way out is the timeout.
+      const evaluationGate = holdCompletionEvaluation();
+
+      const created = yield* service.create({
+        ...createInput("local"),
+        mode: "heartbeat",
+        targetThreadId,
+        completionPolicy: heartbeatCompletionPolicy("the PR is ready"),
+      });
+      const { run } = yield* service.runNow({ automationId: created.id });
+      yield* completeHeartbeatRun({
+        run,
+        threadId: targetThreadId,
+        turnId: automationTurnId,
+        assistantText: "Still working through the review.",
+      });
+
+      yield* service.reconcileThread({ threadId: targetThreadId });
+      yield* waitForPromise({
+        promise: evaluationGate.started,
+        timeoutMs: 1_000,
+        description: "hung stop evaluation to start",
+      });
+
+      // Fire the 30s evaluation timeout via virtual time.
+      yield* TestClock.adjust(Duration.seconds(31));
+
+      const listed = yield* waitForAutomationList({
+        service,
+        description: "timed-out stop evaluation",
+        predicate: (current) => {
+          const evaluatedRun = current.runs.find((entry) => entry.id === run.id);
+          return (
+            (evaluatedRun?.result?.completionEvaluation?.reason ?? "")
+              .toLowerCase()
+              .includes("timed out") &&
+            evaluatedRun?.result?.completionEvaluation?.stopMatched === false
+          );
+        },
+      });
+      const updatedDefinition = listed.definitions.find((entry) => entry.id === created.id);
+      const updatedRun = listed.runs.find((entry) => entry.id === run.id);
+      // The hung check times out without retrying, the failure is visible, and the
+      // heartbeat stays enabled rather than being silently stopped.
+      assert.strictEqual(updatedDefinition?.enabled, true);
+      assert.strictEqual(updatedRun?.result?.completionEvaluation?.stopMatched, false);
+      assert.include((updatedRun?.result?.summary ?? "").toLowerCase(), "timed out");
+
+      evaluationGate.release();
     }),
   );
 

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -1328,6 +1328,62 @@ layer("AutomationService", (it) => {
     }),
   );
 
+  it.effect("records a stale stop check when the policy changes during a hung evaluation", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const targetThreadId = ThreadId.makeUnsafe("heartbeat-stop-timeout-stale");
+      const automationTurnId = TurnId.makeUnsafe("turn-stop-timeout-stale");
+      threadShell = Option.some(makeThreadShell({ id: targetThreadId }));
+      completionEvaluation = {
+        stopMatched: true,
+        confidence: 0.99,
+        reason: "Should never be read because the evaluation hangs.",
+      };
+      const evaluationGate = holdCompletionEvaluation();
+
+      const created = yield* service.create({
+        ...createInput("local"),
+        mode: "heartbeat",
+        targetThreadId,
+        completionPolicy: heartbeatCompletionPolicy("the PR is ready"),
+      });
+      const { run } = yield* service.runNow({ automationId: created.id });
+      yield* completeHeartbeatRun({
+        run,
+        threadId: targetThreadId,
+        turnId: automationTurnId,
+        assistantText: "Still working through the review.",
+      });
+
+      yield* service.reconcileThread({ threadId: targetThreadId });
+      yield* waitForPromise({
+        promise: evaluationGate.started,
+        timeoutMs: 1_000,
+        description: "hung stop evaluation to start",
+      });
+
+      // The user clears the completion policy while the provider call is still hung.
+      yield* service.update({ id: created.id, completionPolicy: { type: "none" } });
+      // When the 30s timeout fires it must record the stale-check result, not a live
+      // "timed out" warning for a policy the user already removed.
+      yield* TestClock.adjust(Duration.seconds(31));
+
+      const listed = yield* waitForAutomationList({
+        service,
+        description: "stale timed-out stop evaluation",
+        predicate: (current) =>
+          current.runs.find((entry) => entry.id === run.id)?.result?.completionEvaluation?.reason ===
+          "Stop check ignored because the automation changed before evaluation finished.",
+      });
+      const updatedRun = listed.runs.find((entry) => entry.id === run.id);
+      assert.strictEqual(updatedRun?.result?.completionEvaluation?.stopMatched, false);
+      assert.notInclude((updatedRun?.result?.summary ?? "").toLowerCase(), "timed out");
+
+      evaluationGate.release();
+    }),
+  );
+
   it.effect("does not block reconciliation while AI stop evaluation is pending", () =>
     Effect.gen(function* () {
       resetHarness();

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -50,6 +50,10 @@ import {
 const AUTOMATION_ERROR_MAX_CHARS = 4_000;
 const FAST_INTERVAL_ACKNOWLEDGED_MINIMUM_SECONDS = 1;
 const AUTOMATION_COMPLETION_EVALUATION_WORKERS = 2;
+// Hard ceiling on a single AI stop-evaluation. With only a couple of evaluation
+// workers, a hung provider call would otherwise pin a worker indefinitely and
+// starve stop checks for every other heartbeat automation.
+const AUTOMATION_COMPLETION_EVALUATION_TIMEOUT_MS = 30_000;
 
 interface AutomationCompletionEvaluationJob {
   readonly definition: AutomationDefinition;
@@ -1184,7 +1188,7 @@ export const AutomationServiceLive = Layer.effect(
         });
         const textGenerationInput =
           yield* resolveAutomationCompletionTextGenerationInput(definition);
-        const evaluationRaw = yield* textGeneration
+        const evaluationOption = yield* textGeneration
           .evaluateAutomationCompletion({
             cwd: project.workspaceRoot,
             automationName: definition.name,
@@ -1195,7 +1199,24 @@ export const AutomationServiceLive = Layer.effect(
             threadContext: runThreadContext || "(no run-scoped thread context)",
             ...textGenerationInput,
           })
-          .pipe(Effect.mapError(toServiceError("Failed to evaluate automation stop condition.")));
+          .pipe(
+            Effect.mapError(toServiceError("Failed to evaluate automation stop condition.")),
+            Effect.timeoutOption(AUTOMATION_COMPLETION_EVALUATION_TIMEOUT_MS),
+          );
+        if (Option.isNone(evaluationOption)) {
+          // Timed out: record a visible failed stop check and keep the heartbeat alive,
+          // rather than retrying and risking another stuck worker.
+          const reason = normalizeAutomationCompletionReason("Stop check timed out.");
+          yield* recordCompletionEvaluation({
+            run,
+            evaluation: failedAutomationCompletionEvaluation(reason),
+            matched: false,
+            summary: reason,
+            severity: "warning",
+          });
+          return false;
+        }
+        const evaluationRaw = evaluationOption.value;
         const rawEvaluation = {
           stopMatched: evaluationRaw.stopMatched,
           confidence: Math.max(0, Math.min(1, evaluationRaw.confidence)),

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -1204,16 +1204,29 @@ export const AutomationServiceLive = Layer.effect(
             Effect.timeoutOption(AUTOMATION_COMPLETION_EVALUATION_TIMEOUT_MS),
           );
         if (Option.isNone(evaluationOption)) {
-          // Timed out: record a visible failed stop check and keep the heartbeat alive,
-          // rather than retrying and risking another stuck worker.
+          // Timed out. Reload the definition first: if the automation was edited, disabled,
+          // archived, or its policy changed while the provider call hung, record the same
+          // stale-check result the success path uses rather than surfacing a misleading live
+          // "Stop check timed out." warning for a policy the user already changed. Either way
+          // keep the heartbeat alive without retrying (a retry would risk another stuck worker).
           const reason = normalizeAutomationCompletionReason("Stop check timed out.");
-          yield* recordCompletionEvaluation({
-            run,
-            evaluation: failedAutomationCompletionEvaluation(reason),
-            matched: false,
-            summary: reason,
-            severity: "warning",
-          });
+          const timedOut = failedAutomationCompletionEvaluation(reason);
+          const stillCurrent = Option.isSome(yield* loadCurrentStopDefinition(definition, policy));
+          if (stillCurrent) {
+            yield* recordCompletionEvaluation({
+              run,
+              evaluation: timedOut,
+              matched: false,
+              summary: reason,
+              severity: "warning",
+            });
+          } else {
+            yield* recordCompletionEvaluation({
+              run,
+              evaluation: staleStopCheckEvaluation(timedOut),
+              matched: false,
+            });
+          }
           return false;
         }
         const evaluationRaw = evaluationOption.value;


### PR DESCRIPTION
**Problem:** the completion-evaluation worker pool is small (`AUTOMATION_COMPLETION_EVALUATION_WORKERS = 2`). `evaluateAutomationCompletion` has no timeout, so a hung provider call pins a worker indefinitely and starves stop checks for every other heartbeat automation. (Distinct from the run-level `maxRuntimeSeconds` and the queue cap - those don't bound a single in-flight evaluation call.)

**Fix:** wrap the call with `Effect.timeoutOption(30s)` (`AUTOMATION_COMPLETION_EVALUATION_TIMEOUT_MS`). On timeout, record a visible `"Stop check timed out."` evaluation (severity `warning`) and keep the heartbeat alive **without retrying** - a retry would just risk another stuck worker.

**Test (TestClock):** a stop evaluation held open past 30s records a timed-out check with `stopMatched=false` and leaves the automation enabled. 77/77 pass.