### PR TITLE
[codex] Fix local image download failures

### DIFF
--- a/apps/web/src/components/LocalImagePreview.tsx
+++ b/apps/web/src/components/LocalImagePreview.tsx
@@ -7,11 +7,20 @@
 //        markdown variant (`GeneratedMarkdownImage`) composes the same hook and
 //        error card with its own inline frame/overlay rendering.
 
-import { type ImgHTMLAttributes, type MouseEvent, useEffect, useMemo, useState } from "react";
+import {
+  type ImgHTMLAttributes,
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
+import { downloadUrlAsBlob } from "~/lib/browserDownload";
 import { DownloadIcon, Loader2Icon, TriangleAlertIcon } from "~/lib/icons";
 import { buildLocalImageUrl, localImageFileName } from "~/lib/localImageUrls";
 import { cn } from "~/lib/utils";
+import { toastManager } from "./ui/toast";
 
 export type LocalImagePreviewStatus = "loading" | "ready" | "error";
 
@@ -63,6 +72,35 @@ export function useLocalImagePreview(input: {
   return { previewUrl, downloadUrl, fileName, downloadName: fileName || "", status, imgProps };
 }
 
+// Handles local-image downloads imperatively so failed API responses surface as
+// toasts instead of replacing the whole desktop window with a 404 page.
+export function useLocalImageDownloadClick(input: {
+  downloadUrl: string;
+  downloadName: string;
+  errorTitle?: string | undefined;
+}) {
+  return useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      void downloadUrlAsBlob({
+        url: input.downloadUrl,
+        filename: input.downloadName,
+      }).catch((error: unknown) => {
+        toastManager.add({
+          type: "error",
+          title: input.errorTitle ?? "Could not download image",
+          description:
+            error instanceof Error
+              ? error.message
+              : "The file may have moved or be unavailable.",
+        });
+      });
+    },
+    [input.downloadName, input.downloadUrl, input.errorTitle],
+  );
+}
+
 // Span-only markup so the card stays valid inside markdown paragraphs.
 export function LocalImageErrorCard(props: {
   downloadUrl: string;
@@ -108,6 +146,7 @@ export function LocalImagePreview(props: {
     src: props.src,
     cwd: props.cwd,
   });
+  const handleDownloadClick = useLocalImageDownloadClick({ downloadUrl, downloadName });
 
   if (status === "error") {
     return (
@@ -115,6 +154,7 @@ export function LocalImagePreview(props: {
         downloadUrl={downloadUrl}
         downloadName={downloadName}
         className={props.className}
+        onDownloadClick={handleDownloadClick}
       />
     );
   }
@@ -134,6 +174,7 @@ export function LocalImagePreview(props: {
       <a
         href={downloadUrl}
         download={downloadName}
+        onClick={handleDownloadClick}
         className="local-image-preview__download"
         aria-label="Download image"
         title="Download"

--- a/apps/web/src/components/chat/GeneratedMarkdownImage.tsx
+++ b/apps/web/src/components/chat/GeneratedMarkdownImage.tsx
@@ -12,7 +12,11 @@ import { type MouseEvent, useCallback } from "react";
 
 import { DownloadIcon, Loader2Icon, Maximize2 } from "~/lib/icons";
 
-import { LocalImageErrorCard, useLocalImagePreview } from "../LocalImagePreview";
+import {
+  LocalImageErrorCard,
+  useLocalImageDownloadClick,
+  useLocalImagePreview,
+} from "../LocalImagePreview";
 import type { ExpandedImagePreview } from "./ExpandedImagePreview";
 
 export interface GeneratedMarkdownImageProps {
@@ -27,6 +31,11 @@ export function GeneratedMarkdownImage(props: GeneratedMarkdownImageProps) {
   const { previewUrl, downloadUrl, fileName, downloadName, status, imgProps } =
     useLocalImagePreview({ src, cwd });
   const accessibleName = alt?.trim() || "Generated image";
+  const downloadImage = useLocalImageDownloadClick({
+    downloadUrl,
+    downloadName,
+    errorTitle: "Could not download generated image",
+  });
 
   const expandImage = useCallback(
     (event: MouseEvent<HTMLElement>) => {
@@ -53,7 +62,7 @@ export function GeneratedMarkdownImage(props: GeneratedMarkdownImageProps) {
         downloadName={downloadName}
         className="local-image-error--prose"
         downloadAriaLabel="Download generated image"
-        onDownloadClick={stopPropagation}
+        onDownloadClick={downloadImage}
       />
     );
   }
@@ -82,7 +91,7 @@ export function GeneratedMarkdownImage(props: GeneratedMarkdownImageProps) {
       <a
         href={downloadUrl}
         download={downloadName}
-        onClick={stopPropagation}
+        onClick={downloadImage}
         onMouseDown={stopPropagation}
         className="chat-generated-image__overlay-pill chat-generated-image__overlay-pill--download"
         aria-label="Download generated image"

--- a/apps/web/src/components/profile/shareCardExport.ts
+++ b/apps/web/src/components/profile/shareCardExport.ts
@@ -7,6 +7,8 @@
 import { toBlob } from "html-to-image";
 import { readNativeApi } from "~/nativeApi";
 
+export { downloadBlob } from "~/lib/browserDownload";
+
 const SHARE_BRAND_HANDLE = "@trySynara";
 export const SHARE_TWEET_TEXT = `Just checking my ${SHARE_BRAND_HANDLE} dev stats. Absolute masterpiece of an IDE.`;
 const SHARE_URL = "https://trysynara.com";
@@ -41,20 +43,6 @@ export async function copyImageToClipboard(blob: Blob): Promise<boolean> {
     return true;
   } catch {
     return false;
-  }
-}
-
-export function downloadBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  try {
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = filename;
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-  } finally {
-    URL.revokeObjectURL(url);
   }
 }
 

--- a/apps/web/src/lib/browserDownload.test.ts
+++ b/apps/web/src/lib/browserDownload.test.ts
@@ -1,0 +1,97 @@
+// FILE: browserDownload.test.ts
+// Purpose: Verifies blob-backed downloads do not fall back to top-level navigation on failures.
+// Layer: Web utility tests
+// Depends on: browserDownload helpers with mocked Fetch and DOM anchor APIs.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { downloadUrlAsBlob } from "./browserDownload";
+
+describe("browserDownload", () => {
+  const originalDocument = globalThis.document;
+  const originalFetch = globalThis.fetch;
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+  let click: ReturnType<typeof vi.fn>;
+  let appended: unknown[] = [];
+  let link: {
+    href: string;
+    download: string;
+    click: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    click = vi.fn();
+    appended = [];
+    link = {
+      href: "",
+      download: "",
+      click,
+      remove: vi.fn(),
+    };
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: {
+        createElement: vi.fn((tagName: string) => {
+          if (tagName !== "a") throw new Error(`Unexpected element ${tagName}`);
+          return link;
+        }),
+        body: {
+          appendChild: vi.fn((node: unknown) => {
+            appended.push(node);
+            return node;
+          }),
+        },
+      },
+    });
+    URL.createObjectURL = vi.fn(() => "blob:download");
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+    globalThis.fetch = originalFetch;
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  });
+
+  it("saves a fetched response through a blob URL", async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve(new Response("<svg />", { status: 200 })));
+
+    await downloadUrlAsBlob({
+      url: "http://127.0.0.1:5733/api/local-image?download=1",
+      filename: "favicon.svg",
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:5733/api/local-image?download=1",
+    );
+    expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(link.href).toBe("blob:download");
+    expect(link.download).toBe("favicon.svg");
+    expect(appended).toEqual([link]);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(link.remove).toHaveBeenCalledTimes(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:download");
+  });
+
+  it("throws before creating a download when the server rejects the file", async () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(new Response("Not Found", { status: 404, statusText: "Not Found" })),
+    );
+
+    await expect(
+      downloadUrlAsBlob({
+        url: "http://127.0.0.1:5733/api/local-image?download=1",
+        filename: "favicon.ico",
+      }),
+    ).rejects.toThrow("Download failed with HTTP 404 Not Found.");
+
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(click).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/browserDownload.ts
+++ b/apps/web/src/lib/browserDownload.ts
@@ -1,0 +1,37 @@
+// FILE: browserDownload.ts
+// Purpose: Browser-side file download helpers that keep failed downloads inside the app.
+// Layer: Web utility
+// Exports: downloadBlob, downloadUrlAsBlob
+// Depends on: DOM anchor downloads and Fetch.
+
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  try {
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename.trim() || "download";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function downloadResponseError(response: Response): Error {
+  const statusText = response.statusText ? ` ${response.statusText}` : "";
+  return new Error(`Download failed with HTTP ${response.status}${statusText}.`);
+}
+
+// Fetches a local artifact before saving it so server 404/auth errors cannot
+// navigate the main Electron renderer away from the app.
+export async function downloadUrlAsBlob(input: {
+  readonly url: string;
+  readonly filename: string;
+}): Promise<void> {
+  const response = await fetch(input.url);
+  if (!response.ok) {
+    throw downloadResponseError(response);
+  }
+  downloadBlob(await response.blob(), input.filename);
+}


### PR DESCRIPTION
## Summary

Fixes local image download controls so failed `/api/local-image` responses cannot navigate the whole Synara desktop renderer to a plain `Not Found` page.

## Root Cause

The local image preview surfaces used normal anchor navigation for downloads. In desktop/custom-protocol contexts, a failed local-image request could replace the app window with the API response instead of keeping the user in Synara.

## Changes

- Added a shared `browserDownload` helper that fetches a URL, validates the response, and saves the blob with an object URL.
- Routed local image preview and generated markdown image download clicks through the helper.
- Kept failed downloads in-app by preventing default navigation and showing a toast instead.
- Reused the shared blob helper for profile share-card downloads.

## Validation

- `bun run --cwd apps/web test src/lib/browserDownload.test.ts src/lib/localImageUrls.test.ts src/components/ChatMarkdown.test.tsx src/components/EditorWorkspaceView.test.tsx`
- `git diff --check`

Note: per repo instructions, I did not run `bun fmt`, `bun lint`, or `bun typecheck` because they were not explicitly requested.