### PR TITLE
[codex] Fix profile skill usage counts

### DIFF
--- a/apps/server/src/profileStats.test.ts
+++ b/apps/server/src/profileStats.test.ts
@@ -66,6 +66,30 @@ describe("ProfileStatsQuery", () => {
     ]);
   });
 
+  it("counts repeated slash and dollar skill tokens without double-counting structured echoes", () => {
+    expect(
+      aggregateProfileSkillUsageRows([
+        {
+          messageId: "message-repeat",
+          text: "Use $check-code, /check-code, and /logic-consolidator /logic-consolidator",
+          skillsJson: JSON.stringify([
+            { name: "check-code", path: "/skills/check-code/SKILL.md" },
+            { name: "logic-consolidator", path: "/skills/logic-consolidator/SKILL.md" },
+          ]),
+          mentionsJson: null,
+        },
+      ]),
+    ).toEqual([
+      { name: "check-code", displayName: "$check-code", kind: "skill", runCount: 2 },
+      {
+        name: "logic-consolidator",
+        displayName: "$logic-consolidator",
+        kind: "skill",
+        runCount: 2,
+      },
+    ]);
+  });
+
   it("does not count serialized prompt block closing tags as slash skills", () => {
     expect(
       aggregateProfileSkillUsageRows([
@@ -270,18 +294,83 @@ describe("ProfileStatsQuery", () => {
             updated_at,
             deleted_at
           )
-          VALUES (
-            'thread-skills',
-            'project-profile',
-            'Skill Thread',
-            '{"provider":"codex","model":"gpt-5-codex"}',
-            'full-access',
-            'default',
-            'local',
-            '2026-06-14T09:00:00.000Z',
-            '2026-06-14T09:00:00.000Z',
-            NULL
+          VALUES
+            (
+              'thread-skills',
+              'project-profile',
+              'Skill Thread',
+              '{"provider":"codex","model":"gpt-5-codex"}',
+              'full-access',
+              'default',
+              'local',
+              '2026-06-14T09:00:00.000Z',
+              '2026-06-14T09:00:00.000Z',
+              NULL
+            ),
+            (
+              'thread-retention-hidden',
+              'project-profile',
+              'Retention Hidden Skill Thread',
+              '{"provider":"codex","model":"gpt-5-codex"}',
+              'full-access',
+              'default',
+              'local',
+              '2026-06-08T09:00:00.000Z',
+              '2026-06-08T09:00:00.000Z',
+              '2026-06-15T09:00:00.000Z'
+            ),
+            (
+              'thread-manual-deleted',
+              'project-profile',
+              'Manual Deleted Skill Thread',
+              '{"provider":"codex","model":"gpt-5-codex"}',
+              'full-access',
+              'default',
+              'local',
+              '2026-06-08T10:00:00.000Z',
+              '2026-06-08T10:00:00.000Z',
+              '2026-06-15T10:00:00.000Z'
+            )
+        `;
+
+        yield* sql`
+          INSERT INTO orchestration_events (
+            event_id,
+            aggregate_kind,
+            stream_id,
+            stream_version,
+            event_type,
+            occurred_at,
+            command_id,
+            actor_kind,
+            payload_json,
+            metadata_json
           )
+          VALUES
+            (
+              'event-retention-hidden-delete',
+              'thread',
+              'thread-retention-hidden',
+              1,
+              'thread.deleted',
+              '2026-06-15T09:00:00.000Z',
+              'thread-retention:test-hidden',
+              'system',
+              '{"threadId":"thread-retention-hidden","deletedAt":"2026-06-15T09:00:00.000Z"}',
+              '{}'
+            ),
+            (
+              'event-manual-delete',
+              'thread',
+              'thread-manual-deleted',
+              1,
+              'thread.deleted',
+              '2026-06-15T10:00:00.000Z',
+              'manual-delete:test-hidden',
+              'user',
+              '{"threadId":"thread-manual-deleted","deletedAt":"2026-06-15T10:00:00.000Z"}',
+              '{}'
+            )
         `;
 
         yield* sql`
@@ -326,6 +415,32 @@ describe("ProfileStatsQuery", () => {
               '2026-06-14T09:35:00.000Z'
             ),
             (
+              'message-skill-retention-hidden',
+              'thread-retention-hidden',
+              'turn-skill-retention-hidden',
+              'user',
+              'Retention-hidden /check-code and $check-code should still count',
+              '[{"name":"check-code","path":"/skills/check-code/SKILL.md"}]',
+              NULL,
+              0,
+              'native',
+              '2026-06-08T09:05:00.000Z',
+              '2026-06-08T09:05:00.000Z'
+            ),
+            (
+              'message-skill-manual-deleted',
+              'thread-manual-deleted',
+              'turn-skill-manual-deleted',
+              'user',
+              'Manual deleted /openai-docs should not count',
+              '[{"name":"openai-docs","path":"/skills/openai-docs/SKILL.md"}]',
+              NULL,
+              0,
+              'native',
+              '2026-06-08T10:05:00.000Z',
+              '2026-06-08T10:05:00.000Z'
+            ),
+            (
               'message-skill-import',
               'thread-skills',
               'turn-skill-import',
@@ -343,9 +458,11 @@ describe("ProfileStatsQuery", () => {
         const stats = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
 
         expect(stats.insights.skillsExplored).toBe(4);
-        expect(stats.insights.totalSkillsUsed).toBe(5);
+        expect(stats.insights.totalSkillsUsed).toBe(7);
+        expect(stats.activity.totalPromptsSent).toBe(3);
+        expect(stats.activity.totalThreads).toBe(2);
         expect(stats.skills.slice(0, 4)).toEqual([
-          { name: "check-code", displayName: "$check-code", kind: "skill", runCount: 2 },
+          { name: "check-code", displayName: "$check-code", kind: "skill", runCount: 4 },
           { name: "planner", displayName: "$planner", kind: "skill", runCount: 1 },
           { name: "refactor-code", displayName: "$refactor-code", kind: "skill", runCount: 1 },
           { name: "reviewer", displayName: "@reviewer", kind: "agent", runCount: 1 },

--- a/apps/server/src/profileStats.ts
+++ b/apps/server/src/profileStats.ts
@@ -21,6 +21,7 @@ import { ServerConfig } from "./config";
 
 const HEATMAP_WINDOW_DAYS = 274; // ~9 months, GitHub-style contribution grid.
 const SKILL_RESULT_LIMIT = 12;
+const THREAD_RETENTION_COMMAND_ID_PATTERN = "thread-retention:%";
 const PROVIDER_KINDS = new Set<ProviderKind>([
   "codex",
   "claudeAgent",
@@ -239,29 +240,67 @@ export function aggregateProfileSkillUsageRows(
   const counts = new Map<string, UsageCount>();
 
   for (const row of rows) {
-    const messageUsages = new Map<string, { name: string; kind: UsageKind }>();
-    const addMessageUsage = (kind: UsageKind, rawName: string) => {
+    const messageSkillCounts = new Map<
+      string,
+      { name: string; structuredCount: number; textCount: number }
+    >();
+    const messageAgentUsages = new Map<string, { name: string; kind: UsageKind }>();
+    const addMessageSkillUsage = (rawName: string, source: "structured" | "text") => {
       const name = normalizeUsageName(rawName);
       if (!name) {
         return;
       }
-      const key = usageKey(kind, name);
-      if (!messageUsages.has(key)) {
-        messageUsages.set(key, { name, kind });
+      const key = usageKey("skill", name);
+      const next = messageSkillCounts.get(key) ?? {
+        name,
+        structuredCount: 0,
+        textCount: 0,
+      };
+      if (source === "structured") {
+        next.structuredCount += 1;
+      } else {
+        next.textCount += 1;
+      }
+      messageSkillCounts.set(key, next);
+    };
+    const addMessageAgentUsage = (rawName: string) => {
+      const name = normalizeUsageName(rawName);
+      if (!name) {
+        return;
+      }
+      const key = usageKey("agent", name);
+      if (!messageAgentUsages.has(key)) {
+        messageAgentUsages.set(key, { name, kind: "agent" });
       }
     };
 
     for (const name of parseReferenceNames(row.skillsJson)) {
-      addMessageUsage("skill", name);
+      addMessageSkillUsage(name, "structured");
     }
     for (const name of extractTextSkillNames(row.text)) {
-      addMessageUsage("skill", name);
+      addMessageSkillUsage(name, "text");
     }
     for (const name of parseReferenceNames(row.mentionsJson)) {
-      addMessageUsage("agent", name);
+      addMessageAgentUsage(name);
     }
 
-    for (const usage of messageUsages.values()) {
+    for (const usage of messageSkillCounts.values()) {
+      // Selected skills can appear both as structured refs and visible text.
+      // Count repeated user tokens, but do not double-count the structured echo.
+      const increment = Math.max(usage.structuredCount, usage.textCount);
+      if (increment <= 0) {
+        continue;
+      }
+      const key = usageKey("skill", usage.name);
+      const existing = counts.get(key);
+      if (existing) {
+        existing.runCount += increment;
+      } else {
+        counts.set(key, { name: usage.name, kind: "skill", runCount: increment });
+      }
+    }
+
+    for (const usage of messageAgentUsages.values()) {
       const key = usageKey(usage.kind, usage.name);
       const existing = counts.get(key);
       if (existing) {
@@ -496,6 +535,8 @@ const makeProfileStatsQuery = Effect.gen(function* () {
       ),
     );
 
+  // Retention hides old threads with `thread.delete` but intentionally keeps
+  // their rows for profile history. Manual deletes and deleted projects stay out.
   // ── SQL helpers ──────────────────────────────────────────────────────
 
   // Activity = days/hours the user actually sent a Synara prompt. One day-hour
@@ -513,7 +554,16 @@ const makeProfileStatsQuery = Effect.gen(function* () {
         LEFT JOIN projection_projects p ON p.project_id = t.project_id
         WHERE m.role = 'user'
           AND m.source = 'native'
-          AND t.deleted_at IS NULL
+          AND (
+            t.deleted_at IS NULL
+            OR EXISTS (
+              SELECT 1
+              FROM orchestration_events td
+              WHERE td.event_type = 'thread.deleted'
+                AND td.stream_id = t.thread_id
+                AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
+            )
+          )
           AND p.deleted_at IS NULL
         GROUP BY day, hour
         ORDER BY day ASC, hour ASC
@@ -547,7 +597,16 @@ const makeProfileStatsQuery = Effect.gen(function* () {
           LEFT JOIN projection_projects p ON p.project_id = th.project_id
           WHERE a.kind = 'context-window.updated'
             AND json_extract(a.payload_json, '$.totalProcessedTokens') IS NOT NULL
-            AND th.deleted_at IS NULL
+            AND (
+              th.deleted_at IS NULL
+              OR EXISTS (
+                SELECT 1
+                FROM orchestration_events td
+                WHERE td.event_type = 'thread.deleted'
+                  AND td.stream_id = th.thread_id
+                  AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
+              )
+            )
             AND p.deleted_at IS NULL
         ),
         delta AS (
@@ -577,7 +636,16 @@ const makeProfileStatsQuery = Effect.gen(function* () {
         SELECT COUNT(*) AS count
         FROM projection_threads t
         LEFT JOIN projection_projects p ON p.project_id = t.project_id
-        WHERE t.deleted_at IS NULL
+        WHERE (
+            t.deleted_at IS NULL
+            OR EXISTS (
+              SELECT 1
+              FROM orchestration_events td
+              WHERE td.event_type = 'thread.deleted'
+                AND td.stream_id = t.thread_id
+                AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
+            )
+          )
           AND p.deleted_at IS NULL
       `,
     );
@@ -623,7 +691,16 @@ const makeProfileStatsQuery = Effect.gen(function* () {
             ON t.thread_id = COALESCE(json_extract(e.payload_json, '$.threadId'), e.stream_id)
           LEFT JOIN projection_projects p ON p.project_id = t.project_id
           WHERE e.event_type = 'thread.turn-start-requested'
-            AND t.deleted_at IS NULL
+            AND (
+              t.deleted_at IS NULL
+              OR EXISTS (
+                SELECT 1
+                FROM orchestration_events td
+                WHERE td.event_type = 'thread.deleted'
+                  AND td.stream_id = t.thread_id
+                  AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
+              )
+            )
             AND p.deleted_at IS NULL
         )
         SELECT provider, model, reasoning, COUNT(*) AS count
@@ -650,7 +727,16 @@ const makeProfileStatsQuery = Effect.gen(function* () {
       LEFT JOIN projection_projects p ON p.project_id = t.project_id
       WHERE m.role = 'user'
         AND m.source = 'native'
-        AND t.deleted_at IS NULL
+        AND (
+          t.deleted_at IS NULL
+          OR EXISTS (
+            SELECT 1
+            FROM orchestration_events td
+            WHERE td.event_type = 'thread.deleted'
+              AND td.stream_id = t.thread_id
+              AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
+          )
+        )
         AND p.deleted_at IS NULL
         AND (
           (m.skills_json IS NOT NULL AND TRIM(m.skills_json) NOT IN ('', '[]'))
@@ -676,7 +762,16 @@ const makeProfileStatsQuery = Effect.gen(function* () {
               JOIN projection_threads t ON t.thread_id = m.thread_id
               LEFT JOIN projection_projects p ON p.project_id = t.project_id
               WHERE m.role = 'user'
-                AND t.deleted_at IS NULL
+                AND (
+                  t.deleted_at IS NULL
+                  OR EXISTS (
+                    SELECT 1
+                    FROM orchestration_events td
+                    WHERE td.event_type = 'thread.deleted'
+                      AND td.stream_id = t.thread_id
+                      AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
+                  )
+                )
                 AND p.deleted_at IS NULL
                 AND (
                   m.text GLOB '*$[A-Za-z0-9]*'
@@ -706,7 +801,16 @@ const makeProfileStatsQuery = Effect.gen(function* () {
         JOIN projection_projects p ON p.project_id = t.project_id
         WHERE m.role = 'user'
           AND m.source = 'native'
-          AND t.deleted_at IS NULL
+          AND (
+            t.deleted_at IS NULL
+            OR EXISTS (
+              SELECT 1
+              FROM orchestration_events td
+              WHERE td.event_type = 'thread.deleted'
+                AND td.stream_id = t.thread_id
+                AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
+            )
+          )
           AND p.deleted_at IS NULL
         GROUP BY p.project_id, p.title, p.workspace_root
         ORDER BY


### PR DESCRIPTION
## Summary

Fixes profile skill usage counting so the Profile page reflects real `$skill` and `/skill` usage.

## Root Cause

Profile stats excluded retention-hidden threads by requiring `t.deleted_at IS NULL`, even though retention intentionally keeps those rows for history. Skill aggregation also collapsed repeated `$skill` / `/skill` tokens in the same user message to one run.

## Changes

- Include retention-hidden threads in profile stats while still excluding manually deleted threads and deleted projects.
- Count repeated slash/dollar skill tokens inside a single prompt without double-counting structured skill references.
- Add focused server tests for retention-hidden threads and repeated skill invocations.

## Validation

- `bun run --cwd apps/server test src/profileStats.test.ts`
- `git diff --check`