### PR TITLE
Fix Gemini Antigravity auth guidance

### DIFF
--- a/apps/server/src/provider/geminiAcpProbe.test.ts
+++ b/apps/server/src/provider/geminiAcpProbe.test.ts
@@ -122,6 +122,10 @@ describe("parseGeminiAcpProbeLogFailure", () => {
   it("ignores captured non-auth process output", () => {
     expect(parseGeminiAcpProbeLogFailure("Gemini ACP exited with code 1")).toBeUndefined();
   });
+
+  it("ignores generic configured wording in captured process output", () => {
+    expect(parseGeminiAcpProbeLogFailure("forkpty: Device not configured")).toBeUndefined();
+  });
 });
 
 describe("normalizeGeminiCapabilityProbeResult", () => {

--- a/apps/server/src/provider/geminiAcpProbe.test.ts
+++ b/apps/server/src/provider/geminiAcpProbe.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildGeminiProbeEnv,
+  isGeminiCodeAssistMigrationAuthFailure,
   isGeminiOAuthBrowserPrompt,
   normalizeGeminiCapabilityProbeResult,
+  parseGeminiAcpProbeError,
 } from "./geminiAcpProbe";
 
 describe("buildGeminiProbeEnv", () => {
@@ -30,6 +32,69 @@ describe("isGeminiOAuthBrowserPrompt", () => {
 
   it("ignores ordinary ACP output", () => {
     expect(isGeminiOAuthBrowserPrompt('{"jsonrpc":"2.0","id":1,"result":{}}')).toBe(false);
+  });
+});
+
+describe("isGeminiCodeAssistMigrationAuthFailure", () => {
+  it("detects the Gemini Code Assist to Antigravity migration message", () => {
+    expect(
+      isGeminiCodeAssistMigrationAuthFailure(
+        "Failed to sign in. Message: This client is no longer supported for Gemini Code Assist for individuals. To continue using Gemini, please migrate to the Antigravity suite of products.",
+      ),
+    ).toBe(true);
+  });
+
+  it("detects ACP loadCodeAssist premature-close auth failures", () => {
+    expect(
+      isGeminiCodeAssistMigrationAuthFailure(
+        "Invalid response body while trying to fetch https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist: Premature close",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated transport errors", () => {
+    expect(isGeminiCodeAssistMigrationAuthFailure("Network request failed: Premature close")).toBe(
+      false,
+    );
+  });
+});
+
+describe("parseGeminiAcpProbeError", () => {
+  it("returns actionable auth guidance for the Antigravity migration failure", () => {
+    const parsed = parseGeminiAcpProbeError({
+      message:
+        "Failed to sign in. Message: This client is no longer supported for Gemini Code Assist for individuals. To continue using Gemini, please migrate to the Antigravity suite of products.",
+    });
+
+    expect(parsed.status).toBe("error");
+    expect(parsed.auth.status).toBe("unauthenticated");
+    expect(parsed.message).toContain("Antigravity");
+    expect(parsed.message).toContain("GEMINI_API_KEY");
+    expect(parsed.message).toContain("GOOGLE_GENAI_USE_VERTEXAI");
+  });
+
+  it("maps the issue #224 loadCodeAssist premature close to auth guidance", () => {
+    const parsed = parseGeminiAcpProbeError({
+      code: -32_000,
+      message:
+        "Invalid response body while trying to fetch https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist: Premature close",
+    });
+
+    expect(parsed.status).toBe("error");
+    expect(parsed.auth.status).toBe("unauthenticated");
+    expect(parsed.message).toContain("Antigravity");
+    expect(parsed.message).toContain("Vertex AI");
+  });
+
+  it("adds setup guidance to generic Gemini auth failures", () => {
+    const parsed = parseGeminiAcpProbeError({
+      message: "API key is missing",
+    });
+
+    expect(parsed.status).toBe("error");
+    expect(parsed.auth.status).toBe("unauthenticated");
+    expect(parsed.message).toContain("API key is missing");
+    expect(parsed.message).toContain("~/.gemini/.env");
   });
 });
 

--- a/apps/server/src/provider/geminiAcpProbe.test.ts
+++ b/apps/server/src/provider/geminiAcpProbe.test.ts
@@ -6,6 +6,7 @@ import {
   isGeminiOAuthBrowserPrompt,
   normalizeGeminiCapabilityProbeResult,
   parseGeminiAcpProbeError,
+  parseGeminiAcpProbeLogFailure,
 } from "./geminiAcpProbe";
 
 describe("buildGeminiProbeEnv", () => {
@@ -95,6 +96,31 @@ describe("parseGeminiAcpProbeError", () => {
     expect(parsed.auth.status).toBe("unauthenticated");
     expect(parsed.message).toContain("API key is missing");
     expect(parsed.message).toContain("~/.gemini/.env");
+  });
+});
+
+describe("parseGeminiAcpProbeLogFailure", () => {
+  it("maps captured loadCodeAssist premature-close output to auth guidance", () => {
+    const parsed = parseGeminiAcpProbeLogFailure(
+      "Invalid response body while trying to fetch https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist: Premature close",
+    );
+
+    expect(parsed?.status).toBe("error");
+    expect(parsed?.auth.status).toBe("unauthenticated");
+    expect(parsed?.message).toContain("Antigravity");
+    expect(parsed?.message).toContain("GEMINI_API_KEY");
+  });
+
+  it("maps captured generic Gemini auth output to setup guidance", () => {
+    const parsed = parseGeminiAcpProbeLogFailure("API key is missing");
+
+    expect(parsed?.status).toBe("error");
+    expect(parsed?.auth.status).toBe("unauthenticated");
+    expect(parsed?.message).toContain("~/.gemini/.env");
+  });
+
+  it("ignores captured non-auth process output", () => {
+    expect(parseGeminiAcpProbeLogFailure("Gemini ACP exited with code 1")).toBeUndefined();
   });
 });
 

--- a/apps/server/src/provider/geminiAcpProbe.test.ts
+++ b/apps/server/src/provider/geminiAcpProbe.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildGeminiProbeEnv,
+  captureGeminiAcpProbeLogFailure,
   isGeminiCodeAssistMigrationAuthFailure,
   isGeminiOAuthBrowserPrompt,
   normalizeGeminiCapabilityProbeResult,
@@ -57,6 +58,14 @@ describe("isGeminiCodeAssistMigrationAuthFailure", () => {
     expect(isGeminiCodeAssistMigrationAuthFailure("Network request failed: Premature close")).toBe(
       false,
     );
+  });
+
+  it("ignores non-loadCodeAssist cloudcode premature-close failures", () => {
+    expect(
+      isGeminiCodeAssistMigrationAuthFailure(
+        "Invalid response body while trying to fetch https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse: Premature close",
+      ),
+    ).toBe(false);
   });
 });
 
@@ -125,6 +134,32 @@ describe("parseGeminiAcpProbeLogFailure", () => {
 
   it("ignores generic configured wording in captured process output", () => {
     expect(parseGeminiAcpProbeLogFailure("forkpty: Device not configured")).toBeUndefined();
+  });
+
+  it("ignores non-loadCodeAssist cloudcode premature-close process output", () => {
+    expect(
+      parseGeminiAcpProbeLogFailure(
+        "Invalid response body while trying to fetch https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse: Premature close",
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("captureGeminiAcpProbeLogFailure", () => {
+  it("retains the first auth line when later stack frames are captured", () => {
+    const authFailure = captureGeminiAcpProbeLogFailure(
+      undefined,
+      "Invalid response body while trying to fetch https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist: Premature close",
+    );
+    const afterStackFrame = captureGeminiAcpProbeLogFailure(
+      authFailure,
+      "    at async loadCodeAssist (/path/to/gemini.js:10:3)",
+    );
+
+    expect(afterStackFrame).toBe(authFailure);
+    expect(afterStackFrame?.status).toBe("error");
+    expect(afterStackFrame?.auth.status).toBe("unauthenticated");
+    expect(afterStackFrame?.message).toContain("Antigravity");
   });
 });
 

--- a/apps/server/src/provider/geminiAcpProbe.ts
+++ b/apps/server/src/provider/geminiAcpProbe.ts
@@ -24,6 +24,13 @@ const GEMINI_ACP_AUTH_REQUIRED_CODE = -32_000;
 const MAX_CAPTURED_LOG_LINES = 5;
 const MAX_CAPTURED_LOG_LENGTH = 240;
 const GEMINI_BROWSER_BLOCKLIST_VALUE = "www-browser";
+const GEMINI_API_KEY_ENV_HINT = "`GEMINI_API_KEY`";
+const GEMINI_VERTEX_ENV_HINT =
+  "`GOOGLE_GENAI_USE_VERTEXAI=true`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, plus ADC or `GOOGLE_API_KEY`";
+const GEMINI_HEADLESS_AUTH_GUIDANCE =
+  `Use Gemini API key or Vertex AI auth for Synara: set ${GEMINI_API_KEY_ENV_HINT} in \`~/.gemini/.env\`, or set Vertex AI env (${GEMINI_VERTEX_ENV_HINT}), then refresh provider status.`;
+const GEMINI_CODE_ASSIST_MIGRATION_AUTH_MESSAGE =
+  `Gemini is not authenticated because Google Code Assist OAuth for individual accounts appears to require Antigravity. For Synara, use ${GEMINI_API_KEY_ENV_HINT} or Vertex AI auth (${GEMINI_VERTEX_ENV_HINT}); use Antigravity for individual Code Assist OAuth until Gemini CLI exposes a compatible path.`;
 
 const GEMINI_OAUTH_BROWSER_PROMPT_PATTERNS = [
   /opening your browser for oauth sign-in/i,
@@ -68,7 +75,11 @@ function formatGeminiDiscoveryWarning(detail: string): string {
 }
 
 function formatGeminiAuthMessage(detail: string): string {
-  return `Gemini is not authenticated. ${detail}`;
+  return `Gemini is not authenticated. ${detail} ${GEMINI_HEADLESS_AUTH_GUIDANCE}`;
+}
+
+function formatGeminiCodeAssistMigrationAuthMessage(): string {
+  return GEMINI_CODE_ASSIST_MIGRATION_AUTH_MESSAGE;
 }
 
 function formatGeminiModelDiscoveryFallbackMessage(): string {
@@ -89,8 +100,10 @@ export function parseGeminiAcpProbeError(
   const code = asNumber(record?.code);
   const message = trimToUndefined(record?.message) ?? "Gemini ACP request failed.";
   const lowerMessage = message.toLowerCase();
+  const codeAssistMigrationAuthFailure = isGeminiCodeAssistMigrationAuthFailure(message);
   const unauthenticated =
     code === GEMINI_ACP_AUTH_REQUIRED_CODE ||
+    codeAssistMigrationAuthFailure ||
     lowerMessage.includes("authentication required") ||
     lowerMessage.includes("api key is missing") ||
     lowerMessage.includes("auth method") ||
@@ -100,7 +113,9 @@ export function parseGeminiAcpProbeError(
     return {
       status: "error",
       auth: { status: "unauthenticated" },
-      message: formatGeminiAuthMessage(message),
+      message: codeAssistMigrationAuthFailure
+        ? formatGeminiCodeAssistMigrationAuthMessage()
+        : formatGeminiAuthMessage(message),
     };
   }
 
@@ -124,6 +139,23 @@ export function buildGeminiProbeEnv(env: NodeJS.ProcessEnv = process.env): NodeJ
 
 export function isGeminiOAuthBrowserPrompt(line: string): boolean {
   return GEMINI_OAUTH_BROWSER_PROMPT_PATTERNS.some((pattern) => pattern.test(line));
+}
+
+// Code Assist OAuth failures can surface either as the explicit Antigravity
+// migration message or as a closed loadCodeAssist transport in ACP mode.
+export function isGeminiCodeAssistMigrationAuthFailure(message: string): boolean {
+  const lowerMessage = message.toLowerCase();
+  const explicitMigration =
+    lowerMessage.includes("gemini code assist") &&
+    (lowerMessage.includes("antigravity") ||
+      lowerMessage.includes("client is no longer supported") ||
+      lowerMessage.includes("migrate"));
+  const loadCodeAssistClosed =
+    (lowerMessage.includes("cloudcode-pa.googleapis.com") ||
+      lowerMessage.includes("loadcodeassist")) &&
+    lowerMessage.includes("premature close");
+
+  return explicitMigration || loadCodeAssistClosed;
 }
 
 export function normalizeGeminiCapabilityProbeResult(

--- a/apps/server/src/provider/geminiAcpProbe.ts
+++ b/apps/server/src/provider/geminiAcpProbe.ts
@@ -98,6 +98,16 @@ function isGeminiUnauthenticatedFailure(message: string, code?: number): boolean
   );
 }
 
+function isGeminiLogUnauthenticatedFailure(message: string): boolean {
+  const lowerMessage = message.toLowerCase();
+  return (
+    isGeminiCodeAssistMigrationAuthFailure(message) ||
+    lowerMessage.includes("authentication required") ||
+    lowerMessage.includes("api key is missing") ||
+    lowerMessage.includes("auth method")
+  );
+}
+
 function buildGeminiUnauthenticatedResult(
   message: string,
 ): Omit<GeminiCapabilityProbeResult, "models"> {
@@ -138,7 +148,7 @@ export function parseGeminiAcpProbeError(
 export function parseGeminiAcpProbeLogFailure(
   detail: string,
 ): Omit<GeminiCapabilityProbeResult, "models"> | undefined {
-  return isGeminiUnauthenticatedFailure(detail)
+  return isGeminiLogUnauthenticatedFailure(detail)
     ? buildGeminiUnauthenticatedResult(detail)
     : undefined;
 }

--- a/apps/server/src/provider/geminiAcpProbe.ts
+++ b/apps/server/src/provider/geminiAcpProbe.ts
@@ -86,6 +86,30 @@ function formatGeminiModelDiscoveryFallbackMessage(): string {
   return "Gemini CLI is installed and authenticated, but it did not report any available models. Synara will use its built-in Gemini model list.";
 }
 
+function isGeminiUnauthenticatedFailure(message: string, code?: number): boolean {
+  const lowerMessage = message.toLowerCase();
+  return (
+    code === GEMINI_ACP_AUTH_REQUIRED_CODE ||
+    isGeminiCodeAssistMigrationAuthFailure(message) ||
+    lowerMessage.includes("authentication required") ||
+    lowerMessage.includes("api key is missing") ||
+    lowerMessage.includes("auth method") ||
+    lowerMessage.includes("not configured")
+  );
+}
+
+function buildGeminiUnauthenticatedResult(
+  message: string,
+): Omit<GeminiCapabilityProbeResult, "models"> {
+  return {
+    status: "error",
+    auth: { status: "unauthenticated" },
+    message: isGeminiCodeAssistMigrationAuthFailure(message)
+      ? formatGeminiCodeAssistMigrationAuthMessage()
+      : formatGeminiAuthMessage(message),
+  };
+}
+
 function detailFromProbeLogs(
   stdoutLines: ReadonlyArray<string>,
   stderrLines: ReadonlyArray<string>,
@@ -99,24 +123,9 @@ export function parseGeminiAcpProbeError(
   const record = asRecord(error);
   const code = asNumber(record?.code);
   const message = trimToUndefined(record?.message) ?? "Gemini ACP request failed.";
-  const lowerMessage = message.toLowerCase();
-  const codeAssistMigrationAuthFailure = isGeminiCodeAssistMigrationAuthFailure(message);
-  const unauthenticated =
-    code === GEMINI_ACP_AUTH_REQUIRED_CODE ||
-    codeAssistMigrationAuthFailure ||
-    lowerMessage.includes("authentication required") ||
-    lowerMessage.includes("api key is missing") ||
-    lowerMessage.includes("auth method") ||
-    lowerMessage.includes("not configured");
 
-  if (unauthenticated) {
-    return {
-      status: "error",
-      auth: { status: "unauthenticated" },
-      message: codeAssistMigrationAuthFailure
-        ? formatGeminiCodeAssistMigrationAuthMessage()
-        : formatGeminiAuthMessage(message),
-    };
+  if (isGeminiUnauthenticatedFailure(message, code)) {
+    return buildGeminiUnauthenticatedResult(message);
   }
 
   return {
@@ -124,6 +133,14 @@ export function parseGeminiAcpProbeError(
     auth: { status: "unknown" },
     message: formatGeminiDiscoveryWarning(message),
   };
+}
+
+export function parseGeminiAcpProbeLogFailure(
+  detail: string,
+): Omit<GeminiCapabilityProbeResult, "models"> | undefined {
+  return isGeminiUnauthenticatedFailure(detail)
+    ? buildGeminiUnauthenticatedResult(detail)
+    : undefined;
 }
 
 // Runs Gemini probes as status checks only; they must never launch an OAuth browser.
@@ -327,6 +344,15 @@ export const probeGeminiCapabilities = (input: {
 
         timeout = setTimeout(() => {
           const detail = detailFromProbeLogs(stdoutLines, stderrLines);
+          const authFailure = detail ? parseGeminiAcpProbeLogFailure(detail) : undefined;
+          if (authFailure) {
+            finalize({
+              ...authFailure,
+              models: [],
+            });
+            return;
+          }
+
           finalize({
             status: "warning",
             auth: { status: "unknown" },
@@ -442,6 +468,15 @@ export const probeGeminiCapabilities = (input: {
           }
 
           const detail = detailFromProbeLogs(stdoutLines, stderrLines);
+          const authFailure = detail ? parseGeminiAcpProbeLogFailure(detail) : undefined;
+          if (authFailure) {
+            finalize({
+              ...authFailure,
+              models: [],
+            });
+            return;
+          }
+
           const exitMessage =
             detail ??
             `Gemini ACP exited before responding (code ${code ?? "null"}${signal ? `, signal ${signal}` : ""}).`;

--- a/apps/server/src/provider/geminiAcpProbe.ts
+++ b/apps/server/src/provider/geminiAcpProbe.ts
@@ -153,6 +153,13 @@ export function parseGeminiAcpProbeLogFailure(
     : undefined;
 }
 
+export function captureGeminiAcpProbeLogFailure(
+  captured: Omit<GeminiCapabilityProbeResult, "models"> | undefined,
+  line: string,
+): Omit<GeminiCapabilityProbeResult, "models"> | undefined {
+  return captured ?? parseGeminiAcpProbeLogFailure(line);
+}
+
 // Runs Gemini probes as status checks only; they must never launch an OAuth browser.
 export function buildGeminiProbeEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
   return {
@@ -178,8 +185,7 @@ export function isGeminiCodeAssistMigrationAuthFailure(message: string): boolean
       lowerMessage.includes("client is no longer supported") ||
       lowerMessage.includes("migrate"));
   const loadCodeAssistClosed =
-    (lowerMessage.includes("cloudcode-pa.googleapis.com") ||
-      lowerMessage.includes("loadcodeassist")) &&
+    lowerMessage.includes("loadcodeassist") &&
     lowerMessage.includes("premature close");
 
   return explicitMigration || loadCodeAssistClosed;
@@ -263,6 +269,7 @@ export const probeGeminiCapabilities = (input: {
 
         let settled = false;
         let sessionNewRequested = false;
+        let capturedAuthFailure: Omit<GeminiCapabilityProbeResult, "models"> | undefined;
         let timeout: ReturnType<typeof setTimeout> | undefined;
 
         const cleanup = () => {
@@ -352,9 +359,19 @@ export const probeGeminiCapabilities = (input: {
           });
         };
 
+        const capturePlainAuthLogLine = (line: string) => {
+          const trimmed = line.trim();
+          if (!trimmed || trimmed.startsWith("{")) {
+            return;
+          }
+
+          capturedAuthFailure = captureGeminiAcpProbeLogFailure(capturedAuthFailure, trimmed);
+        };
+
         timeout = setTimeout(() => {
           const detail = detailFromProbeLogs(stdoutLines, stderrLines);
-          const authFailure = detail ? parseGeminiAcpProbeLogFailure(detail) : undefined;
+          const authFailure =
+            capturedAuthFailure ?? (detail ? parseGeminiAcpProbeLogFailure(detail) : undefined);
           if (authFailure) {
             finalize({
               ...authFailure,
@@ -384,6 +401,7 @@ export const probeGeminiCapabilities = (input: {
 
           const trimmed = line.trim();
           if (!trimmed.startsWith("{")) {
+            capturePlainAuthLogLine(line);
             return;
           }
 
@@ -458,7 +476,10 @@ export const probeGeminiCapabilities = (input: {
           pushLogLine(stderrLines, line);
           if (isGeminiOAuthBrowserPrompt(line)) {
             finalizeOAuthBrowserPrompt();
+            return;
           }
+
+          capturePlainAuthLogLine(line);
         });
 
         child.once("error", (error) => {
@@ -478,7 +499,8 @@ export const probeGeminiCapabilities = (input: {
           }
 
           const detail = detailFromProbeLogs(stdoutLines, stderrLines);
-          const authFailure = detail ? parseGeminiAcpProbeLogFailure(detail) : undefined;
+          const authFailure =
+            capturedAuthFailure ?? (detail ? parseGeminiAcpProbeLogFailure(detail) : undefined);
           if (authFailure) {
             finalize({
               ...authFailure,


### PR DESCRIPTION
## Summary
- Detect Gemini Code Assist Antigravity migration failures in the ACP probe, including the reported loadCodeAssist premature-close symptom.
- Surface actionable Synara setup guidance for Gemini API key and Vertex AI auth without changing the provider health contract.
- Add focused parser coverage for the migration message, loadCodeAssist premature close, unrelated premature close, and generic auth failures.

## Verification
- bun run --cwd apps/server test src/provider/geminiAcpProbe.test.ts
- git diff --check

Note: I did not run bun fmt, bun lint, or bun typecheck because AGENTS.md requires explicit current-conversation permission for those heavyweight checks.

Closes #224