### PR TITLE
test(automations): cover DST transitions and long-downtime coalescing

### DIFF
--- a/apps/server/src/automation/schedule.test.ts
+++ b/apps/server/src/automation/schedule.test.ts
@@ -99,7 +99,7 @@ describe("computeNextAutomationRunAt", () => {
     expect(wallClockInZone(next!, "America/New_York")).toBe("2026-03-09 02:30");
   });
 
-  it("fires a fall-back duplicate hour exactly once per day", () => {
+  it("fires a fall-back duplicate hour exactly once per day across both scheduling paths", () => {
     // America/New_York falls back 2026-11-01 02:00 -> 01:00, so 01:30 happens twice:
     // the first at 01:30 EDT (05:30Z) and the second at 01:30 EST (06:30Z). Assert the
     // exact UTC instant, not just the wall clock — both duplicates render "01:30" in the

--- a/apps/server/src/automation/schedule.test.ts
+++ b/apps/server/src/automation/schedule.test.ts
@@ -6,6 +6,24 @@ import {
   computeNextAutomationRunAtAfter,
 } from "./schedule.ts";
 
+// Render a UTC instant as "YYYY-MM-DD HH:MM" wall-clock in a timezone, so DST
+// assertions check the local wall time rather than a hardcoded UTC offset.
+function wallClockInZone(iso: string, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    // Match the production timezoneFormatter (schedule.ts) exactly: hourCycle "h23"
+    // pins midnight to 00:00, whereas hour12:false may resolve to "24:00" per ECMA-402.
+    hourCycle: "h23",
+  }).formatToParts(new Date(iso));
+  const get = (type: string) => parts.find((part) => part.type === type)?.value ?? "??";
+  return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}`;
+}
+
 describe("computeNextAutomationRunAt", () => {
   it("returns null for manual schedules", () => {
     expect(computeNextAutomationRunAt({ type: "manual" }, "2026-06-16T10:00:00.000Z")).toBeNull();
@@ -68,6 +86,50 @@ describe("computeNextAutomationRunAt", () => {
         "2026-06-19T10:00:00.000Z",
       ),
     ).toBe("2026-06-22T09:30:00.000Z");
+  });
+
+  it("skips the spring-forward gap for timezone-aware daily schedules", () => {
+    // America/New_York springs forward 2026-03-08 02:00 -> 03:00, so 02:30 does
+    // not exist that day. The gap day must be skipped to the next real 02:30.
+    const next = computeNextAutomationRunAt(
+      { type: "daily", timeOfDay: "02:30", timezone: "America/New_York" },
+      "2026-03-08T05:00:00.000Z", // 2026-03-08 00:00 EST, before the missing slot
+    );
+    expect(next).toBe("2026-03-09T06:30:00.000Z"); // 02:30 EDT the next day
+    expect(wallClockInZone(next!, "America/New_York")).toBe("2026-03-09 02:30");
+  });
+
+  it("fires a fall-back duplicate hour exactly once per day", () => {
+    // America/New_York falls back 2026-11-01 02:00 -> 01:00, so 01:30 happens twice:
+    // the first at 01:30 EDT (05:30Z) and the second at 01:30 EST (06:30Z). Assert the
+    // exact UTC instant, not just the wall clock — both duplicates render "01:30" in the
+    // zone, so a wall-clock-only check could not tell the first from the second.
+    const first = computeNextAutomationRunAt(
+      { type: "daily", timeOfDay: "01:30", timezone: "America/New_York" },
+      "2026-11-01T04:00:00.000Z", // 2026-11-01 00:00 EDT, before either 01:30
+    );
+    expect(first).toBe("2026-11-01T05:30:00.000Z"); // the FIRST 01:30 (EDT), not 06:30Z
+    // No wall-clock assertion on `first`: both duplicate-hour instants (05:30Z and 06:30Z)
+    // render "01:30" in-zone, so wall clock cannot discriminate the first occurrence. The
+    // UTC assertion above is the real check; `afterFirst` below uses wall clock where it differs.
+
+    // The occurrence after the first 01:30 is the next day, not the second 01:30 on the
+    // fall-back day (no double fire within the duplicated hour).
+    const afterFirst = computeNextAutomationRunAt(
+      { type: "daily", timeOfDay: "01:30", timezone: "America/New_York" },
+      first!,
+    );
+    expect(afterFirst).toBe("2026-11-02T06:30:00.000Z"); // next day's 01:30 (EST), not the 2nd 01:30
+    expect(wallClockInZone(afterFirst!, "America/New_York")).toBe("2026-11-02 01:30");
+
+    // The dispatcher path (computeNextAutomationRunAtAfter with `now` inside the repeated
+    // hour) must also skip the second same-day 01:30 rather than double-firing.
+    const afterInRepeatedHour = computeNextAutomationRunAtAfter(
+      { type: "daily", timeOfDay: "01:30", timezone: "America/New_York" },
+      first!,
+      "2026-11-01T05:45:00.000Z", // 01:45 EDT — still before the second 01:30 (06:30Z)
+    );
+    expect(afterInRepeatedHour).toBe("2026-11-02T06:30:00.000Z");
   });
 
   it("uses timezone-aware daily slots when timezone is present", () => {
@@ -218,6 +280,18 @@ describe("computeNextAutomationRunAtAfter", () => {
         "2026-06-16T10:00:00.000Z",
       ),
     ).toBe("2026-06-16T10:05:00.000Z");
+  });
+
+  it("coalesces more than a day of missed interval slots into one aligned slot", () => {
+    // Hourly interval anchored at midnight, process down ~30h. We must land on the
+    // first aligned slot after now (07:00 the next day), not replay ~30 backlog ticks.
+    expect(
+      computeNextAutomationRunAtAfter(
+        { type: "interval", everySeconds: 3_600 },
+        "2026-06-16T00:00:00.000Z",
+        "2026-06-17T06:15:00.000Z",
+      ),
+    ).toBe("2026-06-17T07:00:00.000Z");
   });
 
   it("lands exactly on the next slot boundary, not the missed one", () => {


### PR DESCRIPTION
Adds scheduler test coverage current main lacks. Pure tests, no production change; verified green against current `schedule.ts` (29/29).

- **spring-forward gap**: daily 02:30 in America/New_York on 2026-03-08 skips the nonexistent slot to the next real 02:30 (asserts exact UTC instant).
- **fall-back duplicate hour fires once**: 01:30 on 2026-11-01 resolves to the first occurrence (05:30Z), next run jumps to the following day, including the dispatcher path inside the repeated hour.
- **>24h downtime coalescing**: hourly interval down ~30h lands on the first aligned slot, not a replay of backlog ticks.

Uses a `wallClockInZone` helper (hourCycle `h23`, matching the production formatter) for readable local-time confirmation where it discriminates.