### PR TITLE
fix(automations): harden approval fallback coverage

### DIFF
--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -869,8 +869,69 @@ layer("AutomationService", (it) => {
       assert.strictEqual(results.length, 0);
       assert.strictEqual(dispatchedCommands.length, 0);
       assert.strictEqual(
-        listed.runs.filter((run) => run.automationId === automationId).length,
-        0,
+        listed.definitions.find((definition) => definition.id === automationId)?.nextRunAt,
+        "2026-06-16T10:05:00.000Z",
+      );
+      assert.strictEqual(
+        listed.runs.find((run) => run.automationId === automationId)?.status,
+        "skipped",
+      );
+    }),
+  );
+
+  it.effect("advances blocked scheduled automations so later eligible definitions can run", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const blockedIds = Array.from({ length: 5 }, (_, index) =>
+        AutomationId.makeUnsafe(`automation-due-blocked-${index}`),
+      );
+      const eligibleId = AutomationId.makeUnsafe("automation-due-eligible-after-blocked");
+
+      for (const automationId of blockedIds) {
+        yield* repository.createDefinition({
+          id: automationId,
+          input: {
+            ...createInput("worktree"),
+            schedule: { type: "interval", everySeconds: 300 },
+            runtimeMode: "full-access",
+            acknowledgedRisks: [],
+          },
+          now: "2026-06-16T10:00:00.000Z",
+        });
+      }
+      yield* repository.createDefinition({
+        id: eligibleId,
+        input: {
+          ...createInput("local"),
+          schedule: { type: "interval", everySeconds: 300 },
+        },
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      const firstPass = yield* service.runDueOnce({
+        now: "2026-06-16T10:00:00.000Z",
+        limit: 5,
+        leaseOwnerId: "test-scheduler",
+      });
+      const secondPass = yield* service.runDueOnce({
+        now: "2026-06-16T10:00:00.000Z",
+        limit: 5,
+        leaseOwnerId: "test-scheduler",
+      });
+      const listed = yield* service.list({ projectId });
+
+      assert.strictEqual(firstPass.length, 0);
+      assert.strictEqual(secondPass.length, 1);
+      assert.strictEqual(secondPass[0]?.run.automationId, eligibleId);
+      assert.strictEqual(
+        listed.runs.filter((run) => blockedIds.includes(run.automationId)).length,
+        5,
+      );
+      assert.strictEqual(
+        listed.definitions.find((definition) => definition.id === eligibleId)?.nextRunAt,
+        "2026-06-16T10:05:00.000Z",
       );
     }),
   );

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -841,6 +841,40 @@ layer("AutomationService", (it) => {
     }),
   );
 
+  it.effect("blocks due scheduled full-access automations until acknowledged", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-due-unapproved-full-access");
+
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("worktree"),
+          schedule: { type: "interval", everySeconds: 300 },
+          runtimeMode: "full-access",
+          acknowledgedRisks: [],
+        },
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      const results = yield* service.runDueOnce({
+        now: "2026-06-16T10:00:00.000Z",
+        limit: 10,
+        leaseOwnerId: "test-scheduler",
+      });
+      const listed = yield* service.list({ projectId });
+
+      assert.strictEqual(results.length, 0);
+      assert.strictEqual(dispatchedCommands.length, 0);
+      assert.strictEqual(
+        listed.runs.filter((run) => run.automationId === automationId).length,
+        0,
+      );
+    }),
+  );
+
   it.effect("records and advances missed scheduled occurrences when misfire policy is skip", () =>
     Effect.gen(function* () {
       resetHarness();

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -879,6 +879,43 @@ layer("AutomationService", (it) => {
     }),
   );
 
+  it.effect("blocks due scheduled fast intervals until acknowledged", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-due-unapproved-fast-interval");
+
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("worktree"),
+          schedule: { type: "interval", everySeconds: 30 },
+          acknowledgedRisks: [],
+        },
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      const results = yield* service.runDueOnce({
+        now: "2026-06-16T10:00:00.000Z",
+        limit: 10,
+        leaseOwnerId: "test-scheduler",
+      });
+      const listed = yield* service.list({ projectId });
+
+      assert.strictEqual(results.length, 0);
+      assert.strictEqual(dispatchedCommands.length, 0);
+      assert.strictEqual(
+        listed.definitions.find((definition) => definition.id === automationId)?.nextRunAt,
+        "2026-06-16T10:00:30.000Z",
+      );
+      assert.strictEqual(
+        listed.runs.find((run) => run.automationId === automationId)?.status,
+        "skipped",
+      );
+    }),
+  );
+
   it.effect("advances blocked scheduled automations so later eligible definitions can run", () =>
     Effect.gen(function* () {
       resetHarness();

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -2134,12 +2134,6 @@ export const AutomationServiceLive = Layer.effect(
           return Option.none<AutomationRunNowResult>();
         }
 
-        yield* validateRiskAcknowledgements({
-          runtimeMode: definition.runtimeMode,
-          worktreeMode: definition.worktreeMode,
-          acknowledgedRisks: definition.acknowledgedRisks,
-        });
-
         const occurrence = scheduledOccurrenceForDefinition(definition, now);
         const { scheduledFor, nextRunAt } = occurrence;
         if (occurrence.skip) {
@@ -2152,6 +2146,26 @@ export const AutomationServiceLive = Layer.effect(
           );
           if (inserted) {
             yield* markScheduledRunSkipped(run, "Scheduled occurrence was missed.", now);
+          }
+          yield* advanceScheduledDefinition(definition, nextRunAt, now);
+          return Option.none<AutomationRunNowResult>();
+        }
+
+        const riskBlockReason = riskAcknowledgementError({
+          runtimeMode: definition.runtimeMode,
+          worktreeMode: definition.worktreeMode,
+          acknowledgedRisks: definition.acknowledgedRisks,
+        });
+        if (riskBlockReason !== null) {
+          const { run, inserted } = yield* createPendingRun(
+            definition,
+            { type: "scheduled" },
+            scheduledFor,
+            now,
+            { threadIdOverride: null },
+          );
+          if (inserted) {
+            yield* markScheduledRunSkipped(run, riskBlockReason, now);
           }
           yield* advanceScheduledDefinition(definition, nextRunAt, now);
           return Option.none<AutomationRunNowResult>();

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -2015,6 +2015,11 @@ export const AutomationServiceLive = Layer.effect(
       Effect.gen(function* () {
         const definition = yield* requireDefinition(input.automationId);
         const now = isoNow();
+        yield* validateRiskAcknowledgements({
+          runtimeMode: definition.runtimeMode,
+          worktreeMode: definition.worktreeMode,
+          acknowledgedRisks: definition.acknowledgedRisks,
+        });
         // Heartbeat automations continue a single shared thread, so a manual run must not
         // race a scheduled (or earlier manual) run that is still in flight. Standalone
         // automations spawn independent threads, so concurrent manual runs are fine.
@@ -2128,6 +2133,12 @@ export const AutomationServiceLive = Layer.effect(
           yield* publishDefinition(definition.id);
           return Option.none<AutomationRunNowResult>();
         }
+
+        yield* validateRiskAcknowledgements({
+          runtimeMode: definition.runtimeMode,
+          worktreeMode: definition.worktreeMode,
+          acknowledgedRisks: definition.acknowledgedRisks,
+        });
 
         const occurrence = scheduledOccurrenceForDefinition(definition, now);
         const { scheduledFor, nextRunAt } = occurrence;

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -302,7 +302,9 @@ function effectiveMinimumIntervalSeconds(input: {
 function riskAcknowledgementError(input: {
   readonly runtimeMode: AutomationDefinition["runtimeMode"];
   readonly worktreeMode: AutomationDefinition["worktreeMode"];
+  readonly schedule?: AutomationDefinition["schedule"];
   readonly acknowledgedRisks: readonly string[];
+  readonly now?: string;
 }): string | null {
   const acknowledgedRisks = new Set(input.acknowledgedRisks);
   if (input.runtimeMode === "full-access" && !acknowledgedRisks.has("full-access")) {
@@ -310,6 +312,16 @@ function riskAcknowledgementError(input: {
   }
   if (input.worktreeMode === "local" && !acknowledgedRisks.has("local-checkout")) {
     return "Automation local checkout mode requires an explicit acknowledgement.";
+  }
+  if (input.schedule !== undefined && input.now !== undefined) {
+    const spacingSeconds = computeAutomationScheduleSpacingSeconds(input.schedule, input.now);
+    if (
+      spacingSeconds !== null &&
+      spacingSeconds < DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS &&
+      !acknowledgedRisks.has("fast-interval")
+    ) {
+      return "Automation fast interval mode requires an explicit acknowledgement.";
+    }
   }
   return null;
 }
@@ -677,7 +689,9 @@ export const AutomationServiceLive = Layer.effect(
     const validateRiskAcknowledgements = (input: {
       readonly runtimeMode: AutomationDefinition["runtimeMode"];
       readonly worktreeMode: AutomationDefinition["worktreeMode"];
+      readonly schedule?: AutomationDefinition["schedule"];
       readonly acknowledgedRisks: readonly string[];
+      readonly now?: string;
     }) => {
       const message = riskAcknowledgementError(input);
       return message
@@ -2018,7 +2032,9 @@ export const AutomationServiceLive = Layer.effect(
         yield* validateRiskAcknowledgements({
           runtimeMode: definition.runtimeMode,
           worktreeMode: definition.worktreeMode,
+          schedule: definition.schedule,
           acknowledgedRisks: definition.acknowledgedRisks,
+          now,
         });
         // Heartbeat automations continue a single shared thread, so a manual run must not
         // race a scheduled (or earlier manual) run that is still in flight. Standalone
@@ -2154,7 +2170,9 @@ export const AutomationServiceLive = Layer.effect(
         const riskBlockReason = riskAcknowledgementError({
           runtimeMode: definition.runtimeMode,
           worktreeMode: definition.worktreeMode,
+          schedule: definition.schedule,
           acknowledgedRisks: definition.acknowledgedRisks,
+          now,
         });
         if (riskBlockReason !== null) {
           const { run, inserted } = yield* createPendingRun(

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -222,6 +222,16 @@ describe("automationApprovalGaps", () => {
     expect(gaps.acknowledgedRisks).toEqual(["local-checkout"]);
   });
 
+  it("requires local-checkout approval for standalone auto fallback", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      worktreeMode: "auto",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["local-checkout"]);
+    expect(gaps.acknowledgedRisks).toEqual(["local-checkout"]);
+  });
+
   it("reports both blocking risks together", () => {
     const gaps = automationApprovalGaps({
       ...base,

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -262,17 +262,41 @@ describe("automationApprovalGaps", () => {
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
-  it("does not show a fast interval as a run blocker but persists it on approve", () => {
-    // fast-interval never blocks a run, so it is not in the banner warnings. But it must be
-    // persisted alongside full-access, or automation.update would reject the sub-minute
-    // schedule and the one-click approval would fail to save.
+  it("shows fast interval approval when it will be persisted", () => {
     const gaps = automationApprovalGaps({
       ...base,
       schedule: { type: "interval", everySeconds: 15 },
       runtimeMode: "full-access",
       acknowledgedRisks: [],
     });
-    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual([
+      "fast-recurring-interval",
+      "full-access",
+    ]);
     expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "fast-interval"]));
+  });
+
+  it("caps enabled legacy fast intervals when approving", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      schedule: { type: "interval", everySeconds: 15 },
+      runtimeMode: "full-access",
+      acknowledgedRisks: [],
+      enabled: true,
+      maxIterations: null,
+    });
+    expect(gaps.maxIterations).toBe(10);
+  });
+
+  it("keeps an existing compliant fast interval cap", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      schedule: { type: "interval", everySeconds: 15 },
+      runtimeMode: "full-access",
+      acknowledgedRisks: [],
+      enabled: true,
+      maxIterations: 3,
+    });
+    expect(gaps.maxIterations).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -208,8 +208,8 @@ describe("automationApprovalGaps", () => {
       runtimeMode: "full-access",
       acknowledgedRisks: [],
     });
-    expect(gaps.risks).toEqual(["full-access"]);
     expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(gaps.acknowledgedRisks).toEqual(["full-access"]);
   });
 
   it("requires local-checkout approval for a local worktree", () => {
@@ -218,7 +218,8 @@ describe("automationApprovalGaps", () => {
       worktreeMode: "local",
       acknowledgedRisks: [],
     });
-    expect(gaps.risks).toEqual(["local-checkout"]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["local-checkout"]);
+    expect(gaps.acknowledgedRisks).toEqual(["local-checkout"]);
   });
 
   it("reports both blocking risks together", () => {
@@ -228,34 +229,40 @@ describe("automationApprovalGaps", () => {
       worktreeMode: "local",
       acknowledgedRisks: [],
     });
-    expect(new Set(gaps.risks)).toEqual(new Set(["full-access", "local-checkout"]));
+    expect(new Set(gaps.warnings.map((warning) => warning.id))).toEqual(
+      new Set(["full-access", "local-checkout"]),
+    );
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
-  it("clears once the risks are acknowledged", () => {
+  it("clears the banner once the risks are acknowledged", () => {
     const gaps = automationApprovalGaps({
       ...base,
       runtimeMode: "full-access",
       worktreeMode: "local",
       acknowledgedRisks: ["full-access", "local-checkout"],
     });
-    expect(gaps.risks).toEqual([]);
     expect(gaps.warnings).toEqual([]);
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
   it("needs no approval for an approval-required worktree automation", () => {
     const gaps = automationApprovalGaps({ ...base, acknowledgedRisks: [] });
-    expect(gaps.risks).toEqual([]);
+    expect(gaps.warnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
-  it("does not treat a fast interval as a run blocker", () => {
-    // fast-interval only caps cadence; it never blocks a run, so an otherwise-approved
-    // automation needs no approval even with a sub-minute interval.
+  it("does not show a fast interval as a run blocker but persists it on approve", () => {
+    // fast-interval never blocks a run, so it is not in the banner warnings. But it must be
+    // persisted alongside full-access, or automation.update would reject the sub-minute
+    // schedule and the one-click approval would fail to save.
     const gaps = automationApprovalGaps({
       ...base,
       schedule: { type: "interval", everySeconds: 15 },
       runtimeMode: "full-access",
-      acknowledgedRisks: ["full-access"],
+      acknowledgedRisks: [],
     });
-    expect(gaps.risks).toEqual([]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "fast-interval"]));
   });
 });

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   acknowledgedWarningIdsForAutomaticChatAutomation,
   acknowledgedRiskIdsForDraft,
+  automationApprovalGaps,
   buildAutomationDraftWarnings,
   hasBlockingAutomationDraftWarnings,
   warningIdsForAcknowledgedRisks,
@@ -189,5 +190,72 @@ describe("automation draft warnings", () => {
 
     expect(warnings.map((warning) => warning.id)).not.toContain("local-checkout");
     expect(warnings.map((warning) => warning.id)).not.toContain("worktree-cleanup");
+  });
+});
+
+describe("automationApprovalGaps", () => {
+  const base = {
+    schedule: { type: "daily" as const, timeOfDay: "09:00" },
+    mode: "standalone" as const,
+    runtimeMode: "approval-required" as const,
+    worktreeMode: "worktree" as const,
+    prompt: "Check the build.",
+  };
+
+  it("requires full-access approval when unacknowledged", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.risks).toEqual(["full-access"]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+  });
+
+  it("requires local-checkout approval for a local worktree", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      worktreeMode: "local",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.risks).toEqual(["local-checkout"]);
+  });
+
+  it("reports both blocking risks together", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      worktreeMode: "local",
+      acknowledgedRisks: [],
+    });
+    expect(new Set(gaps.risks)).toEqual(new Set(["full-access", "local-checkout"]));
+  });
+
+  it("clears once the risks are acknowledged", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      worktreeMode: "local",
+      acknowledgedRisks: ["full-access", "local-checkout"],
+    });
+    expect(gaps.risks).toEqual([]);
+    expect(gaps.warnings).toEqual([]);
+  });
+
+  it("needs no approval for an approval-required worktree automation", () => {
+    const gaps = automationApprovalGaps({ ...base, acknowledgedRisks: [] });
+    expect(gaps.risks).toEqual([]);
+  });
+
+  it("does not treat a fast interval as a run blocker", () => {
+    // fast-interval only caps cadence; it never blocks a run, so an otherwise-approved
+    // automation needs no approval even with a sub-minute interval.
+    const gaps = automationApprovalGaps({
+      ...base,
+      schedule: { type: "interval", everySeconds: 15 },
+      runtimeMode: "full-access",
+      acknowledgedRisks: ["full-access"],
+    });
+    expect(gaps.risks).toEqual([]);
   });
 });

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -153,17 +153,6 @@ export function buildAutomationDraftWarnings(input: {
   return warnings;
 }
 
-type RunBlockingRiskWarningId = Extract<
-  AutomationAcknowledgedRiskId,
-  "full-access" | "local-checkout"
->;
-
-function isRunBlockingRiskWarningId(
-  id: AutomationDraftWarningId,
-): id is RunBlockingRiskWarningId {
-  return id === "full-access" || id === "local-checkout";
-}
-
 function warningIdsRequiringAcknowledgement(
   warnings: readonly AutomationDraftWarning[],
 ): ReadonlySet<AutomationDraftWarningId> {
@@ -173,12 +162,10 @@ function warningIdsRequiringAcknowledgement(
 }
 
 // Computes the approval an existing automation still needs before it can run.
-// `warnings` are the run-blocking risks that have not been acknowledged — they drive the
-// approval banner (empty means no approval needed). `acknowledgedRisks` is the full set to
-// persist when approving: every risk the config requires, merged with what is already
-// acknowledged. It includes fast-interval when the schedule is sub-minute, because
-// automation.update revalidates the whole definition and rejects such a schedule unless
-// fast-interval is acknowledged — so a banner approval would otherwise fail to save.
+// `warnings` are the visible risks that the approval will persist, and `acknowledgedRisks`
+// is the full risk set to save: every risk the config requires, merged with existing
+// acknowledgements. Sub-minute schedules may also need a capped maxIterations patch so the
+// acknowledgement-only update passes the server's active-schedule validation.
 export function automationApprovalGaps(input: {
   readonly schedule: AutomationSchedule;
   readonly mode: AutomationMode;
@@ -186,11 +173,13 @@ export function automationApprovalGaps(input: {
   readonly worktreeMode: AutomationWorktreeMode;
   readonly prompt: string;
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
+  readonly enabled?: boolean;
+  readonly maxIterations?: number | null;
 }): {
   readonly warnings: readonly AutomationDraftWarning[];
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
+  readonly maxIterations?: number;
 } {
-  const acknowledged = new Set(input.acknowledgedRisks);
   const allWarnings = buildAutomationDraftWarnings({
     schedule: input.schedule,
     mode: input.mode,
@@ -202,11 +191,12 @@ export function automationApprovalGaps(input: {
     prompt: input.prompt,
   });
   const requiredWarningIds = warningIdsRequiringAcknowledgement(allWarnings);
+  const acknowledgedWarningIds = warningIdsForAcknowledgedRisks(input.acknowledgedRisks);
   const warnings = allWarnings.filter(
     (warning) =>
       warning.requiresAcknowledgement &&
-      isRunBlockingRiskWarningId(warning.id) &&
-      !acknowledged.has(warning.id),
+      requiredWarningIds.has(warning.id) &&
+      !acknowledgedWarningIds.has(warning.id),
   );
   const acknowledgedRisks = Array.from(
     new Set([
@@ -214,7 +204,16 @@ export function automationApprovalGaps(input: {
       ...acknowledgedRiskIdsForDraft(allWarnings, requiredWarningIds),
     ]),
   );
-  return { warnings, acknowledgedRisks };
+  const maxIterations =
+    input.enabled === true &&
+    input.schedule.type === "interval" &&
+    input.schedule.everySeconds < 60 &&
+    (input.maxIterations === null ||
+      (input.maxIterations ?? DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS) >
+        DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS)
+      ? DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS
+      : undefined;
+  return { warnings, acknowledgedRisks, maxIterations };
 }
 
 export function acknowledgedRiskIdsForDraft(

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -161,9 +161,13 @@ const RUN_BLOCKING_WARNING_IDS: ReadonlySet<AutomationDraftWarningId> = new Set(
   "local-checkout",
 ]);
 
-// Computes the approval an existing automation still needs before it can run: the
-// run-blocking risks it carries that have not yet been acknowledged. Returns the missing
-// warnings (for display) and the risk ids to persist. Empty when nothing is required.
+// Computes the approval an existing automation still needs before it can run.
+// `warnings` are the run-blocking risks that have not been acknowledged — they drive the
+// approval banner (empty means no approval needed). `acknowledgedRisks` is the full set to
+// persist when approving: every risk the config requires, merged with what is already
+// acknowledged. It includes fast-interval when the schedule is sub-minute, because
+// automation.update revalidates the whole definition and rejects such a schedule unless
+// fast-interval is acknowledged — so a banner approval would otherwise fail to save.
 export function automationApprovalGaps(input: {
   readonly schedule: AutomationSchedule;
   readonly mode: AutomationMode;
@@ -173,10 +177,10 @@ export function automationApprovalGaps(input: {
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 }): {
   readonly warnings: readonly AutomationDraftWarning[];
-  readonly risks: readonly AutomationAcknowledgedRiskId[];
+  readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 } {
   const acknowledged = new Set(input.acknowledgedRisks);
-  const warnings = buildAutomationDraftWarnings({
+  const requiredWarnings = buildAutomationDraftWarnings({
     schedule: input.schedule,
     mode: input.mode,
     runtimeMode: input.runtimeMode,
@@ -185,17 +189,23 @@ export function automationApprovalGaps(input: {
     generatedConfidence: null,
     generatedNeedsConfirmation: false,
     prompt: input.prompt,
-  }).filter(
+  }).filter((warning) => warning.requiresAcknowledgement);
+  const warnings = requiredWarnings.filter(
     (warning) =>
-      warning.requiresAcknowledgement &&
       RUN_BLOCKING_WARNING_IDS.has(warning.id) &&
       // full-access and local-checkout warning ids map 1:1 to their risk ids.
       !acknowledged.has(warning.id as AutomationAcknowledgedRiskId),
   );
-  return {
-    warnings,
-    risks: warnings.map((warning) => warning.id as AutomationAcknowledgedRiskId),
-  };
+  const acknowledgedRisks = Array.from(
+    new Set([
+      ...input.acknowledgedRisks,
+      ...acknowledgedRiskIdsForDraft(
+        requiredWarnings,
+        new Set(requiredWarnings.map((warning) => warning.id)),
+      ),
+    ]),
+  );
+  return { warnings, acknowledgedRisks };
 }
 
 export function acknowledgedRiskIdsForDraft(

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -153,13 +153,24 @@ export function buildAutomationDraftWarnings(input: {
   return warnings;
 }
 
-// The server refuses to start a run only for these two risks (full-access runtime and a
-// local checkout); fast-interval merely caps the cadence, so it never blocks a run and is
-// intentionally excluded from approval detection.
-const RUN_BLOCKING_WARNING_IDS: ReadonlySet<AutomationDraftWarningId> = new Set([
-  "full-access",
-  "local-checkout",
-]);
+type RunBlockingRiskWarningId = Extract<
+  AutomationAcknowledgedRiskId,
+  "full-access" | "local-checkout"
+>;
+
+function isRunBlockingRiskWarningId(
+  id: AutomationDraftWarningId,
+): id is RunBlockingRiskWarningId {
+  return id === "full-access" || id === "local-checkout";
+}
+
+function warningIdsRequiringAcknowledgement(
+  warnings: readonly AutomationDraftWarning[],
+): ReadonlySet<AutomationDraftWarningId> {
+  return new Set(
+    warnings.filter((warning) => warning.requiresAcknowledgement).map((warning) => warning.id),
+  );
+}
 
 // Computes the approval an existing automation still needs before it can run.
 // `warnings` are the run-blocking risks that have not been acknowledged — they drive the
@@ -180,7 +191,7 @@ export function automationApprovalGaps(input: {
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 } {
   const acknowledged = new Set(input.acknowledgedRisks);
-  const requiredWarnings = buildAutomationDraftWarnings({
+  const allWarnings = buildAutomationDraftWarnings({
     schedule: input.schedule,
     mode: input.mode,
     runtimeMode: input.runtimeMode,
@@ -189,20 +200,18 @@ export function automationApprovalGaps(input: {
     generatedConfidence: null,
     generatedNeedsConfirmation: false,
     prompt: input.prompt,
-  }).filter((warning) => warning.requiresAcknowledgement);
-  const warnings = requiredWarnings.filter(
+  });
+  const requiredWarningIds = warningIdsRequiringAcknowledgement(allWarnings);
+  const warnings = allWarnings.filter(
     (warning) =>
-      RUN_BLOCKING_WARNING_IDS.has(warning.id) &&
-      // full-access and local-checkout warning ids map 1:1 to their risk ids.
-      !acknowledged.has(warning.id as AutomationAcknowledgedRiskId),
+      warning.requiresAcknowledgement &&
+      isRunBlockingRiskWarningId(warning.id) &&
+      !acknowledged.has(warning.id),
   );
   const acknowledgedRisks = Array.from(
     new Set([
       ...input.acknowledgedRisks,
-      ...acknowledgedRiskIdsForDraft(
-        requiredWarnings,
-        new Set(requiredWarnings.map((warning) => warning.id)),
-      ),
+      ...acknowledgedRiskIdsForDraft(allWarnings, requiredWarningIds),
     ]),
   );
   return { warnings, acknowledgedRisks };

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -37,7 +37,7 @@ export interface AutomationDraftWarning {
   readonly requiresAcknowledgement: boolean;
 }
 
-type AutomationAcknowledgedRiskId = "full-access" | "local-checkout" | "fast-interval";
+export type AutomationAcknowledgedRiskId = "full-access" | "local-checkout" | "fast-interval";
 
 export interface AutomationCreationDraft {
   readonly source: AutomationCreationDraftSource;
@@ -151,6 +151,51 @@ export function buildAutomationDraftWarnings(input: {
     });
   }
   return warnings;
+}
+
+// The server refuses to start a run only for these two risks (full-access runtime and a
+// local checkout); fast-interval merely caps the cadence, so it never blocks a run and is
+// intentionally excluded from approval detection.
+const RUN_BLOCKING_WARNING_IDS: ReadonlySet<AutomationDraftWarningId> = new Set([
+  "full-access",
+  "local-checkout",
+]);
+
+// Computes the approval an existing automation still needs before it can run: the
+// run-blocking risks it carries that have not yet been acknowledged. Returns the missing
+// warnings (for display) and the risk ids to persist. Empty when nothing is required.
+export function automationApprovalGaps(input: {
+  readonly schedule: AutomationSchedule;
+  readonly mode: AutomationMode;
+  readonly runtimeMode: RuntimeMode;
+  readonly worktreeMode: AutomationWorktreeMode;
+  readonly prompt: string;
+  readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
+}): {
+  readonly warnings: readonly AutomationDraftWarning[];
+  readonly risks: readonly AutomationAcknowledgedRiskId[];
+} {
+  const acknowledged = new Set(input.acknowledgedRisks);
+  const warnings = buildAutomationDraftWarnings({
+    schedule: input.schedule,
+    mode: input.mode,
+    runtimeMode: input.runtimeMode,
+    worktreeMode: input.worktreeMode,
+    hasEphemeralContext: false,
+    generatedConfidence: null,
+    generatedNeedsConfirmation: false,
+    prompt: input.prompt,
+  }).filter(
+    (warning) =>
+      warning.requiresAcknowledgement &&
+      RUN_BLOCKING_WARNING_IDS.has(warning.id) &&
+      // full-access and local-checkout warning ids map 1:1 to their risk ids.
+      !acknowledged.has(warning.id as AutomationAcknowledgedRiskId),
+  );
+  return {
+    warnings,
+    risks: warnings.map((warning) => warning.id as AutomationAcknowledgedRiskId),
+  };
 }
 
 export function acknowledgedRiskIdsForDraft(

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -23,6 +23,7 @@ import {
   ComposerPickerMenuSubPopup,
 } from "~/components/chat/ComposerPickerMenuPopup";
 import { ProviderModelPicker } from "~/components/chat/ProviderModelPicker";
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Dialog, DialogPopup, DialogTitle } from "~/components/ui/dialog";
 import {
@@ -642,6 +643,50 @@ export function maxIterationOptions(
     return MAX_ITERATION_PRESETS;
   }
   return [{ value, label: maxIterationLabel(value) }, ...MAX_ITERATION_PRESETS];
+}
+
+// Shown at the top of an automation's detail panel when it still needs a one-time risk
+// approval before it can run. Approving persists on the automation, so it never asks again.
+export function AutomationApprovalBanner({
+  warnings,
+  busy,
+  onApprove,
+  onApproveAndRun,
+}: {
+  readonly warnings: readonly AutomationDraftWarning[];
+  readonly busy: boolean;
+  readonly onApprove: () => void;
+  readonly onApproveAndRun: () => void;
+}) {
+  if (warnings.length === 0) {
+    return null;
+  }
+  return (
+    <Alert variant="warning">
+      <AlertTitle>Approval needed to run</AlertTitle>
+      <AlertDescription>
+        <span>
+          This automation needs your approval once before it can run. It won&apos;t ask again.
+        </span>
+        <ul className="flex flex-col gap-1.5">
+          {warnings.map((warning) => (
+            <li key={warning.id} className="text-xs">
+              <span className="font-medium text-foreground/90">{warning.title}</span>
+              <span className="block">{warning.detail}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={onApprove}>
+            Approve
+          </Button>
+          <Button type="button" size="sm" disabled={busy} onClick={onApproveAndRun}>
+            Approve &amp; run now
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
 }
 
 export function AutomationModelPicker({

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -267,6 +267,8 @@ function AutomationDetailView() {
     worktreeMode: definition.worktreeMode,
     prompt: definition.prompt,
     acknowledgedRisks: definition.acknowledgedRisks,
+    enabled: definition.enabled,
+    maxIterations: definition.maxIterations,
   });
   const approveAutomationRisks = () =>
     // Records consent only, persisting the full required risk set so the update validates.
@@ -275,6 +277,9 @@ function AutomationDetailView() {
     updateMutation.mutateAsync({
       id: definition.id,
       acknowledgedRisks: approvalGaps.acknowledgedRisks,
+      ...(approvalGaps.maxIterations !== undefined
+        ? { maxIterations: approvalGaps.maxIterations }
+        : {}),
     });
   const handleApproveAndRunNow = async () => {
     try {

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -485,7 +485,9 @@ function AutomationDetailView() {
               <AutomationApprovalBanner
                 warnings={approvalGaps.warnings}
                 busy={approvalBusy}
-                onApprove={() => void approveAutomationRisks()}
+                // Swallow the rejection here; the mutation's onError already toasts. Without
+                // this, void-ing the rejected promise would surface an unhandled rejection.
+                onApprove={() => void approveAutomationRisks().catch(() => undefined)}
                 onApproveAndRun={() => void handleApproveAndRunNow()}
               />
               <DetailGroup title="Status">

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -268,14 +268,14 @@ function AutomationDetailView() {
     prompt: definition.prompt,
     acknowledgedRisks: definition.acknowledgedRisks,
   });
-  const approveAutomationRisks = () => {
-    const acknowledgedRisks = Array.from(
-      new Set([...definition.acknowledgedRisks, ...approvalGaps.risks]),
-    );
-    // Records consent only. Pause/resume stays a separate, explicit action so approving
-    // never silently re-enables an automation the user deliberately paused.
-    return updateMutation.mutateAsync({ id: definition.id, acknowledgedRisks });
-  };
+  const approveAutomationRisks = () =>
+    // Records consent only, persisting the full required risk set so the update validates.
+    // Pause/resume stays a separate, explicit action so approving never silently re-enables
+    // an automation the user deliberately paused.
+    updateMutation.mutateAsync({
+      id: definition.id,
+      acknowledgedRisks: approvalGaps.acknowledgedRisks,
+    });
   const handleApproveAndRunNow = async () => {
     try {
       await approveAutomationRisks();
@@ -460,7 +460,14 @@ function AutomationDetailView() {
                   type="button"
                   size="sm"
                   className="ml-1.5"
-                  disabled={runNowMutation.isPending || approvalGaps.warnings.length > 0}
+                  disabled={
+                    runNowMutation.isPending ||
+                    // Stay disabled while an approval update is in flight: the cache merges
+                    // acknowledgedRisks optimistically, so warnings clears before the server
+                    // persists and a run dispatched in that window hits the old definition.
+                    updateMutation.isPending ||
+                    approvalGaps.warnings.length > 0
+                  }
                   title={
                     approvalGaps.warnings.length > 0 ? "Approve the automation first" : undefined
                   }

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -29,6 +29,7 @@ import { SidebarHeaderNavigationControls } from "~/components/SidebarHeaderNavig
 import { Button } from "~/components/ui/button";
 import { SidebarInset } from "~/components/ui/sidebar";
 import {
+  automationApprovalGaps,
   hasBlockingAutomationDraftWarnings,
   warningIdsForAcknowledgedRisks,
   type AutomationDraftWarning,
@@ -55,6 +56,7 @@ import { ensureNativeApi } from "~/nativeApi";
 import { useStore } from "~/store";
 import {
   type AutomationFormState,
+  AutomationApprovalBanner,
   AutomationDialog,
   AutomationModelPicker,
   acknowledgedRiskIdsForFormWarnings,
@@ -256,6 +258,34 @@ function AutomationDetailView() {
   const patch = (input: Omit<AutomationUpdateInput, "id">) =>
     updateMutation.mutate({ id: definition.id, ...input });
 
+  // One-time risk approval surfaced at the top of the panel when an already-created
+  // automation still needs it (e.g. created via the API). Persists on the automation.
+  const approvalGaps = automationApprovalGaps({
+    schedule: definition.schedule,
+    mode: definition.mode,
+    runtimeMode: definition.runtimeMode,
+    worktreeMode: definition.worktreeMode,
+    prompt: definition.prompt,
+    acknowledgedRisks: definition.acknowledgedRisks,
+  });
+  const approveAutomationRisks = () => {
+    const acknowledgedRisks = Array.from(
+      new Set([...definition.acknowledgedRisks, ...approvalGaps.risks]),
+    );
+    // Records consent only. Pause/resume stays a separate, explicit action so approving
+    // never silently re-enables an automation the user deliberately paused.
+    return updateMutation.mutateAsync({ id: definition.id, acknowledgedRisks });
+  };
+  const handleApproveAndRunNow = async () => {
+    try {
+      await approveAutomationRisks();
+    } catch {
+      return; // update failed; the mutation already surfaced the error toast
+    }
+    runNowMutation.mutate(definition);
+  };
+  const approvalBusy = updateMutation.isPending || runNowMutation.isPending;
+
   // Applying a new model selection (model swap or a capability tweak) refreshes the saved
   // provider start options the same way the model picker does, then patches both at once.
   const applyModelSelection = (nextModelSelection: ModelSelection) => {
@@ -430,7 +460,10 @@ function AutomationDetailView() {
                   type="button"
                   size="sm"
                   className="ml-1.5"
-                  disabled={runNowMutation.isPending}
+                  disabled={runNowMutation.isPending || approvalGaps.warnings.length > 0}
+                  title={
+                    approvalGaps.warnings.length > 0 ? "Approve the automation first" : undefined
+                  }
                   onClick={() => runNowMutation.mutate(definition)}
                 >
                   <CentralIcon name="play" className="size-4" />
@@ -442,6 +475,12 @@ function AutomationDetailView() {
 
           <div className="min-h-0 flex-1 overflow-y-auto border-l border-[var(--app-surface-divider)]">
             <div className="flex flex-col gap-6 px-4 py-8">
+              <AutomationApprovalBanner
+                warnings={approvalGaps.warnings}
+                busy={approvalBusy}
+                onApprove={() => void approveAutomationRisks()}
+                onApproveAndRun={() => void handleApproveAndRunNow()}
+              />
               <DetailGroup title="Status">
                 <DetailRow label="Status">
                   <StatusValue>


### PR DESCRIPTION
Follow-up to #242 (`feat(automations): one-click approval for blocked automations`).

This branch starts from the current PR #242 head and keeps the follow-up isolated on `codex/pr-242-approval-gate-fixes`.

What changed:
- Refactors the existing-automation approval helper to avoid the warning-id-to-risk-id cast and reuse the shared warning-to-risk mapper for the full persisted approval payload.
- Adds focused coverage for standalone `auto` worktree fallback so one-click approval persists `local-checkout` as expected.

Verification:
- `bun run --cwd apps/web test automationDraft.test.ts`
- `git diff --check`

Review passes:
- Same-directory check-code review pass 1: no actionable findings.
- Same-directory check-code review pass 2: no actionable findings.