### PR TITLE
Show transcript tool call details

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2961,6 +2961,72 @@ describe("ProviderRuntimeIngestion", () => {
     expect(rawOutput.output).toBe("first line\nsecond line\n");
   });
 
+  it("keeps buffered command output when completed raw streams are empty", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-empty-stream-buffered-output"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-empty-stream-output"),
+      itemId: asItemId("item-empty-stream-output"),
+      payload: {
+        streamKind: "command_output",
+        delta: "captured through delta\n",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-empty-stream-completed"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-empty-stream-output"),
+      itemId: asItemId("item-empty-stream-output"),
+      payload: {
+        itemType: "command_execution",
+        status: "completed",
+        title: "Ran command",
+        detail: "printf buffered",
+        data: {
+          rawInput: { command: "printf buffered" },
+          rawOutput: {
+            stdout: "",
+            stderr: "",
+          },
+        },
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.activities.some((activity) => activity.id === "evt-empty-stream-completed"),
+    );
+    const activity = thread.activities.find(
+      (entry) => entry.id === "evt-empty-stream-completed",
+    );
+    const payload =
+      activity?.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : {};
+    const data =
+      payload.data && typeof payload.data === "object"
+        ? (payload.data as Record<string, unknown>)
+        : {};
+    const rawOutput =
+      data.rawOutput && typeof data.rawOutput === "object"
+        ? (data.rawOutput as Record<string, unknown>)
+        : {};
+
+    expect(rawOutput).toMatchObject({
+      stdout: "",
+      stderr: "",
+      output: "captured through delta\n",
+    });
+  });
+
   it("hard-caps pathological tool activity data", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2892,6 +2892,75 @@ describe("ProviderRuntimeIngestion", () => {
     expect(String(rawOutput.stdout ?? "").length).toBeLessThan(3_000);
   });
 
+  it("attaches buffered command output deltas to the completed tool activity", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-command-output-1"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-command-output"),
+      itemId: asItemId("item-command-output"),
+      payload: {
+        streamKind: "command_output",
+        delta: "first line\n",
+      },
+    });
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-command-output-2"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-command-output"),
+      itemId: asItemId("item-command-output"),
+      payload: {
+        streamKind: "command_output",
+        delta: "second line\n",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-command-completed"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-command-output"),
+      itemId: asItemId("item-command-output"),
+      payload: {
+        itemType: "command_execution",
+        status: "completed",
+        title: "Ran command",
+        detail: "printf lines",
+        data: {
+          rawInput: { command: "printf lines" },
+        },
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.activities.some((activity) => activity.id === "evt-command-completed"),
+    );
+    const activity = thread.activities.find((entry) => entry.id === "evt-command-completed");
+    const payload =
+      activity?.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : {};
+    const data =
+      payload.data && typeof payload.data === "object"
+        ? (payload.data as Record<string, unknown>)
+        : {};
+    const rawOutput =
+      data.rawOutput && typeof data.rawOutput === "object"
+        ? (data.rawOutput as Record<string, unknown>)
+        : {};
+
+    expect(rawOutput.output).toBe("first line\nsecond line\n");
+  });
+
   it("hard-caps pathological tool activity data", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -275,6 +275,10 @@ function toolOutputBufferKey(event: ProviderRuntimeEvent): string | null {
   return [event.threadId, event.turnId ?? "no-turn", event.itemId].join(":");
 }
 
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 function mergeBufferedToolOutputData(
   data: unknown,
   bufferedOutput: BufferedToolOutput,
@@ -286,9 +290,9 @@ function mergeBufferedToolOutputData(
       ? { output: baseData.rawOutput }
       : {};
   const hasStructuredOutput =
-    typeof existingRawOutput.output === "string" ||
-    typeof existingRawOutput.stdout === "string" ||
-    typeof existingRawOutput.stderr === "string";
+    hasNonEmptyString(existingRawOutput.output) ||
+    hasNonEmptyString(existingRawOutput.stdout) ||
+    hasNonEmptyString(existingRawOutput.stderr);
   return {
     ...baseData,
     rawOutput: {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -60,8 +60,11 @@ const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY = 1_024;
 const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL = Duration.minutes(60);
 const BUFFERED_PROPOSED_PLAN_BY_ID_CACHE_CAPACITY = 1_024;
 const BUFFERED_PROPOSED_PLAN_BY_ID_TTL = Duration.minutes(60);
+const BUFFERED_TOOL_OUTPUT_BY_KEY_CACHE_CAPACITY = 2_048;
+const BUFFERED_TOOL_OUTPUT_BY_KEY_TTL = Duration.minutes(60);
 const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
 const MAX_BUFFERED_PROPOSED_PLAN_CHARS = 64_000;
+const MAX_BUFFERED_TOOL_OUTPUT_CHARS = 24_000;
 const MAX_ACTIVITY_DATA_JSON_CHARS = 16_000;
 const MAX_ACTIVITY_DATA_STRING_CHARS = 2_000;
 const MAX_ACTIVITY_DATA_ARRAY_ITEMS = 24;
@@ -86,6 +89,11 @@ type RuntimeIngestionInput =
     };
 
 type ActivityPayload = OrchestrationThreadActivity["payload"];
+type ToolOutputStreamKind = "command_output" | "file_change_output";
+type BufferedToolOutput = {
+  readonly text: string;
+  readonly truncated: boolean;
+};
 type ProviderDiffPlaceholder = {
   readonly checkpointRef: CheckpointRef;
   readonly checkpointTurnCount: number;
@@ -246,6 +254,71 @@ export function appendCappedBufferedText(existing: string, delta: string, limit:
     0,
     normalizedLimit - BUFFERED_TEXT_TRUNCATION_MARKER.length,
   )}${BUFFERED_TEXT_TRUNCATION_MARKER}`;
+}
+
+function toolOutputStreamKind(
+  event: ProviderRuntimeEvent,
+): ToolOutputStreamKind | undefined {
+  if (event.type !== "content.delta") {
+    return undefined;
+  }
+  return event.payload.streamKind === "command_output" ||
+    event.payload.streamKind === "file_change_output"
+    ? event.payload.streamKind
+    : undefined;
+}
+
+function toolOutputBufferKey(event: ProviderRuntimeEvent): string | null {
+  if (!event.itemId) {
+    return null;
+  }
+  return [event.threadId, event.turnId ?? "no-turn", event.itemId].join(":");
+}
+
+function mergeBufferedToolOutputData(
+  data: unknown,
+  bufferedOutput: BufferedToolOutput,
+): Record<string, unknown> {
+  const baseData = isJsonObject(data) ? data : {};
+  const existingRawOutput = isJsonObject(baseData.rawOutput)
+    ? baseData.rawOutput
+    : typeof baseData.rawOutput === "string" && baseData.rawOutput.trim().length > 0
+      ? { output: baseData.rawOutput }
+      : {};
+  const hasStructuredOutput =
+    typeof existingRawOutput.output === "string" ||
+    typeof existingRawOutput.stdout === "string" ||
+    typeof existingRawOutput.stderr === "string";
+  return {
+    ...baseData,
+    rawOutput: {
+      ...existingRawOutput,
+      ...(hasStructuredOutput ? {} : { output: bufferedOutput.text }),
+      ...(bufferedOutput.truncated ? { truncated: true } : {}),
+    },
+  };
+}
+
+function withBufferedToolOutputData(
+  event: ProviderRuntimeEvent,
+  bufferedOutput: BufferedToolOutput | undefined,
+): ProviderRuntimeEvent {
+  if (!bufferedOutput) {
+    return event;
+  }
+  if (event.type !== "item.updated" && event.type !== "item.completed") {
+    return event;
+  }
+  if (event.payload.itemType !== "command_execution" && event.payload.itemType !== "file_change") {
+    return event;
+  }
+  return {
+    ...event,
+    payload: {
+      ...event.payload,
+      data: mergeBufferedToolOutputData(event.payload.data, bufferedOutput),
+    },
+  } as ProviderRuntimeEvent;
 }
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {
@@ -1215,6 +1288,11 @@ const make = Effect.gen(function* () {
     timeToLive: BUFFERED_PROPOSED_PLAN_BY_ID_TTL,
     lookup: () => Effect.succeed({ text: "", createdAt: "" }),
   });
+  const bufferedToolOutputByKey = yield* Cache.make<string, BufferedToolOutput | undefined>({
+    capacity: BUFFERED_TOOL_OUTPUT_BY_KEY_CACHE_CAPACITY,
+    timeToLive: BUFFERED_TOOL_OUTPUT_BY_KEY_TTL,
+    lookup: () => Effect.succeed(undefined),
+  });
   const providerDiffPlaceholdersRef = yield* Ref.make(new Map<string, ProviderDiffPlaceholder>());
 
   const getThreadDetail = Effect.fnUntraced(function* (
@@ -1390,6 +1468,37 @@ const make = Effect.gen(function* () {
 
   const clearBufferedProposedPlan = (planId: string) =>
     Cache.invalidate(bufferedProposedPlanById, planId);
+
+  const appendBufferedToolOutput = (key: string, delta: string) =>
+    Cache.getOption(bufferedToolOutputByKey, key).pipe(
+      Effect.flatMap((existingEntry) => {
+        const existing = Option.getOrUndefined(existingEntry);
+        const existingText = existing?.text ?? "";
+        const truncated = existingText.length + delta.length > MAX_BUFFERED_TOOL_OUTPUT_CHARS;
+        return Cache.set(bufferedToolOutputByKey, key, {
+          text: appendCappedBufferedText(
+            existingText,
+            delta,
+            MAX_BUFFERED_TOOL_OUTPUT_CHARS,
+          ),
+          truncated: existing?.truncated === true || truncated,
+        });
+      }),
+    );
+
+  const getBufferedToolOutput = (key: string) =>
+    Cache.getOption(bufferedToolOutputByKey, key).pipe(
+      Effect.map((existingEntry) => Option.getOrUndefined(existingEntry)),
+    );
+
+  const takeBufferedToolOutput = (key: string) =>
+    Cache.getOption(bufferedToolOutputByKey, key).pipe(
+      Effect.flatMap((existingEntry) =>
+        Cache.invalidate(bufferedToolOutputByKey, key).pipe(
+          Effect.as(Option.getOrUndefined(existingEntry)),
+        ),
+      ),
+    );
 
   const clearAssistantMessageState = (messageId: MessageId) =>
     clearBufferedAssistantText(messageId);
@@ -2150,6 +2259,17 @@ const make = Effect.gen(function* () {
         }
       }
 
+      const toolOutputKind = toolOutputStreamKind(event);
+      const toolOutputKey = toolOutputBufferKey(event);
+      if (
+        toolOutputKind &&
+        toolOutputKey &&
+        event.type === "content.delta" &&
+        event.payload.delta.length > 0
+      ) {
+        yield* appendBufferedToolOutput(toolOutputKey, event.payload.delta);
+      }
+
       const assistantDelta =
         event.type === "content.delta" && event.payload.streamKind === "assistant_text"
           ? event.payload.delta
@@ -2441,7 +2561,13 @@ const make = Effect.gen(function* () {
         }
       }
 
-      const activities = runtimeEventToActivities(event);
+      const activityEvent =
+        event.type === "item.completed" && toolOutputKey
+          ? withBufferedToolOutputData(event, yield* takeBufferedToolOutput(toolOutputKey))
+          : event.type === "item.updated" && toolOutputKey
+            ? withBufferedToolOutputData(event, yield* getBufferedToolOutput(toolOutputKey))
+            : event;
+      const activities = runtimeEventToActivities(activityEvent);
       yield* Effect.forEach(activities, (activity) =>
         orchestrationEngine.dispatch({
           type: "thread.activity.append",

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -555,6 +555,57 @@ function workLogAutomationsEqual(a: WorkLogEntry["automation"], b: WorkLogEntry[
   return a.id === b.id && a.name === b.name && a.cadenceLabel === b.cadenceLabel;
 }
 
+function workLogToolOutputsEqual(
+  a: NonNullable<WorkLogEntry["toolDetails"]>["output"],
+  b: NonNullable<WorkLogEntry["toolDetails"]>["output"],
+) {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.output === b.output &&
+    a.stdout === b.stdout &&
+    a.stderr === b.stderr &&
+    a.exitCode === b.exitCode &&
+    a.truncated === b.truncated
+  );
+}
+
+function workLogToolEditsEqual(
+  left: NonNullable<WorkLogEntry["toolDetails"]>["edits"],
+  right: NonNullable<WorkLogEntry["toolDetails"]>["edits"],
+) {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  if (left.length !== right.length) return false;
+  return left.every((edit, index) => {
+    const other = right[index];
+    return (
+      other !== undefined &&
+      edit.path === other.path &&
+      edit.oldText === other.oldText &&
+      edit.newText === other.newText
+    );
+  });
+}
+
+function workLogToolDetailsEqual(
+  a: WorkLogEntry["toolDetails"],
+  b: WorkLogEntry["toolDetails"],
+) {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.kind === b.kind &&
+    a.title === b.title &&
+    a.command === b.command &&
+    a.diff === b.diff &&
+    a.content === b.content &&
+    stringArraysEqual(a.files, b.files) &&
+    workLogToolOutputsEqual(a.output, b.output) &&
+    workLogToolEditsEqual(a.edits, b.edits)
+  );
+}
+
 function workLogEntryContentEqual(a: WorkLogEntry, b: WorkLogEntry): boolean {
   return (
     a.id === b.id &&
@@ -574,7 +625,8 @@ function workLogEntryContentEqual(a: WorkLogEntry, b: WorkLogEntry): boolean {
     stringArraysEqual(a.changedFiles, b.changedFiles) &&
     workLogSubagentActionsEqual(a.subagentAction, b.subagentAction) &&
     workLogSubagentsEqual(a.subagents, b.subagents) &&
-    workLogAutomationsEqual(a.automation, b.automation)
+    workLogAutomationsEqual(a.automation, b.automation) &&
+    workLogToolDetailsEqual(a.toolDetails, b.toolDetails)
   );
 }
 

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1783,6 +1783,93 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Searched");
   });
 
+  it("finds tool details entries attached inline to assistant message rows", async () => {
+    const { findToolDetailsEntryById } = await import("./MessagesTimeline");
+    const entry = findToolDetailsEntryById(
+      [
+        {
+          kind: "message",
+          id: "row-assistant-inline-work",
+          createdAt: "2026-03-17T19:12:28.000Z",
+          message: {
+            id: MessageId.makeUnsafe("assistant-inline-work"),
+            role: "assistant",
+            text: "done",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            streaming: false,
+          },
+          inlineWorkEntries: [
+            {
+              id: "inline-command-details",
+              createdAt: "2026-03-17T19:12:27.000Z",
+              label: "Ran command",
+              tone: "tool",
+              itemType: "command_execution",
+              toolDetails: {
+                kind: "command",
+                title: "Searched",
+                command: "rg toolDetails",
+              },
+            },
+          ],
+          durationStart: "2026-03-17T19:12:27.000Z",
+          showAssistantCopyButton: true,
+          assistantCopyStreaming: false,
+        },
+      ],
+      "inline-command-details",
+    );
+
+    expect(entry?.toolDetails?.kind).toBe("command");
+    expect(entry?.toolDetails?.command).toBe("rg toolDetails");
+  });
+
+  it("finds tool details entries inside collapsed assistant work disclosures", async () => {
+    const { findToolDetailsEntryById } = await import("./MessagesTimeline");
+    const entry = findToolDetailsEntryById(
+      [
+        {
+          kind: "message",
+          id: "row-assistant-collapsed-work",
+          createdAt: "2026-03-17T19:12:28.000Z",
+          message: {
+            id: MessageId.makeUnsafe("assistant-collapsed-work"),
+            role: "assistant",
+            text: "done",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            streaming: false,
+          },
+          collapsedTurnItems: [
+            {
+              kind: "work",
+              id: "collapsed-command-details",
+              entry: {
+                id: "collapsed-command-details",
+                createdAt: "2026-03-17T19:12:27.000Z",
+                label: "Ran command",
+                tone: "tool",
+                itemType: "command_execution",
+                toolDetails: {
+                  kind: "command",
+                  title: "Searched",
+                  command: "rg collapsed",
+                },
+              },
+            },
+          ],
+          collapsedWorkElapsed: "1s",
+          durationStart: "2026-03-17T19:12:27.000Z",
+          showAssistantCopyButton: true,
+          assistantCopyStreaming: false,
+        },
+      ],
+      "collapsed-command-details",
+    );
+
+    expect(entry?.toolDetails?.kind).toBe("command");
+    expect(entry?.toolDetails?.command).toBe("rg collapsed");
+  });
+
   it("renders command text even when commandActions provide a short preview", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -1561,6 +1561,16 @@ describe("MessagesTimeline", () => {
               tone: "tool",
               requestKind: "file-change",
               changedFiles: ["apps/web/src/components/chat/MessagesTimeline.test.tsx"],
+              toolDetails: {
+                kind: "file-change",
+                title: "Edited",
+                diff: [
+                  "diff --git a/apps/web/src/components/chat/MessagesTimeline.test.tsx b/apps/web/src/components/chat/MessagesTimeline.test.tsx",
+                  "-old",
+                  "+new",
+                ].join("\n"),
+                files: ["apps/web/src/components/chat/MessagesTimeline.test.tsx"],
+              },
             },
           },
           {
@@ -1620,6 +1630,56 @@ describe("MessagesTimeline", () => {
     );
   });
 
+  it("marks visible file-change rows with captured details as clickable", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        hasMessages
+        isWorking={false}
+        activeTurnInProgress={false}
+        activeTurnStartedAt={null}
+        timelineEntries={[
+          {
+            id: "entry-file-change-details",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-file-change-details",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "File Change",
+              tone: "tool",
+              requestKind: "file-change",
+              changedFiles: ["apps/web/src/components/chat/MessagesTimeline.test.tsx"],
+              toolDetails: {
+                kind: "file-change",
+                title: "Edited",
+                diff: "-old\n+new",
+                files: ["apps/web/src/components/chat/MessagesTimeline.test.tsx"],
+              },
+            },
+          },
+        ]}
+        turnDiffSummaryByAssistantMessageId={new Map()}
+        nowIso="2026-03-17T19:12:30.000Z"
+        expandedWorkGroups={{}}
+        onToggleWorkGroup={() => {}}
+        onOpenTurnDiff={() => {}}
+        revertTurnCountByUserMessageId={new Map()}
+        onRevertUserMessage={() => {}}
+        isRevertingCheckpoint={false}
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        resolvedTheme="dark"
+        timestampFormat="locale"
+        workspaceRoot={undefined}
+      />,
+    );
+
+    expect(markup).toContain('data-tool-detail-trigger="true"');
+    expect(markup).toContain('title="View tool details"');
+    expect(markup).toContain("Details");
+  });
+
   it("renders command rows with a readable summary and keeps the full command on hover", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(
@@ -1668,6 +1728,59 @@ describe("MessagesTimeline", () => {
       `title="/bin/zsh -lc &#x27;rg -n &quot;ProjectionSnapshotQuery&quot; apps/server/src&#x27;"`,
     );
     expect(markup).not.toContain("&gt;/bin/zsh -lc");
+  });
+
+  it("marks command rows with captured details as clickable", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        hasMessages
+        isWorking={false}
+        activeTurnInProgress={false}
+        activeTurnStartedAt={null}
+        timelineEntries={[
+          {
+            id: "entry-command-details",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-command-details",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Ran command",
+              tone: "tool",
+              itemType: "command_execution",
+              toolTitle: "Searched",
+              command: `rg -n "toolDetails" apps/web/src`,
+              toolDetails: {
+                kind: "command",
+                title: "Searched",
+                command: `rg -n "toolDetails" apps/web/src`,
+                output: {
+                  stdout: "apps/web/src/session-logic.ts:55: toolDetails",
+                },
+              },
+            },
+          },
+        ]}
+        turnDiffSummaryByAssistantMessageId={new Map()}
+        nowIso="2026-03-17T19:12:30.000Z"
+        expandedWorkGroups={{}}
+        onToggleWorkGroup={() => {}}
+        onOpenTurnDiff={() => {}}
+        revertTurnCountByUserMessageId={new Map()}
+        onRevertUserMessage={() => {}}
+        isRevertingCheckpoint={false}
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        resolvedTheme="dark"
+        timestampFormat="locale"
+        workspaceRoot={undefined}
+      />,
+    );
+
+    expect(markup).toContain('data-tool-detail-trigger="true"');
+    expect(markup).toContain('title="View tool details"');
+    expect(markup).toContain("Searched");
   });
 
   it("renders command text even when commandActions provide a short preview", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -470,23 +470,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     ],
   );
   const rows = useStableRows(rawRows);
-  const selectedToolDetailsEntry = useMemo(() => {
-    if (!selectedToolDetailsEntryId) {
-      return null;
-    }
-    for (const row of rows) {
-      if (row.kind !== "work") {
-        continue;
-      }
-      const matchingEntry = row.groupedEntries.find(
-        (entry) => entry.id === selectedToolDetailsEntryId,
-      );
-      if (matchingEntry) {
-        return matchingEntry;
-      }
-    }
-    return null;
-  }, [rows, selectedToolDetailsEntryId]);
+  const selectedToolDetailsEntry = useMemo(
+    () => findToolDetailsEntryById(rows, selectedToolDetailsEntryId),
+    [rows, selectedToolDetailsEntryId],
+  );
   // Latest rows kept in a ref so the imperative scroll controller can look up a message's
   // index lazily without re-installing the controller on every transcript change.
   const rowsRef = useRef(rows);
@@ -1576,6 +1563,38 @@ export const MessagesTimeline = memo(function MessagesTimeline({
 
 type TimelineMessage = Extract<MessagesTimelineRow, { kind: "message" }>["message"];
 type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["groupedEntries"][number];
+
+export function findToolDetailsEntryById(
+  rows: ReadonlyArray<MessagesTimelineRow>,
+  entryId: string | null,
+): TimelineWorkEntry | null {
+  if (!entryId) {
+    return null;
+  }
+  for (const row of rows) {
+    if (row.kind === "work") {
+      const matchingEntry = row.groupedEntries.find((entry) => entry.id === entryId);
+      if (matchingEntry) {
+        return matchingEntry;
+      }
+      continue;
+    }
+    if (row.kind !== "message") {
+      continue;
+    }
+    const matchingInlineEntry = row.inlineWorkEntries?.find((entry) => entry.id === entryId);
+    if (matchingInlineEntry) {
+      return matchingInlineEntry;
+    }
+    const matchingCollapsedEntry = row.collapsedTurnItems?.find(
+      (item) => item.kind === "work" && item.entry.id === entryId,
+    );
+    if (matchingCollapsedEntry?.kind === "work") {
+      return matchingCollapsedEntry.entry;
+    }
+  }
+  return null;
+}
 
 // Reuse stable row references so streaming updates only force React work for
 // rows whose visible content actually changed.

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -58,6 +58,7 @@ import { Button } from "../ui/button";
 import { AutomationCreatedCard } from "./AutomationCreatedCard";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
+import { ToolCallDetailsDialog } from "./ToolCallDetailsDialog";
 import { DiffStatLabel } from "./DiffStatLabel";
 import { ReviewChangesButton } from "./ReviewChangesButton";
 import { FileEntryIcon } from "./FileEntryIcon";
@@ -385,6 +386,15 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   const [editingUserMessageId, setEditingUserMessageId] = useState<MessageId | null>(null);
   const [submittingEditedUserMessageId, setSubmittingEditedUserMessageId] =
     useState<MessageId | null>(null);
+  const [selectedToolDetailsEntryId, setSelectedToolDetailsEntryId] = useState<string | null>(null);
+  const openToolDetails = useCallback((workEntry: TimelineWorkEntry) => {
+    setSelectedToolDetailsEntryId(workEntry.id);
+  }, []);
+  const handleToolDetailsOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setSelectedToolDetailsEntryId(null);
+    }
+  }, []);
   // Transient highlight applied to a message jumped-to from the pinned-message checklist.
   const [highlightedMessageId, setHighlightedMessageId] = useState<MessageId | null>(null);
   // Index markers once per update so each assistant row avoids a full marker scan.
@@ -460,6 +470,23 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     ],
   );
   const rows = useStableRows(rawRows);
+  const selectedToolDetailsEntry = useMemo(() => {
+    if (!selectedToolDetailsEntryId) {
+      return null;
+    }
+    for (const row of rows) {
+      if (row.kind !== "work") {
+        continue;
+      }
+      const matchingEntry = row.groupedEntries.find(
+        (entry) => entry.id === selectedToolDetailsEntryId,
+      );
+      if (matchingEntry) {
+        return matchingEntry;
+      }
+    }
+    return null;
+  }, [rows, selectedToolDetailsEntryId]);
   // Latest rows kept in a ref so the imperative scroll controller can look up a message's
   // index lazily without re-installing the controller on every transcript change.
   const rowsRef = useRef(rows);
@@ -743,6 +770,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     density={prefersCompactWorkEntryRow(workEntry) ? "compact" : "default"}
                     markdownCwd={markdownCwd}
                     onImageExpand={onImageExpand}
+                    onOpenToolDetails={openToolDetails}
                     {...(onOpenAgentActivity ? { onOpenAgentActivity } : {})}
                     {...(onOpenThread ? { onOpenThread } : {})}
                     {...(onOpenAutomation ? { onOpenAutomation } : {})}
@@ -1112,6 +1140,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                               }
                               markdownCwd={markdownCwd}
                               onImageExpand={onImageExpand}
+                              onOpenToolDetails={openToolDetails}
                               {...(onOpenAgentActivity ? { onOpenAgentActivity } : {})}
                               {...(onOpenThread ? { onOpenThread } : {})}
                               {...(onOpenAutomation ? { onOpenAutomation } : {})}
@@ -1162,6 +1191,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                           markdownCwd={markdownCwd}
                           onImageExpand={onImageExpand}
                           onOpenTurnDiff={onOpenTurnDiff}
+                          onOpenToolDetails={openToolDetails}
                           {...(onOpenAgentActivity ? { onOpenAgentActivity } : {})}
                           {...(onOpenThread ? { onOpenThread } : {})}
                           {...(onOpenAutomation ? { onOpenAutomation } : {})}
@@ -1197,6 +1227,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                         density={prefersCompactWorkEntryRow(workEntry) ? "compact" : "default"}
                         markdownCwd={markdownCwd}
                         onImageExpand={onImageExpand}
+                        onOpenToolDetails={openToolDetails}
                         {...(onOpenAgentActivity ? { onOpenAgentActivity } : {})}
                         {...(onOpenThread ? { onOpenThread } : {})}
                         {...(onOpenAutomation ? { onOpenAutomation } : {})}
@@ -1533,6 +1564,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           CHAT_COLUMN_GUTTER_CLASS_NAME,
         )}
         {...(listScrollStyle ? { style: listScrollStyle } : {})}
+      />
+      <ToolCallDetailsDialog
+        entry={selectedToolDetailsEntry}
+        open={selectedToolDetailsEntry !== null}
+        onOpenChange={handleToolDetailsOpenChange}
       />
     </div>
   );
@@ -2250,6 +2286,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   onImageExpand: (preview: ExpandedImagePreview) => void;
   turnId?: TurnId;
   onOpenTurnDiff?: (turnId: TurnId, filePath?: string) => void;
+  onOpenToolDetails?: (workEntry: TimelineWorkEntry) => void;
   onOpenAgentActivity?: (activityId: string) => void;
   onOpenThread?: (threadId: ThreadId) => void;
   onOpenAutomation?: (automationId: string) => void;
@@ -2264,6 +2301,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
     onImageExpand,
     turnId,
     onOpenTurnDiff,
+    onOpenToolDetails,
     onOpenAgentActivity,
     onOpenThread,
     onOpenAutomation,
@@ -2300,6 +2338,8 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   const openAgentActivity = canOpenAgentActivity
     ? () => onOpenAgentActivity?.(workEntry.id)
     : undefined;
+  const canOpenToolDetails = Boolean(onOpenToolDetails) && Boolean(workEntry.toolDetails);
+  const openToolDetails = canOpenToolDetails ? () => onOpenToolDetails?.(workEntry) : undefined;
   // File-read rows open the referenced file in the in-app viewer when the
   // hosting surface provides an opener (right-dock file pane / editor pane).
   const opener = useWorkspaceFileOpener();
@@ -2345,22 +2385,30 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
           {changedFiles.map((changedFilePath) => {
             const changedFileStat = fileDiffStatByPath?.get(changedFilePath);
             const canOpenEditedDiff = Boolean(turnId && onOpenTurnDiff);
+            const canOpenEditedRow = canOpenToolDetails || canOpenEditedDiff;
             return (
               <button
                 key={`${workEntry.id}:${changedFilePath}`}
                 type="button"
                 data-file-change-row="true"
+                data-tool-detail-trigger={canOpenToolDetails ? "true" : undefined}
                 className={cn(
                   "group/file-row flex w-full max-w-full items-baseline gap-1 text-left transition-opacity duration-150",
                   compact
                     ? "px-0 py-[1px] hover:opacity-95"
                     : "rounded-md border border-border/45 bg-background/65 px-2 py-2 hover:bg-background/80",
-                  canOpenEditedDiff ? "cursor-pointer" : "cursor-default",
+                  canOpenEditedRow ? "cursor-pointer" : "cursor-default",
                 )}
-                title={changedFilePath}
-                disabled={!canOpenEditedDiff}
+                title={canOpenToolDetails ? "View tool details" : changedFilePath}
+                disabled={!canOpenEditedRow}
                 onClick={() => {
-                  if (!turnId || !onOpenTurnDiff) return;
+                  if (openToolDetails) {
+                    openToolDetails();
+                    return;
+                  }
+                  if (!turnId || !onOpenTurnDiff) {
+                    return;
+                  }
                   onOpenTurnDiff(turnId, changedFilePath);
                 }}
               >
@@ -2387,6 +2435,14 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
                       additions={changedFileStat.additions}
                       deletions={changedFileStat.deletions}
                     />
+                  </span>
+                ) : null}
+                {canOpenToolDetails ? (
+                  <span
+                    className="font-system-ui ml-auto shrink-0 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/45"
+                    style={{ fontSize: `${Math.max(10, rowFontSizePx - 2)}px` }}
+                  >
+                    Details
                   </span>
                 ) : null}
               </button>
@@ -2590,11 +2646,18 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
           );
           const rowContent = (
             <AgentActivityOpenSurface
-              canOpen={canOpenAgentActivity || canOpenReadFile}
+              canOpen={canOpenAgentActivity || canOpenReadFile || canOpenToolDetails}
               compact={compact}
-              title={canOpenReadFile ? (readFilePath ?? hoverText) : hoverText}
-              onOpen={openAgentActivity ?? openReadFile}
+              title={
+                canOpenToolDetails
+                  ? "View tool details"
+                  : canOpenReadFile
+                    ? (readFilePath ?? hoverText)
+                    : hoverText
+              }
+              onOpen={openAgentActivity ?? openReadFile ?? openToolDetails}
               onHover={prefetchReadFile}
+              dataToolDetailTrigger={canOpenToolDetails}
             >
               {rowContentChildren}
             </AgentActivityOpenSurface>
@@ -2626,6 +2689,7 @@ function AgentActivityOpenSurface(props: {
   onHover?: (() => void) | undefined;
   onOpen?: (() => void) | undefined;
   title?: string | undefined;
+  dataToolDetailTrigger?: boolean | undefined;
 }) {
   const className = cn(
     "flex w-full items-center text-left transition-[opacity,translate] duration-200",
@@ -2642,6 +2706,7 @@ function AgentActivityOpenSurface(props: {
         className={className}
         title={props.title}
         onClick={props.onOpen}
+        data-tool-detail-trigger={props.dataToolDetailTrigger ? "true" : undefined}
         {...(props.onHover ? { onPointerEnter: props.onHover, onFocus: props.onHover } : {})}
       >
         {props.children}

--- a/apps/web/src/components/chat/ToolCallDetailsDialog.tsx
+++ b/apps/web/src/components/chat/ToolCallDetailsDialog.tsx
@@ -1,0 +1,277 @@
+// FILE: ToolCallDetailsDialog.tsx
+// Purpose: Modal inspector for command and file-change tool calls from transcript rows.
+// Layer: Chat presentation component
+// Exports: ToolCallDetailsDialog
+// Depends on: WorkLogEntry.toolDetails and shared dialog chrome
+
+import type { ReactNode } from "react";
+import { ChangesIcon, TerminalIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+import type { WorkLogToolOutputDetails } from "../../lib/toolCallDetails";
+import type { WorkLogEntry } from "../../session-logic";
+import {
+  Dialog,
+  DialogDescription,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "../ui/dialog";
+
+const DETAIL_HEADER_CLASS_NAME =
+  "border-b border-border/45 px-3 py-2 text-[10px] font-medium uppercase tracking-[0.14em]";
+const DETAIL_CODE_BLOCK_CLASS_NAME =
+  "max-h-[min(46vh,30rem)] overflow-auto whitespace-pre-wrap break-words font-chat-code text-[11px] leading-relaxed text-foreground/88";
+
+interface ToolCallDetailsDialogProps {
+  entry: WorkLogEntry | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ToolCallDetailsDialog({
+  entry,
+  open,
+  onOpenChange,
+}: ToolCallDetailsDialogProps) {
+  const details = entry?.toolDetails;
+  const Icon = details?.kind === "file-change" ? ChangesIcon : TerminalIcon;
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup surface="solid" className="max-h-[min(86vh,760px)] max-w-4xl gap-0 p-0">
+        <DialogHeader className="border-b border-border/55 pr-10">
+          <div className="flex min-w-0 items-start gap-3">
+            <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md border border-border/45 bg-background/65 text-muted-foreground/62">
+              <Icon className="size-3.5" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <DialogTitle className="truncate text-base">
+                {details?.title ?? "Tool call"}
+              </DialogTitle>
+              <DialogDescription>
+                {details?.kind === "file-change"
+                  ? "Edit payload captured for this tool call."
+                  : "Command payload captured for this tool call."}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+        <DialogPanel
+          className="max-h-[min(72vh,620px)] space-y-4 px-4 py-4"
+          data-tool-details-dialog="true"
+        >
+          {details ? (
+            <>
+              {details.command ? (
+                <ToolDetailSection title="Command">
+                  <ToolCodeBlock tone="command">{details.command}</ToolCodeBlock>
+                </ToolDetailSection>
+              ) : null}
+
+              {details.files?.length ? (
+                <ToolDetailSection title="Files">
+                  <div className="flex flex-wrap gap-1.5">
+                    {details.files.map((file) => (
+                      <span
+                        key={file}
+                        className="max-w-full rounded-md border border-border/45 bg-background/70 px-2 py-1 font-chat-code text-[11px] text-foreground/82"
+                        title={file}
+                      >
+                        {file}
+                      </span>
+                    ))}
+                  </div>
+                </ToolDetailSection>
+              ) : null}
+
+              {details.diff ? (
+                <ToolDetailSection title="Diff">
+                  <DiffCodeBlock>{details.diff}</DiffCodeBlock>
+                </ToolDetailSection>
+              ) : null}
+
+              {details.edits?.length ? (
+                <ToolDetailSection title="Edits">
+                  <div className="space-y-3">
+                    {details.edits.map((edit, index) => (
+                      <div
+                        key={`${edit.path ?? "edit"}:${index}`}
+                        className="overflow-hidden rounded-lg border border-border/45 bg-background/58"
+                      >
+                        {edit.path ? (
+                          <div className="border-b border-border/45 px-3 py-2 font-chat-code text-[11px] text-muted-foreground/72">
+                            {edit.path}
+                          </div>
+                        ) : null}
+                        <div className="grid gap-0 md:grid-cols-2">
+                          {edit.oldText !== undefined ? (
+                            <TextChangeBlock title="Before" tone="remove">
+                              {edit.oldText}
+                            </TextChangeBlock>
+                          ) : null}
+                          {edit.newText !== undefined ? (
+                            <TextChangeBlock title="After" tone="add">
+                              {edit.newText}
+                            </TextChangeBlock>
+                          ) : null}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </ToolDetailSection>
+              ) : null}
+
+              {details.content ? (
+                <ToolDetailSection title="Written Content">
+                  <ToolCodeBlock>{details.content}</ToolCodeBlock>
+                </ToolDetailSection>
+              ) : null}
+
+              {details.output ? <ToolOutputSection output={details.output} /> : null}
+            </>
+          ) : (
+            <div className="rounded-lg border border-border/45 bg-background/60 px-3 py-2 text-sm text-muted-foreground">
+              No detailed payload was available for this tool call.
+            </div>
+          )}
+        </DialogPanel>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+function ToolDetailSection(props: { title: string; children: ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground/56">
+        {props.title}
+      </h3>
+      {props.children}
+    </section>
+  );
+}
+
+function ToolOutputSection({ output }: { output: WorkLogToolOutputDetails }) {
+  return (
+    <ToolDetailSection title="Output">
+      <div className="space-y-3">
+        {output.output ? <ToolCodeBlock>{output.output}</ToolCodeBlock> : null}
+        {output.stdout ? (
+          <LabeledCodeBlock title="Stdout" tone="output">
+            {output.stdout}
+          </LabeledCodeBlock>
+        ) : null}
+        {output.stderr ? (
+          <LabeledCodeBlock title="Stderr" tone="error">
+            {output.stderr}
+          </LabeledCodeBlock>
+        ) : null}
+        {output.exitCode !== undefined || output.truncated ? (
+          <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground/68">
+            {output.exitCode !== undefined ? (
+              <span className="rounded-full border border-border/45 px-2 py-0.5">
+                Exit code {output.exitCode}
+              </span>
+            ) : null}
+            {output.truncated ? (
+              <span className="rounded-full border border-amber-500/30 bg-amber-500/8 px-2 py-0.5 text-amber-200/90">
+                Truncated
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </ToolDetailSection>
+  );
+}
+
+function LabeledCodeBlock(props: {
+  title: string;
+  tone: "output" | "error";
+  children: string;
+}) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/45 bg-background/58">
+      <div
+        className={cn(
+          DETAIL_HEADER_CLASS_NAME,
+          props.tone === "error" ? "text-rose-200/88" : "text-muted-foreground/60",
+        )}
+      >
+        {props.title}
+      </div>
+      <ToolCodeBlock bare>{props.children}</ToolCodeBlock>
+    </div>
+  );
+}
+
+function TextChangeBlock(props: {
+  title: string;
+  tone: "add" | "remove";
+  children: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "min-w-0 border-border/45 md:[&:not(:first-child)]:border-l",
+        props.tone === "add" ? "bg-emerald-500/5" : "bg-rose-500/5",
+      )}
+    >
+      <div
+        className={cn(
+          DETAIL_HEADER_CLASS_NAME,
+          props.tone === "add" ? "text-emerald-200/82" : "text-rose-200/82",
+        )}
+      >
+        {props.title}
+      </div>
+      <ToolCodeBlock bare>{props.children}</ToolCodeBlock>
+    </div>
+  );
+}
+
+function ToolCodeBlock(props: {
+  children: string;
+  tone?: "default" | "command";
+  bare?: boolean;
+}) {
+  return (
+    <pre
+      className={cn(
+        DETAIL_CODE_BLOCK_CLASS_NAME,
+        props.tone === "command" && "text-sky-100/92",
+        props.bare
+          ? "px-3 py-2.5"
+          : "rounded-lg border border-border/45 bg-background/70 px-3 py-2.5",
+      )}
+    >
+      {props.children}
+    </pre>
+  );
+}
+
+function DiffCodeBlock({ children }: { children: string }) {
+  const lines = children.split(/\r?\n/);
+  return (
+    <pre className="max-h-[min(52vh,34rem)] overflow-auto rounded-lg border border-border/45 bg-background/70 px-0 py-2 font-chat-code text-[11px] leading-relaxed">
+      {lines.map((line, index) => (
+        <span
+          key={`${index}:${line.slice(0, 24)}`}
+          className={cn(
+            "block min-w-max whitespace-pre-wrap break-words px-3",
+            line.startsWith("+") && !line.startsWith("+++")
+              ? "bg-emerald-500/8 text-emerald-100/92"
+              : null,
+            line.startsWith("-") && !line.startsWith("---")
+              ? "bg-rose-500/8 text-rose-100/92"
+              : null,
+            line.startsWith("@@") ? "text-sky-200/90" : null,
+            /^(diff --git|index |--- |\+\+\+ )/.test(line) ? "text-muted-foreground/62" : null,
+          )}
+        >
+          {line.length > 0 ? line : " "}
+        </span>
+      ))}
+    </pre>
+  );
+}

--- a/apps/web/src/lib/toolCallDetails.ts
+++ b/apps/web/src/lib/toolCallDetails.ts
@@ -84,6 +84,15 @@ function firstOutputText(...values: unknown[]): string | undefined {
   return undefined;
 }
 
+function asRawOutputRecord(value: unknown): Record<string, unknown> | null {
+  const record = asRecord(value);
+  if (record) {
+    return record;
+  }
+  const output = firstOutputText(value);
+  return output !== undefined ? { output } : null;
+}
+
 function firstNumber(...values: unknown[]): number | undefined {
   for (const value of values) {
     const normalized = asFiniteNumber(value);
@@ -139,7 +148,7 @@ function extractToolOutputDetails(input: {
   command?: string | undefined;
 }): WorkLogToolOutputDetails | undefined {
   const data = asRecord(input.payload?.data);
-  const rawOutput = asRecord(data?.rawOutput);
+  const rawOutput = asRawOutputRecord(data?.rawOutput);
   const rawOutputDetails = asRecord(rawOutput?.details);
   const item = asRecord(data?.item);
   const itemResult = asRecord(item?.result);

--- a/apps/web/src/lib/toolCallDetails.ts
+++ b/apps/web/src/lib/toolCallDetails.ts
@@ -1,0 +1,447 @@
+// FILE: toolCallDetails.ts
+// Purpose: Extract bounded command/edit details from provider tool lifecycle payloads.
+// Layer: Web transcript data utility
+// Exports: deriveWorkLogToolDetails, mergeWorkLogToolDetails
+// Depends on: provider runtime item metadata already truncated by server ingestion
+
+import type { ToolLifecycleItemType } from "@t3tools/contracts";
+
+type WorkLogRequestKind = "command" | "file-read" | "file-change";
+
+export interface WorkLogToolOutputDetails {
+  output?: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  truncated?: boolean;
+}
+
+export interface WorkLogToolEditDetails {
+  path?: string;
+  oldText?: string;
+  newText?: string;
+}
+
+export interface WorkLogToolDetails {
+  kind: "command" | "file-change";
+  title: string;
+  command?: string;
+  output?: WorkLogToolOutputDetails;
+  diff?: string;
+  content?: string;
+  edits?: ReadonlyArray<WorkLogToolEditDetails>;
+  files?: ReadonlyArray<string>;
+}
+
+export interface DeriveWorkLogToolDetailsInput {
+  payload: Record<string, unknown> | null;
+  itemType?: ToolLifecycleItemType | undefined;
+  requestKind?: WorkLogRequestKind | undefined;
+  command?: string | undefined;
+  rawCommand?: string | undefined;
+  detail?: string | undefined;
+  changedFiles?: ReadonlyArray<string> | undefined;
+  label: string;
+  toolTitle?: string | undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value : null;
+}
+
+function asTrimmedString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const normalized = asTrimmedString(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return undefined;
+}
+
+function firstOutputText(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    if (value.trim().length === 0) {
+      continue;
+    }
+    return value;
+  }
+  return undefined;
+}
+
+function firstNumber(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    const normalized = asFiniteNumber(value);
+    if (normalized !== undefined) {
+      return normalized;
+    }
+  }
+  return undefined;
+}
+
+function stripTrailingExitCode(value: string): {
+  output: string | null;
+  exitCode?: number | undefined;
+} {
+  const trimmed = value.trim();
+  const match = /^(?<output>[\s\S]*?)(?:\s*<exited with exit code (?<code>\d+)>)\s*$/i.exec(
+    trimmed,
+  );
+  if (!match?.groups) {
+    return { output: value.trim().length > 0 ? value : null };
+  }
+  const exitCode = Number.parseInt(match.groups.code ?? "", 10);
+  const output = value.replace(/\s*<exited with exit code \d+>\s*$/i, "");
+  return {
+    output: output.trim().length > 0 ? output : null,
+    ...(Number.isInteger(exitCode) ? { exitCode } : {}),
+  };
+}
+
+function outputText(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined;
+  }
+  return stripTrailingExitCode(value).output ?? undefined;
+}
+
+function outputExitCode(value: unknown): number | undefined {
+  const normalized = asTrimmedString(value);
+  return normalized ? stripTrailingExitCode(normalized).exitCode : undefined;
+}
+
+function commandEqualsDetail(command: string | undefined, detail: string | undefined): boolean {
+  if (!command || !detail) {
+    return false;
+  }
+  return command.trim() === stripTrailingExitCode(detail).output;
+}
+
+// Collects command output without stringifying the full payload; ingestion already bounds each field.
+function extractToolOutputDetails(input: {
+  payload: Record<string, unknown> | null;
+  detail?: string | undefined;
+  command?: string | undefined;
+}): WorkLogToolOutputDetails | undefined {
+  const data = asRecord(input.payload?.data);
+  const rawOutput = asRecord(data?.rawOutput);
+  const rawOutputDetails = asRecord(rawOutput?.details);
+  const item = asRecord(data?.item);
+  const itemResult = asRecord(item?.result);
+  const result = asRecord(data?.result);
+  const partialResult = asRecord(data?.partialResult);
+  const stdout = outputText(
+    firstOutputText(
+      rawOutput?.stdout,
+      rawOutput?.out,
+      data?.stdout,
+      itemResult?.stdout,
+      result?.stdout,
+    ),
+  );
+  const stderr = outputText(
+    firstOutputText(
+      rawOutput?.stderr,
+      rawOutput?.err,
+      data?.stderr,
+      itemResult?.stderr,
+      result?.stderr,
+    ),
+  );
+  let output = outputText(
+    firstOutputText(
+      rawOutput?.output,
+      rawOutput?.content,
+      data?.output,
+      itemResult?.output,
+      itemResult?.content,
+      result?.output,
+      result?.content,
+      partialResult?.output,
+      partialResult?.content,
+      rawOutputDetails?.output,
+    ),
+  );
+  if (
+    !stdout &&
+    !stderr &&
+    !output &&
+    input.detail &&
+    !commandEqualsDetail(input.command, input.detail)
+  ) {
+    output = stripTrailingExitCode(input.detail).output ?? undefined;
+  }
+  const exitCode = firstNumber(
+    rawOutput?.exitCode,
+    rawOutput?.code,
+    data?.exitCode,
+    itemResult?.exitCode,
+    result?.exitCode,
+    outputExitCode(input.detail),
+  );
+  const truncated = rawOutput?.truncated === true || data?.__synaraTruncated === true;
+  if (!stdout && !stderr && !output && exitCode === undefined && !truncated) {
+    return undefined;
+  }
+  return {
+    ...(output ? { output } : {}),
+    ...(stdout ? { stdout } : {}),
+    ...(stderr ? { stderr } : {}),
+    ...(exitCode !== undefined ? { exitCode } : {}),
+    ...(truncated ? { truncated } : {}),
+  };
+}
+
+function extractUnifiedDiff(payload: Record<string, unknown> | null): string | undefined {
+  const data = asRecord(payload?.data);
+  const rawOutput = asRecord(data?.rawOutput);
+  const rawOutputDetails = asRecord(rawOutput?.details);
+  const result = asRecord(data?.result);
+  const resultDetails = asRecord(result?.details);
+  const item = asRecord(data?.item);
+  const itemResult = asRecord(item?.result);
+  return firstString(
+    data?.unifiedDiff,
+    data?.diff,
+    data?.patch,
+    rawOutput?.unifiedDiff,
+    rawOutput?.diff,
+    rawOutput?.patch,
+    rawOutputDetails?.unifiedDiff,
+    rawOutputDetails?.diff,
+    rawOutputDetails?.patch,
+    result?.unifiedDiff,
+    result?.diff,
+    result?.patch,
+    resultDetails?.unifiedDiff,
+    resultDetails?.diff,
+    resultDetails?.patch,
+    itemResult?.unifiedDiff,
+    itemResult?.diff,
+    itemResult?.patch,
+  );
+}
+
+function extractWriteContent(payload: Record<string, unknown> | null): string | undefined {
+  const data = asRecord(payload?.data);
+  const input = asRecord(data?.input);
+  const rawInput = asRecord(data?.rawInput);
+  const item = asRecord(data?.item);
+  const itemInput = asRecord(item?.input);
+  return firstString(
+    data?.content,
+    input?.content,
+    rawInput?.content,
+    item?.content,
+    itemInput?.content,
+  );
+}
+
+function editText(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function extractEditPath(record: Record<string, unknown>): string | undefined {
+  return firstString(
+    record.path,
+    record.filePath,
+    record.file_path,
+    record.filename,
+    record.file,
+    record.relativePath,
+  );
+}
+
+function normalizeEditEntry(value: unknown): WorkLogToolEditDetails | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  const path = extractEditPath(record);
+  const oldText = editText(
+    record.oldText ?? record.old_string ?? record.oldString ?? record.before ?? record.original,
+  );
+  const newText = editText(
+    record.newText ?? record.new_string ?? record.newString ?? record.after ?? record.replacement,
+  );
+  if (oldText === undefined && newText === undefined) {
+    return undefined;
+  }
+  return {
+    ...(path ? { path } : {}),
+    ...(oldText !== undefined ? { oldText } : {}),
+    ...(newText !== undefined ? { newText } : {}),
+  };
+}
+
+function collectEditEntries(value: unknown, target: WorkLogToolEditDetails[]) {
+  if (!Array.isArray(value)) {
+    const edit = normalizeEditEntry(value);
+    if (edit) {
+      target.push(edit);
+    }
+    return;
+  }
+  for (const entry of value) {
+    const edit = normalizeEditEntry(entry);
+    if (edit) {
+      target.push(edit);
+    }
+  }
+}
+
+function dedupeEditEntries(
+  edits: ReadonlyArray<WorkLogToolEditDetails>,
+): WorkLogToolEditDetails[] {
+  const seen = new Set<string>();
+  const deduped: WorkLogToolEditDetails[] = [];
+  for (const edit of edits) {
+    const key = JSON.stringify([edit.path ?? "", edit.oldText ?? "", edit.newText ?? ""]);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(edit);
+  }
+  return deduped;
+}
+
+function extractEditEntries(payload: Record<string, unknown> | null): WorkLogToolEditDetails[] {
+  const data = asRecord(payload?.data);
+  const input = asRecord(data?.input);
+  const rawInput = asRecord(data?.rawInput);
+  const item = asRecord(data?.item);
+  const itemInput = asRecord(item?.input);
+  const edits: WorkLogToolEditDetails[] = [];
+  collectEditEntries(data?.edits, edits);
+  collectEditEntries(input?.edits, edits);
+  collectEditEntries(rawInput?.edits, edits);
+  collectEditEntries(item?.edits, edits);
+  collectEditEntries(itemInput?.edits, edits);
+  collectEditEntries(rawInput, edits);
+  collectEditEntries(input, edits);
+  return dedupeEditEntries(edits);
+}
+
+function detailsTitle(input: DeriveWorkLogToolDetailsInput): string {
+  return input.toolTitle ?? input.label;
+}
+
+function shouldBuildCommandDetails(input: DeriveWorkLogToolDetailsInput): boolean {
+  return (
+    input.requestKind === "command" ||
+    input.itemType === "command_execution" ||
+    Boolean(input.command)
+  );
+}
+
+function shouldBuildFileChangeDetails(input: DeriveWorkLogToolDetailsInput): boolean {
+  return input.requestKind === "file-change" || input.itemType === "file_change";
+}
+
+export function deriveWorkLogToolDetails(
+  input: DeriveWorkLogToolDetailsInput,
+): WorkLogToolDetails | undefined {
+  const command = input.rawCommand ?? input.command;
+  if (shouldBuildCommandDetails(input)) {
+    const output = extractToolOutputDetails({
+      payload: input.payload,
+      detail: input.detail,
+      command,
+    });
+    if (!command && !output) {
+      return undefined;
+    }
+    return {
+      kind: "command",
+      title: detailsTitle(input),
+      ...(command ? { command } : {}),
+      ...(output ? { output } : {}),
+    };
+  }
+
+  if (!shouldBuildFileChangeDetails(input)) {
+    return undefined;
+  }
+  const diff = extractUnifiedDiff(input.payload);
+  const content = extractWriteContent(input.payload);
+  const edits = extractEditEntries(input.payload);
+  const output = extractToolOutputDetails({
+    payload: input.payload,
+    command: undefined,
+  });
+  const files = input.changedFiles?.length ? input.changedFiles : undefined;
+  if (!diff && !content && edits.length === 0 && !output) {
+    return undefined;
+  }
+  return {
+    kind: "file-change",
+    title: detailsTitle(input),
+    ...(diff ? { diff } : {}),
+    ...(content ? { content } : {}),
+    ...(edits.length > 0 ? { edits } : {}),
+    ...(files ? { files } : {}),
+    ...(output ? { output } : {}),
+  };
+}
+
+function mergeStringArrays(
+  left: ReadonlyArray<string> | undefined,
+  right: ReadonlyArray<string> | undefined,
+): ReadonlyArray<string> | undefined {
+  const merged = [...(left ?? []), ...(right ?? [])];
+  return merged.length > 0 ? [...new Set(merged)] : undefined;
+}
+
+function mergeOutputs(
+  left: WorkLogToolOutputDetails | undefined,
+  right: WorkLogToolOutputDetails | undefined,
+): WorkLogToolOutputDetails | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  return {
+    ...(left.output || right.output ? { output: right.output ?? left.output } : {}),
+    ...(left.stdout || right.stdout ? { stdout: right.stdout ?? left.stdout } : {}),
+    ...(left.stderr || right.stderr ? { stderr: right.stderr ?? left.stderr } : {}),
+    ...(left.exitCode !== undefined || right.exitCode !== undefined
+      ? { exitCode: right.exitCode ?? left.exitCode }
+      : {}),
+    ...(left.truncated === true || right.truncated === true ? { truncated: true } : {}),
+  };
+}
+
+export function mergeWorkLogToolDetails(
+  left: WorkLogToolDetails | undefined,
+  right: WorkLogToolDetails | undefined,
+): WorkLogToolDetails | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  if (left.kind !== right.kind) return right;
+  const output = mergeOutputs(left.output, right.output);
+  const files = mergeStringArrays(left.files, right.files);
+  return {
+    kind: right.kind,
+    title: right.title || left.title,
+    ...(right.command ?? left.command ? { command: right.command ?? left.command } : {}),
+    ...(output ? { output } : {}),
+    ...(right.diff ?? left.diff ? { diff: right.diff ?? left.diff } : {}),
+    ...(right.content ?? left.content ? { content: right.content ?? left.content } : {}),
+    ...(right.edits ?? left.edits ? { edits: right.edits ?? left.edits } : {}),
+    ...(files ? { files } : {}),
+  };
+}

--- a/apps/web/src/lib/toolCallLabel.ts
+++ b/apps/web/src/lib/toolCallLabel.ts
@@ -121,6 +121,7 @@ export function isGenericToolTitle(value: string): boolean {
     normalized === "ran command" ||
     normalized === "running command" ||
     normalized === "command execution" ||
+    normalized === "file change" ||
     normalized === "find" ||
     normalized === "read file"
   );

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1129,6 +1129,36 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("keeps command output details when rawOutput is stored as a string", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-tool-string-output",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            item: {
+              command: "gemini --version",
+            },
+            rawOutput: "gemini 1.2.3\n",
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.toolDetails).toEqual({
+      kind: "command",
+      title: "Ran",
+      command: "gemini --version",
+      output: {
+        output: "gemini 1.2.3\n",
+      },
+    });
+  });
+
   it("merges command detail payloads across started and completed lifecycle rows", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1092,6 +1092,87 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.command).toBe("bun run lint");
   });
 
+  it("keeps full command output details for command tool activities", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-tool-details",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-detail-1",
+            item: {
+              command: `/bin/zsh -lc 'rg -n "toolDetails" apps/web/src'`,
+            },
+            rawOutput: {
+              stdout: "apps/web/src/session-logic.ts:55: toolDetails\nsecond line",
+              stderr: "warning: ignored binary file",
+              exitCode: 2,
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.toolDetails).toEqual({
+      kind: "command",
+      title: "Searched",
+      command: `/bin/zsh -lc 'rg -n "toolDetails" apps/web/src'`,
+      output: {
+        stdout: "apps/web/src/session-logic.ts:55: toolDetails\nsecond line",
+        stderr: "warning: ignored binary file",
+        exitCode: 2,
+      },
+    });
+  });
+
+  it("merges command detail payloads across started and completed lifecycle rows", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-merge-1",
+            command: "bun run --cwd apps/web test session-logic.test.ts",
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-merge-1",
+            rawOutput: {
+              stdout: "passed",
+              exitCode: 0,
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.id).toBe("command-complete");
+    expect(entry?.toolDetails).toMatchObject({
+      kind: "command",
+      command: "bun run --cwd apps/web test session-logic.test.ts",
+      output: { stdout: "passed", exitCode: 0 },
+    });
+  });
+
   it("falls back to command-like detail when structured command metadata is missing", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
@@ -1712,6 +1793,85 @@ describe("deriveWorkLogEntries", () => {
       "apps/web/src/components/ChatView.tsx",
       "apps/web/src/session-logic.ts",
     ]);
+    expect(entry?.toolDetails).toBeUndefined();
+  });
+
+  it("does not create tool details from a path-only file-change input", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "file-tool-path-only-input",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          data: {
+            rawInput: {
+              path: "apps/web/src/session-logic.ts",
+            },
+            item: {
+              changes: [{ path: "apps/web/src/session-logic.ts" }],
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.changedFiles).toEqual(["apps/web/src/session-logic.ts"]);
+    expect(entry?.toolDetails).toBeUndefined();
+  });
+
+  it("keeps edit diff details for file-change tool activities", () => {
+    const unifiedDiff = [
+      "diff --git a/apps/web/src/session-logic.ts b/apps/web/src/session-logic.ts",
+      "--- a/apps/web/src/session-logic.ts",
+      "+++ b/apps/web/src/session-logic.ts",
+      "@@ -1,1 +1,1 @@",
+      "-old line",
+      "+new line",
+    ].join("\n");
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "file-tool-details",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          title: "File change",
+          data: {
+            unifiedDiff,
+            rawInput: {
+              path: "apps/web/src/session-logic.ts",
+              oldText: "old line",
+              newText: "new line",
+            },
+            edits: [
+              {
+                path: "apps/web/src/session-logic.ts",
+                oldText: "old line",
+                newText: "new line",
+              },
+            ],
+            files: [{ path: "apps/web/src/session-logic.ts" }],
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.toolDetails).toEqual({
+      kind: "file-change",
+      title: "Edited",
+      diff: unifiedDiff,
+      edits: [
+        {
+          path: "apps/web/src/session-logic.ts",
+          oldText: "old line",
+          newText: "new line",
+        },
+      ],
+      files: ["apps/web/src/session-logic.ts"],
+    });
   });
 
   it("identifies file-change work by lifecycle metadata, not any changedFiles array", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -23,6 +23,11 @@ import {
   isGenericToolTitle,
   normalizeCompactToolLabel,
 } from "./lib/toolCallLabel";
+import {
+  deriveWorkLogToolDetails,
+  mergeWorkLogToolDetails,
+  type WorkLogToolDetails,
+} from "./lib/toolCallDetails";
 import { isStalePendingRequestFailureDetail } from "./lib/pendingInteraction";
 import { stripProposedPlanBlocksFromText } from "./proposedPlan";
 
@@ -66,6 +71,7 @@ export interface WorkLogEntry {
   toolTitle?: string;
   toolName?: string;
   toolCallId?: string;
+  toolDetails?: WorkLogToolDetails;
   itemType?: ToolLifecycleItemType;
   requestKind?: PendingApproval["requestKind"];
   subagents?: ReadonlyArray<WorkLogSubagent>;
@@ -968,6 +974,20 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   ) {
     delete entry.detail;
   }
+  const toolDetails = deriveWorkLogToolDetails({
+    payload,
+    itemType,
+    requestKind,
+    command: entry.command,
+    rawCommand: entry.rawCommand,
+    detail: entry.detail,
+    changedFiles: entry.changedFiles ?? changedFiles,
+    label: entry.label,
+    toolTitle: entry.toolTitle,
+  });
+  if (toolDetails) {
+    entry.toolDetails = toolDetails;
+  }
   const collapseKey = deriveToolLifecycleCollapseKey(entry);
   if (collapseKey) {
     entry.collapseKey = collapseKey;
@@ -1135,6 +1155,7 @@ function mergeDerivedWorkLogEntries(
   const collapseKey = next.collapseKey ?? previous.collapseKey;
   const toolName = next.toolName ?? previous.toolName;
   const toolCallId = next.toolCallId ?? previous.toolCallId;
+  const toolDetails = mergeWorkLogToolDetails(previous.toolDetails, next.toolDetails);
   const turnId = next.turnId ?? previous.turnId;
   return {
     ...previous,
@@ -1153,6 +1174,7 @@ function mergeDerivedWorkLogEntries(
     ...(collapseKey ? { collapseKey } : {}),
     ...(toolName ? { toolName } : {}),
     ...(toolCallId ? { toolCallId } : {}),
+    ...(toolDetails ? { toolDetails } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- add a click-through details dialog for transcript command and file-change tool rows
- derive bounded command output, diffs, write content, and edit entries from stored tool payloads
- buffer command/file-change output deltas into completed tool activity payloads so command output is available in the details view

## Verification
- bun run --cwd apps/server test src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
- bun run --cwd apps/web test src/session-logic.test.ts src/components/chat/MessagesTimeline.test.tsx src/components/chat/MessagesTimeline.logic.test.ts
- git diff --check

Closes #171