### PR TITLE
fix(automations): always confirm LLM-generated automations before creating them

### DIFF
--- a/apps/web/src/lib/automationIntent.test.ts
+++ b/apps/web/src/lib/automationIntent.test.ts
@@ -508,6 +508,9 @@ describe("parseChatAutomationIntent", () => {
     expect(resolved).toMatchObject({
       source: "deterministic",
       mode: "heartbeat",
+      // The schedule parsed deterministically, but name/prompt are LLM-rewritten, so the
+      // draft must still go through human review even though needsConfirmation was false.
+      requiresReview: true,
       intent: {
         name: "Generated",
         prompt: "Generated prompt",

--- a/apps/web/src/lib/automationIntent.test.ts
+++ b/apps/web/src/lib/automationIntent.test.ts
@@ -674,10 +674,42 @@ describe("parseChatAutomationIntent", () => {
     expect(resolved).toMatchObject({
       source: "generated",
       mode: "heartbeat",
+      // High-confidence (0.93), thread-scoped, no stop policy: must still require human
+      // review rather than silently auto-creating a recurring background automation.
+      requiresReview: true,
       intent: {
         name: "Controlla disponibilita",
         cadenceLabel: "Every 6h",
       },
+    });
+  });
+
+  it("always requires review for generated intents, even high-confidence ones with no stop policy", () => {
+    // Safety invariant: an LLM-interpreted ("generated") intent must never auto-create.
+    // Only deterministic, explicitly-parsed intents may skip the confirmation dialog
+    // (e.g. the bounded-fast-loop case covered above, which keeps requiresReview false).
+    const resolved = resolveChatAutomationIntent({
+      deterministicIntent: null,
+      generatedIntent: {
+        isAutomation: true,
+        confidence: 0.99,
+        language: "en",
+        name: "Check the dashboard",
+        taskPrompt: "check the dashboard",
+        schedule: { type: "interval", everySeconds: 21_600 },
+        mode: "heartbeat",
+        completionPolicy: { type: "none" },
+        missingFields: [],
+        needsConfirmation: false,
+        reason: null,
+      },
+      defaultMode: "heartbeat",
+      executionScope: "thread",
+    });
+
+    expect(resolved).toMatchObject({
+      source: "generated",
+      requiresReview: true,
     });
   });
 

--- a/apps/web/src/lib/automationIntent.ts
+++ b/apps/web/src/lib/automationIntent.ts
@@ -993,8 +993,13 @@ export function resolveChatAutomationIntent(input: {
       mode,
       source: "deterministic",
       requiresReview:
+        // Any LLM-influenced draft requires human review before creating: when the prompt
+        // is terse the generator rewrites name/prompt/maxIterations even though the schedule
+        // parsed deterministically (enrichment !== null), so the confirmation must not be
+        // skipped. Purely local parses keep their finer gating, including the deliberate
+        // bounded-fast-loop auto-submit (which skips generation, so enrichment stays null).
+        enrichment !== null ||
         resolvedExecutionScope !== "thread" ||
-        enrichmentNeedsConfirmation ||
         requiresCompletionPolicyReview(requestedMode, input.deterministicIntent.completionPolicy),
       generatedConfidence: enrichment ? (input.generatedIntent?.confidence ?? null) : null,
       generatedNeedsConfirmation: enrichmentNeedsConfirmation,

--- a/apps/web/src/lib/automationIntent.ts
+++ b/apps/web/src/lib/automationIntent.ts
@@ -1021,9 +1021,13 @@ export function resolveChatAutomationIntent(input: {
     intent: generatedIntent,
     mode,
     source: "generated",
-    requiresReview:
-      generatedIntent.executionScope !== "thread" ||
-      requiresCompletionPolicyReview(requestedMode, generatedIntent.completionPolicy),
+    // Generated (LLM-interpreted) intents always require a human confirmation step: a
+    // misread message must never silently create a recurring background automation, no
+    // matter how confident the model is. Deterministic explicit intents keep their
+    // finer-grained gating above, including the intentional bounded-fast-loop
+    // auto-submit, which never reaches this branch because generation is skipped for it
+    // in resolveComposerAutomationRequest.
+    requiresReview: true,
     generatedConfidence: input.generatedIntent?.confidence ?? null,
     generatedNeedsConfirmation:
       (input.generatedIntent?.needsConfirmation ?? false) || fastRecurringInterval,


### PR DESCRIPTION
**Safety hole:** a high-confidence, thread-scoped *generated* (LLM-interpreted) intent with no completion policy resolves to `requiresReview=false`, so the draft gate (`needsDraftReview = resolution.requiresReview || ...`) lets it **auto-create with no confirmation dialog**. A misread chat message could silently spin up a recurring background automation.

**Fix:** force `requiresReview = true` for `source === "generated"` in `resolveChatAutomationIntent`. Because `needsDraftReview` is `requiresReview || ...`, the resolver is the single choke point and this can only ever *add* a confirmation, never remove one.

**Preserves your deterministic gating:** explicit, locally-parsed intents keep their finer-grained logic, including the intentional bounded-fast-loop auto-submit (`isAutoSubmittableBoundedFastLoop`) — that path skips generation entirely, so it never reaches the generated branch.

**Judgment call for you:** this also makes an LLM-*generated* bounded fast loop require review (only the *deterministic* one auto-submits). That seemed right since generated intents are the model's interpretation, but happy to scope it differently if you prefer.

Tests: strengthened the existing generated-intent test to assert `requiresReview`, added an explicit invariant test; composerAutomation + automationDraft suites still green.