### PR TITLE
chore(automations): make recovery failures and lease contention observable

### DIFF
--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -111,6 +111,15 @@ function errorMessage(cause: unknown): string {
   return redactSecrets(raw).slice(0, AUTOMATION_ERROR_MAX_CHARS);
 }
 
+// Recovery/reconcile failures arrive already wrapped by `toServiceError`, whose message
+// is the static wrapper string; the real failure (SQLite error, defect) is in `.cause`.
+// Prefer the underlying cause so the logged warning is actually useful.
+function recoveryErrorMessage(error: unknown): string {
+  return error instanceof AutomationServiceError && error.cause != null
+    ? errorMessage(error.cause)
+    : errorMessage(error);
+}
+
 function resultSummary(value: string | null | undefined, fallback?: string): string | null {
   return automationRunResultSummary(value, fallback);
 }
@@ -1575,7 +1584,16 @@ export const AutomationServiceLive = Layer.effect(
         Effect.flatMap((runs) =>
           Effect.forEach(
             runs,
-            (run) => reconcileActiveRun(run, isoNow()).pipe(Effect.catch(() => Effect.void)),
+            (run) =>
+              reconcileActiveRun(run, isoNow()).pipe(
+                Effect.catch((error) =>
+                  Effect.logWarning("automation active-run reconcile failed", {
+                    automationId: run.automationId,
+                    runId: run.id,
+                    error: recoveryErrorMessage(error),
+                  }),
+                ),
+              ),
             { concurrency: 1 },
           ),
         ),
@@ -1597,7 +1615,13 @@ export const AutomationServiceLive = Layer.effect(
                 return interruptRunForRecovery(run, now).pipe(
                   Effect.mapError(toServiceError("Failed to recover automation run.")),
                   Effect.asVoid,
-                  Effect.catch(() => Effect.void),
+                  Effect.catch((error) =>
+                    Effect.logWarning("automation orphaned-run recovery failed", {
+                      automationId: run.automationId,
+                      runId: run.id,
+                      error: recoveryErrorMessage(error),
+                    }),
+                  ),
                 );
               }
               return projectionSnapshotQuery.getThreadShellById(threadId).pipe(
@@ -1621,7 +1645,13 @@ export const AutomationServiceLive = Layer.effect(
                         ),
                       ),
                 ),
-                Effect.catch(() => Effect.void),
+                Effect.catch((error) =>
+                  Effect.logWarning("automation pending-run recovery failed", {
+                    automationId: run.automationId,
+                    runId: run.id,
+                    error: recoveryErrorMessage(error),
+                  }),
+                ),
               );
             },
             { concurrency: 1 },
@@ -2043,6 +2073,9 @@ export const AutomationServiceLive = Layer.effect(
           })
           .pipe(Effect.mapError(toServiceError("Failed to acquire automation scheduler lease.")));
         if (!acquired) {
+          // Another instance holds the scheduler lease. Expected under multi-instance;
+          // logged at debug so lease contention is observable without log noise.
+          yield* Effect.logDebug("automation scheduler lease not acquired", { ownerId });
           return [];
         }
 

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -111,13 +111,24 @@ function errorMessage(cause: unknown): string {
   return redactSecrets(raw).slice(0, AUTOMATION_ERROR_MAX_CHARS);
 }
 
-// Recovery/reconcile failures arrive already wrapped by `toServiceError`, whose message
-// is the static wrapper string; the real failure (SQLite error, defect) is in `.cause`.
-// Prefer the underlying cause so the logged warning is actually useful.
+// Recovery/reconcile failures arrive multiply wrapped: toServiceError ->
+// AutomationServiceError whose `.cause` is often a PersistenceSqlError whose own `.cause`
+// holds the real driver failure ("database is locked", a constraint, ...). Each layer's
+// own `message` is a generic wrapper string, so walk down the `.cause` chain to the root
+// and log that, otherwise the warning is unactionable. Bounded to avoid a cyclic cause.
 function recoveryErrorMessage(error: unknown): string {
-  return error instanceof AutomationServiceError && error.cause != null
-    ? errorMessage(error.cause)
-    : errorMessage(error);
+  let current: unknown = error;
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (current == null || typeof current !== "object" || !("cause" in current)) {
+      break;
+    }
+    const cause = (current as { readonly cause?: unknown }).cause;
+    if (cause == null) {
+      break;
+    }
+    current = cause;
+  }
+  return errorMessage(current);
 }
 
 function resultSummary(value: string | null | undefined, fallback?: string): string | null {


### PR DESCRIPTION
`reconcileActiveRuns` and `recoverPendingRuns` swallowed every failure with `Effect.catch(() => Effect.void)`, so a run that fails to reconcile or recover vanished silently. The scheduler-lease loser also returned `[]` with no trace, hiding multi-instance contention.

**Change (log-only, behavior unchanged):**
- `logWarning` (with automationId/runId) in the three recovery catches.
- `logDebug` when the scheduler lease is not acquired.
- New `recoveryErrorMessage` helper unwraps `AutomationServiceError.cause` (the static wrapper message alone is useless) on top of your existing redacting `errorMessage`.

Scoped to the recovery/lease paths - deliberately does **not** touch the queue/worker/scheduled-run logging you already added elsewhere. The catches still recover to void; this only makes the failures visible. 76/76 pass.