### PR TITLE
Fix idle provider runtime memory retention

### DIFF
--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1453,7 +1453,7 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
     }),
   );
 
-  it.effect("ignores a fired idle stop when new turn work invalidates its generation", () =>
+  it.effect("serializes a fired idle stop before starting new turn work", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;
       const runtimeRepository = yield* ProviderSessionRuntimeRepository;
@@ -1470,6 +1470,18 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
         runtimeMode: "full-access",
       });
       const { resumeCursor: _omittedResumeCursor, ...staleReadySession } = session;
+
+      idleCleanup.codex.listSessions
+        .mockImplementationOnce(() => Effect.succeed([session]))
+        .mockImplementationOnce(() =>
+          Effect.promise(
+            () =>
+              new Promise<ReadonlyArray<ProviderSession>>((resolve) => {
+                listSessionsStarted = true;
+                releaseListSessions = resolve;
+              }),
+          ),
+        );
 
       yield* idleCleanup.codex.waitForRuntimeSubscribers();
       idleCleanup.codex.emit({
@@ -1501,29 +1513,23 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
         20,
         "runtime completion persistence",
       );
-      idleCleanup.codex.listSessions.mockImplementationOnce(() =>
-        Effect.promise(
-          () =>
-            new Promise<ReadonlyArray<ProviderSession>>((resolve) => {
-              listSessionsStarted = true;
-              releaseListSessions = resolve;
-            }),
-        ),
-      );
       yield* waitUntil(() => listSessionsStarted, 500, 20, "idle listSessions start");
 
-      yield* provider.sendTurn({
-        threadId,
-        input: "new turn after idle timeout fired",
-        attachments: [],
-      });
+      const sendTurnFiber = yield* provider
+        .sendTurn({
+          threadId,
+          input: "new turn after idle timeout fired",
+          attachments: [],
+        })
+        .pipe(Effect.forkChild);
 
       const release = releaseListSessions;
       assert.equal(typeof release, "function");
       release([staleReadySession]);
+      yield* Fiber.join(sendTurnFiber);
       yield* sleep(100);
 
-      assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 0);
+      assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 1);
       const persistedAfter = yield* runtimeRepository.getByThreadId({ threadId });
       assert.equal(Option.isSome(persistedAfter), true);
       if (Option.isSome(persistedAfter)) {
@@ -1537,6 +1543,72 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
           true,
         );
       }
+    }),
+  );
+
+  it.effect("restores idle cleanup when new turn dispatch is interrupted", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = asThreadId("thread-idle-interrupted-dispatch");
+
+      idleCleanup.codex.stopSession.mockClear();
+      const session = yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      idleCleanup.codex.updateSession(threadId, (existing) => {
+        const { resumeCursor: _omittedResumeCursor, ...withoutResumeCursor } = existing;
+        return withoutResumeCursor;
+      });
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-idle-before-interrupted-dispatch"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "completed" },
+      });
+
+      yield* waitUntilEffect(
+        () =>
+          runtimeRepository.getByThreadId({ threadId }).pipe(
+            Effect.map((runtime) => {
+              if (Option.isNone(runtime)) {
+                return false;
+              }
+              const payload = runtime.value.runtimePayload;
+              return (
+                payload !== null &&
+                typeof payload === "object" &&
+                !Array.isArray(payload) &&
+                (payload as Record<string, unknown>).lastRuntimeEvent === "turn.completed"
+              );
+            }),
+          ),
+        500,
+        20,
+        "runtime completion persistence",
+      );
+
+      idleCleanup.codex.sendTurn.mockImplementationOnce(() => Effect.interrupt);
+      yield* Effect.exit(
+        provider.sendTurn({
+          threadId: session.threadId,
+          input: "new turn interrupted before runtime events",
+          attachments: [],
+        }),
+      );
+
+      yield* waitUntil(
+        () => idleCleanup.codex.stopSession.mock.calls.length > 0,
+        500,
+        20,
+        "idle runtime stop after interrupted dispatch",
+      );
+      assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], threadId);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -168,6 +168,10 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
       Effect.succeed({ threadId, turns: [] }),
   );
 
+  const compactThread = vi.fn((_threadId: ThreadId): Effect.Effect<void, ProviderAdapterError> =>
+    Effect.void,
+  );
+
   const stopAll = vi.fn(
     (): Effect.Effect<void, ProviderAdapterError> =>
       Effect.sync(() => {
@@ -190,6 +194,7 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
     hasSession,
     readThread,
     rollbackThread,
+    compactThread,
     stopAll,
     streamEvents: Stream.fromPubSub(runtimeEventPubSub),
   };
@@ -232,6 +237,7 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
     hasSession,
     readThread,
     rollbackThread,
+    compactThread,
     stopAll,
   };
 }
@@ -1669,6 +1675,109 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
         500,
         20,
         "idle runtime stop after successful rollback",
+      );
+      assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], threadId);
+    }),
+  );
+
+  it.effect("waits for fired idle cleanup before removing an explicit stop binding", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = asThreadId("thread-idle-stop-remove-race");
+      let listSessionsStarted = false;
+      let releaseListSessions:
+        | ((sessions: ReadonlyArray<ProviderSession>) => void)
+        | undefined;
+
+      const session = yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const { resumeCursor: _omittedResumeCursor, ...staleReadySession } = session;
+      idleCleanup.codex.listSessions
+        .mockImplementationOnce(() => Effect.succeed([session]))
+        .mockImplementationOnce(() =>
+          Effect.promise(
+            () =>
+              new Promise<ReadonlyArray<ProviderSession>>((resolve) => {
+                listSessionsStarted = true;
+                releaseListSessions = resolve;
+              }),
+          ),
+        );
+
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-idle-before-explicit-stop"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "completed" },
+      });
+      yield* waitUntilEffect(
+        () =>
+          runtimeRepository.getByThreadId({ threadId }).pipe(
+            Effect.map((runtime) => {
+              if (Option.isNone(runtime)) {
+                return false;
+              }
+              const payload = runtime.value.runtimePayload;
+              return (
+                payload !== null &&
+                typeof payload === "object" &&
+                !Array.isArray(payload) &&
+                (payload as Record<string, unknown>).lastRuntimeEvent === "turn.completed"
+              );
+            }),
+          ),
+        500,
+        20,
+        "runtime completion persistence",
+      );
+      yield* waitUntil(() => listSessionsStarted, 500, 20, "idle listSessions start");
+
+      const stopFiber = yield* provider.stopSession({ threadId }).pipe(Effect.forkChild);
+      const release = releaseListSessions;
+      assert.equal(typeof release, "function");
+      release([staleReadySession]);
+      yield* Fiber.join(stopFiber);
+
+      const binding = yield* directory.getBinding(threadId);
+      assert.equal(Option.isNone(binding), true);
+    }),
+  );
+
+  it.effect("stops a compacted runtime that remains running without an active turn", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-idle-compact-running");
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      idleCleanup.codex.stopSession.mockClear();
+      idleCleanup.codex.compactThread.mockImplementationOnce((inputThreadId) =>
+        Effect.sync(() => {
+          idleCleanup.codex.updateSession(inputThreadId, (existing) => ({
+            ...existing,
+            status: "running",
+            activeTurnId: undefined,
+          }));
+        }),
+      );
+      yield* provider.compactThread({ threadId });
+
+      yield* waitUntil(
+        () => idleCleanup.codex.stopSession.mock.calls.length > 0,
+        500,
+        20,
+        "idle runtime stop after compact",
       );
       assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], threadId);
     }),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -255,6 +255,24 @@ const waitUntil = (
     }
   });
 
+const waitUntilEffect = <E = never, R = never>(
+  predicate: () => Effect.Effect<boolean, E, R>,
+  timeoutMs = 500,
+  intervalMs = 20,
+  description = "condition",
+): Effect.Effect<void, E, R> =>
+  Effect.gen(function* () {
+    const deadline = Date.now() + timeoutMs;
+    let matched = yield* predicate();
+    while (!matched && Date.now() < deadline) {
+      yield* sleep(intervalMs);
+      matched = yield* predicate();
+    }
+    if (!matched) {
+      assert.fail(`Timed out waiting for ${description}`);
+    }
+  });
+
 function makeProviderServiceLayer(options?: Parameters<typeof makeProviderServiceLive>[0]) {
   const codex = makeFakeCodexAdapter();
   const claude = makeFakeCodexAdapter("claudeAgent");
@@ -1321,7 +1339,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
   );
 });
 
-const idleCleanup = makeProviderServiceLayer({ runtimeIdleStopMs: 20 });
+const idleCleanup = makeProviderServiceLayer({ runtimeIdleStopMs: 100 });
 idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
   it.effect("stops idle ready runtime using the persisted cursor when the live snapshot omits it", () =>
     Effect.gen(function* () {
@@ -1374,6 +1392,64 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
         assert.equal(persistedAfter.value.status, "stopped");
         assert.deepEqual(persistedAfter.value.resumeCursor, session.resumeCursor);
       }
+    }),
+  );
+
+  it.effect("clears a pending idle stop before dispatching new turn work", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = asThreadId("thread-idle-new-turn");
+
+      idleCleanup.codex.stopSession.mockClear();
+      const session = yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      idleCleanup.codex.updateSession(threadId, (existing) => {
+        const { resumeCursor: _omittedResumeCursor, ...withoutResumeCursor } = existing;
+        return withoutResumeCursor;
+      });
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-idle-before-new-turn"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "completed" },
+      });
+
+      yield* waitUntilEffect(
+        () =>
+          runtimeRepository.getByThreadId({ threadId }).pipe(
+            Effect.map((runtime) => {
+              if (Option.isNone(runtime)) {
+                return false;
+              }
+              const payload = runtime.value.runtimePayload;
+              return (
+                payload !== null &&
+                typeof payload === "object" &&
+                !Array.isArray(payload) &&
+                (payload as Record<string, unknown>).lastRuntimeEvent === "turn.completed"
+              );
+            }),
+          ),
+        500,
+        20,
+        "runtime completion persistence",
+      );
+
+      yield* provider.sendTurn({
+        threadId: session.threadId,
+        input: "new turn before idle stop",
+        attachments: [],
+      });
+      yield* sleep(150);
+
+      assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 0);
     }),
   );
 });

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -198,6 +198,14 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
     Effect.runSync(PubSub.publish(runtimeEventPubSub, event as unknown as ProviderRuntimeEvent));
   };
 
+  const waitForRuntimeSubscribers = (count = 1): Effect.Effect<void> =>
+    waitUntil(
+      () => runtimeEventPubSub.subscribers.size >= count,
+      500,
+      20,
+      `${provider} runtime event subscriber`,
+    );
+
   const updateSession = (
     threadId: ThreadId,
     update: (session: ProviderSession) => ProviderSession,
@@ -212,6 +220,7 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
   return {
     adapter,
     emit,
+    waitForRuntimeSubscribers,
     updateSession,
     startSession,
     sendTurn,
@@ -230,7 +239,23 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
 const sleep = (ms: number) =>
   Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, ms)));
 
-function makeProviderServiceLayer() {
+const waitUntil = (
+  predicate: () => boolean,
+  timeoutMs = 500,
+  intervalMs = 20,
+  description = "condition",
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const deadline = Date.now() + timeoutMs;
+    while (!predicate() && Date.now() < deadline) {
+      yield* sleep(intervalMs);
+    }
+    if (!predicate()) {
+      assert.fail(`Timed out waiting for ${description}`);
+    }
+  });
+
+function makeProviderServiceLayer(options?: Parameters<typeof makeProviderServiceLive>[0]) {
   const codex = makeFakeCodexAdapter();
   const claude = makeFakeCodexAdapter("claudeAgent");
   const registry: typeof ProviderAdapterRegistry.Service = {
@@ -251,7 +276,7 @@ function makeProviderServiceLayer() {
 
   const layer = it.layer(
     Layer.mergeAll(
-      makeProviderServiceLive().pipe(
+      makeProviderServiceLive(options).pipe(
         Layer.provide(providerAdapterLayer),
         Layer.provide(directoryLayer),
         Layer.provideMerge(AnalyticsService.layerTest),
@@ -1293,6 +1318,63 @@ routing.layer("ProviderServiceLive routing", (it) => {
 
       fs.rmSync(tempDir, { recursive: true, force: true });
     }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});
+
+const idleCleanup = makeProviderServiceLayer({ runtimeIdleStopMs: 20 });
+idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
+  it.effect("stops idle ready runtime using the persisted cursor when the live snapshot omits it", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+
+      const session = yield* provider.startSession(asThreadId("thread-idle-persisted-cursor"), {
+        provider: "codex",
+        threadId: asThreadId("thread-idle-persisted-cursor"),
+        runtimeMode: "full-access",
+      });
+
+      const persistedBefore = yield* runtimeRepository.getByThreadId({
+        threadId: session.threadId,
+      });
+      assert.equal(Option.isSome(persistedBefore), true);
+      if (Option.isSome(persistedBefore)) {
+        assert.deepEqual(persistedBefore.value.resumeCursor, session.resumeCursor);
+      }
+
+      idleCleanup.codex.updateSession(session.threadId, (existing) => {
+        const { resumeCursor: _omittedResumeCursor, ...withoutResumeCursor } = existing;
+        return withoutResumeCursor;
+      });
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-idle-persisted-cursor-complete"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId: session.threadId,
+        payload: { state: "completed" },
+      });
+
+      yield* waitUntil(
+        () => idleCleanup.codex.stopSession.mock.calls.length > 0,
+        500,
+        20,
+        "idle runtime stop",
+      );
+
+      assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 1);
+      assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], session.threadId);
+
+      const persistedAfter = yield* runtimeRepository.getByThreadId({
+        threadId: session.threadId,
+      });
+      assert.equal(Option.isSome(persistedAfter), true);
+      if (Option.isSome(persistedAfter)) {
+        assert.equal(persistedAfter.value.status, "stopped");
+        assert.deepEqual(persistedAfter.value.resumeCursor, session.resumeCursor);
+      }
+    }),
   );
 });
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1452,6 +1452,77 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
       assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 0);
     }),
   );
+
+  it.effect("restores idle cleanup when new turn dispatch fails before runtime events", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = asThreadId("thread-idle-failed-dispatch");
+      const dispatchFailure = new ProviderAdapterSessionNotFoundError({
+        provider: "codex",
+        threadId,
+      });
+
+      idleCleanup.codex.stopSession.mockClear();
+      const session = yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      idleCleanup.codex.updateSession(threadId, (existing) => {
+        const { resumeCursor: _omittedResumeCursor, ...withoutResumeCursor } = existing;
+        return withoutResumeCursor;
+      });
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-idle-before-failed-dispatch"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "completed" },
+      });
+
+      yield* waitUntilEffect(
+        () =>
+          runtimeRepository.getByThreadId({ threadId }).pipe(
+            Effect.map((runtime) => {
+              if (Option.isNone(runtime)) {
+                return false;
+              }
+              const payload = runtime.value.runtimePayload;
+              return (
+                payload !== null &&
+                typeof payload === "object" &&
+                !Array.isArray(payload) &&
+                (payload as Record<string, unknown>).lastRuntimeEvent === "turn.completed"
+              );
+            }),
+          ),
+        500,
+        20,
+        "runtime completion persistence",
+      );
+
+      idleCleanup.codex.sendTurn.mockImplementationOnce(() => Effect.fail(dispatchFailure));
+      const failedTurn = yield* Effect.result(
+        provider.sendTurn({
+          threadId: session.threadId,
+          input: "new turn that fails before runtime events",
+          attachments: [],
+        }),
+      );
+      assertFailure(failedTurn, dispatchFailure);
+
+      yield* waitUntil(
+        () => idleCleanup.codex.stopSession.mock.calls.length > 0,
+        500,
+        20,
+        "idle runtime stop after failed dispatch",
+      );
+      assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], threadId);
+    }),
+  );
 });
 
 const fanout = makeProviderServiceLayer();

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1129,7 +1129,6 @@ routing.layer("ProviderServiceLive routing", (it) => {
         provider: "codex",
         createdAt: "2026-02-27T00:05:00.000Z",
         threadId: session.threadId,
-        turnId: turn.turnId,
         payload: { state: "compacted" },
       });
       yield* sleep(50);
@@ -1828,6 +1827,140 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
 
       const binding = yield* directory.getBinding(threadId);
       assert.equal(Option.isNone(binding), true);
+    }),
+  );
+
+  it.effect("waits for fired idle cleanup before explicit runtime stop", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = asThreadId("thread-idle-runtime-stop-race");
+      let listSessionsStarted = false;
+      let releaseListSessions:
+        | ((sessions: ReadonlyArray<ProviderSession>) => void)
+        | undefined;
+
+      const session = yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const { resumeCursor: _omittedResumeCursor, ...staleReadySession } = session;
+      idleCleanup.codex.stopSession.mockClear();
+      idleCleanup.codex.listSessions
+        .mockImplementationOnce(() => Effect.succeed([session]))
+        .mockImplementationOnce(() =>
+          Effect.promise(
+            () =>
+              new Promise<ReadonlyArray<ProviderSession>>((resolve) => {
+                listSessionsStarted = true;
+                releaseListSessions = resolve;
+              }),
+          ),
+        );
+
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-idle-before-runtime-stop"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "completed" },
+      });
+      yield* waitUntilEffect(
+        () =>
+          runtimeRepository.getByThreadId({ threadId }).pipe(
+            Effect.map((runtime) => {
+              if (Option.isNone(runtime)) {
+                return false;
+              }
+              const payload = runtime.value.runtimePayload;
+              return (
+                payload !== null &&
+                typeof payload === "object" &&
+                !Array.isArray(payload) &&
+                (payload as Record<string, unknown>).lastRuntimeEvent === "turn.completed"
+              );
+            }),
+          ),
+        500,
+        20,
+        "runtime completion persistence",
+      );
+      yield* waitUntil(() => listSessionsStarted, 500, 20, "idle listSessions start");
+
+      assert.equal(typeof provider.stopRuntimeSession, "function");
+      if (!provider.stopRuntimeSession) {
+        assert.fail("stopRuntimeSession unavailable");
+      }
+      const stopFiber = yield* provider.stopRuntimeSession({ threadId }).pipe(Effect.forkChild);
+      const release = releaseListSessions;
+      assert.equal(typeof release, "function");
+      release([staleReadySession]);
+      yield* Fiber.join(stopFiber);
+
+      assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 1);
+      assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], threadId);
+    }),
+  );
+
+  it.effect("reschedules idle cleanup after successful compact work", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = asThreadId("thread-idle-compact-success");
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      idleCleanup.codex.updateSession(threadId, (existing) => {
+        const { resumeCursor: _omittedResumeCursor, ...withoutResumeCursor } = existing;
+        return withoutResumeCursor;
+      });
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-idle-before-compact-success"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "completed" },
+      });
+
+      yield* waitUntilEffect(
+        () =>
+          runtimeRepository.getByThreadId({ threadId }).pipe(
+            Effect.map((runtime) => {
+              if (Option.isNone(runtime)) {
+                return false;
+              }
+              const payload = runtime.value.runtimePayload;
+              return (
+                payload !== null &&
+                typeof payload === "object" &&
+                !Array.isArray(payload) &&
+                (payload as Record<string, unknown>).lastRuntimeEvent === "turn.completed"
+              );
+            }),
+          ),
+        500,
+        20,
+        "runtime completion persistence",
+      );
+
+      idleCleanup.codex.stopSession.mockClear();
+      yield* provider.compactThread({ threadId });
+
+      yield* waitUntil(
+        () => idleCleanup.codex.stopSession.mock.calls.length > 0,
+        500,
+        20,
+        "idle runtime stop after successful compact",
+      );
+      assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], threadId);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1538,6 +1538,68 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
     }),
   );
 
+  it.effect("clears a pending idle stop when a runtime turn starts", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = asThreadId("thread-idle-runtime-turn-start");
+
+      idleCleanup.codex.stopSession.mockClear();
+      const session = yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      idleCleanup.codex.updateSession(threadId, (existing) => {
+        const { resumeCursor: _omittedResumeCursor, ...withoutResumeCursor } = existing;
+        return withoutResumeCursor;
+      });
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-idle-before-runtime-turn-start"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "completed" },
+      });
+
+      yield* waitUntilEffect(
+        () =>
+          runtimeRepository.getByThreadId({ threadId }).pipe(
+            Effect.map((runtime) => {
+              if (Option.isNone(runtime)) {
+                return false;
+              }
+              const payload = runtime.value.runtimePayload;
+              return (
+                payload !== null &&
+                typeof payload === "object" &&
+                !Array.isArray(payload) &&
+                (payload as Record<string, unknown>).lastRuntimeEvent === "turn.completed"
+              );
+            }),
+          ),
+        500,
+        20,
+        "runtime completion persistence",
+      );
+
+      idleCleanup.codex.emit({
+        type: "turn.started",
+        eventId: asEventId("runtime-turn-start-clears-idle"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:01.000Z",
+        threadId: session.threadId,
+        turnId: asTurnId("turn-runtime-clears-idle"),
+        payload: { state: "running" },
+      });
+      yield* sleep(150);
+
+      assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 0);
+    }),
+  );
+
   it.effect("serializes a fired idle stop before starting new turn work", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;
@@ -1952,6 +2014,15 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
       );
 
       idleCleanup.codex.stopSession.mockClear();
+      idleCleanup.codex.compactThread.mockImplementationOnce((inputThreadId) =>
+        Effect.sync(() => {
+          idleCleanup.codex.updateSession(inputThreadId, (existing) => ({
+            ...existing,
+            status: "running",
+            activeTurnId: undefined,
+          }));
+        }),
+      );
       yield* provider.compactThread({ threadId });
 
       yield* waitUntil(
@@ -1959,6 +2030,37 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
         500,
         20,
         "idle runtime stop after successful compact",
+      );
+      assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], threadId);
+    }),
+  );
+
+  it.effect("schedules idle cleanup for closed thread state changes", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const threadId = asThreadId("thread-idle-closed-state");
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      idleCleanup.codex.stopSession.mockClear();
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "thread.state.changed",
+        eventId: asEventId("runtime-idle-closed-state"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "closed" },
+      });
+
+      yield* waitUntil(
+        () => idleCleanup.codex.stopSession.mock.calls.length > 0,
+        500,
+        20,
+        "idle runtime stop after closed thread state",
       );
       assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], threadId);
     }),
@@ -1975,20 +2077,12 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
         runtimeMode: "full-access",
       });
       idleCleanup.codex.stopSession.mockClear();
-      idleCleanup.codex.compactThread.mockImplementationOnce((inputThreadId) =>
-        Effect.sync(() => {
-          idleCleanup.codex.updateSession(inputThreadId, (existing) => ({
-            ...existing,
-            status: "running",
-            activeTurnId: undefined,
-          }));
-        }),
-      );
+      idleCleanup.codex.updateSession(threadId, (existing) => ({
+        ...existing,
+        status: "running",
+        activeTurnId: undefined,
+      }));
       yield* idleCleanup.codex.waitForRuntimeSubscribers();
-      yield* provider.compactThread({ threadId });
-      yield* sleep(150);
-      assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 0);
-
       idleCleanup.codex.emit({
         type: "thread.state.changed",
         eventId: asEventId("runtime-idle-compact-completed"),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1453,6 +1453,93 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
     }),
   );
 
+  it.effect("ignores a fired idle stop when new turn work invalidates its generation", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = asThreadId("thread-idle-fired-new-turn");
+      let listSessionsStarted = false;
+      let releaseListSessions:
+        | ((sessions: ReadonlyArray<ProviderSession>) => void)
+        | undefined;
+
+      idleCleanup.codex.stopSession.mockClear();
+      const session = yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      const { resumeCursor: _omittedResumeCursor, ...staleReadySession } = session;
+
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-idle-fired-before-new-turn"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "completed" },
+      });
+
+      yield* waitUntilEffect(
+        () =>
+          runtimeRepository.getByThreadId({ threadId }).pipe(
+            Effect.map((runtime) => {
+              if (Option.isNone(runtime)) {
+                return false;
+              }
+              const payload = runtime.value.runtimePayload;
+              return (
+                payload !== null &&
+                typeof payload === "object" &&
+                !Array.isArray(payload) &&
+                (payload as Record<string, unknown>).lastRuntimeEvent === "turn.completed"
+              );
+            }),
+          ),
+        500,
+        20,
+        "runtime completion persistence",
+      );
+      idleCleanup.codex.listSessions.mockImplementationOnce(() =>
+        Effect.promise(
+          () =>
+            new Promise<ReadonlyArray<ProviderSession>>((resolve) => {
+              listSessionsStarted = true;
+              releaseListSessions = resolve;
+            }),
+        ),
+      );
+      yield* waitUntil(() => listSessionsStarted, 500, 20, "idle listSessions start");
+
+      yield* provider.sendTurn({
+        threadId,
+        input: "new turn after idle timeout fired",
+        attachments: [],
+      });
+
+      const release = releaseListSessions;
+      assert.equal(typeof release, "function");
+      release([staleReadySession]);
+      yield* sleep(100);
+
+      assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 0);
+      const persistedAfter = yield* runtimeRepository.getByThreadId({ threadId });
+      assert.equal(Option.isSome(persistedAfter), true);
+      if (Option.isSome(persistedAfter)) {
+        assert.equal(persistedAfter.value.status, "running");
+        const payload = persistedAfter.value.runtimePayload;
+        assert.equal(
+          payload !== null &&
+            typeof payload === "object" &&
+            !Array.isArray(payload) &&
+            (payload as Record<string, unknown>).activeTurnId === `turn-${String(threadId)}`,
+          true,
+        );
+      }
+    }),
+  );
+
   it.effect("restores idle cleanup when new turn dispatch fails before runtime events", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1771,7 +1771,19 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
           }));
         }),
       );
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
       yield* provider.compactThread({ threadId });
+      yield* sleep(150);
+      assert.equal(idleCleanup.codex.stopSession.mock.calls.length, 0);
+
+      idleCleanup.codex.emit({
+        type: "thread.state.changed",
+        eventId: asEventId("runtime-idle-compact-completed"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "compacted" },
+      });
 
       yield* waitUntil(
         () => idleCleanup.codex.stopSession.mock.calls.length > 0,

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1070,6 +1070,86 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  it.effect("marks terminal thread state changes stopped or errored", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+
+      const session = yield* provider.startSession(asThreadId("thread-runtime-state-error"), {
+        provider: "codex",
+        threadId: asThreadId("thread-runtime-state-error"),
+        runtimeMode: "full-access",
+      });
+
+      routing.codex.emit({
+        type: "thread.state.changed",
+        eventId: asEventId("runtime-thread-state-error"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:05:00.000Z",
+        threadId: session.threadId,
+        payload: { state: "error" },
+      });
+      yield* sleep(50);
+
+      const runtime = yield* runtimeRepository.getByThreadId({
+        threadId: session.threadId,
+      });
+      assert.equal(Option.isSome(runtime), true);
+      if (Option.isSome(runtime)) {
+        assert.equal(runtime.value.status, "error");
+        const payload = runtime.value.runtimePayload;
+        assert.equal(payload !== null && typeof payload === "object", true);
+        if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
+          assert.equal((payload as Record<string, unknown>).activeTurnId, null);
+          assert.equal((payload as Record<string, unknown>).lastRuntimeEvent, "thread.state.changed");
+        }
+      }
+    }),
+  );
+
+  it.effect("preserves active turns across compacted thread state boundaries", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+
+      const session = yield* provider.startSession(asThreadId("thread-runtime-compact-boundary"), {
+        provider: "codex",
+        threadId: asThreadId("thread-runtime-compact-boundary"),
+        runtimeMode: "full-access",
+      });
+      const turn = yield* provider.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      routing.codex.emit({
+        type: "thread.state.changed",
+        eventId: asEventId("runtime-thread-compact-boundary"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:05:00.000Z",
+        threadId: session.threadId,
+        turnId: turn.turnId,
+        payload: { state: "compacted" },
+      });
+      yield* sleep(50);
+
+      const runtime = yield* runtimeRepository.getByThreadId({
+        threadId: session.threadId,
+      });
+      assert.equal(Option.isSome(runtime), true);
+      if (Option.isSome(runtime)) {
+        assert.equal(runtime.value.status, "running");
+        const payload = runtime.value.runtimePayload;
+        assert.equal(payload !== null && typeof payload === "object", true);
+        if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
+          assert.equal((payload as Record<string, unknown>).activeTurnId, turn.turnId);
+          assert.equal((payload as Record<string, unknown>).lastRuntimeEvent, "thread.state.changed");
+        }
+      }
+    }),
+  );
+
   it.effect("reuses persisted resume cursor when startSession is called after a restart", () =>
     Effect.gen(function* () {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-provider-service-start-"));

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1612,6 +1612,68 @@ idleCleanup.layer("ProviderServiceLive idle cleanup", (it) => {
     }),
   );
 
+  it.effect("reschedules idle cleanup after successful rollback work", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+      const threadId = asThreadId("thread-idle-rollback-success");
+
+      yield* provider.startSession(threadId, {
+        provider: "codex",
+        threadId,
+        runtimeMode: "full-access",
+      });
+      idleCleanup.codex.updateSession(threadId, (existing) => {
+        const { resumeCursor: _omittedResumeCursor, ...withoutResumeCursor } = existing;
+        return withoutResumeCursor;
+      });
+      yield* idleCleanup.codex.waitForRuntimeSubscribers();
+      idleCleanup.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("runtime-idle-before-rollback"),
+        provider: "codex",
+        createdAt: "2026-02-27T00:04:00.000Z",
+        threadId,
+        payload: { state: "completed" },
+      });
+
+      yield* waitUntilEffect(
+        () =>
+          runtimeRepository.getByThreadId({ threadId }).pipe(
+            Effect.map((runtime) => {
+              if (Option.isNone(runtime)) {
+                return false;
+              }
+              const payload = runtime.value.runtimePayload;
+              return (
+                payload !== null &&
+                typeof payload === "object" &&
+                !Array.isArray(payload) &&
+                (payload as Record<string, unknown>).lastRuntimeEvent === "turn.completed"
+              );
+            }),
+          ),
+        500,
+        20,
+        "runtime completion persistence",
+      );
+
+      idleCleanup.codex.stopSession.mockClear();
+      yield* provider.rollbackConversation({
+        threadId,
+        numTurns: 1,
+      });
+
+      yield* waitUntil(
+        () => idleCleanup.codex.stopSession.mock.calls.length > 0,
+        500,
+        20,
+        "idle runtime stop after successful rollback",
+      );
+      assert.deepEqual(idleCleanup.codex.stopSession.mock.calls[0]?.[0], threadId);
+    }),
+  );
+
   it.effect("restores idle cleanup when new turn dispatch fails before runtime events", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -27,7 +27,7 @@ import {
   type ProviderRuntimeEvent,
   type ProviderSession,
 } from "@t3tools/contracts";
-import { Cause, Effect, Layer, Option, PubSub, Schema, SchemaIssue, Stream } from "effect";
+import { Cause, Effect, Exit, Layer, Option, PubSub, Schema, SchemaIssue, Stream } from "effect";
 
 import { ProviderValidationError } from "../Errors.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
@@ -232,24 +232,31 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const runtimeIdleTimers = new Map<ThreadId, ReturnType<typeof setTimeout>>();
     // Fired idle callbacks outlive their timer map entry, so use generations to
     // invalidate async stop work when new user work starts in that gap.
-    const runtimeIdleGenerations = new Map<ThreadId, number>();
+    const runtimeIdleGenerations = new Map<ThreadId, symbol>();
+    const runtimeIdleStopsInFlight = new Map<ThreadId, Promise<void>>();
     const runtimeIdleStopMs = Math.max(
       0,
       options?.runtimeIdleStopMs ?? PROVIDER_RUNTIME_IDLE_STOP_MS,
     );
-    let stopIdleRuntimeSession: ((threadId: ThreadId, generation: number) => void) | null = null;
+    let stopIdleRuntimeSession: ((threadId: ThreadId, generation: symbol) => void) | null = null;
 
-    const bumpRuntimeIdleGeneration = (threadId: ThreadId): number => {
-      const generation = (runtimeIdleGenerations.get(threadId) ?? 0) + 1;
+    const invalidateRuntimeIdleGeneration = (threadId: ThreadId): symbol => {
+      const generation = Symbol(String(threadId));
       runtimeIdleGenerations.set(threadId, generation);
       return generation;
     };
 
-    const isRuntimeIdleGenerationCurrent = (threadId: ThreadId, generation: number): boolean =>
+    const isRuntimeIdleGenerationCurrent = (threadId: ThreadId, generation: symbol): boolean =>
       runtimeIdleGenerations.get(threadId) === generation;
 
+    const retireRuntimeIdleGeneration = (threadId: ThreadId, generation?: symbol): void => {
+      if (generation === undefined || isRuntimeIdleGenerationCurrent(threadId, generation)) {
+        runtimeIdleGenerations.delete(threadId);
+      }
+    };
+
     const clearRuntimeIdleTimer = (threadId: ThreadId) => {
-      bumpRuntimeIdleGeneration(threadId);
+      invalidateRuntimeIdleGeneration(threadId);
       const timer = runtimeIdleTimers.get(threadId);
       if (!timer) {
         return;
@@ -264,7 +271,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         return;
       }
 
-      const generation = bumpRuntimeIdleGeneration(threadId);
+      const generation = invalidateRuntimeIdleGeneration(threadId);
       const timer = setTimeout(() => {
         runtimeIdleTimers.delete(threadId);
         stopIdleRuntimeSession?.(threadId, generation);
@@ -273,11 +280,30 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       runtimeIdleTimers.set(threadId, timer);
     };
 
-    const restoreRuntimeIdleTimerOnError = <A, E, R>(
+    const waitForRuntimeIdleStop = (threadId: ThreadId): Effect.Effect<void> =>
+      Effect.promise(() => runtimeIdleStopsInFlight.get(threadId) ?? Promise.resolve());
+
+    const runIdleSensitiveProviderWork = <A, E, R>(
       threadId: ThreadId,
       effect: Effect.Effect<A, E, R>,
     ): Effect.Effect<A, E, R> =>
-      effect.pipe(Effect.tapError(() => Effect.sync(() => scheduleRuntimeIdleStop(threadId))));
+      Effect.suspend(() => {
+        const existingIdleStop = runtimeIdleStopsInFlight.get(threadId);
+        const waitForExistingIdleStop =
+          existingIdleStop !== undefined
+            ? Effect.promise(() => existingIdleStop)
+            : Effect.void;
+        return waitForExistingIdleStop.pipe(
+          Effect.tap(() => Effect.sync(() => clearRuntimeIdleTimer(threadId))),
+          Effect.flatMap(() => waitForRuntimeIdleStop(threadId)),
+          Effect.flatMap(() => effect),
+          Effect.onExit((exit) =>
+            Exit.isSuccess(exit)
+              ? Effect.void
+              : Effect.sync(() => scheduleRuntimeIdleStop(threadId)),
+          ),
+        );
+      });
 
     const reconcileRuntimeIdleTimer = (event: ProviderRuntimeEvent) => {
       switch (event.type) {
@@ -292,6 +318,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           return;
         case "session.exited":
           clearRuntimeIdleTimer(event.threadId);
+          retireRuntimeIdleGeneration(event.threadId);
           return;
       }
     };
@@ -592,6 +619,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           provider: parsed.provider ?? "codex",
         };
         clearRuntimeIdleTimer(threadId);
+        yield* waitForRuntimeIdleStop(threadId);
         const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
         const effectiveResumeCursor =
           input.resumeCursor ??
@@ -760,39 +788,39 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             "Either input text or at least one attachment is required",
           );
         }
-        clearRuntimeIdleTimer(input.threadId);
-        const routed = yield* restoreRuntimeIdleTimerOnError(
+        return yield* runIdleSensitiveProviderWork(
           input.threadId,
-          resolveRoutableSession({
-            threadId: input.threadId,
-            operation: "ProviderService.sendTurn",
-            allowRecovery: true,
+          Effect.gen(function* () {
+            const routed = yield* resolveRoutableSession({
+              threadId: input.threadId,
+              operation: "ProviderService.sendTurn",
+              allowRecovery: true,
+            });
+            const turn = yield* routed.adapter.sendTurn(input);
+            yield* directory.upsert({
+              threadId: input.threadId,
+              provider: routed.adapter.provider,
+              status: "running",
+              ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
+              runtimePayload: {
+                ...(input.modelSelection !== undefined
+                  ? { modelSelection: input.modelSelection }
+                  : {}),
+                activeTurnId: turn.turnId,
+                lastRuntimeEvent: "provider.sendTurn",
+                lastRuntimeEventAt: new Date().toISOString(),
+              },
+            });
+            yield* analytics.record("provider.turn.sent", {
+              provider: routed.adapter.provider,
+              model: input.modelSelection?.model,
+              interactionMode: input.interactionMode,
+              attachmentCount: input.attachments.length,
+              hasInput: typeof input.input === "string" && input.input.trim().length > 0,
+            });
+            return turn;
           }),
         );
-        const turn = yield* restoreRuntimeIdleTimerOnError(
-          input.threadId,
-          routed.adapter.sendTurn(input),
-        );
-        yield* directory.upsert({
-          threadId: input.threadId,
-          provider: routed.adapter.provider,
-          status: "running",
-          ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
-          runtimePayload: {
-            ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
-            activeTurnId: turn.turnId,
-            lastRuntimeEvent: "provider.sendTurn",
-            lastRuntimeEventAt: new Date().toISOString(),
-          },
-        });
-        yield* analytics.record("provider.turn.sent", {
-          provider: routed.adapter.provider,
-          model: input.modelSelection?.model,
-          interactionMode: input.interactionMode,
-          attachmentCount: input.attachments.length,
-          hasInput: typeof input.input === "string" && input.input.trim().length > 0,
-        });
-        return turn;
       });
 
     const steerTurn: ProviderServiceShape["steerTurn"] = (rawInput) =>
@@ -813,49 +841,48 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             "Either input text or at least one attachment is required",
           );
         }
-        clearRuntimeIdleTimer(input.threadId);
-        const routed = yield* restoreRuntimeIdleTimerOnError(
+        return yield* runIdleSensitiveProviderWork(
           input.threadId,
-          resolveRoutableSession({
-            threadId: input.threadId,
-            operation: "ProviderService.steerTurn",
-            allowRecovery: true,
+          Effect.gen(function* () {
+            const routed = yield* resolveRoutableSession({
+              threadId: input.threadId,
+              operation: "ProviderService.steerTurn",
+              allowRecovery: true,
+            });
+            if (
+              !routed.adapter.steerTurn ||
+              routed.adapter.capabilities.supportsTurnSteering !== true
+            ) {
+              return yield* toValidationError(
+                "ProviderService.steerTurn",
+                `Provider '${routed.adapter.provider}' does not support steering an active turn.`,
+              );
+            }
+            const turn = yield* routed.adapter.steerTurn(input);
+            yield* directory.upsert({
+              threadId: input.threadId,
+              provider: routed.adapter.provider,
+              status: "running",
+              ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
+              runtimePayload: {
+                ...(input.modelSelection !== undefined
+                  ? { modelSelection: input.modelSelection }
+                  : {}),
+                activeTurnId: turn.turnId,
+                lastRuntimeEvent: "provider.steerTurn",
+                lastRuntimeEventAt: new Date().toISOString(),
+              },
+            });
+            yield* analytics.record("provider.turn.steered", {
+              provider: routed.adapter.provider,
+              model: input.modelSelection?.model,
+              interactionMode: input.interactionMode,
+              attachmentCount: input.attachments.length,
+              hasInput: typeof input.input === "string" && input.input.trim().length > 0,
+            });
+            return turn;
           }),
         );
-        if (
-          !routed.adapter.steerTurn ||
-          routed.adapter.capabilities.supportsTurnSteering !== true
-        ) {
-          scheduleRuntimeIdleStop(input.threadId);
-          return yield* toValidationError(
-            "ProviderService.steerTurn",
-            `Provider '${routed.adapter.provider}' does not support steering an active turn.`,
-          );
-        }
-        const turn = yield* restoreRuntimeIdleTimerOnError(
-          input.threadId,
-          routed.adapter.steerTurn(input),
-        );
-        yield* directory.upsert({
-          threadId: input.threadId,
-          provider: routed.adapter.provider,
-          status: "running",
-          ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
-          runtimePayload: {
-            ...(input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {}),
-            activeTurnId: turn.turnId,
-            lastRuntimeEvent: "provider.steerTurn",
-            lastRuntimeEventAt: new Date().toISOString(),
-          },
-        });
-        yield* analytics.record("provider.turn.steered", {
-          provider: routed.adapter.provider,
-          model: input.modelSelection?.model,
-          interactionMode: input.interactionMode,
-          attachmentCount: input.attachments.length,
-          hasInput: typeof input.input === "string" && input.input.trim().length > 0,
-        });
-        return turn;
       });
 
     const startReview: ProviderServiceShape["startReview"] = (rawInput) =>
@@ -866,43 +893,40 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           payload: rawInput,
         });
 
-        clearRuntimeIdleTimer(input.threadId);
-        const routed = yield* restoreRuntimeIdleTimerOnError(
+        return yield* runIdleSensitiveProviderWork(
           input.threadId,
-          resolveRoutableSession({
-            threadId: input.threadId,
-            operation: "ProviderService.startReview",
-            allowRecovery: true,
+          Effect.gen(function* () {
+            const routed = yield* resolveRoutableSession({
+              threadId: input.threadId,
+              operation: "ProviderService.startReview",
+              allowRecovery: true,
+            });
+            if (!routed.adapter.startReview) {
+              return yield* toValidationError(
+                "ProviderService.startReview",
+                `Provider '${routed.adapter.provider}' does not support native review.`,
+              );
+            }
+
+            const turn = yield* routed.adapter.startReview(input);
+            yield* directory.upsert({
+              threadId: input.threadId,
+              provider: routed.adapter.provider,
+              status: "running",
+              ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
+              runtimePayload: {
+                activeTurnId: turn.turnId,
+                lastRuntimeEvent: "provider.startReview",
+                lastRuntimeEventAt: new Date().toISOString(),
+              },
+            });
+            yield* analytics.record("provider.review.started", {
+              provider: routed.adapter.provider,
+              target: input.target.type,
+            });
+            return turn;
           }),
         );
-        if (!routed.adapter.startReview) {
-          scheduleRuntimeIdleStop(input.threadId);
-          return yield* toValidationError(
-            "ProviderService.startReview",
-            `Provider '${routed.adapter.provider}' does not support native review.`,
-          );
-        }
-
-        const turn = yield* restoreRuntimeIdleTimerOnError(
-          input.threadId,
-          routed.adapter.startReview(input),
-        );
-        yield* directory.upsert({
-          threadId: input.threadId,
-          provider: routed.adapter.provider,
-          status: "running",
-          ...(turn.resumeCursor !== undefined ? { resumeCursor: turn.resumeCursor } : {}),
-          runtimePayload: {
-            activeTurnId: turn.turnId,
-            lastRuntimeEvent: "provider.startReview",
-            lastRuntimeEventAt: new Date().toISOString(),
-          },
-        });
-        yield* analytics.record("provider.review.started", {
-          provider: routed.adapter.provider,
-          target: input.target.type,
-        });
-        return turn;
       });
 
     const interruptTurn: ProviderServiceShape["interruptTurn"] = (rawInput) =>
@@ -974,6 +998,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           yield* routed.adapter.stopSession(routed.threadId);
         }
         yield* directory.remove(input.threadId);
+        retireRuntimeIdleGeneration(input.threadId);
         yield* analytics.record("provider.session.stopped", {
           provider: routed.adapter.provider,
         });
@@ -981,7 +1006,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const stopRuntimeSessionInternal = (
       rawInput,
-      expectedIdleGeneration?: number,
+      expectedIdleGeneration?: symbol,
     ): ReturnType<NonNullable<ProviderServiceShape["stopRuntimeSession"]>> =>
       Effect.gen(function* () {
         const input = yield* decodeInputOrValidationError({
@@ -1010,6 +1035,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         if (hasActiveSession) {
           yield* adapter.stopSession(input.threadId);
         }
+        if (!isExpectedIdleStopCurrent()) {
+          return;
+        }
         yield* directory.upsert({
           threadId: input.threadId,
           provider: binding.provider,
@@ -1031,6 +1059,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         yield* analytics.record("provider.session.runtime_stopped", {
           provider: binding.provider,
         });
+        retireRuntimeIdleGeneration(input.threadId, expectedIdleGeneration);
       });
 
     const stopRuntimeSession: NonNullable<ProviderServiceShape["stopRuntimeSession"]> = (
@@ -1039,38 +1068,43 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       stopRuntimeSessionInternal(rawInput);
 
     stopIdleRuntimeSession = (threadId, generation) => {
-      void Effect.runPromise(
-        Effect.gen(function* () {
-          const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
-          if (!binding) {
-            return;
-          }
+      const stopEffect = Effect.gen(function* () {
+        const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
+        if (!binding) {
+          retireRuntimeIdleGeneration(threadId, generation);
+          return;
+        }
 
-          const adapter = yield* registry.getByProvider(binding.provider);
-          const sessions = yield* adapter.listSessions();
-          const session = sessions.find((entry) => entry.threadId === threadId);
-          if (!session || session.status !== "ready" || session.activeTurnId !== undefined) {
-            return;
-          }
-          // Live adapter snapshots can temporarily omit cursors even though the
-          // directory already persisted one from an earlier runtime event.
-          if (!hasResumeCursor(session.resumeCursor) && !hasResumeCursor(binding.resumeCursor)) {
-            return;
-          }
-          if (!isRuntimeIdleGenerationCurrent(threadId, generation)) {
-            return;
-          }
+        const adapter = yield* registry.getByProvider(binding.provider);
+        const sessions = yield* adapter.listSessions();
+        const session = sessions.find((entry) => entry.threadId === threadId);
+        if (!session || session.status !== "ready" || session.activeTurnId !== undefined) {
+          return;
+        }
+        // Live adapter snapshots can temporarily omit cursors even though the
+        // directory already persisted one from an earlier runtime event.
+        if (!hasResumeCursor(session.resumeCursor) && !hasResumeCursor(binding.resumeCursor)) {
+          return;
+        }
+        if (!isRuntimeIdleGenerationCurrent(threadId, generation)) {
+          return;
+        }
 
-          yield* stopRuntimeSessionInternal({ threadId }, generation);
-        }).pipe(
-          Effect.catchCause((cause) =>
-            Effect.logWarning("provider.session.idle_stop_failed", {
-              threadId,
-              cause,
-            }),
-          ),
+        yield* stopRuntimeSessionInternal({ threadId }, generation);
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("provider.session.idle_stop_failed", {
+            threadId,
+            cause,
+          }),
         ),
       );
+      const stopPromise = Effect.runPromise(stopEffect).finally(() => {
+        if (runtimeIdleStopsInFlight.get(threadId) === stopPromise) {
+          runtimeIdleStopsInFlight.delete(threadId);
+        }
+      });
+      runtimeIdleStopsInFlight.set(threadId, stopPromise);
     };
 
     const clearSessionResumeCursor: NonNullable<
@@ -1105,6 +1139,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         yield* analytics.record("provider.session.resume_cursor_cleared", {
           provider: binding.provider,
         });
+        retireRuntimeIdleGeneration(input.threadId);
       });
 
     const listSessions: ProviderServiceShape["listSessions"] = () =>
@@ -1167,16 +1202,21 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         if (input.numTurns === 0) {
           return;
         }
-        const routed = yield* resolveRoutableSession({
-          threadId: input.threadId,
-          operation: "ProviderService.rollbackConversation",
-          allowRecovery: true,
-        });
-        yield* routed.adapter.rollbackThread(routed.threadId, input.numTurns);
-        yield* analytics.record("provider.conversation.rolled_back", {
-          provider: routed.adapter.provider,
-          turns: input.numTurns,
-        });
+        yield* runIdleSensitiveProviderWork(
+          input.threadId,
+          Effect.gen(function* () {
+            const routed = yield* resolveRoutableSession({
+              threadId: input.threadId,
+              operation: "ProviderService.rollbackConversation",
+              allowRecovery: true,
+            });
+            yield* routed.adapter.rollbackThread(routed.threadId, input.numTurns);
+            yield* analytics.record("provider.conversation.rolled_back", {
+              provider: routed.adapter.provider,
+              turns: input.numTurns,
+            });
+          }),
+        );
       });
 
     const compactThread: ProviderServiceShape["compactThread"] = (rawInput) =>
@@ -1186,21 +1226,26 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           schema: ProviderCompactThreadInput,
           payload: rawInput,
         });
-        const routed = yield* resolveRoutableSession({
-          threadId: input.threadId,
-          operation: "ProviderService.compactThread",
-          allowRecovery: true,
-        });
-        if (!routed.adapter.compactThread) {
-          return yield* toValidationError(
-            "ProviderService.compactThread",
-            `Context compaction is unavailable for provider '${routed.adapter.provider}'.`,
-          );
-        }
-        yield* routed.adapter.compactThread(routed.threadId);
-        yield* analytics.record("provider.thread.compacted", {
-          provider: routed.adapter.provider,
-        });
+        yield* runIdleSensitiveProviderWork(
+          input.threadId,
+          Effect.gen(function* () {
+            const routed = yield* resolveRoutableSession({
+              threadId: input.threadId,
+              operation: "ProviderService.compactThread",
+              allowRecovery: true,
+            });
+            if (!routed.adapter.compactThread) {
+              return yield* toValidationError(
+                "ProviderService.compactThread",
+                `Context compaction is unavailable for provider '${routed.adapter.provider}'.`,
+              );
+            }
+            yield* routed.adapter.compactThread(routed.threadId);
+            yield* analytics.record("provider.thread.compacted", {
+              provider: routed.adapter.provider,
+            });
+          }),
+        );
       });
 
     const runStopAll = () =>
@@ -1231,6 +1276,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           clearTimeout(timer);
         }
         runtimeIdleTimers.clear();
+        runtimeIdleGenerations.clear();
+        runtimeIdleStopsInFlight.clear();
         stopIdleRuntimeSession = null;
       }).pipe(
         Effect.andThen(runStopAll()),

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -291,6 +291,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     ): Effect.Effect<A, E, R> =>
       Effect.suspend(() => {
         const existingIdleStop = runtimeIdleStopsInFlight.get(threadId);
+        const displacedIdleStop =
+          existingIdleStop !== undefined || runtimeIdleTimers.has(threadId);
         const waitForExistingIdleStop =
           existingIdleStop !== undefined
             ? Effect.promise(() => existingIdleStop)
@@ -304,7 +306,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               ? options?.scheduleIdleStopOnSuccess === true
                 ? Effect.sync(() => scheduleRuntimeIdleStop(threadId))
                 : Effect.void
-              : Effect.sync(() => scheduleRuntimeIdleStop(threadId)),
+              : displacedIdleStop
+                ? Effect.sync(() => scheduleRuntimeIdleStop(threadId))
+                : Effect.sync(() => retireRuntimeIdleGeneration(threadId)),
           ),
         );
       });
@@ -992,6 +996,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           schema: ProviderStopSessionInput,
           payload: rawInput,
         });
+        yield* waitForRuntimeIdleStop(input.threadId);
         clearRuntimeIdleTimer(input.threadId);
         const routed = yield* resolveRoutableSession({
           threadId: input.threadId,
@@ -1001,6 +1006,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         if (routed.isActive) {
           yield* routed.adapter.stopSession(routed.threadId);
         }
+        yield* waitForRuntimeIdleStop(input.threadId);
         yield* directory.remove(input.threadId);
         retireRuntimeIdleGeneration(input.threadId);
         yield* analytics.record("provider.session.stopped", {
@@ -1082,7 +1088,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         const adapter = yield* registry.getByProvider(binding.provider);
         const sessions = yield* adapter.listSessions();
         const session = sessions.find((entry) => entry.threadId === threadId);
-        if (!session || session.status !== "ready" || session.activeTurnId !== undefined) {
+        const bindingRuntimePayload = runtimePayloadRecord(binding.runtimePayload);
+        const isIdleReadySession =
+          session?.status === "ready" ||
+          (session?.status === "running" &&
+            session.activeTurnId === undefined &&
+            bindingRuntimePayload.lastRuntimeEvent === "provider.compactThread");
+        if (!session || !isIdleReadySession || session.activeTurnId !== undefined) {
           return;
         }
         // Live adapter snapshots can temporarily omit cursors even though the
@@ -1246,6 +1258,16 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               );
             }
             yield* routed.adapter.compactThread(routed.threadId);
+            yield* directory.upsert({
+              threadId: input.threadId,
+              provider: routed.adapter.provider,
+              status: "stopped",
+              runtimePayload: {
+                activeTurnId: null,
+                lastRuntimeEvent: "provider.compactThread",
+                lastRuntimeEventAt: new Date().toISOString(),
+              },
+            });
             yield* analytics.record("provider.thread.compacted", {
               provider: routed.adapter.provider,
             });

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -740,6 +740,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             "Either input text or at least one attachment is required",
           );
         }
+        clearRuntimeIdleTimer(input.threadId);
         const routed = yield* resolveRoutableSession({
           threadId: input.threadId,
           operation: "ProviderService.sendTurn",
@@ -786,6 +787,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             "Either input text or at least one attachment is required",
           );
         }
+        clearRuntimeIdleTimer(input.threadId);
         const routed = yield* resolveRoutableSession({
           threadId: input.threadId,
           operation: "ProviderService.steerTurn",
@@ -831,6 +833,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           payload: rawInput,
         });
 
+        clearRuntimeIdleTimer(input.threadId);
         const routed = yield* resolveRoutableSession({
           threadId: input.threadId,
           operation: "ProviderService.startReview",

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -43,6 +43,7 @@ import { AnalyticsService } from "../../telemetry/Services/AnalyticsService.ts";
 export interface ProviderServiceLiveOptions {
   readonly canonicalEventLogPath?: string;
   readonly canonicalEventLogger?: EventNdjsonLogger;
+  readonly runtimeIdleStopMs?: number;
 }
 
 const DEFAULT_PROVIDER_RUNTIME_IDLE_STOP_MS = 10 * 60 * 1000;
@@ -162,6 +163,10 @@ function runtimePayloadRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
+function hasResumeCursor(value: unknown): boolean {
+  return value !== null && value !== undefined;
+}
+
 function runtimeStatusForEvent(event: ProviderRuntimeEvent): "running" | "stopped" | "error" {
   switch (event.type) {
     case "session.state.changed":
@@ -225,6 +230,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const directory = yield* ProviderSessionDirectory;
     const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
     const runtimeIdleTimers = new Map<ThreadId, ReturnType<typeof setTimeout>>();
+    const runtimeIdleStopMs = Math.max(
+      0,
+      options?.runtimeIdleStopMs ?? PROVIDER_RUNTIME_IDLE_STOP_MS,
+    );
     let stopIdleRuntimeSession: ((threadId: ThreadId) => void) | null = null;
 
     const clearRuntimeIdleTimer = (threadId: ThreadId) => {
@@ -238,14 +247,14 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
 
     const scheduleRuntimeIdleStop = (threadId: ThreadId) => {
       clearRuntimeIdleTimer(threadId);
-      if (PROVIDER_RUNTIME_IDLE_STOP_MS <= 0) {
+      if (runtimeIdleStopMs <= 0) {
         return;
       }
 
       const timer = setTimeout(() => {
         runtimeIdleTimers.delete(threadId);
         stopIdleRuntimeSession?.(threadId);
-      }, PROVIDER_RUNTIME_IDLE_STOP_MS);
+      }, runtimeIdleStopMs);
       timer.unref();
       runtimeIdleTimers.set(threadId, timer);
     };
@@ -446,8 +455,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     }) =>
       Effect.gen(function* () {
         const adapter = yield* registry.getByProvider(input.binding.provider);
-        const hasResumeCursor =
-          input.binding.resumeCursor !== null && input.binding.resumeCursor !== undefined;
+        const hasPersistedResumeCursor = hasResumeCursor(input.binding.resumeCursor);
         const hasActiveSession = yield* adapter.hasSession(input.binding.threadId);
         if (hasActiveSession) {
           const activeSessions = yield* adapter.listSessions();
@@ -459,13 +467,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             yield* analytics.record("provider.session.recovered", {
               provider: existing.provider,
               strategy: "adopt-existing",
-              hasResumeCursor: existing.resumeCursor !== undefined,
+              hasResumeCursor: hasResumeCursor(existing.resumeCursor),
             });
             return { adapter, session: existing } as const;
           }
         }
 
-        if (!hasResumeCursor) {
+        if (!hasPersistedResumeCursor) {
           return yield* toValidationError(
             input.operation,
             `Cannot recover thread '${input.binding.threadId}' because no provider resume state is persisted.`,
@@ -482,7 +490,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           ...(persistedCwd ? { cwd: persistedCwd } : {}),
           ...(persistedModelSelection ? { modelSelection: persistedModelSelection } : {}),
           ...(persistedProviderOptions ? { providerOptions: persistedProviderOptions } : {}),
-          ...(hasResumeCursor ? { resumeCursor: input.binding.resumeCursor } : {}),
+          ...(hasPersistedResumeCursor ? { resumeCursor: input.binding.resumeCursor } : {}),
           runtimeMode: input.binding.runtimeMode ?? "full-access",
         });
         if (resumed.provider !== adapter.provider) {
@@ -496,7 +504,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         yield* analytics.record("provider.session.recovered", {
           provider: resumed.provider,
           strategy: "resume-thread",
-          hasResumeCursor: resumed.resumeCursor !== undefined,
+          hasResumeCursor: hasResumeCursor(resumed.resumeCursor),
         });
         return { adapter, session: resumed } as const;
       });
@@ -598,7 +606,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         yield* analytics.record("provider.session.started", {
           provider: session.provider,
           runtimeMode: input.runtimeMode,
-          hasResumeCursor: session.resumeCursor !== undefined,
+          hasResumeCursor: hasResumeCursor(session.resumeCursor),
           hasCwd: typeof input.cwd === "string" && input.cwd.trim().length > 0,
           hasModel:
             typeof input.modelSelection?.model === "string" &&
@@ -985,7 +993,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           if (!session || session.status !== "ready" || session.activeTurnId !== undefined) {
             return;
           }
-          if (session.resumeCursor === undefined) {
+          // Live adapter snapshots can temporarily omit cursors even though the
+          // directory already persisted one from an earlier runtime event.
+          if (!hasResumeCursor(session.resumeCursor) && !hasResumeCursor(binding.resumeCursor)) {
             return;
           }
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -259,6 +259,12 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       runtimeIdleTimers.set(threadId, timer);
     };
 
+    const restoreRuntimeIdleTimerOnError = <A, E, R>(
+      threadId: ThreadId,
+      effect: Effect.Effect<A, E, R>,
+    ): Effect.Effect<A, E, R> =>
+      effect.pipe(Effect.tapError(() => Effect.sync(() => scheduleRuntimeIdleStop(threadId))));
+
     const reconcileRuntimeIdleTimer = (event: ProviderRuntimeEvent) => {
       switch (event.type) {
         case "turn.started":
@@ -741,12 +747,18 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           );
         }
         clearRuntimeIdleTimer(input.threadId);
-        const routed = yield* resolveRoutableSession({
-          threadId: input.threadId,
-          operation: "ProviderService.sendTurn",
-          allowRecovery: true,
-        });
-        const turn = yield* routed.adapter.sendTurn(input);
+        const routed = yield* restoreRuntimeIdleTimerOnError(
+          input.threadId,
+          resolveRoutableSession({
+            threadId: input.threadId,
+            operation: "ProviderService.sendTurn",
+            allowRecovery: true,
+          }),
+        );
+        const turn = yield* restoreRuntimeIdleTimerOnError(
+          input.threadId,
+          routed.adapter.sendTurn(input),
+        );
         yield* directory.upsert({
           threadId: input.threadId,
           provider: routed.adapter.provider,
@@ -788,21 +800,28 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           );
         }
         clearRuntimeIdleTimer(input.threadId);
-        const routed = yield* resolveRoutableSession({
-          threadId: input.threadId,
-          operation: "ProviderService.steerTurn",
-          allowRecovery: true,
-        });
+        const routed = yield* restoreRuntimeIdleTimerOnError(
+          input.threadId,
+          resolveRoutableSession({
+            threadId: input.threadId,
+            operation: "ProviderService.steerTurn",
+            allowRecovery: true,
+          }),
+        );
         if (
           !routed.adapter.steerTurn ||
           routed.adapter.capabilities.supportsTurnSteering !== true
         ) {
+          scheduleRuntimeIdleStop(input.threadId);
           return yield* toValidationError(
             "ProviderService.steerTurn",
             `Provider '${routed.adapter.provider}' does not support steering an active turn.`,
           );
         }
-        const turn = yield* routed.adapter.steerTurn(input);
+        const turn = yield* restoreRuntimeIdleTimerOnError(
+          input.threadId,
+          routed.adapter.steerTurn(input),
+        );
         yield* directory.upsert({
           threadId: input.threadId,
           provider: routed.adapter.provider,
@@ -834,19 +853,26 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         });
 
         clearRuntimeIdleTimer(input.threadId);
-        const routed = yield* resolveRoutableSession({
-          threadId: input.threadId,
-          operation: "ProviderService.startReview",
-          allowRecovery: true,
-        });
+        const routed = yield* restoreRuntimeIdleTimerOnError(
+          input.threadId,
+          resolveRoutableSession({
+            threadId: input.threadId,
+            operation: "ProviderService.startReview",
+            allowRecovery: true,
+          }),
+        );
         if (!routed.adapter.startReview) {
+          scheduleRuntimeIdleStop(input.threadId);
           return yield* toValidationError(
             "ProviderService.startReview",
             `Provider '${routed.adapter.provider}' does not support native review.`,
           );
         }
 
-        const turn = yield* routed.adapter.startReview(input);
+        const turn = yield* restoreRuntimeIdleTimerOnError(
+          input.threadId,
+          routed.adapter.startReview(input),
+        );
         yield* directory.upsert({
           threadId: input.threadId,
           provider: routed.adapter.provider,

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -230,13 +230,26 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const directory = yield* ProviderSessionDirectory;
     const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
     const runtimeIdleTimers = new Map<ThreadId, ReturnType<typeof setTimeout>>();
+    // Fired idle callbacks outlive their timer map entry, so use generations to
+    // invalidate async stop work when new user work starts in that gap.
+    const runtimeIdleGenerations = new Map<ThreadId, number>();
     const runtimeIdleStopMs = Math.max(
       0,
       options?.runtimeIdleStopMs ?? PROVIDER_RUNTIME_IDLE_STOP_MS,
     );
-    let stopIdleRuntimeSession: ((threadId: ThreadId) => void) | null = null;
+    let stopIdleRuntimeSession: ((threadId: ThreadId, generation: number) => void) | null = null;
+
+    const bumpRuntimeIdleGeneration = (threadId: ThreadId): number => {
+      const generation = (runtimeIdleGenerations.get(threadId) ?? 0) + 1;
+      runtimeIdleGenerations.set(threadId, generation);
+      return generation;
+    };
+
+    const isRuntimeIdleGenerationCurrent = (threadId: ThreadId, generation: number): boolean =>
+      runtimeIdleGenerations.get(threadId) === generation;
 
     const clearRuntimeIdleTimer = (threadId: ThreadId) => {
+      bumpRuntimeIdleGeneration(threadId);
       const timer = runtimeIdleTimers.get(threadId);
       if (!timer) {
         return;
@@ -251,9 +264,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         return;
       }
 
+      const generation = bumpRuntimeIdleGeneration(threadId);
       const timer = setTimeout(() => {
         runtimeIdleTimers.delete(threadId);
-        stopIdleRuntimeSession?.(threadId);
+        stopIdleRuntimeSession?.(threadId, generation);
       }, runtimeIdleStopMs);
       timer.unref();
       runtimeIdleTimers.set(threadId, timer);
@@ -965,23 +979,34 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         });
       });
 
-    const stopRuntimeSession: NonNullable<ProviderServiceShape["stopRuntimeSession"]> = (
+    const stopRuntimeSessionInternal = (
       rawInput,
-    ) =>
+      expectedIdleGeneration?: number,
+    ): ReturnType<NonNullable<ProviderServiceShape["stopRuntimeSession"]>> =>
       Effect.gen(function* () {
         const input = yield* decodeInputOrValidationError({
           operation: "ProviderService.stopRuntimeSession",
           schema: ProviderStopSessionInput,
           payload: rawInput,
         });
-        clearRuntimeIdleTimer(input.threadId);
+        const isExpectedIdleStopCurrent = () =>
+          expectedIdleGeneration === undefined ||
+          isRuntimeIdleGenerationCurrent(input.threadId, expectedIdleGeneration);
+        if (expectedIdleGeneration === undefined) {
+          clearRuntimeIdleTimer(input.threadId);
+        } else if (!isExpectedIdleStopCurrent()) {
+          return;
+        }
         const bindingOption = yield* directory.getBinding(input.threadId);
         const binding = Option.getOrUndefined(bindingOption);
-        if (!binding) {
+        if (!binding || !isExpectedIdleStopCurrent()) {
           return;
         }
         const adapter = yield* registry.getByProvider(binding.provider);
         const hasActiveSession = yield* adapter.hasSession(input.threadId);
+        if (!isExpectedIdleStopCurrent()) {
+          return;
+        }
         if (hasActiveSession) {
           yield* adapter.stopSession(input.threadId);
         }
@@ -1008,7 +1033,12 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         });
       });
 
-    stopIdleRuntimeSession = (threadId) => {
+    const stopRuntimeSession: NonNullable<ProviderServiceShape["stopRuntimeSession"]> = (
+      rawInput,
+    ) =>
+      stopRuntimeSessionInternal(rawInput);
+
+    stopIdleRuntimeSession = (threadId, generation) => {
       void Effect.runPromise(
         Effect.gen(function* () {
           const binding = Option.getOrUndefined(yield* directory.getBinding(threadId));
@@ -1027,8 +1057,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           if (!hasResumeCursor(session.resumeCursor) && !hasResumeCursor(binding.resumeCursor)) {
             return;
           }
+          if (!isRuntimeIdleGenerationCurrent(threadId, generation)) {
+            return;
+          }
 
-          yield* stopRuntimeSession({ threadId });
+          yield* stopRuntimeSessionInternal({ threadId }, generation);
         }).pipe(
           Effect.catchCause((cause) =>
             Effect.logWarning("provider.session.idle_stop_failed", {

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -167,7 +167,10 @@ function hasResumeCursor(value: unknown): boolean {
   return value !== null && value !== undefined;
 }
 
-function runtimeStatusForEvent(event: ProviderRuntimeEvent): "running" | "stopped" | "error" {
+function runtimeStatusForEvent(
+  event: ProviderRuntimeEvent,
+  activeTurnId?: unknown,
+): "running" | "stopped" | "error" {
   switch (event.type) {
     case "session.state.changed":
       switch (event.payload.state) {
@@ -186,7 +189,7 @@ function runtimeStatusForEvent(event: ProviderRuntimeEvent): "running" | "stoppe
         case "closed":
           return "stopped";
         case "compacted":
-          return event.turnId === undefined ? "stopped" : "running";
+          return event.turnId === undefined && activeTurnId == null ? "stopped" : "running";
         default:
           return "running";
       }
@@ -470,11 +473,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           return;
         }
 
+        const currentActiveTurnId =
+          runtimePayloadRecord(binding.runtimePayload).activeTurnId ?? null;
         const activeTurnId =
           event.type === "turn.started"
             ? (event.turnId ?? null)
-            : event.type === "thread.state.changed" && event.payload.state === "compacted"
-              ? (event.turnId ?? null)
+          : event.type === "thread.state.changed" && event.payload.state === "compacted"
+              ? (event.turnId ?? currentActiveTurnId)
             : event.type === "turn.completed" ||
                 event.type === "turn.aborted" ||
                 (event.type === "thread.state.changed" &&
@@ -488,7 +493,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
                     event.payload.state === "stopped" ||
                     event.payload.state === "error"))
               ? null
-              : (runtimePayloadRecord(binding.runtimePayload).activeTurnId ?? null);
+              : currentActiveTurnId;
         const lastError = runtimeLastErrorForEvent(event);
         const resumeCursor = yield* refreshResumeCursorFromActiveSession(event, binding);
 
@@ -497,7 +502,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           provider: binding.provider,
           ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
           ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
-          status: runtimeStatusForEvent(event),
+          status: runtimeStatusForEvent(event, activeTurnId),
           ...(resumeCursor !== undefined ? { resumeCursor } : {}),
           runtimePayload: {
             activeTurnId,
@@ -1057,6 +1062,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           expectedIdleGeneration === undefined ||
           isRuntimeIdleGenerationCurrent(input.threadId, expectedIdleGeneration);
         if (expectedIdleGeneration === undefined) {
+          yield* waitForRuntimeIdleStop(input.threadId);
           clearRuntimeIdleTimer(input.threadId);
         } else if (!isExpectedIdleStopCurrent()) {
           return;
@@ -1296,6 +1302,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               provider: routed.adapter.provider,
             });
           }),
+          { scheduleIdleStopOnSuccess: true },
         );
       });
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -345,7 +345,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           scheduleRuntimeIdleStop(event.threadId);
           return;
         case "thread.state.changed":
-          if (event.payload.state === "compacted") {
+          if (
+            event.payload.state === "compacted" ||
+            event.payload.state === "archived" ||
+            event.payload.state === "closed"
+          ) {
             scheduleRuntimeIdleStop(event.threadId);
           }
           return;
@@ -527,8 +531,19 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       registry.getByProvider(provider),
     );
     const processRuntimeEvent = (event: ProviderRuntimeEvent): Effect.Effect<void> =>
-      updateSessionBindingFromRuntimeEvent(event).pipe(
-        Effect.andThen(Effect.sync(() => reconcileRuntimeIdleTimer(event))),
+      Effect.sync(() => {
+        if (event.type === "turn.started") {
+          reconcileRuntimeIdleTimer(event);
+        }
+      }).pipe(
+        Effect.andThen(updateSessionBindingFromRuntimeEvent(event)),
+        Effect.andThen(
+          Effect.sync(() => {
+            if (event.type !== "turn.started") {
+              reconcileRuntimeIdleTimer(event);
+            }
+          }),
+        ),
         Effect.andThen(publishRuntimeEvent(event)),
       );
 
@@ -1129,7 +1144,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           (session?.status === "running" &&
             session.activeTurnId === undefined &&
             binding.status === "stopped" &&
-            bindingRuntimePayload.lastRuntimeEvent === "thread.state.changed");
+            (bindingRuntimePayload.lastRuntimeEvent === "thread.state.changed" ||
+              bindingRuntimePayload.lastRuntimeEvent === "provider.compactThread"));
         if (!session || !isIdleReadySession || session.activeTurnId !== undefined) {
           retireRuntimeIdleGeneration(threadId, generation);
           return;
@@ -1298,6 +1314,23 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               );
             }
             yield* routed.adapter.compactThread(routed.threadId);
+            const binding = Option.getOrUndefined(yield* directory.getBinding(routed.threadId));
+            if (binding) {
+              yield* directory.upsert({
+                threadId: routed.threadId,
+                provider: binding.provider,
+                ...(binding.adapterKey !== undefined ? { adapterKey: binding.adapterKey } : {}),
+                ...(binding.runtimeMode !== undefined ? { runtimeMode: binding.runtimeMode } : {}),
+                status: "stopped",
+                resumeCursor: binding.resumeCursor,
+                runtimePayload: {
+                  ...runtimePayloadRecord(binding.runtimePayload),
+                  activeTurnId: null,
+                  lastRuntimeEvent: "provider.compactThread",
+                  lastRuntimeEventAt: new Date().toISOString(),
+                },
+              });
+            }
             yield* analytics.record("provider.thread.compacted", {
               provider: routed.adapter.provider,
             });

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -268,6 +268,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const scheduleRuntimeIdleStop = (threadId: ThreadId) => {
       clearRuntimeIdleTimer(threadId);
       if (runtimeIdleStopMs <= 0) {
+        retireRuntimeIdleGeneration(threadId);
         return;
       }
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -178,15 +178,24 @@ function runtimeStatusForEvent(event: ProviderRuntimeEvent): "running" | "stoppe
         default:
           return "running";
       }
+    case "thread.state.changed":
+      switch (event.payload.state) {
+        case "error":
+          return "error";
+        case "archived":
+        case "closed":
+          return "stopped";
+        case "compacted":
+          return event.turnId === undefined ? "stopped" : "running";
+        default:
+          return "running";
+      }
     case "session.exited":
     case "turn.completed":
     case "turn.aborted":
-    case "thread.state.changed":
       // A completed turn can still carry a resume cursor, but it must not keep
       // the desktop app treating the provider process as active after restart.
-      return event.type === "thread.state.changed" && event.payload.state !== "compacted"
-        ? "running"
-        : "stopped";
+      return "stopped";
     case "runtime.error":
       return "error";
     default:
@@ -197,7 +206,9 @@ function runtimeStatusForEvent(event: ProviderRuntimeEvent): "running" | "stoppe
 function shouldRefreshResumeCursorForEvent(event: ProviderRuntimeEvent): boolean {
   return (
     event.type === "thread.started" ||
-    (event.type === "thread.state.changed" && event.payload.state === "compacted") ||
+    (event.type === "thread.state.changed" &&
+      event.payload.state === "compacted" &&
+      event.turnId === undefined) ||
     event.type === "turn.completed" ||
     event.type === "turn.aborted"
   );
@@ -209,10 +220,11 @@ function runtimeLastErrorForEvent(event: ProviderRuntimeEvent): string | null | 
       return event.payload.message;
     case "session.state.changed":
       return event.payload.state === "error" ? (event.payload.reason ?? "Session error") : null;
+    case "thread.state.changed":
+      return event.payload.state === "error" ? "Thread error" : null;
     case "turn.started":
     case "turn.completed":
     case "turn.aborted":
-    case "thread.state.changed":
     case "session.exited":
       return null;
     default:
@@ -461,9 +473,14 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         const activeTurnId =
           event.type === "turn.started"
             ? (event.turnId ?? null)
+            : event.type === "thread.state.changed" && event.payload.state === "compacted"
+              ? (event.turnId ?? null)
             : event.type === "turn.completed" ||
                 event.type === "turn.aborted" ||
-                (event.type === "thread.state.changed" && event.payload.state === "compacted") ||
+                (event.type === "thread.state.changed" &&
+                  (event.payload.state === "archived" ||
+                    event.payload.state === "closed" ||
+                    event.payload.state === "error")) ||
                 event.type === "session.exited" ||
                 event.type === "runtime.error" ||
                 (event.type === "session.state.changed" &&
@@ -505,8 +522,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       registry.getByProvider(provider),
     );
     const processRuntimeEvent = (event: ProviderRuntimeEvent): Effect.Effect<void> =>
-      Effect.sync(() => reconcileRuntimeIdleTimer(event)).pipe(
-        Effect.andThen(updateSessionBindingFromRuntimeEvent(event)),
+      updateSessionBindingFromRuntimeEvent(event).pipe(
+        Effect.andThen(Effect.sync(() => reconcileRuntimeIdleTimer(event))),
         Effect.andThen(publishRuntimeEvent(event)),
       );
 
@@ -1147,6 +1164,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           schema: ProviderStopSessionInput,
           payload: rawInput,
         });
+        yield* waitForRuntimeIdleStop(input.threadId);
         clearRuntimeIdleTimer(input.threadId);
         const bindingOption = yield* directory.getBinding(input.threadId);
         const binding = Option.getOrUndefined(bindingOption);
@@ -1158,6 +1176,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         if (hasActiveSession) {
           yield* adapter.stopSession(input.threadId);
         }
+        yield* waitForRuntimeIdleStop(input.threadId);
         yield* directory.upsert({
           threadId: input.threadId,
           provider: binding.provider,

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -286,6 +286,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const runIdleSensitiveProviderWork = <A, E, R>(
       threadId: ThreadId,
       effect: Effect.Effect<A, E, R>,
+      options?: { readonly scheduleIdleStopOnSuccess?: boolean },
     ): Effect.Effect<A, E, R> =>
       Effect.suspend(() => {
         const existingIdleStop = runtimeIdleStopsInFlight.get(threadId);
@@ -299,7 +300,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           Effect.flatMap(() => effect),
           Effect.onExit((exit) =>
             Exit.isSuccess(exit)
-              ? Effect.void
+              ? options?.scheduleIdleStopOnSuccess === true
+                ? Effect.sync(() => scheduleRuntimeIdleStop(threadId))
+                : Effect.void
               : Effect.sync(() => scheduleRuntimeIdleStop(threadId)),
           ),
         );
@@ -1216,6 +1219,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               turns: input.numTurns,
             });
           }),
+          { scheduleIdleStopOnSuccess: true },
         );
       });
 
@@ -1245,6 +1249,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               provider: routed.adapter.provider,
             });
           }),
+          { scheduleIdleStopOnSuccess: true },
         );
       });
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -181,9 +181,12 @@ function runtimeStatusForEvent(event: ProviderRuntimeEvent): "running" | "stoppe
     case "session.exited":
     case "turn.completed":
     case "turn.aborted":
+    case "thread.state.changed":
       // A completed turn can still carry a resume cursor, but it must not keep
       // the desktop app treating the provider process as active after restart.
-      return "stopped";
+      return event.type === "thread.state.changed" && event.payload.state !== "compacted"
+        ? "running"
+        : "stopped";
     case "runtime.error":
       return "error";
     default:
@@ -194,6 +197,7 @@ function runtimeStatusForEvent(event: ProviderRuntimeEvent): "running" | "stoppe
 function shouldRefreshResumeCursorForEvent(event: ProviderRuntimeEvent): boolean {
   return (
     event.type === "thread.started" ||
+    (event.type === "thread.state.changed" && event.payload.state === "compacted") ||
     event.type === "turn.completed" ||
     event.type === "turn.aborted"
   );
@@ -208,6 +212,7 @@ function runtimeLastErrorForEvent(event: ProviderRuntimeEvent): string | null | 
     case "turn.started":
     case "turn.completed":
     case "turn.aborted":
+    case "thread.state.changed":
     case "session.exited":
       return null;
     default:
@@ -324,6 +329,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         case "turn.aborted":
           scheduleRuntimeIdleStop(event.threadId);
           return;
+        case "thread.state.changed":
+          if (event.payload.state === "compacted") {
+            scheduleRuntimeIdleStop(event.threadId);
+          }
+          return;
         case "session.exited":
           clearRuntimeIdleTimer(event.threadId);
           retireRuntimeIdleGeneration(event.threadId);
@@ -431,6 +441,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         case "session.started":
         case "session.state.changed":
         case "thread.started":
+        case "thread.state.changed":
         case "turn.started":
         case "turn.completed":
         case "turn.aborted":
@@ -452,6 +463,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             ? (event.turnId ?? null)
             : event.type === "turn.completed" ||
                 event.type === "turn.aborted" ||
+                (event.type === "thread.state.changed" && event.payload.state === "compacted") ||
                 event.type === "session.exited" ||
                 event.type === "runtime.error" ||
                 (event.type === "session.state.changed" &&
@@ -1093,13 +1105,16 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           session?.status === "ready" ||
           (session?.status === "running" &&
             session.activeTurnId === undefined &&
-            bindingRuntimePayload.lastRuntimeEvent === "provider.compactThread");
+            binding.status === "stopped" &&
+            bindingRuntimePayload.lastRuntimeEvent === "thread.state.changed");
         if (!session || !isIdleReadySession || session.activeTurnId !== undefined) {
+          retireRuntimeIdleGeneration(threadId, generation);
           return;
         }
         // Live adapter snapshots can temporarily omit cursors even though the
         // directory already persisted one from an earlier runtime event.
         if (!hasResumeCursor(session.resumeCursor) && !hasResumeCursor(binding.resumeCursor)) {
+          retireRuntimeIdleGeneration(threadId, generation);
           return;
         }
         if (!isRuntimeIdleGenerationCurrent(threadId, generation)) {
@@ -1258,21 +1273,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
               );
             }
             yield* routed.adapter.compactThread(routed.threadId);
-            yield* directory.upsert({
-              threadId: input.threadId,
-              provider: routed.adapter.provider,
-              status: "stopped",
-              runtimePayload: {
-                activeTurnId: null,
-                lastRuntimeEvent: "provider.compactThread",
-                lastRuntimeEventAt: new Date().toISOString(),
-              },
-            });
             yield* analytics.record("provider.thread.compacted", {
               provider: routed.adapter.provider,
             });
           }),
-          { scheduleIdleStopOnSuccess: true },
         );
       });
 


### PR DESCRIPTION
## Summary

- stop idle provider runtimes when the persisted binding still has a resume cursor even if the live adapter snapshot omits it
- preserve resumability by requiring either the live snapshot cursor or the persisted cursor before stopping a ready idle runtime
- add regression coverage for the persisted-cursor idle cleanup path with deterministic event-subscriber readiness

## Validation

- `bun run --cwd apps/server test src/provider/Layers/ProviderService.test.ts`
- `git diff --check`
- two same-worktree `/review` passes; first small test-flakiness finding fixed, second review clean

Skipped `bun fmt`, `bun lint`, and `bun typecheck` because `AGENTS.md` requires explicit current-conversation permission for those heavyweight checks.

Closes #213
