### PR TITLE
Fix desktop Node deprecation warnings

### DIFF
--- a/apps/desktop/src/electronUpdaterSecurity.test.ts
+++ b/apps/desktop/src/electronUpdaterSecurity.test.ts
@@ -1,0 +1,164 @@
+// FILE: electronUpdaterSecurity.test.ts
+// Purpose: Verifies the Windows updater hardening stays shell-free.
+// Layer: Desktop update runtime tests
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildPowerShellExecArgs,
+  buildPowerShellExecutablePath,
+  hardenElectronUpdater,
+  parseDistinguishedName,
+  verifyWindowsUpdateCodeSignature,
+} from "./electronUpdaterSecurity";
+
+describe("electronUpdaterSecurity", () => {
+  it("uses the absolute Windows PowerShell executable", () => {
+    expect(buildPowerShellExecutablePath({ SystemRoot: "D:\\Windows" })).toBe(
+      "D:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+  });
+
+  it("runs PowerShell with arguments instead of a shell command", () => {
+    const args = buildPowerShellExecArgs("Get-AuthenticodeSignature test.exe");
+
+    expect(args).toContain("-NoProfile");
+    expect(args).toContain("-NonInteractive");
+    expect(args).toContain("-Command");
+    expect(args.join(" ")).toContain("Get-AuthenticodeSignature test.exe");
+    expect(args.join(" ")).not.toContain("cmd.exe");
+  });
+
+  it("parses distinguished names the same way as builder-util-runtime", () => {
+    const parsed = parseDistinguishedName('CN=Synara, O="Acme, Inc.", OU=Tools\\2C Desktop');
+
+    expect(parsed.get("CN")).toBe("Synara");
+    expect(parsed.get("O")).toBe("Acme, Inc.");
+    expect(parsed.get("OU")).toBe("Tools, Desktop");
+  });
+
+  it("validates a matching full distinguished name with shell-free execFile options", async () => {
+    const execFile = vi.fn((file, args, options, callback) => {
+      callback(
+        null,
+        JSON.stringify({
+          Status: 0,
+          Path: "C:\\Users\\test\\AppData\\Local\\Temp\\SynaraSetup.exe",
+          SignerCertificate: {
+            Subject: "CN=Synara, O=Acme Tools",
+          },
+        }),
+        "",
+      );
+    });
+
+    const result = await verifyWindowsUpdateCodeSignature(
+      ["CN=Synara, O=Acme Tools"],
+      "C:\\Users\\test\\AppData\\Local\\Temp\\SynaraSetup.exe",
+      { info: vi.fn(), warn: vi.fn() },
+      {
+        env: { SystemRoot: "C:\\Windows" },
+        execFile,
+      },
+    );
+
+    expect(result).toBeNull();
+    expect(execFile).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      expect.arrayContaining(["-NoProfile", "-NonInteractive", "-Command"]),
+      expect.objectContaining({
+        encoding: "utf8",
+        shell: false,
+        windowsHide: true,
+        env: expect.objectContaining({ PSModulePath: "" }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it("keeps the upstream CN-only fallback warning", async () => {
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const result = await verifyWindowsUpdateCodeSignature(
+      ["Synara"],
+      "C:\\Temp\\SynaraSetup.exe",
+      logger,
+      {
+        env: { SystemRoot: "C:\\Windows" },
+        execFile: vi.fn((_file, _args, _options, callback) => {
+          callback(
+            null,
+            JSON.stringify({
+              Status: 0,
+              Path: "C:\\Temp\\SynaraSetup.exe",
+              SignerCertificate: { Subject: "CN=Synara, O=Acme Tools" },
+            }),
+            "",
+          );
+        }),
+      },
+    );
+
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Signature validated using only CN Synara"),
+    );
+  });
+
+  it("returns a mismatch summary for an unexpected publisher", async () => {
+    const result = await verifyWindowsUpdateCodeSignature(
+      ["CN=Synara, O=Acme Tools"],
+      "C:\\Temp\\SynaraSetup.exe",
+      { info: vi.fn(), warn: vi.fn() },
+      {
+        env: { SystemRoot: "C:\\Windows" },
+        execFile: vi.fn((_file, _args, _options, callback) => {
+          callback(
+            null,
+            JSON.stringify({
+              Status: 0,
+              Path: "C:\\Temp\\SynaraSetup.exe",
+              SignerCertificate: { Subject: "CN=Someone Else, O=Acme Tools" },
+            }),
+            "",
+          );
+        }),
+      },
+    );
+
+    expect(result).toContain("publisherNames: CN=Synara, O=Acme Tools");
+    expect(result).toContain("Someone Else");
+  });
+
+  it("patches electron-updater BaseUpdater spawnSyncLog only on Windows", () => {
+    class FakeBaseUpdater {}
+    const updaterModule = { BaseUpdater: FakeBaseUpdater };
+    const prototype = FakeBaseUpdater.prototype as {
+      spawnSyncLog?: (cmd: string, args?: string[]) => string;
+      __synaraSpawnSyncLogPatched?: boolean;
+    };
+
+    hardenElectronUpdater(updaterModule, {}, "darwin");
+    expect("spawnSyncLog" in prototype).toBe(false);
+
+    hardenElectronUpdater(updaterModule, {}, "win32");
+    const instance = {
+      _logger: { info: vi.fn(), error: vi.fn() },
+    };
+    const output = prototype.spawnSyncLog?.call(instance, process.execPath, ["--version"]);
+
+    expect(output).toMatch(/^v\d+\.\d+\.\d+/);
+    expect(prototype.__synaraSpawnSyncLogPatched).toBe(true);
+  });
+
+  it("replaces the NSIS signature verifier on Windows", async () => {
+    const updater = {
+      verifyUpdateCodeSignature: vi.fn(async () => "old verifier"),
+    };
+    const oldVerifier = updater.verifyUpdateCodeSignature;
+
+    hardenElectronUpdater({ BaseUpdater: class {} }, updater, "win32");
+
+    expect(updater.verifyUpdateCodeSignature).not.toBe(oldVerifier);
+    expect(oldVerifier).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/electronUpdaterSecurity.ts
+++ b/apps/desktop/src/electronUpdaterSecurity.ts
@@ -1,0 +1,426 @@
+// FILE: electronUpdaterSecurity.ts
+// Purpose: Hardens electron-updater Windows process calls against Node deprecations.
+// Layer: Desktop update runtime
+// Exports: updater patching, shell-free PowerShell signature verification helpers.
+
+import {
+  execFile,
+  execFileSync,
+  spawnSync,
+  type ExecFileException,
+  type ExecFileOptions,
+} from "node:child_process";
+import * as OS from "node:os";
+import * as Path from "node:path";
+
+import { prepareWindowsSafeProcess, resolveWindowsSystemRoot } from "@t3tools/shared/windowsProcess";
+
+type Logger = {
+  info?(message: string): void;
+  warn?(message: string): void;
+  error?(message: string): void;
+};
+
+type UpdaterModule = {
+  BaseUpdater?: unknown;
+};
+
+type UpdaterPrototype = {
+  spawnSyncLog?: (cmd: string, args?: string[], env?: Record<string, string>) => string;
+  __synaraSpawnSyncLogPatched?: boolean;
+};
+
+type UpdaterWithSignatureVerifier = {
+  verifyUpdateCodeSignature?: (
+    publisherNames: string[],
+    unescapedTempUpdateFile: string,
+  ) => Promise<string | null>;
+};
+
+type ExecFileLike = (
+  file: string,
+  args: ReadonlyArray<string>,
+  options: ExecFileOptions & { encoding: "utf8" },
+  callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+) => void;
+
+type ExecFileSyncLike = (
+  file: string,
+  args: ReadonlyArray<string>,
+  options: ExecFileOptions & { encoding: "utf8" },
+) => string | Buffer;
+
+interface PowerShellRunResult {
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface PowerShellFailure extends Error {
+  readonly stderr?: string;
+}
+
+interface SignatureVerifierOptions {
+  readonly execFile?: ExecFileLike;
+  readonly execFileSync?: ExecFileSyncLike;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly platformRelease?: string;
+}
+
+export function buildPowerShellExecutablePath(env: NodeJS.ProcessEnv = process.env): string {
+  return Path.win32.join(
+    resolveWindowsSystemRoot(env),
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+}
+
+export function buildPowerShellExecArgs(command: string): string[] {
+  const utf8Preamble =
+    "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; " +
+    "$OutputEncoding = [System.Text.Encoding]::UTF8;";
+  return [
+    "-NoProfile",
+    "-NonInteractive",
+    "-InputFormat",
+    "None",
+    "-Command",
+    `${utf8Preamble} ${command}`,
+  ];
+}
+
+function buildPowerShellExecOptions(
+  timeout: number,
+  env: NodeJS.ProcessEnv,
+): ExecFileOptions & { encoding: "utf8" } {
+  return {
+    env: { ...env, PSModulePath: "" },
+    encoding: "utf8",
+    shell: false,
+    timeout,
+    windowsHide: true,
+  };
+}
+
+function runPowerShell(
+  command: string,
+  timeout: number,
+  options: SignatureVerifierOptions,
+): Promise<PowerShellRunResult> {
+  const env = options.env ?? process.env;
+  return new Promise((resolve, reject) => {
+    const execFileImpl: ExecFileLike =
+      options.execFile ??
+      ((file, args, execOptions, callback) => {
+        execFile(file, [...args], execOptions, (error, stdout, stderr) => {
+          callback(error, String(stdout), String(stderr));
+        });
+      });
+    execFileImpl(
+      buildPowerShellExecutablePath(env),
+      buildPowerShellExecArgs(command),
+      buildPowerShellExecOptions(timeout, env),
+      (error, stdout, stderr) => {
+        if (error) {
+          const failure = error as PowerShellFailure;
+          Object.defineProperty(failure, "stderr", {
+            value: stderr,
+            enumerable: false,
+            configurable: true,
+          });
+          reject(failure);
+          return;
+        }
+        resolve({ stdout, stderr });
+      },
+    );
+  });
+}
+
+function runPowerShellSync(
+  command: string,
+  timeout: number,
+  options: SignatureVerifierOptions,
+): void {
+  const env = options.env ?? process.env;
+  const execFileSyncImpl: ExecFileSyncLike =
+    options.execFileSync ??
+    ((file, args, execOptions) => execFileSync(file, [...args], execOptions));
+  execFileSyncImpl(
+    buildPowerShellExecutablePath(env),
+    buildPowerShellExecArgs(command),
+    buildPowerShellExecOptions(timeout, env),
+  );
+}
+
+export function parseDistinguishedName(seq: string): Map<string, string> {
+  let quoted = false;
+  let key: string | null = null;
+  let token = "";
+  let nextNonSpace = 0;
+  const result = new Map<string, string>();
+  const trimmed = seq.trim();
+
+  for (let i = 0; i <= trimmed.length; i += 1) {
+    if (i === trimmed.length) {
+      if (key !== null) {
+        result.set(key, token);
+      }
+      break;
+    }
+    const ch = trimmed[i];
+    if (quoted) {
+      if (ch === '"') {
+        quoted = false;
+        continue;
+      }
+    } else {
+      if (ch === '"') {
+        quoted = true;
+        continue;
+      }
+      if (ch === "\\") {
+        i += 1;
+        const ord = Number.parseInt(trimmed.slice(i, i + 2), 16);
+        if (Number.isNaN(ord)) {
+          token += trimmed[i] ?? "";
+        } else {
+          i += 1;
+          token += String.fromCharCode(ord);
+        }
+        continue;
+      }
+      if (key === null && ch === "=") {
+        key = token;
+        token = "";
+        continue;
+      }
+      if (ch === "," || ch === ";" || ch === "+") {
+        if (key !== null) {
+          result.set(key, token);
+        }
+        key = null;
+        token = "";
+        continue;
+      }
+    }
+    if (ch === " " && !quoted) {
+      if (token.length === 0) {
+        continue;
+      }
+      if (i > nextNonSpace) {
+        let j = i;
+        while (trimmed[j] === " ") {
+          j += 1;
+        }
+        nextNonSpace = j;
+      }
+      if (
+        nextNonSpace >= trimmed.length ||
+        trimmed[nextNonSpace] === "," ||
+        trimmed[nextNonSpace] === ";" ||
+        (key === null && trimmed[nextNonSpace] === "=") ||
+        (key !== null && trimmed[nextNonSpace] === "+")
+      ) {
+        i = nextNonSpace - 1;
+        continue;
+      }
+    }
+    token += ch;
+  }
+
+  return result;
+}
+
+function parseSignatureOutput(out: string): Record<string, unknown> {
+  const data = JSON.parse(out) as Record<string, unknown>;
+  delete data.PrivateKey;
+  delete data.IsOSBinary;
+  delete data.SignatureType;
+
+  const signerCertificate =
+    typeof data.SignerCertificate === "object" && data.SignerCertificate !== null
+      ? (data.SignerCertificate as Record<string, unknown>)
+      : null;
+  if (signerCertificate) {
+    delete signerCertificate.Archived;
+    delete signerCertificate.Extensions;
+    delete signerCertificate.Handle;
+    delete signerCertificate.HasPrivateKey;
+    delete signerCertificate.SubjectName;
+  }
+
+  return data;
+}
+
+function isOldWin6(release: string = OS.release()): boolean {
+  return release.startsWith("6.") && !release.startsWith("6.3");
+}
+
+function handleSignatureError(
+  logger: Logger,
+  error: unknown,
+  stderr: string | null,
+  options: SignatureVerifierOptions,
+): null {
+  if (isOldWin6(options.platformRelease)) {
+    logger.warn?.(
+      `Cannot execute Get-AuthenticodeSignature: ${String(
+        error ?? stderr,
+      )}. Ignoring signature validation due to unsupported powershell version. Please upgrade to powershell 3 or higher.`,
+    );
+    return null;
+  }
+
+  try {
+    runPowerShellSync("ConvertTo-Json test", 10 * 1000, options);
+  } catch (testError) {
+    const message = testError instanceof Error ? testError.message : String(testError);
+    logger.warn?.(
+      `Cannot execute ConvertTo-Json: ${message}. Ignoring signature validation due to unsupported powershell version. Please upgrade to powershell 3 or higher.`,
+    );
+    return null;
+  }
+
+  if (error != null) {
+    throw error;
+  }
+  if (stderr) {
+    throw new Error(
+      `Cannot execute Get-AuthenticodeSignature, stderr: ${stderr}. Failing signature validation due to unknown stderr.`,
+    );
+  }
+  return null;
+}
+
+export async function verifyWindowsUpdateCodeSignature(
+  publisherNames: string[],
+  unescapedTempUpdateFile: string,
+  logger: Logger = console,
+  options: SignatureVerifierOptions = {},
+): Promise<string | null> {
+  const tempUpdateFile = unescapedTempUpdateFile.replace(/'/g, "''");
+  logger.info?.(`Verifying signature ${tempUpdateFile}`);
+
+  let stdout: string;
+  try {
+    const result = await runPowerShell(
+      `Get-AuthenticodeSignature -LiteralPath '${tempUpdateFile}' | ConvertTo-Json -Compress`,
+      20 * 1000,
+      options,
+    );
+    if (result.stderr) {
+      return handleSignatureError(logger, null, result.stderr, options);
+    }
+    stdout = result.stdout;
+  } catch (error) {
+    return handleSignatureError(
+      logger,
+      error,
+      error instanceof Error ? ((error as PowerShellFailure).stderr ?? null) : null,
+      options,
+    );
+  }
+
+  try {
+    const data = parseSignatureOutput(stdout);
+    if (data.Status === 0) {
+      const signerCertificate =
+        typeof data.SignerCertificate === "object" && data.SignerCertificate !== null
+          ? (data.SignerCertificate as Record<string, unknown>)
+          : null;
+      const subject =
+        typeof signerCertificate?.Subject === "string"
+          ? parseDistinguishedName(signerCertificate.Subject)
+          : new Map<string, string>();
+
+      const normalizedUpdateFile = Path.win32.normalize(unescapedTempUpdateFile);
+      const normalizedSignaturePath =
+        typeof data.Path === "string" ? Path.win32.normalize(data.Path) : null;
+      if (normalizedSignaturePath && normalizedSignaturePath !== normalizedUpdateFile) {
+        return handleSignatureError(
+          logger,
+          new Error(
+            `LiteralPath of ${normalizedSignaturePath} is different than ${normalizedUpdateFile}`,
+          ),
+          null,
+          options,
+        );
+      }
+
+      for (const name of publisherNames) {
+        const dn = parseDistinguishedName(name);
+        if (dn.size > 0) {
+          const keys = Array.from(dn.keys());
+          if (keys.every((key) => dn.get(key) === subject.get(key))) {
+            return null;
+          }
+        } else if (name === subject.get("CN")) {
+          logger.warn?.(
+            `Signature validated using only CN ${name}. Please add your full Distinguished Name (DN) to publisherNames configuration`,
+          );
+          return null;
+        }
+      }
+    }
+
+    const result =
+      `publisherNames: ${publisherNames.join(" | ")}, raw info: ` +
+      JSON.stringify(data, (name, value) => (name === "RawData" ? undefined : value), 2);
+    logger.warn?.(`Sign verification failed, installer signed with incorrect certificate: ${result}`);
+    return result;
+  } catch (error) {
+    return handleSignatureError(logger, error, null, options);
+  }
+}
+
+export function hardenElectronUpdater(
+  updaterModule: UpdaterModule,
+  updater: unknown,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (platform !== "win32") {
+    return;
+  }
+
+  const prototype =
+    typeof updaterModule.BaseUpdater === "function"
+      ? ((updaterModule.BaseUpdater as { prototype?: UpdaterPrototype }).prototype ?? null)
+      : null;
+  if (prototype && !prototype.__synaraSpawnSyncLogPatched) {
+    prototype.spawnSyncLog = function spawnSyncLog(
+      this: { _logger?: Logger },
+      cmd: string,
+      args: string[] = [],
+      env: Record<string, string> = {},
+    ): string {
+      this._logger?.info?.(`Executing: ${cmd} with args: ${args}`);
+      const mergedEnv = { ...process.env, ...env };
+      const prepared = prepareWindowsSafeProcess(cmd, args, { env: mergedEnv });
+      const response = spawnSync(prepared.command, prepared.args, {
+        env: mergedEnv,
+        encoding: "utf8",
+        shell: prepared.shell,
+        windowsHide: prepared.windowsHide,
+      });
+      const { error, status, stdout, stderr } = response;
+      if (error) {
+        this._logger?.error?.(stderr ?? "");
+        throw error;
+      }
+      if (status != null && status !== 0) {
+        this._logger?.error?.(stderr ?? "");
+        throw new Error(`Command ${cmd} exited with code ${status}`);
+      }
+      return (stdout ?? "").trim();
+    };
+    prototype.__synaraSpawnSyncLogPatched = true;
+  }
+
+  const nsisUpdater = updater as UpdaterWithSignatureVerifier | null;
+  if (nsisUpdater && "verifyUpdateCodeSignature" in nsisUpdater) {
+    nsisUpdater.verifyUpdateCodeSignature = (publisherNames, unescapedTempUpdateFile) =>
+      verifyWindowsUpdateCodeSignature(publisherNames, unescapedTempUpdateFile, console);
+  }
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -35,7 +35,7 @@ import type {
   DesktopUpdateActionResult,
   DesktopUpdateState,
 } from "@t3tools/contracts";
-import { autoUpdater, CancellationToken } from "electron-updater";
+import { autoUpdater, BaseUpdater, CancellationToken } from "electron-updater";
 
 import type { ContextMenuItem } from "@t3tools/contracts";
 import { getMacTrafficLightPosition } from "@t3tools/shared/desktopChrome";
@@ -51,6 +51,7 @@ import {
   installResumableUpdateDownloader,
   type ResumableDownloaderTarget,
 } from "./resumableUpdateDownload";
+import { hardenElectronUpdater } from "./electronUpdaterSecurity";
 import { ServerListeningDetector } from "./serverListeningDetector";
 import { syncShellEnvironment } from "./syncShellEnvironment";
 import {
@@ -1702,6 +1703,7 @@ function configureAutoUpdater(): void {
     return;
   }
   updaterConfigured = true;
+  hardenElectronUpdater({ BaseUpdater }, autoUpdater);
   configuredGitHubUpdateSource = resolveGitHubUpdateSource(appUpdateYml);
   if (configuredGitHubUpdateSource !== null) {
     // The updater itself uses app-update.yml; this URL is only the human fallback.

--- a/apps/desktop/src/voiceTranscription.ts
+++ b/apps/desktop/src/voiceTranscription.ts
@@ -11,6 +11,7 @@ import type {
   ServerVoiceTranscriptionInput,
   ServerVoiceTranscriptionResult,
 } from "@t3tools/contracts";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 
 export const SERVER_TRANSCRIBE_VOICE_CHANNEL = "desktop:server-transcribe-voice";
 
@@ -81,11 +82,16 @@ async function resolveDesktopVoiceAuth(
   cwd: string,
 ): Promise<{ token: string; transcriptionUrl: string }> {
   return new Promise((resolve, reject) => {
-    const child = ChildProcess.spawn("codex", ["app-server"], {
+    const prepared = prepareWindowsSafeProcess("codex", ["app-server"], {
+      cwd,
+      env: process.env,
+    });
+    const child = ChildProcess.spawn(prepared.command, prepared.args, {
       cwd,
       env: process.env,
       stdio: ["pipe", "pipe", "pipe"],
-      shell: process.platform === "win32",
+      shell: prepared.shell,
+      windowsHide: prepared.windowsHide,
     });
 
     let settled = false;

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -39,6 +39,7 @@ import {
   type ServerVoiceTranscriptionResult,
 } from "@t3tools/contracts";
 import { getModelSelectionBooleanOptionValue, normalizeModelSlug } from "@t3tools/shared/model";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 import { Effect, ServiceMap } from "effect";
 
 import {
@@ -527,11 +528,8 @@ export function resolveCodexModelForAccount(
   return CODEX_DEFAULT_MODEL;
 }
 
-/**
- * On Windows with `shell: true`, `child.kill()` only terminates the `cmd.exe`
- * wrapper, leaving the actual command running. Use `taskkill /T` to kill the
- * entire process tree instead.
- */
+// Windows `.cmd` shims still run under an explicit cmd.exe wrapper; taskkill
+// keeps cancellation from leaving the real provider process behind.
 function killChildTree(child: ChildProcessWithoutNullStreams): void {
   if (process.platform === "win32" && child.pid !== undefined) {
     try {
@@ -544,6 +542,24 @@ function killChildTree(child: ChildProcessWithoutNullStreams): void {
     }
   }
   child.kill();
+}
+
+function spawnCodexAppServer(input: {
+  readonly binaryPath: string;
+  readonly cwd: string;
+  readonly env: NodeJS.ProcessEnv;
+}): ChildProcessWithoutNullStreams {
+  const prepared = prepareWindowsSafeProcess(input.binaryPath, ["app-server"], {
+    cwd: input.cwd,
+    env: input.env,
+  });
+  return spawn(prepared.command, prepared.args, {
+    cwd: input.cwd,
+    env: input.env,
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: prepared.shell,
+    windowsHide: prepared.windowsHide,
+  });
 }
 
 export function normalizeCodexModelSlug(
@@ -773,13 +789,12 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         cwd: resolvedCwd,
         ...(codexHomePath ? { homePath: codexHomePath } : {}),
       });
-      const child = spawn(codexBinaryPath, ["app-server"], {
+      const child = spawnCodexAppServer({
+        binaryPath: codexBinaryPath,
         cwd: resolvedCwd,
         env: buildCodexProcessEnv({
           ...(codexHomePath ? { homePath: codexHomePath } : {}),
         }),
-        stdio: ["pipe", "pipe", "pipe"],
-        shell: process.platform === "win32",
       });
       const output = readline.createInterface({ input: child.stdout });
 
@@ -1392,13 +1407,12 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         cwd: resolvedCwd,
         ...(codexHomePath ? { homePath: codexHomePath } : {}),
       });
-      const child = spawn(codexBinaryPath, ["app-server"], {
+      const child = spawnCodexAppServer({
+        binaryPath: codexBinaryPath,
         cwd: resolvedCwd,
         env: buildCodexProcessEnv({
           ...(codexHomePath ? { homePath: codexHomePath } : {}),
         }),
-        stdio: ["pipe", "pipe", "pipe"],
-        shell: process.platform === "win32",
       });
       const output = readline.createInterface({ input: child.stdout });
 
@@ -1977,11 +1991,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       binaryPath: "codex",
       cwd: normalizedCwd,
     });
-    const child = spawn("codex", ["app-server"], {
+    const child = spawnCodexAppServer({
+      binaryPath: "codex",
       cwd: normalizedCwd,
       env: buildCodexProcessEnv(),
-      stdio: ["pipe", "pipe", "pipe"],
-      shell: process.platform === "win32",
     });
     const output = readline.createInterface({ input: child.stdout });
     const context: CodexSessionContext = {
@@ -3344,16 +3357,22 @@ function assertSupportedCodexCliVersion(input: {
   readonly cwd: string;
   readonly homePath?: string;
 }): void {
-  const result = spawnSync(input.binaryPath, ["--version"], {
+  const env = buildCodexProcessEnv({
+    ...(input.homePath ? { homePath: input.homePath } : {}),
+  });
+  const prepared = prepareWindowsSafeProcess(input.binaryPath, ["--version"], {
     cwd: input.cwd,
-    env: buildCodexProcessEnv({
-      ...(input.homePath ? { homePath: input.homePath } : {}),
-    }),
+    env,
+  });
+  const result = spawnSync(prepared.command, prepared.args, {
+    cwd: input.cwd,
+    env,
     encoding: "utf8",
-    shell: process.platform === "win32",
+    shell: prepared.shell,
     stdio: ["ignore", "pipe", "pipe"],
     timeout: CODEX_VERSION_CHECK_TIMEOUT_MS,
     maxBuffer: 1024 * 1024,
+    windowsHide: prepared.windowsHide,
   });
 
   if (result.error) {

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -7,6 +7,7 @@ import { DEFAULT_GIT_TEXT_GENERATION_MODEL } from "@t3tools/contracts";
 import { sanitizeGeneratedThreadTitle } from "@t3tools/shared/chatThreads";
 import { resolveCodexHome } from "@t3tools/shared/codexConfig";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { buildCodexProcessEnv } from "../../codexProcessEnv.ts";
@@ -301,31 +302,34 @@ const makeCodexTextGeneration = Effect.gen(function* () {
       const isolatedCodexHome = yield* prepareIsolatedCodexHome(operation, resolvedCodexHomePath);
 
       const runCodexCommand = Effect.gen(function* () {
+        const env = buildCodexProcessEnv({ homePath: isolatedCodexHome.homePath });
+        const args = [
+          "exec",
+          "--ephemeral",
+          "--skip-git-repo-check",
+          "--config",
+          'approval_policy="never"',
+          "-s",
+          "read-only",
+          "--model",
+          resolveCodexModel(model, modelSelection) ?? DEFAULT_GIT_TEXT_GENERATION_MODEL,
+          "--config",
+          `model_reasoning_effort="${CODEX_REASONING_EFFORT}"`,
+          "--output-schema",
+          schemaPath,
+          "--output-last-message",
+          outputPath,
+          ...imagePaths.flatMap((imagePath) => ["--image", imagePath]),
+          "-",
+        ];
+        const prepared = prepareWindowsSafeProcess(codexBinaryPath, args, { cwd, env });
         const command = ChildProcess.make(
-          codexBinaryPath,
-          [
-            "exec",
-            "--ephemeral",
-            "--skip-git-repo-check",
-            "--config",
-            'approval_policy="never"',
-            "-s",
-            "read-only",
-            "--model",
-            resolveCodexModel(model, modelSelection) ?? DEFAULT_GIT_TEXT_GENERATION_MODEL,
-            "--config",
-            `model_reasoning_effort="${CODEX_REASONING_EFFORT}"`,
-            "--output-schema",
-            schemaPath,
-            "--output-last-message",
-            outputPath,
-            ...imagePaths.flatMap((imagePath) => ["--image", imagePath]),
-            "-",
-          ],
+          prepared.command,
+          prepared.args,
           {
             cwd,
-            env: buildCodexProcessEnv({ homePath: isolatedCodexHome.homePath }),
-            shell: process.platform === "win32",
+            env,
+            shell: prepared.shell,
             stdin: {
               stream: Stream.make(new TextEncoder().encode(prompt)),
             },

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -11,6 +11,7 @@ import { accessSync, constants, statSync } from "node:fs";
 import { dirname, extname, join } from "node:path";
 
 import { EDITORS, type EditorId } from "@t3tools/contracts";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 import { ServiceMap, Schema, Effect, Layer } from "effect";
 import {
   getEditorMacApplications,
@@ -448,10 +449,12 @@ export const launchDetached = (launch: EditorLaunch) =>
     yield* Effect.callback<void, OpenError>((resume) => {
       let child;
       try {
-        child = spawn(launch.command, [...launch.args], {
+        const prepared = prepareWindowsSafeProcess(launch.command, launch.args);
+        child = spawn(prepared.command, prepared.args, {
           detached: true,
           stdio: "ignore",
-          shell: process.platform === "win32",
+          shell: prepared.shell,
+          windowsHide: prepared.windowsHide,
         });
       } catch (error) {
         return resume(

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess as ChildProcessHandle, spawn, spawnSync } from "node:child_process";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 
 export interface ProcessRunOptions {
   cwd?: string | undefined;
@@ -80,11 +81,8 @@ function normalizeBufferError(
 
 const DEFAULT_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
 
-/**
- * On Windows with `shell: true`, `child.kill()` only terminates the `cmd.exe`
- * wrapper, leaving the actual command running. Use `taskkill /T` to kill the
- * entire process tree instead.
- */
+// Windows `.cmd` shims may run under an explicit cmd.exe wrapper; taskkill keeps
+// timeout/cancel paths from leaving the real command behind.
 function killChild(child: ChildProcessHandle, signal: NodeJS.Signals = "SIGTERM"): void {
   if (process.platform === "win32" && child.pid !== undefined) {
     try {
@@ -135,11 +133,16 @@ export async function runProcess(
   const outputMode = options.outputMode ?? "error";
 
   return new Promise<ProcessRunResult>((resolve, reject) => {
-    const child = spawn(command, args, {
+    const prepared = prepareWindowsSafeProcess(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+    });
+    const child = spawn(prepared.command, prepared.args, {
       cwd: options.cwd,
       env: options.env,
       stdio: "pipe",
-      shell: process.platform === "win32",
+      shell: prepared.shell,
+      windowsHide: prepared.windowsHide,
     });
 
     let stdout = "";

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -22,6 +22,7 @@ import {
   type ThreadId,
   TurnId,
 } from "@t3tools/contracts";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 import {
   DateTime,
   Deferred,
@@ -1476,15 +1477,18 @@ export function makeCursorAdapter(
       );
       const effectiveApiEndpoint = apiEndpoint || cursorSettings.apiEndpoint;
       const runCursorModelListCommand = Effect.gen(function* () {
+        const args = [
+          ...(effectiveApiEndpoint ? (["-e", effectiveApiEndpoint] as const) : []),
+          "models",
+        ];
+        const prepared = prepareWindowsSafeProcess(effectiveBinaryPath, args, {
+          env: process.env,
+        });
         const child = yield* childProcessSpawner.spawn(
-          ChildProcess.make(
-            effectiveBinaryPath,
-            [...(effectiveApiEndpoint ? (["-e", effectiveApiEndpoint] as const) : []), "models"],
-            {
-              shell: process.platform === "win32",
-              env: process.env,
-            },
-          ),
+          ChildProcess.make(prepared.command, prepared.args, {
+            shell: prepared.shell,
+            env: process.env,
+          }),
         );
         const [stdout, stderr, exitCode] = yield* Effect.all(
           [

--- a/apps/server/src/provider/Layers/GeminiAdapter.ts
+++ b/apps/server/src/provider/Layers/GeminiAdapter.ts
@@ -39,6 +39,7 @@ import {
   hasEffortLevel,
   resolveGeminiApiModelId,
 } from "@t3tools/shared/model";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 import { Effect, FileSystem, Layer, Queue, Stream } from "effect";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
@@ -783,13 +784,20 @@ const makeGeminiAdapter = Effect.fn("makeGeminiAdapter")(function* (
     env?: NodeJS.ProcessEnv,
   ) {
     return yield* Effect.try({
-      try: () =>
-        spawn(binaryPath, ["--acp"], {
+      try: () => {
+        const childEnv = env ?? process.env;
+        const prepared = prepareWindowsSafeProcess(binaryPath, ["--acp"], {
           cwd,
-          env: env ?? process.env,
+          env: childEnv,
+        });
+        return spawn(prepared.command, prepared.args, {
+          cwd,
+          env: childEnv,
           stdio: ["pipe", "pipe", "pipe"],
-          shell: process.platform === "win32",
-        }),
+          shell: prepared.shell,
+          windowsHide: prepared.windowsHide,
+        });
+      },
       catch: (cause) =>
         new ProviderAdapterProcessError({
           provider: PROVIDER,

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -21,6 +21,7 @@ import {
   type ThreadId,
   TurnId,
 } from "@t3tools/contracts";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 import {
   Cause,
   DateTime,
@@ -1677,9 +1678,10 @@ export function makeGrokAdapter(
         let cliError: unknown;
         let apiError: ProviderAdapterRequestError | undefined;
         const cliModels = yield* Effect.gen(function* () {
+          const prepared = prepareWindowsSafeProcess(binaryPath, ["models"], { env: process.env });
           const child = yield* childProcessSpawner.spawn(
-            ChildProcess.make(binaryPath, ["models"], {
-              shell: process.platform === "win32",
+            ChildProcess.make(prepared.command, prepared.args, {
+              shell: prepared.shell,
               env: process.env,
             }),
           );

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -20,6 +20,7 @@ import type {
 import { ServerProviderUpdateError } from "@t3tools/contracts";
 import { parseCodexConfigModelProvider } from "@t3tools/shared/codexConfig";
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 import { query as claudeQuery, type SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 import {
   Array,
@@ -708,8 +709,9 @@ const runProviderCommand = (
 ) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const command = ChildProcess.make(executable, [...args], {
-      shell: process.platform === "win32",
+    const prepared = prepareWindowsSafeProcess(executable, args, { env });
+    const command = ChildProcess.make(prepared.command, prepared.args, {
+      shell: prepared.shell,
       env,
     });
 
@@ -2212,9 +2214,10 @@ export const ProviderHealthLive = Layer.effect(
       readonly command: string;
       readonly args: ReadonlyArray<string>;
     }) {
+      const prepared = prepareWindowsSafeProcess(input.command, input.args, { env: process.env });
       const child = yield* spawner.spawn(
-        ChildProcess.make(input.command, [...input.args], {
-          shell: process.platform === "win32",
+        ChildProcess.make(prepared.command, prepared.args, {
+          shell: prepared.shell,
           env: process.env,
         }),
       );

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -1,3 +1,4 @@
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 import {
   Cause,
   Deferred,
@@ -204,12 +205,17 @@ const makeAcpSessionRuntime = (
         ),
       );
 
+    const env = options.spawn.env ? { ...process.env, ...options.spawn.env } : process.env;
+    const prepared = prepareWindowsSafeProcess(options.spawn.command, options.spawn.args, {
+      cwd: options.spawn.cwd,
+      env,
+    });
     const child = yield* spawner
       .spawn(
-        ChildProcess.make(options.spawn.command, [...options.spawn.args], {
+        ChildProcess.make(prepared.command, prepared.args, {
           ...(options.spawn.cwd ? { cwd: options.spawn.cwd } : {}),
-          ...(options.spawn.env ? { env: { ...process.env, ...options.spawn.env } } : {}),
-          shell: process.platform === "win32",
+          env,
+          shell: prepared.shell,
         }),
       )
       .pipe(

--- a/apps/server/src/provider/geminiAcpProbe.ts
+++ b/apps/server/src/provider/geminiAcpProbe.ts
@@ -13,6 +13,7 @@ import {
   GEMINI_3_MODEL_CAPABILITIES,
   geminiCapabilitiesForModel,
 } from "@t3tools/shared/model";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 import { Effect } from "effect";
 import { asNumber, asRecord, trimToUndefined } from "./geminiValue.ts";
 
@@ -177,10 +178,16 @@ export const probeGeminiCapabilities = (input: {
   Effect.tryPromise(
     () =>
       new Promise<GeminiCapabilityProbeResult>((resolve) => {
-        const child = spawn(input.binaryPath, ["--acp"], {
+        const env = buildGeminiProbeEnv();
+        const prepared = prepareWindowsSafeProcess(input.binaryPath, ["--acp"], {
           cwd: input.cwd,
-          env: buildGeminiProbeEnv(),
-          shell: process.platform === "win32",
+          env,
+        });
+        const child = spawn(prepared.command, prepared.args, {
+          cwd: input.cwd,
+          env,
+          shell: prepared.shell,
+          windowsHide: prepared.windowsHide,
           stdio: ["pipe", "pipe", "pipe"],
         });
 

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -39,6 +39,7 @@ import * as Semaphore from "effect/Semaphore";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { NetService } from "@t3tools/shared/Net";
+import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 import { isWindowsShellCommandMissingResult } from "../shell-command-detection.ts";
 
 const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 20_000;
@@ -831,9 +832,13 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
 
   const runOpenCodeCommand: OpenCodeRuntimeShape["runOpenCodeCommand"] = (input) =>
     Effect.gen(function* () {
+      const prepared = prepareWindowsSafeProcess(input.binaryPath, input.args, {
+        cwd: input.cwd,
+        env: process.env,
+      });
       const child = yield* spawner.spawn(
-        ChildProcess.make(input.binaryPath, [...input.args], {
-          shell: process.platform === "win32",
+        ChildProcess.make(prepared.command, prepared.args, {
+          shell: prepared.shell,
           ...(input.cwd ? { cwd: input.cwd } : {}),
           env: process.env,
         }),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,6 +24,10 @@
       "types": "./src/shell.ts",
       "import": "./src/shell.ts"
     },
+    "./windowsProcess": {
+      "types": "./src/windowsProcess.ts",
+      "import": "./src/windowsProcess.ts"
+    },
     "./codexConfig": {
       "types": "./src/codexConfig.ts",
       "import": "./src/codexConfig.ts"

--- a/packages/shared/src/windowsProcess.test.ts
+++ b/packages/shared/src/windowsProcess.test.ts
@@ -1,0 +1,190 @@
+// FILE: windowsProcess.test.ts
+// Purpose: Verifies Windows process preparation avoids Node shell-mode deprecations.
+// Layer: Shared Node runtime utility tests
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildWindowsBatchCommandArgs,
+  isWindowsBatchCommand,
+  prepareWindowsSafeProcess,
+  resolveWindowsCommandPath,
+  resolveWindowsComSpec,
+} from "./windowsProcess";
+
+describe("windowsProcess", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("leaves non-Windows commands shell-free and otherwise unchanged", () => {
+    expect(
+      prepareWindowsSafeProcess("codex", ["app-server"], {
+        platform: "darwin",
+      }),
+    ).toEqual({ command: "codex", args: ["app-server"], shell: false });
+  });
+
+  it("resolves Windows PATH commands through where.exe", () => {
+    const spawnSync = vi.fn(() => ({
+      stdout: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd\r\n",
+      status: 0,
+    }));
+
+    expect(
+      resolveWindowsCommandPath("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toBe("C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd");
+    expect(spawnSync).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\where.exe",
+      ["codex"],
+      expect.objectContaining({ shell: false, windowsHide: true }),
+    );
+  });
+
+  it("skips current-directory command hits from where.exe", () => {
+    const spawnSync = vi.fn(() => ({
+      stdout: [
+        "C:\\projects\\synara\\codex.cmd",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+      ].join("\r\n"),
+      status: 0,
+    }));
+
+    expect(
+      resolveWindowsCommandPath("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toBe("C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd");
+  });
+
+  it("uses process.cwd for current-directory filtering when cwd is omitted", () => {
+    vi.spyOn(process, "cwd").mockReturnValue("C:\\projects\\synara");
+    const spawnSync = vi.fn(() => ({
+      stdout: [
+        "C:\\projects\\synara\\codex.cmd",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+      ].join("\r\n"),
+      status: 0,
+    }));
+
+    expect(
+      resolveWindowsCommandPath("codex", {
+        platform: "win32",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toBe("C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd");
+    expect(spawnSync).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\where.exe",
+      ["codex"],
+      expect.objectContaining({ cwd: "C:\\projects\\synara" }),
+    );
+  });
+
+  it("wraps .cmd shims through cmd.exe without shell true", () => {
+    const spawnSync = vi.fn(() => ({
+      stdout: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd\r\n",
+      status: 0,
+    }));
+
+    expect(
+      prepareWindowsSafeProcess("codex", ["app-server"], {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { ComSpec: "C:\\Windows\\System32\\cmd.exe", SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/v:off",
+        "/c",
+        '"C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
+      ],
+      shell: false,
+      windowsHide: true,
+    });
+  });
+
+  it("quotes batch commands and arguments in a single cmd.exe command line", () => {
+    expect(
+      buildWindowsBatchCommandArgs("C:\\Users\\Test User\\npm\\tool.cmd", [
+        "path with spaces",
+        "flag=value",
+      ]),
+    ).toEqual([
+      "/d",
+      "/s",
+      "/v:off",
+      "/c",
+      '"C:\\Users\\Test User\\npm\\tool.cmd" "path with spaces" "flag=value"',
+    ]);
+  });
+
+  it("escapes batch arguments that cmd.exe can expand or reinterpret", () => {
+    expect(
+      buildWindowsBatchCommandArgs("C:\\tools\\bad%path\\codex.cmd", [
+        '%PATH%',
+        'approval_policy="never"',
+        "one&two",
+        "bang!value",
+      ]),
+    ).toEqual([
+      "/d",
+      "/s",
+      "/v:off",
+      "/c",
+      '"C:\\tools\\bad%%path\\codex.cmd" "%%PATH%%" "approval_policy=^"never^"" "one^&two" "bang^!value"',
+    ]);
+  });
+
+  it("rejects batch tokens with line breaks", () => {
+    expect(() => buildWindowsBatchCommandArgs("C:\\tools\\codex.cmd", ["line\nbreak"])).toThrow(
+      /Cannot safely execute Windows batch argument/,
+    );
+  });
+
+  it("keeps resolved .exe commands direct", () => {
+    const spawnSync = vi.fn(() => ({
+      stdout: "C:\\Program Files\\Codex\\codex.exe\r\n",
+      status: 0,
+    }));
+
+    expect(
+      prepareWindowsSafeProcess("codex", ["--version"], {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toEqual({
+      command: "C:\\Program Files\\Codex\\codex.exe",
+      args: ["--version"],
+      shell: false,
+      windowsHide: true,
+    });
+  });
+
+  it("resolves ComSpec from environment before falling back", () => {
+    expect(resolveWindowsComSpec({ ComSpec: "D:\\cmd.exe" })).toBe("D:\\cmd.exe");
+    expect(resolveWindowsComSpec({ SystemRoot: "D:\\Windows" })).toBe(
+      "D:\\Windows\\System32\\cmd.exe",
+    );
+  });
+
+  it("detects batch shims by extension", () => {
+    expect(isWindowsBatchCommand("codex.cmd")).toBe(true);
+    expect(isWindowsBatchCommand("tool.bat")).toBe(true);
+    expect(isWindowsBatchCommand("tool.exe")).toBe(false);
+  });
+});

--- a/packages/shared/src/windowsProcess.test.ts
+++ b/packages/shared/src/windowsProcess.test.ts
@@ -89,6 +89,49 @@ describe("windowsProcess", () => {
     );
   });
 
+  it("resolves extensionless path-like Windows shims before spawning", () => {
+    const spawnSync = vi.fn(() => ({
+      stdout: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd\r\n",
+      status: 0,
+    }));
+
+    expect(
+      resolveWindowsCommandPath("C:\\Users\\test\\AppData\\Roaming\\npm\\codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toBe("C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd");
+    expect(spawnSync).toHaveBeenCalledWith(
+      "C:\\Windows\\System32\\where.exe",
+      ["C:\\Users\\test\\AppData\\Roaming\\npm\\codex"],
+      expect.objectContaining({ shell: false, windowsHide: true }),
+    );
+  });
+
+  it("keeps explicit path-like Windows executables without resolving", () => {
+    const spawnSync = vi.fn();
+
+    expect(
+      resolveWindowsCommandPath("C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toBe("C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd");
+    expect(
+      resolveWindowsCommandPath("C:\\Program Files\\Codex\\codex.exe", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toBe("C:\\Program Files\\Codex\\codex.exe");
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
   it("wraps .cmd shims through cmd.exe without shell true", () => {
     const spawnSync = vi.fn(() => ({
       stdout: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd\r\n",
@@ -102,6 +145,37 @@ describe("windowsProcess", () => {
         env: { ComSpec: "C:\\Windows\\System32\\cmd.exe", SystemRoot: "C:\\Windows" },
         spawnSync,
       }),
+    ).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/v:off",
+        "/c",
+        '"C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
+      ],
+      shell: false,
+      windowsHide: true,
+    });
+  });
+
+  it("wraps resolved extensionless path-like shims through cmd.exe", () => {
+    const spawnSync = vi.fn(() => ({
+      stdout: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd\r\n",
+      status: 0,
+    }));
+
+    expect(
+      prepareWindowsSafeProcess(
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
+        ["app-server"],
+        {
+          platform: "win32",
+          cwd: "C:\\projects\\synara",
+          env: { ComSpec: "C:\\Windows\\System32\\cmd.exe", SystemRoot: "C:\\Windows" },
+          spawnSync,
+        },
+      ),
     ).toEqual({
       command: "C:\\Windows\\System32\\cmd.exe",
       args: [

--- a/packages/shared/src/windowsProcess.ts
+++ b/packages/shared/src/windowsProcess.ts
@@ -1,0 +1,164 @@
+// FILE: windowsProcess.ts
+// Purpose: Prepares Windows child-process launches without Node's `shell: true`.
+// Layer: Shared Node runtime utility
+// Exports: command resolution plus safe spawn/spawnSync argument preparation.
+
+import { spawnSync } from "node:child_process";
+import * as Path from "node:path";
+
+type SpawnSyncLike = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    encoding: "utf8";
+    shell: false;
+    stdio: ["ignore", "pipe", "ignore"];
+    timeout: number;
+    windowsHide: true;
+  },
+) => { stdout?: string | null; status?: number | null; error?: Error | undefined };
+
+export interface WindowsSafeProcessInput {
+  readonly platform?: NodeJS.Platform;
+  readonly cwd?: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly spawnSync?: SpawnSyncLike;
+}
+
+export interface WindowsSafeProcessCommand {
+  readonly command: string;
+  readonly args: string[];
+  readonly shell: false;
+  readonly windowsHide?: true;
+}
+
+const WINDOWS_BATCH_EXTENSION_PATTERN = /\.(?:cmd|bat)$/i;
+const WINDOWS_PATH_SEPARATOR_PATTERN = /[\\/]/;
+const WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN = /[\r\n]/;
+const WINDOWS_BATCH_CARET_ESCAPE_PATTERN = /[&|<>()^"!]/g;
+const WHERE_TIMEOUT_MS = 2_000;
+
+function trimNonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function resolveWindowsSystemRoot(env: NodeJS.ProcessEnv = process.env): string {
+  return trimNonEmpty(env.SystemRoot) ?? trimNonEmpty(env.SYSTEMROOT) ?? "C:\\Windows";
+}
+
+export function resolveWindowsComSpec(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    trimNonEmpty(env.ComSpec) ??
+    trimNonEmpty(env.COMSPEC) ??
+    Path.win32.join(resolveWindowsSystemRoot(env), "System32", "cmd.exe")
+  );
+}
+
+function resolveWindowsWhereExe(env: NodeJS.ProcessEnv = process.env): string {
+  return Path.win32.join(resolveWindowsSystemRoot(env), "System32", "where.exe");
+}
+
+export function isWindowsBatchCommand(command: string): boolean {
+  return WINDOWS_BATCH_EXTENSION_PATTERN.test(command);
+}
+
+function quoteWindowsBatchToken(token: string, label: string): string {
+  if (WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN.test(token)) {
+    throw new Error(
+      `Cannot safely execute Windows batch ${label} containing line breaks.`,
+    );
+  }
+  const escaped = token
+    .replace(/%/g, "%%")
+    .replace(WINDOWS_BATCH_CARET_ESCAPE_PATTERN, (match) => `^${match}`);
+  return `"${escaped}"`;
+}
+
+export function buildWindowsBatchCommandArgs(
+  command: string,
+  args: ReadonlyArray<string>,
+): string[] {
+  const commandLine = [
+    quoteWindowsBatchToken(command, "command"),
+    ...args.map((arg) => quoteWindowsBatchToken(arg, "argument")),
+  ].join(" ");
+  return ["/d", "/s", "/v:off", "/c", commandLine];
+}
+
+function isPathLikeCommand(command: string): boolean {
+  return WINDOWS_PATH_SEPARATOR_PATTERN.test(command) || Path.win32.isAbsolute(command);
+}
+
+function isFromCurrentDirectory(candidate: string, cwd: string | undefined): boolean {
+  if (!cwd) {
+    return false;
+  }
+  const candidateDir = Path.win32.resolve(Path.win32.dirname(candidate)).toLowerCase();
+  const currentDir = Path.win32.resolve(cwd).toLowerCase();
+  return candidateDir === currentDir;
+}
+
+// Resolve PATH/PATHEXT commands through where.exe so `.cmd` shims can be wrapped
+// explicitly. We skip current-directory hits to avoid restoring shell-style CWD
+// command hijacking.
+export function resolveWindowsCommandPath(
+  command: string,
+  input: WindowsSafeProcessInput = {},
+): string {
+  if (isPathLikeCommand(command)) {
+    return command;
+  }
+
+  const env = input.env ?? process.env;
+  const cwd = input.cwd ?? process.cwd();
+  const result = (input.spawnSync ?? spawnSync)(resolveWindowsWhereExe(env), [command], {
+    cwd,
+    env,
+    encoding: "utf8",
+    shell: false,
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: WHERE_TIMEOUT_MS,
+    windowsHide: true,
+  });
+  if (result.error || result.status !== 0) {
+    return command;
+  }
+
+  const candidates = (result.stdout ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return candidates.find((candidate) => !isFromCurrentDirectory(candidate, cwd)) ?? command;
+}
+
+export function prepareWindowsSafeProcess(
+  command: string,
+  args: ReadonlyArray<string>,
+  input: WindowsSafeProcessInput = {},
+): WindowsSafeProcessCommand {
+  const platform = input.platform ?? process.platform;
+  if (platform !== "win32") {
+    return { command, args: [...args], shell: false };
+  }
+
+  const env = input.env ?? process.env;
+  const resolvedCommand = resolveWindowsCommandPath(command, input);
+  if (!isWindowsBatchCommand(resolvedCommand)) {
+    return {
+      command: resolvedCommand,
+      args: [...args],
+      shell: false,
+      windowsHide: true,
+    };
+  }
+
+  return {
+    command: resolveWindowsComSpec(env),
+    args: buildWindowsBatchCommandArgs(resolvedCommand, args),
+    shell: false,
+    windowsHide: true,
+  };
+}

--- a/packages/shared/src/windowsProcess.ts
+++ b/packages/shared/src/windowsProcess.ts
@@ -92,6 +92,10 @@ function isPathLikeCommand(command: string): boolean {
   return WINDOWS_PATH_SEPARATOR_PATTERN.test(command) || Path.win32.isAbsolute(command);
 }
 
+function hasWindowsExecutableExtension(command: string): boolean {
+  return Path.win32.extname(command).length > 0;
+}
+
 function isFromCurrentDirectory(candidate: string, cwd: string | undefined): boolean {
   if (!cwd) {
     return false;
@@ -108,7 +112,8 @@ export function resolveWindowsCommandPath(
   command: string,
   input: WindowsSafeProcessInput = {},
 ): string {
-  if (isPathLikeCommand(command)) {
+  const pathLikeCommand = isPathLikeCommand(command);
+  if (pathLikeCommand && hasWindowsExecutableExtension(command)) {
     return command;
   }
 
@@ -131,6 +136,9 @@ export function resolveWindowsCommandPath(
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
+  if (pathLikeCommand) {
+    return candidates[0] ?? command;
+  }
   return candidates.find((candidate) => !isFromCurrentDirectory(candidate, cwd)) ?? command;
 }
 


### PR DESCRIPTION
## Summary
- add a shared Windows process launcher helper that resolves PATH commands, wraps `.cmd`/`.bat` shims without `shell: true`, escapes cmd metacharacters, and filters current-directory shim hits
- move desktop/server startup and provider process launches off Windows shell mode
- harden `electron-updater` Windows process paths by patching updater sync spawns and replacing NSIS signature verification with shell-free PowerShell execution

## Validation
- `bun run --cwd packages/shared test src/windowsProcess.test.ts`
- `bun run --cwd apps/desktop test src/electronUpdaterSecurity.test.ts`
- `bun run --cwd apps/server build`
- `bun run --cwd apps/desktop build` (passes; existing unrelated `MODULE_TYPELESS_PACKAGE_JSON` warning from `apps/desktop/tsdown.config.ts`)
- `git diff --check`
- isolated Electron startup smoke with `NODE_OPTIONS='--trace-deprecation --trace-warnings'`: `DEP0169=false`, `DEP0190=false`, `DEP0180=false`

## Notes
- Direct Windows/Electron reproduction was not available in this environment, so Windows behavior is covered by focused unit tests and static startup-path checks.
- `bun fmt`, `bun lint`, and `bun typecheck` were not run because `AGENTS.md` requires explicit current-conversation permission for those heavyweight checks.

Closes #209
