### PR TITLE
fix(automations): strip setup filler from carried prompts

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1452,6 +1452,15 @@ export default function ChatView({
   activeThreadIdRef.current = threadId;
   const pendingAutomationConversationRef = useRef(pendingAutomationConversation);
   pendingAutomationConversationRef.current = pendingAutomationConversation;
+  // Ephemeral setup bubbles are rendered as ordinary transcript messages, so persistent
+  // actions (pin, markers) must skip them — their ids vanish when setup ends and would
+  // otherwise leave orphaned side-panel entries.
+  const isPendingSetupBubbleId = useCallback(
+    (messageId: MessageId): boolean =>
+      pendingAutomationConversationRef.current?.bubbles.some((bubble) => bubble.id === messageId) ??
+      false,
+    [],
+  );
   // A composer-local automation setup belongs to the thread it began in; drop it when
   // the active thread changes so the prompt never leaks onto another conversation.
   useEffect(() => {
@@ -2637,6 +2646,16 @@ export default function ChatView({
     handleRenamePinnedMessage,
     handleNotesChange,
   } = usePinnedMessageActions({ activeThreadId, pinnedMessages });
+  const handleTogglePinMessageGuarded = useCallback(
+    (messageId: MessageId) => {
+      // Never pin an ephemeral automation-setup bubble; its id vanishes when setup ends.
+      if (isPendingSetupBubbleId(messageId)) {
+        return;
+      }
+      handleTogglePinMessage(messageId);
+    },
+    [handleTogglePinMessage, isPendingSetupBubbleId],
+  );
   const handleCopyProjectInstructionsToNotes = useCallback(() => {
     if (!activeThreadId) {
       return;
@@ -4700,6 +4719,12 @@ export default function ChatView({
         return;
       }
       const messageId = MessageId.makeUnsafe(pendingSelection.selection.assistantMessageId);
+      if (isPendingSetupBubbleId(messageId)) {
+        // Don't mark an ephemeral automation-setup bubble; it disappears when setup ends.
+        dismissTranscriptSelectionAction();
+        window.getSelection()?.removeAllRanges();
+        return;
+      }
       const message = timelineMessages.find((candidate) => candidate.id === messageId);
       if (!message) {
         toastManager.add({
@@ -4761,6 +4786,7 @@ export default function ChatView({
     [
       activeThreadId,
       dismissTranscriptSelectionAction,
+      isPendingSetupBubbleId,
       pendingTranscriptSelectionAction,
       threadMarkers,
       timelineMessages,
@@ -6566,6 +6592,9 @@ export default function ChatView({
     if (hasPromptOnlySendableContent) {
       const handledSlashCommand = await handleStandaloneSlashCommand(trimmedPromptForSend);
       if (handledSlashCommand) {
+        // A slash command (e.g. /clear) consumes the composer, so abandon any in-progress
+        // automation setup rather than leaving a stale banner/request behind.
+        setPendingAutomationConversation(null);
         return true;
       }
     }
@@ -10040,7 +10069,7 @@ export default function ChatView({
                     listRef={legendListRef}
                     timelineControllerRef={timelineControllerRef}
                     pinnedMessageIds={pinnedMessageIds}
-                    onTogglePinMessage={handleTogglePinMessage}
+                    onTogglePinMessage={handleTogglePinMessageGuarded}
                     threadMarkers={threadMarkers}
                     timelineEntries={timelineEntries}
                     turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -127,6 +127,7 @@ import {
 import { reconcileDeletedThreadFromClient } from "../lib/deletedThreadClientReconciliation";
 import { extractChatAutomationInvocation } from "../lib/automationIntent";
 import {
+  automationClarificationPrompt,
   buildComposerAutomationDraft,
   resolveComposerAutomationRequest,
 } from "../lib/composerAutomation";
@@ -1421,6 +1422,18 @@ export default function ChatView({
   const [automationDraftOpen, setAutomationDraftOpen] = useState(false);
   const [isAutomationDraftSubmitting, setIsAutomationDraftSubmitting] = useState(false);
   const automationDraftSubmittingRef = useRef(false);
+  // While set, Synara is mid-conversation gathering an automation's missing details.
+  // `accumulatedMessage` carries everything said so far so the next reply re-resolves
+  // against the full request rather than the answer alone.
+  const [pendingAutomationConversation, setPendingAutomationConversation] = useState<{
+    accumulatedMessage: string;
+    question: string;
+  } | null>(null);
+  // A composer-local automation setup belongs to the thread it began in; drop it when
+  // the active thread changes so the prompt never leaks onto another conversation.
+  useEffect(() => {
+    setPendingAutomationConversation(null);
+  }, [threadId]);
   const projectInstructions = useProjectInstructionsStore((state) =>
     activeProjectId ? (state.instructionsByProjectId[activeProjectId] ?? "") : "",
   );
@@ -5863,6 +5876,22 @@ export default function ChatView({
     ],
   );
 
+  const cancelAutomationConversation = useCallback(() => {
+    // Abandon the in-progress setup and put everything the user typed back into the
+    // composer, so a false-positive detection never costs them their message.
+    if (pendingAutomationConversation && activeThread) {
+      promptRef.current = pendingAutomationConversation.accumulatedMessage;
+      clearComposerDraftContent(activeThread.id);
+      setComposerDraftPrompt(activeThread.id, pendingAutomationConversation.accumulatedMessage);
+    }
+    setPendingAutomationConversation(null);
+  }, [
+    activeThread,
+    clearComposerDraftContent,
+    pendingAutomationConversation,
+    setComposerDraftPrompt,
+  ]);
+
   const toggleAutomationWarning = useCallback((id: AutomationDraftWarningId, checked: boolean) => {
     setAcknowledgedAutomationWarnings((current) => {
       const next = new Set(current);
@@ -6533,23 +6562,30 @@ export default function ChatView({
     }
     if (!activeProject) return false;
     if (queuedChatTurn === null && !isLivePlanFollowUpSubmission) {
+      // While gathering missing details, fold the reply into everything said so far so
+      // the request re-resolves as a whole instead of parsing the bare answer.
+      const messageForAutomation = pendingAutomationConversation
+        ? `${pendingAutomationConversation.accumulatedMessage}\n${trimmedPromptForSend}`
+        : trimmedPromptForSend;
       const automationRequest = await resolveComposerAutomationRequest({
-        message: trimmedPromptForSend,
+        message: messageForAutomation,
         cwd: activeProject.cwd,
         generateIntent: (request) => api.server.generateAutomationIntent(request),
       });
       if (automationRequest.type !== "normal-chat") {
-        if (automationRequest.type === "missing-schedule") {
-          toastManager.add({
-            type: "warning",
-            title: "Automation schedule needed",
-            description:
-              automationRequest.reason ??
-              "Try /automation every 6h check the page, or @automation daily at 9:00.",
+        if (automationRequest.type === "needs-clarification") {
+          // Keep the message out of the thread and ask for what's missing. The user
+          // answers in the now-empty composer; the banner holds the question and the
+          // raw text so Cancel can restore everything they typed.
+          clearComposerInput(activeThread.id);
+          setPendingAutomationConversation({
+            accumulatedMessage: messageForAutomation,
+            question: automationClarificationPrompt(automationRequest.missingFields),
           });
           return true;
         }
 
+        setPendingAutomationConversation(null);
         const automationIntent = automationRequest.resolution.intent;
         const automationTargetThreadId =
           automationIntent.executionScope === "thread" ? activeThread.id : null;
@@ -6587,6 +6623,11 @@ export default function ChatView({
             : {}),
         });
         return true;
+      }
+      if (pendingAutomationConversation) {
+        // The combined text no longer reads as an automation; abandon setup and let
+        // this message send as a normal chat turn instead of looping on the question.
+        setPendingAutomationConversation(null);
       }
     }
     const sendProviderAvailability = resolveProviderSendAvailability({
@@ -9239,6 +9280,15 @@ export default function ChatView({
                       ? {
                           id: activeProposedPlan.id,
                           title: proposedPlanTitle(activeProposedPlan.planMarkdown) ?? null,
+                        }
+                      : null
+                  }
+                  automationSetup={
+                    pendingAutomationConversation
+                      ? {
+                          question: pendingAutomationConversation.question,
+                          request: pendingAutomationConversation.accumulatedMessage,
+                          onCancel: cancelAutomationConversation,
                         }
                       : null
                   }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5906,17 +5906,13 @@ export default function ChatView({
       const restored = draft
         ? `${pendingAutomationConversation.accumulatedMessage}\n${draft}`
         : pendingAutomationConversation.accumulatedMessage;
+      // Restore only the prompt text; any attachments/skills/mentions the user added
+      // during setup stay in the draft so Cancel never discards them.
       promptRef.current = restored;
-      clearComposerDraftContent(activeThread.id);
       setComposerDraftPrompt(activeThread.id, restored);
     }
     setPendingAutomationConversation(null);
-  }, [
-    activeThread,
-    clearComposerDraftContent,
-    pendingAutomationConversation,
-    setComposerDraftPrompt,
-  ]);
+  }, [activeThread, pendingAutomationConversation, setComposerDraftPrompt]);
 
   const toggleAutomationWarning = useCallback((id: AutomationDraftWarningId, checked: boolean) => {
     setAcknowledgedAutomationWarnings((current) => {
@@ -6625,7 +6621,14 @@ export default function ChatView({
           // automationMessage accumulates for the next re-resolve and for Cancel's restore.
           const question = automationClarificationPrompt(automationRequest.missingFields);
           const priorBubbles = conversation?.bubbles ?? [];
-          clearComposerInput(activeThread.id);
+          // Clear only the submitted text so a fresh answer can be typed; anything added
+          // while intent generation was resolving (a new attachment, or more typing) is
+          // preserved rather than wiped.
+          if (promptRef.current.trim() === trimmedPromptForSend) {
+            promptRef.current = "";
+            setComposerDraftPrompt(activeThread.id, "");
+            setComposerTrigger(null);
+          }
           setPendingAutomationConversation({
             accumulatedMessage: automationRequest.automationMessage,
             bubbles: [
@@ -6659,8 +6662,8 @@ export default function ChatView({
           if (conversation !== null) {
             // Keep the full multi-turn request in the composer so dismissing the review
             // dialog doesn't lose it (the single-turn path likewise leaves its text).
+            // Restore only the text; any attachments/mentions on the final reply stay.
             promptRef.current = messageForAutomation;
-            clearComposerDraftContent(activeThread.id);
             setComposerDraftPrompt(activeThread.id, messageForAutomation);
           }
           setAutomationEditingDefinition(null);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1446,12 +1446,13 @@ export default function ChatView({
     accumulatedMessage: string;
     bubbles: ChatMessage[];
   } | null>(null);
-  // Tracks the live thread + the live setup so an async automation resolve that finishes
-  // after a thread switch or a cancel never commits a stale result.
+  // Tracks the live thread + setup/send state so an async automation resolve that
+  // finishes after navigation, cancel, or a later send never commits a stale result.
   const activeThreadIdRef = useRef(threadId);
   activeThreadIdRef.current = threadId;
   const pendingAutomationConversationRef = useRef(pendingAutomationConversation);
   pendingAutomationConversationRef.current = pendingAutomationConversation;
+  const hasLiveTurnRef = useRef(false);
   // Ephemeral setup bubbles are rendered as ordinary transcript messages, so persistent
   // actions (pin, markers) must skip them — their ids vanish when setup ends and would
   // otherwise leave orphaned side-panel entries.
@@ -1461,11 +1462,19 @@ export default function ChatView({
       false,
     [],
   );
-  // A composer-local automation setup belongs to the thread it began in; drop it when
-  // the active thread changes so the prompt never leaks onto another conversation.
+  // A composer-local automation setup belongs to the thread it began in; restore its
+  // carried request before dropping ephemeral bubbles on navigation.
   useEffect(() => {
+    const conversation = pendingAutomationConversationRef.current;
+    if (conversation && conversation.threadId !== threadId) {
+      const draft = promptRef.current.trim();
+      const restored = draft
+        ? `${conversation.accumulatedMessage}\n${draft}`
+        : conversation.accumulatedMessage;
+      setComposerDraftPrompt(conversation.threadId, restored);
+    }
     setPendingAutomationConversation(null);
-  }, [threadId]);
+  }, [setComposerDraftPrompt, threadId]);
   const projectInstructions = useProjectInstructionsStore((state) =>
     activeProjectId ? (state.instructionsByProjectId[activeProjectId] ?? "") : "",
   );
@@ -2353,6 +2362,7 @@ export default function ChatView({
   const isSendBusy = localDispatch !== null && !serverAcknowledgedLocalDispatch;
   const isPreparingWorktree = localDispatch?.preparingWorktree ?? false;
   const hasLiveTurn = phase === "running";
+  hasLiveTurnRef.current = hasLiveTurn;
   const isWorking = hasLiveTurn || isSendBusy || isConnecting || isRevertingCheckpoint;
   const hasStreamingAssistantText =
     activeThread?.messages.some((message) => message.role === "assistant" && message.streaming) ??
@@ -6639,7 +6649,8 @@ export default function ChatView({
       // setup, while generateAutomationIntent was awaiting.
       if (
         activeThreadIdRef.current !== threadId ||
-        pendingAutomationConversationRef.current !== conversation
+        pendingAutomationConversationRef.current !== conversation ||
+        (!hasLiveTurn && hasLiveTurnRef.current)
       ) {
         return true;
       }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4711,6 +4711,8 @@ export default function ChatView({
     composerFilesRef,
     composerAssistantSelectionsRef,
     addComposerAssistantSelectionToDraft,
+    canReferenceAssistantSelection: (selection) =>
+      !isPendingSetupBubbleId(MessageId.makeUnsafe(selection.assistantMessageId)),
     scheduleComposerFocus,
     onMessagesClickCaptureBase,
     onMessagesPointerCancelBase,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -849,6 +849,20 @@ function composerPromptStillMatchesRestoredQueuedDraft(
   return probe.length >= 16 && next.includes(probe);
 }
 
+// Builds an ephemeral transcript bubble for the conversational automation-setup
+// exchange. These never reach a provider and are not persisted; they render the
+// back-and-forth (user request, Synara's clarifying questions) inline like Codex.
+function makeAutomationSetupBubble(role: "user" | "assistant", text: string): ChatMessage {
+  return {
+    id: newMessageId(),
+    role,
+    text,
+    createdAt: new Date().toISOString(),
+    streaming: false,
+    source: "native",
+  };
+}
+
 export default function ChatView({
   threadId,
   paneScopeId = "single",
@@ -1424,10 +1438,12 @@ export default function ChatView({
   const automationDraftSubmittingRef = useRef(false);
   // While set, Synara is mid-conversation gathering an automation's missing details.
   // `accumulatedMessage` carries everything said so far so the next reply re-resolves
-  // against the full request rather than the answer alone.
+  // against the full request (not the bare answer); `bubbles` is the ephemeral
+  // in-thread exchange rendered in the transcript until the automation resolves or
+  // the user cancels.
   const [pendingAutomationConversation, setPendingAutomationConversation] = useState<{
     accumulatedMessage: string;
-    question: string;
+    bubbles: ChatMessage[];
   } | null>(null);
   // A composer-local automation setup belongs to the thread it began in; drop it when
   // the active thread changes so the prompt never leaks onto another conversation.
@@ -2538,20 +2554,21 @@ export default function ChatView({
             return changed ? { ...message, attachments } : message;
           });
 
-    if (optimisticUserMessages.length === 0) {
-      return serverMessagesWithPreviewHandoff;
-    }
+    // Ephemeral automation-setup bubbles render after everything else, at the tail.
+    const setupBubbles = pendingAutomationConversation?.bubbles ?? [];
     const serverIds = new Set(serverMessagesWithPreviewHandoff.map((message) => message.id));
     const pendingMessages = optimisticUserMessages.filter((message) => !serverIds.has(message.id));
-    if (pendingMessages.length === 0) {
-      return serverMessagesWithPreviewHandoff;
-    }
-    return [...serverMessagesWithPreviewHandoff, ...pendingMessages];
+    const withPending =
+      pendingMessages.length === 0
+        ? serverMessagesWithPreviewHandoff
+        : [...serverMessagesWithPreviewHandoff, ...pendingMessages];
+    return setupBubbles.length === 0 ? withPending : [...withPending, ...setupBubbles];
   }, [
     activeThread?.sidechatSourceThreadId,
     serverMessages,
     attachmentPreviewHandoffByMessageId,
     optimisticUserMessages,
+    pendingAutomationConversation?.bubbles,
   ]);
   const timelineEntries = useMemo(
     () =>
@@ -5877,12 +5894,17 @@ export default function ChatView({
   );
 
   const cancelAutomationConversation = useCallback(() => {
-    // Abandon the in-progress setup and put everything the user typed back into the
-    // composer, so a false-positive detection never costs them their message.
+    // Abandon setup and put everything back into the composer: the accumulated request
+    // plus any reply the user had started typing but not yet sent, so cancelling never
+    // costs them their words.
     if (pendingAutomationConversation && activeThread) {
-      promptRef.current = pendingAutomationConversation.accumulatedMessage;
+      const draft = promptRef.current.trim();
+      const restored = draft
+        ? `${pendingAutomationConversation.accumulatedMessage}\n${draft}`
+        : pendingAutomationConversation.accumulatedMessage;
+      promptRef.current = restored;
       clearComposerDraftContent(activeThread.id);
-      setComposerDraftPrompt(activeThread.id, pendingAutomationConversation.accumulatedMessage);
+      setComposerDraftPrompt(activeThread.id, restored);
     }
     setPendingAutomationConversation(null);
   }, [
@@ -6562,10 +6584,12 @@ export default function ChatView({
     }
     if (!activeProject) return false;
     if (queuedChatTurn === null && !isLivePlanFollowUpSubmission) {
-      // While gathering missing details, fold the reply into everything said so far so
-      // the request re-resolves as a whole instead of parsing the bare answer.
-      const messageForAutomation = pendingAutomationConversation
-        ? `${pendingAutomationConversation.accumulatedMessage}\n${trimmedPromptForSend}`
+      const conversation = pendingAutomationConversation;
+      // While gathering missing details, fold the reply into the cleaned request so it
+      // re-resolves as a whole rather than parsing the bare answer (and never re-parses
+      // "could you create an automation" scaffolding as the task).
+      const messageForAutomation = conversation
+        ? `${conversation.accumulatedMessage}\n${trimmedPromptForSend}`
         : trimmedPromptForSend;
       const automationRequest = await resolveComposerAutomationRequest({
         message: messageForAutomation,
@@ -6574,13 +6598,31 @@ export default function ChatView({
       });
       if (automationRequest.type !== "normal-chat") {
         if (automationRequest.type === "needs-clarification") {
-          // Keep the message out of the thread and ask for what's missing. The user
-          // answers in the now-empty composer; the banner holds the question and the
-          // raw text so Cancel can restore everything they typed.
+          // Conversational setup only runs for prompt-only sends: clearing the composer
+          // would otherwise drop attachments/mentions that Cancel cannot restore.
+          if (!hasPromptOnlySendableContent) {
+            toastManager.add({
+              type: "warning",
+              title: "Automation needs a bit more detail",
+              description:
+                automationRequest.reason ??
+                'Add what it should do and how often, e.g. "every weekday at 9am, summarize my PRs".',
+            });
+            return true;
+          }
+          // Render the exchange in-thread: echo the user's words as a bubble and ask for
+          // what's missing as an assistant bubble. Nothing reaches a provider; the cleaned
+          // automationMessage accumulates for the next re-resolve and for Cancel's restore.
+          const question = automationClarificationPrompt(automationRequest.missingFields);
+          const priorBubbles = conversation?.bubbles ?? [];
           clearComposerInput(activeThread.id);
           setPendingAutomationConversation({
-            accumulatedMessage: messageForAutomation,
-            question: automationClarificationPrompt(automationRequest.missingFields),
+            accumulatedMessage: automationRequest.automationMessage,
+            bubbles: [
+              ...priorBubbles,
+              makeAutomationSetupBubble("user", trimmedPromptForSend),
+              makeAutomationSetupBubble("assistant", question),
+            ],
           });
           return true;
         }
@@ -6600,7 +6642,13 @@ export default function ChatView({
           targetThreadId: automationTargetThreadId,
           hasEphemeralContext: !hasPromptOnlySendableContent,
         });
-        if (automationDraft.needsDraftReview) {
+        // A multi-turn setup always confirms before creating, so the user reviews the
+        // parsed task/schedule (and any scaffolding the parser kept) rather than it
+        // silently auto-creating a recurring job.
+        if (automationDraft.needsDraftReview || conversation !== null) {
+          if (conversation !== null) {
+            clearComposerInput(activeThread.id);
+          }
           setAutomationEditingDefinition(null);
           setAutomationDraftWarningContext(automationDraft.warningContext);
           setAutomationDraftForm(automationDraft.form);
@@ -6624,7 +6672,7 @@ export default function ChatView({
         });
         return true;
       }
-      if (pendingAutomationConversation) {
+      if (conversation) {
         // The combined text no longer reads as an automation; abandon setup and let
         // this message send as a normal chat turn instead of looping on the question.
         setPendingAutomationConversation(null);
@@ -9285,11 +9333,7 @@ export default function ChatView({
                   }
                   automationSetup={
                     pendingAutomationConversation
-                      ? {
-                          question: pendingAutomationConversation.question,
-                          request: pendingAutomationConversation.accumulatedMessage,
-                          onCancel: cancelAutomationConversation,
-                        }
+                      ? { onCancel: cancelAutomationConversation }
                       : null
                   }
                 />

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5947,18 +5947,20 @@ export default function ChatView({
     // Abandon setup and put everything back into the composer: the accumulated request
     // plus any reply the user had started typing but not yet sent, so cancelling never
     // costs them their words.
-    if (pendingAutomationConversation && activeThread) {
+    if (pendingAutomationConversation) {
       const draft = promptRef.current.trim();
       const restored = draft
         ? `${pendingAutomationConversation.accumulatedMessage}\n${draft}`
         : pendingAutomationConversation.accumulatedMessage;
       // Restore only the prompt text; any attachments/skills/mentions the user added
       // during setup stay in the draft so Cancel never discards them.
-      promptRef.current = restored;
-      setComposerDraftPrompt(activeThread.id, restored);
+      if (pendingAutomationConversation.threadId === threadId) {
+        promptRef.current = restored;
+      }
+      setComposerDraftPrompt(pendingAutomationConversation.threadId, restored);
     }
     setPendingAutomationConversation(null);
-  }, [activeThread, pendingAutomationConversation, setComposerDraftPrompt]);
+  }, [pendingAutomationConversation, setComposerDraftPrompt, threadId]);
 
   const toggleAutomationWarning = useCallback((id: AutomationDraftWarningId, checked: boolean) => {
     setAcknowledgedAutomationWarnings((current) => {
@@ -9407,7 +9409,8 @@ export default function ChatView({
                       : null
                   }
                   automationSetup={
-                    pendingAutomationConversation
+                    pendingAutomationConversation &&
+                    pendingAutomationConversation.threadId === threadId
                       ? { onCancel: cancelAutomationConversation }
                       : null
                   }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1442,13 +1442,16 @@ export default function ChatView({
   // in-thread exchange rendered in the transcript until the automation resolves or
   // the user cancels.
   const [pendingAutomationConversation, setPendingAutomationConversation] = useState<{
+    threadId: ThreadId;
     accumulatedMessage: string;
     bubbles: ChatMessage[];
   } | null>(null);
-  // Tracks the live thread so an automation resolve that finishes after a thread switch
-  // never commits the old thread's setup onto whatever is now active.
+  // Tracks the live thread + the live setup so an async automation resolve that finishes
+  // after a thread switch or a cancel never commits a stale result.
   const activeThreadIdRef = useRef(threadId);
   activeThreadIdRef.current = threadId;
+  const pendingAutomationConversationRef = useRef(pendingAutomationConversation);
+  pendingAutomationConversationRef.current = pendingAutomationConversation;
   // A composer-local automation setup belongs to the thread it began in; drop it when
   // the active thread changes so the prompt never leaks onto another conversation.
   useEffect(() => {
@@ -2559,7 +2562,13 @@ export default function ChatView({
           });
 
     // Ephemeral automation-setup bubbles render after everything else, at the tail.
-    const setupBubbles = pendingAutomationConversation?.bubbles ?? [];
+    // Gated on the originating thread so a same-pane switch never leaks the previous
+    // thread's setup into the newly rendered conversation (the reset effect runs after
+    // the first render, so the guard must be here too).
+    const setupBubbles =
+      pendingAutomationConversation && pendingAutomationConversation.threadId === threadId
+        ? pendingAutomationConversation.bubbles
+        : [];
     const serverIds = new Set(serverMessagesWithPreviewHandoff.map((message) => message.id));
     const pendingMessages = optimisticUserMessages.filter((message) => !serverIds.has(message.id));
     const withPending =
@@ -2572,7 +2581,8 @@ export default function ChatView({
     serverMessages,
     attachmentPreviewHandoffByMessageId,
     optimisticUserMessages,
-    pendingAutomationConversation?.bubbles,
+    pendingAutomationConversation,
+    threadId,
   ]);
   const timelineEntries = useMemo(
     () =>
@@ -6596,9 +6606,12 @@ export default function ChatView({
         cwd: activeProject.cwd,
         generateIntent: (request) => api.server.generateAutomationIntent(request),
       });
-      // If the user switched threads while this resolved, don't commit the old thread's
-      // setup (bubbles/draft) onto whatever is now active.
-      if (activeThreadIdRef.current !== threadId) {
+      // Drop a stale resolve: bail if the user switched threads, or cancelled/changed the
+      // setup, while generateAutomationIntent was awaiting.
+      if (
+        activeThreadIdRef.current !== threadId ||
+        pendingAutomationConversationRef.current !== conversation
+      ) {
         return true;
       }
       if (automationRequest.type !== "normal-chat") {
@@ -6621,15 +6634,20 @@ export default function ChatView({
           // automationMessage accumulates for the next re-resolve and for Cancel's restore.
           const question = automationClarificationPrompt(automationRequest.missingFields);
           const priorBubbles = conversation?.bubbles ?? [];
-          // Clear only the submitted text so a fresh answer can be typed; anything added
-          // while intent generation was resolving (a new attachment, or more typing) is
-          // preserved rather than wiped.
-          if (promptRef.current.trim() === trimmedPromptForSend) {
-            promptRef.current = "";
-            setComposerDraftPrompt(activeThread.id, "");
-            setComposerTrigger(null);
-          }
+          // Drop the submitted request from the composer (it is captured in
+          // accumulatedMessage, so re-folding it would duplicate the scaffold) while
+          // preserving anything typed *after* it during the async resolve.
+          const liveDraft = promptRef.current.trimStart();
+          const leftover = liveDraft.startsWith(trimmedPromptForSend)
+            ? liveDraft.slice(trimmedPromptForSend.length).trimStart()
+            : liveDraft;
+          promptRef.current = leftover;
+          setComposerDraftPrompt(activeThread.id, leftover);
+          setComposerTrigger(null);
+          // Bring the new question into view even if the user had scrolled up.
+          armTranscriptAutoFollow(activeThread.id);
           setPendingAutomationConversation({
+            threadId: activeThread.id,
             accumulatedMessage: automationRequest.automationMessage,
             bubbles: [
               ...priorBubbles,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1445,6 +1445,10 @@ export default function ChatView({
     accumulatedMessage: string;
     bubbles: ChatMessage[];
   } | null>(null);
+  // Tracks the live thread so an automation resolve that finishes after a thread switch
+  // never commits the old thread's setup onto whatever is now active.
+  const activeThreadIdRef = useRef(threadId);
+  activeThreadIdRef.current = threadId;
   // A composer-local automation setup belongs to the thread it began in; drop it when
   // the active thread changes so the prompt never leaks onto another conversation.
   useEffect(() => {
@@ -6596,11 +6600,17 @@ export default function ChatView({
         cwd: activeProject.cwd,
         generateIntent: (request) => api.server.generateAutomationIntent(request),
       });
+      // If the user switched threads while this resolved, don't commit the old thread's
+      // setup (bubbles/draft) onto whatever is now active.
+      if (activeThreadIdRef.current !== threadId) {
+        return true;
+      }
       if (automationRequest.type !== "normal-chat") {
         if (automationRequest.type === "needs-clarification") {
-          // Conversational setup only runs for prompt-only sends: clearing the composer
-          // would otherwise drop attachments/mentions that Cancel cannot restore.
-          if (!hasPromptOnlySendableContent) {
+          // Conversational setup only runs for prompt-only sends while no turn is live:
+          // clearing the composer would drop attachments/mentions Cancel can't restore,
+          // and ephemeral setup bubbles must not anchor a running turn's work rows.
+          if (!hasPromptOnlySendableContent || hasLiveTurn) {
             toastManager.add({
               type: "warning",
               title: "Automation needs a bit more detail",
@@ -6647,7 +6657,11 @@ export default function ChatView({
         // silently auto-creating a recurring job.
         if (automationDraft.needsDraftReview || conversation !== null) {
           if (conversation !== null) {
-            clearComposerInput(activeThread.id);
+            // Keep the full multi-turn request in the composer so dismissing the review
+            // dialog doesn't lose it (the single-turn path likewise leaves its text).
+            promptRef.current = messageForAutomation;
+            clearComposerDraftContent(activeThread.id);
+            setComposerDraftPrompt(activeThread.id, messageForAutomation);
           }
           setAutomationEditingDefinition(null);
           setAutomationDraftWarningContext(automationDraft.warningContext);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1462,19 +1462,36 @@ export default function ChatView({
       false,
     [],
   );
-  // A composer-local automation setup belongs to the thread it began in; restore its
-  // carried request before dropping ephemeral bubbles on navigation.
-  useEffect(() => {
-    const conversation = pendingAutomationConversationRef.current;
-    if (conversation && conversation.threadId !== threadId) {
+  const restorePendingAutomationConversationDraft = useCallback(
+    (conversation: NonNullable<typeof pendingAutomationConversation>) => {
       const draft = promptRef.current.trim();
       const restored = draft
         ? `${conversation.accumulatedMessage}\n${draft}`
         : conversation.accumulatedMessage;
       setComposerDraftPrompt(conversation.threadId, restored);
+    },
+    [setComposerDraftPrompt],
+  );
+  // A composer-local automation setup belongs to the thread it began in; restore its
+  // carried request before dropping ephemeral bubbles on navigation or unmount.
+  useEffect(() => {
+    const conversation = pendingAutomationConversationRef.current;
+    if (conversation && conversation.threadId !== threadId) {
+      restorePendingAutomationConversationDraft(conversation);
+      pendingAutomationConversationRef.current = null;
     }
-    setPendingAutomationConversation(null);
-  }, [setComposerDraftPrompt, threadId]);
+    if (pendingAutomationConversationRef.current === null) {
+      setPendingAutomationConversation(null);
+    }
+    return () => {
+      const pendingConversation = pendingAutomationConversationRef.current;
+      if (!pendingConversation) {
+        return;
+      }
+      restorePendingAutomationConversationDraft(pendingConversation);
+      pendingAutomationConversationRef.current = null;
+    };
+  }, [restorePendingAutomationConversationDraft, threadId]);
   const projectInstructions = useProjectInstructionsStore((state) =>
     activeProjectId ? (state.instructionsByProjectId[activeProjectId] ?? "") : "",
   );
@@ -5961,6 +5978,7 @@ export default function ChatView({
       }
       setComposerDraftPrompt(pendingAutomationConversation.threadId, restored);
     }
+    pendingAutomationConversationRef.current = null;
     setPendingAutomationConversation(null);
   }, [pendingAutomationConversation, setComposerDraftPrompt, threadId]);
 
@@ -6608,6 +6626,7 @@ export default function ChatView({
       if (handledSlashCommand) {
         // A slash command (e.g. /clear) consumes the composer, so abandon any in-progress
         // automation setup rather than leaving a stale banner/request behind.
+        pendingAutomationConversationRef.current = null;
         setPendingAutomationConversation(null);
         return true;
       }
@@ -6702,6 +6721,7 @@ export default function ChatView({
           return true;
         }
 
+        pendingAutomationConversationRef.current = null;
         setPendingAutomationConversation(null);
         const automationIntent = automationRequest.resolution.intent;
         const automationTargetThreadId =
@@ -6725,8 +6745,15 @@ export default function ChatView({
             // Keep the full multi-turn request in the composer so dismissing the review
             // dialog doesn't lose it (the single-turn path likewise leaves its text).
             // Restore only the text; any attachments/mentions on the final reply stay.
-            promptRef.current = messageForAutomation;
-            setComposerDraftPrompt(activeThread.id, messageForAutomation);
+            const liveDraft = promptRef.current.trimStart();
+            const leftover = liveDraft.startsWith(trimmedPromptForSend)
+              ? liveDraft.slice(trimmedPromptForSend.length).trimStart()
+              : liveDraft;
+            const restoredPrompt = leftover
+              ? `${messageForAutomation}\n${leftover}`
+              : messageForAutomation;
+            promptRef.current = restoredPrompt;
+            setComposerDraftPrompt(activeThread.id, restoredPrompt);
           }
           setAutomationEditingDefinition(null);
           setAutomationDraftWarningContext(automationDraft.warningContext);
@@ -6754,6 +6781,7 @@ export default function ChatView({
       if (conversation) {
         // The combined text no longer reads as an automation; abandon setup and let
         // this message send as a normal chat turn instead of looping on the question.
+        pendingAutomationConversationRef.current = null;
         setPendingAutomationConversation(null);
       }
     }
@@ -10085,6 +10113,7 @@ export default function ChatView({
                     listRef={legendListRef}
                     timelineControllerRef={timelineControllerRef}
                     pinnedMessageIds={pinnedMessageIds}
+                    canPinMessage={(messageId) => !isPendingSetupBubbleId(messageId)}
                     onTogglePinMessage={handleTogglePinMessageGuarded}
                     threadMarkers={threadMarkers}
                     timelineEntries={timelineEntries}

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -45,6 +45,7 @@ interface ChatTranscriptPaneProps {
   listRef: RefObject<LegendListRef | null>;
   timelineControllerRef?: RefObject<MessagesTimelineController | null>;
   pinnedMessageIds?: ReadonlySet<MessageId>;
+  canPinMessage?: (messageId: MessageId) => boolean;
   onTogglePinMessage?: (messageId: MessageId) => void;
   threadMarkers?: readonly ThreadMarker[];
   markdownCwd: string | undefined;
@@ -98,6 +99,7 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
   listRef,
   timelineControllerRef,
   pinnedMessageIds,
+  canPinMessage,
   onTogglePinMessage,
   threadMarkers,
   markdownCwd,
@@ -168,6 +170,7 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
             listRef={listRef}
             {...(timelineControllerRef ? { controllerRef: timelineControllerRef } : {})}
             {...(pinnedMessageIds ? { pinnedMessageIds } : {})}
+            {...(canPinMessage ? { canPinMessage } : {})}
             {...(onTogglePinMessage ? { onTogglePinMessage } : {})}
             {...(threadMarkers ? { threadMarkers } : {})}
             timelineEntries={timelineEntries}

--- a/apps/web/src/components/chat/ComposerAutomationSetupBanner.tsx
+++ b/apps/web/src/components/chat/ComposerAutomationSetupBanner.tsx
@@ -1,0 +1,40 @@
+// FILE: ComposerAutomationSetupBanner.tsx
+// Purpose: Above-composer prompt shown while Synara is gathering the missing details
+// (task and/or schedule) for a chat-created automation. The user answers in the
+// composer like any other message; Cancel abandons the setup.
+// Layer: Chat composer UI
+// Exports: ComposerAutomationSetupBanner
+
+import { memo } from "react";
+
+export const ComposerAutomationSetupBanner = memo(function ComposerAutomationSetupBanner({
+  question,
+  request,
+  onCancel,
+}: {
+  question: string;
+  request: string | null;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="px-5 pt-4 pb-4 sm:px-6 sm:pt-4.5 sm:pb-5">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-[11px] font-semibold tracking-widest text-muted-foreground/50 uppercase">
+          Set up automation
+        </span>
+        <button
+          type="button"
+          aria-label="Cancel automation setup"
+          onClick={onCancel}
+          className="rounded-full border border-[color:var(--color-border-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-foreground-secondary)] transition-colors duration-150 hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border)]"
+        >
+          Cancel
+        </button>
+      </div>
+      {request ? (
+        <p className="mt-1.5 truncate text-xs text-muted-foreground/65">{request}</p>
+      ) : null}
+      <p className="mt-1 text-sm text-foreground/90">{question}</p>
+    </div>
+  );
+});

--- a/apps/web/src/components/chat/ComposerAutomationSetupBanner.tsx
+++ b/apps/web/src/components/chat/ComposerAutomationSetupBanner.tsx
@@ -1,40 +1,31 @@
 // FILE: ComposerAutomationSetupBanner.tsx
-// Purpose: Above-composer prompt shown while Synara is gathering the missing details
-// (task and/or schedule) for a chat-created automation. The user answers in the
-// composer like any other message; Cancel abandons the setup.
+// Purpose: Slim control strip shown above the composer while Synara is gathering the
+// missing details (task and/or schedule) for a chat-created automation. The actual
+// back-and-forth renders as message bubbles in the transcript; this strip just marks
+// setup mode and lets the user cancel (which restores their text).
 // Layer: Chat composer UI
 // Exports: ComposerAutomationSetupBanner
 
 import { memo } from "react";
 
 export const ComposerAutomationSetupBanner = memo(function ComposerAutomationSetupBanner({
-  question,
-  request,
   onCancel,
 }: {
-  question: string;
-  request: string | null;
   onCancel: () => void;
 }) {
   return (
-    <div className="px-5 pt-4 pb-4 sm:px-6 sm:pt-4.5 sm:pb-5">
-      <div className="flex items-center justify-between gap-3">
-        <span className="text-[11px] font-semibold tracking-widest text-muted-foreground/50 uppercase">
-          Set up automation
-        </span>
-        <button
-          type="button"
-          aria-label="Cancel automation setup"
-          onClick={onCancel}
-          className="rounded-full border border-[color:var(--color-border-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-foreground-secondary)] transition-colors duration-150 hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border)]"
-        >
-          Cancel
-        </button>
-      </div>
-      {request ? (
-        <p className="mt-1.5 truncate text-xs text-muted-foreground/65">{request}</p>
-      ) : null}
-      <p className="mt-1 text-sm text-foreground/90">{question}</p>
+    <div className="flex items-center justify-between gap-3 px-5 pt-4 pb-4 sm:px-6 sm:pt-4.5 sm:pb-5">
+      <span className="text-[11px] font-semibold tracking-widest text-muted-foreground/50 uppercase">
+        Setting up automation
+      </span>
+      <button
+        type="button"
+        aria-label="Cancel automation setup"
+        onClick={onCancel}
+        className="rounded-full border border-[color:var(--color-border-light)] px-3 py-1.5 text-xs font-medium text-[var(--color-text-foreground-secondary)] transition-colors duration-150 hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-border)]"
+      >
+        Cancel
+      </button>
     </div>
   );
 });

--- a/apps/web/src/components/chat/ComposerInputBanners.tsx
+++ b/apps/web/src/components/chat/ComposerInputBanners.tsx
@@ -8,6 +8,7 @@
 import { type ComponentProps, memo, type ReactNode } from "react";
 
 import { cn } from "~/lib/utils";
+import { ComposerAutomationSetupBanner } from "./ComposerAutomationSetupBanner";
 import { ComposerPendingApprovalPanel } from "./ComposerPendingApprovalPanel";
 import { ComposerPendingUserInputPanel } from "./ComposerPendingUserInputPanel";
 import { ComposerPlanFollowUpBanner } from "./ComposerPlanFollowUpBanner";
@@ -31,6 +32,8 @@ interface ComposerInputBannersProps {
   onCancelUserInput: PendingUserInputPanelProps["onCancel"];
   // `id` keys the banner so it remounts when the proposed plan changes.
   planFollowUp: { id: string; title: string | null } | null;
+  // Conversational follow-up while gathering an automation's task/schedule.
+  automationSetup: { question: string; request: string | null; onCancel: () => void } | null;
 }
 
 export const ComposerInputBanners = memo(function ComposerInputBanners({
@@ -45,6 +48,7 @@ export const ComposerInputBanners = memo(function ComposerInputBanners({
   onAdvanceUserInput,
   onCancelUserInput,
   planFollowUp,
+  automationSetup,
 }: ComposerInputBannersProps) {
   let content: ReactNode = null;
   if (activeApproval) {
@@ -65,6 +69,14 @@ export const ComposerInputBanners = memo(function ComposerInputBanners({
     );
   } else if (planFollowUp) {
     content = <ComposerPlanFollowUpBanner key={planFollowUp.id} planTitle={planFollowUp.title} />;
+  } else if (automationSetup) {
+    content = (
+      <ComposerAutomationSetupBanner
+        question={automationSetup.question}
+        request={automationSetup.request}
+        onCancel={automationSetup.onCancel}
+      />
+    );
   }
 
   if (!content) {

--- a/apps/web/src/components/chat/ComposerInputBanners.tsx
+++ b/apps/web/src/components/chat/ComposerInputBanners.tsx
@@ -32,8 +32,9 @@ interface ComposerInputBannersProps {
   onCancelUserInput: PendingUserInputPanelProps["onCancel"];
   // `id` keys the banner so it remounts when the proposed plan changes.
   planFollowUp: { id: string; title: string | null } | null;
-  // Conversational follow-up while gathering an automation's task/schedule.
-  automationSetup: { question: string; request: string | null; onCancel: () => void } | null;
+  // Setup-mode control while gathering an automation's task/schedule (the exchange
+  // itself renders as bubbles in the transcript).
+  automationSetup: { onCancel: () => void } | null;
 }
 
 export const ComposerInputBanners = memo(function ComposerInputBanners({
@@ -70,13 +71,7 @@ export const ComposerInputBanners = memo(function ComposerInputBanners({
   } else if (planFollowUp) {
     content = <ComposerPlanFollowUpBanner key={planFollowUp.id} planTitle={planFollowUp.title} />;
   } else if (automationSetup) {
-    content = (
-      <ComposerAutomationSetupBanner
-        question={automationSetup.question}
-        request={automationSetup.request}
-        onCancel={automationSetup.onCancel}
-      />
-    );
+    content = <ComposerAutomationSetupBanner onCancel={automationSetup.onCancel} />;
   }
 
   if (!content) {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -233,6 +233,8 @@ interface MessagesTimelineProps {
   controllerRef?: RefObject<MessagesTimelineController | null>;
   /** Message ids currently pinned for the active thread (drives the footer pin toggle state). */
   pinnedMessageIds?: ReadonlySet<MessageId>;
+  /** Excludes transient rows from persistent pin affordances. */
+  canPinMessage?: (messageId: MessageId) => boolean;
   /** Toggle a message's pinned state from the assistant footer. */
   onTogglePinMessage?: (messageId: MessageId) => void;
   /** Text markers for assistant messages in the active thread. */
@@ -287,6 +289,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   listRef,
   controllerRef,
   pinnedMessageIds,
+  canPinMessage,
   onTogglePinMessage,
   threadMarkers = [],
   timelineEntries,
@@ -1021,10 +1024,13 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             streaming: row.assistantCopyStreaming,
           });
           const messagePinned = pinnedMessageIds?.has(row.message.id) ?? false;
+          const messageCanPin = canPinMessage?.(row.message.id) ?? true;
           // Offer the pin toggle wherever copy is offered (a complete, terminal answer);
           // keep it visible for an already-pinned message so it can always be unpinned.
           const showPinToggle =
-            Boolean(onTogglePinMessage) && (assistantCopyState.visible || messagePinned);
+            messageCanPin &&
+            Boolean(onTogglePinMessage) &&
+            (assistantCopyState.visible || messagePinned);
           const turnSummary = row.assistantTurnDiffSummary;
           const fileDiffStatByPath = new Map(
             (turnSummary?.files ?? []).map((file) => [

--- a/apps/web/src/components/chat/useTranscriptAssistantSelectionAction.ts
+++ b/apps/web/src/components/chat/useTranscriptAssistantSelectionAction.ts
@@ -43,6 +43,7 @@ interface UseTranscriptAssistantSelectionActionOptions {
   addComposerAssistantSelectionToDraft: (
     selection: ComposerAssistantSelectionAttachment,
   ) => boolean;
+  canReferenceAssistantSelection?: (selection: TranscriptAssistantSelection) => boolean;
   scheduleComposerFocus: () => void;
   onMessagesClickCaptureBase: MouseEventHandler<HTMLDivElement>;
   onMessagesPointerDownBase: PointerEventHandler<HTMLDivElement>;
@@ -65,6 +66,7 @@ export function useTranscriptAssistantSelectionAction(
     composerFilesRef,
     composerAssistantSelectionsRef,
     addComposerAssistantSelectionToDraft,
+    canReferenceAssistantSelection,
     scheduleComposerFocus,
     onMessagesClickCaptureBase,
     onMessagesPointerDownBase,
@@ -162,7 +164,11 @@ export function useTranscriptAssistantSelectionAction(
         }
 
         const selectionState = readTranscriptAssistantSelection({ container });
-        if (!selectionState) {
+        if (
+          !selectionState ||
+          (canReferenceAssistantSelection &&
+            !canReferenceAssistantSelection(selectionState.selection))
+        ) {
           setPendingTranscriptSelectionAction(null);
           return;
         }
@@ -179,12 +185,21 @@ export function useTranscriptAssistantSelectionAction(
         });
       });
     },
-    [enabled],
+    [canReferenceAssistantSelection, enabled],
   );
 
   const commitTranscriptAssistantSelection = useCallback(() => {
     const pendingSelection = pendingTranscriptSelectionAction;
     if (!pendingSelection) {
+      return;
+    }
+
+    if (
+      canReferenceAssistantSelection &&
+      !canReferenceAssistantSelection(pendingSelection.selection)
+    ) {
+      setPendingTranscriptSelectionAction(null);
+      window.getSelection()?.removeAllRanges();
       return;
     }
 
@@ -222,6 +237,7 @@ export function useTranscriptAssistantSelectionAction(
     }
   }, [
     addComposerAssistantSelectionToDraft,
+    canReferenceAssistantSelection,
     composerAssistantSelectionsRef,
     composerFilesRef,
     composerImagesRef,

--- a/apps/web/src/lib/automationIntent.ts
+++ b/apps/web/src/lib/automationIntent.ts
@@ -199,6 +199,20 @@ export function extractPlainChatAutomationCreationInvocation(value: string): str
   return PLAIN_INVOCATION_AUTOMATION_CREATION_PREFIX_PATTERN.test(candidate) ? candidate : null;
 }
 
+// Keeps a clarification carry-forward parseable as an automation across turns. Explicit
+// /automation markers and cadence-only remainders lose their trigger once stripped, so we
+// re-seed a canonical creation scaffold when none survives; the parser strips it back out.
+export function ensureAutomationConversationScaffold(message: string): string {
+  const normalized = normalizeInlineText(message);
+  if (!normalized) {
+    return "create an automation";
+  }
+  if (PLAIN_INVOCATION_AUTOMATION_CREATION_PREFIX_PATTERN.test(normalized)) {
+    return normalized;
+  }
+  return `create an automation ${normalized}`;
+}
+
 function removeMatchedText(value: string, match: RegExpExecArray): string {
   return normalizeInlineText(
     `${value.slice(0, match.index)} ${value.slice(match.index + match[0].length)}`,

--- a/apps/web/src/lib/automationIntent.ts
+++ b/apps/web/src/lib/automationIntent.ts
@@ -124,6 +124,12 @@ const INTERVAL_UNIT_PATTERN =
 const BARE_INTERVAL_UNIT_PATTERN =
   "(?:seconds|second|secs|sec|secondi|secondo|minutes|minute|mins|minuti|minuto|min|hours|hour|hrs|hr|ore|ora|s|m|h)";
 const INTERVAL_PATTERN = `(\\d{1,4})\\s*(${INTERVAL_UNIT_PATTERN})`;
+const BARE_INTERVAL_LEADING_REMAINDER_PATTERN =
+  "(?=$|\\s*(?:,|and\\b|to\\b|then\\b)|\\s+(?:check|verify|monitor|watch|remind|notify|alert|tell|controlla|verifica|monitora|avvisami|ricordami)\\b)";
+const BARE_INTERVAL_LEADING_ACTION_PATTERN = new RegExp(
+  `^(?:every|each|ogni)\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s+(?:check|verify|monitor|watch|remind|notify|alert|tell|controlla|verifica|monitora|avvisami|ricordami)\\b`,
+  "i",
+);
 
 function normalizeInlineText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
@@ -180,7 +186,9 @@ function isLikelyPlainAutomationAction(value: string, politeRequest: boolean): b
     : PLAIN_INVOCATION_ACTION_PREFIX_PATTERN;
   const normalized = normalizeInlineText(value);
   return (
-    pattern.test(normalized) || PLAIN_INVOCATION_AUTOMATION_CREATION_PREFIX_PATTERN.test(normalized)
+    pattern.test(normalized) ||
+    PLAIN_INVOCATION_AUTOMATION_CREATION_PREFIX_PATTERN.test(normalized) ||
+    BARE_INTERVAL_LEADING_ACTION_PATTERN.test(normalized)
   );
 }
 
@@ -452,9 +460,17 @@ function parseIntervalSchedule(searchText: string): ParsedSchedule | null {
     searchText.match(new RegExp(`\\bogni\\s+${INTERVAL_PATTERN}\\b`));
   const bareMatch =
     match == null
-      ? (searchText.match(new RegExp(`^(?:every|each)\\s+(${BARE_INTERVAL_UNIT_PATTERN})\\b`)) ??
+      ? (searchText.match(
+          new RegExp(
+            `^(?:every|each)\\s+(${BARE_INTERVAL_UNIT_PATTERN})\\b${BARE_INTERVAL_LEADING_REMAINDER_PATTERN}`,
+          ),
+        ) ??
         searchText.match(new RegExp(`\\b(?:every|each)\\s+(${BARE_INTERVAL_UNIT_PATTERN})$`)) ??
-        searchText.match(new RegExp(`^ogni\\s+(${BARE_INTERVAL_UNIT_PATTERN})\\b`)) ??
+        searchText.match(
+          new RegExp(
+            `^ogni\\s+(${BARE_INTERVAL_UNIT_PATTERN})\\b${BARE_INTERVAL_LEADING_REMAINDER_PATTERN}`,
+          ),
+        ) ??
         searchText.match(new RegExp(`\\bogni\\s+(${BARE_INTERVAL_UNIT_PATTERN})$`)))
       : null;
   if (!match && !bareMatch) {
@@ -668,7 +684,7 @@ function stripAutomationScaffold(value: string): string {
       "",
     )
     .replace(
-      /^(?:please\s+)?(?:crea|creare|aggiungi|imposta|fai)\s+(?:un[' ]?)?(?:automazione|task|controllo|monitoraggio)\s*(?:per\s+(?:me|noi)\s*)?(?:che|per|dove)?\s*/i,
+      /^(?:please\s+)?(?:crea|creare|aggiungi|imposta|fai)\s+(?:un[' ]?)?(?:automazione|task|controllo|monitoraggio)\s*(?:per\s+(?:me|noi)\b\s*)?(?:che|per|dove)?\s*/i,
       "",
     )
     .replace(
@@ -695,13 +711,19 @@ function stripAutomationScaffold(value: string): string {
     )
     .replace(new RegExp(`\\bevery\\s+${INTERVAL_PATTERN}\\b\\s*(?:and|to|then|,)?\\s*`, "i"), "")
     .replace(
-      new RegExp(`^every\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s*(?:and|to|then|,)?\\s*`, "i"),
+      new RegExp(
+        `^every\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s*(?:and|to|then|,)?\\s*${BARE_INTERVAL_LEADING_REMAINDER_PATTERN}`,
+        "i",
+      ),
       "",
     )
     .replace(new RegExp(`\\bevery\\s+${BARE_INTERVAL_UNIT_PATTERN}$`, "i"), "")
     .replace(new RegExp(`\\bogni\\s+${INTERVAL_PATTERN}\\b\\s*(?:e|poi|per|,)?\\s*`, "i"), "")
     .replace(
-      new RegExp(`^ogni\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s*(?:e|poi|per|,)?\\s*`, "i"),
+      new RegExp(
+        `^ogni\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s*(?:e|poi|per|,)?\\s*${BARE_INTERVAL_LEADING_REMAINDER_PATTERN}`,
+        "i",
+      ),
       "",
     )
     .replace(new RegExp(`\\bogni\\s+${BARE_INTERVAL_UNIT_PATTERN}$`, "i"), "")

--- a/apps/web/src/lib/automationIntent.ts
+++ b/apps/web/src/lib/automationIntent.ts
@@ -119,8 +119,11 @@ const WEEKDAY_STRIP_PATTERN = [
 ].join("|");
 
 const TIME_PATTERN = "((?:[01]?\\d|2[0-3])(?::[0-5]\\d)?\\s*(?:am|pm)?)";
-const INTERVAL_PATTERN =
-  "(\\d{1,4})\\s*(seconds|second|secs|sec|secondi|secondo|minutes|minute|mins|minuti|minuto|min|hours|hour|hrs|hr|ore|ora|days|day|giorni|giorno|s|m|h|d|g)";
+const INTERVAL_UNIT_PATTERN =
+  "(?:seconds|second|secs|sec|secondi|secondo|minutes|minute|mins|minuti|minuto|min|hours|hour|hrs|hr|ore|ora|days|day|giorni|giorno|s|m|h|d|g)";
+const BARE_INTERVAL_UNIT_PATTERN =
+  "(?:seconds|second|secs|sec|secondi|secondo|minutes|minute|mins|minuti|minuto|min|hours|hour|hrs|hr|ore|ora|s|m|h)";
+const INTERVAL_PATTERN = `(\\d{1,4})\\s*(${INTERVAL_UNIT_PATTERN})`;
 
 function normalizeInlineText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
@@ -447,12 +450,17 @@ function parseIntervalSchedule(searchText: string): ParsedSchedule | null {
   const match =
     searchText.match(new RegExp(`\\b(?:every|each)\\s+${INTERVAL_PATTERN}\\b`)) ??
     searchText.match(new RegExp(`\\bogni\\s+${INTERVAL_PATTERN}\\b`));
-  if (!match) {
+  const bareMatch =
+    match == null
+      ? (searchText.match(new RegExp(`\\b(?:every|each)\\s+(${BARE_INTERVAL_UNIT_PATTERN})\\b`)) ??
+        searchText.match(new RegExp(`\\bogni\\s+(${BARE_INTERVAL_UNIT_PATTERN})\\b`)))
+      : null;
+  if (!match && !bareMatch) {
     return null;
   }
 
-  const amount = Number.parseInt(match[1] ?? "", 10);
-  const unit = match[2] ?? "m";
+  const amount = match ? Number.parseInt(match[1] ?? "", 10) : 1;
+  const unit = match?.[2] ?? bareMatch?.[1] ?? "m";
   if (!Number.isFinite(amount) || amount <= 0) {
     return null;
   }
@@ -654,7 +662,7 @@ function stripAutomationScaffold(value: string): string {
   let cleaned = normalizeInlineText(value);
   cleaned = cleaned
     .replace(
-      /^(?:please\s+)?(?:make|create|set up|setup|add|start|build)\s+(?:an?\s+)?automation\s*(?:for\s+(?:me|us|myself)\s*)?(?:where|that|to|which)?\s*/i,
+      /^(?:please\s+)?(?:make|create|set up|setup|add|start|build)\s+(?:an?\s+)?automation\s*(?:for\s+(?:me|myself)\s*)?(?:where|that|to|which)?\s*/i,
       "",
     )
     .replace(
@@ -662,11 +670,11 @@ function stripAutomationScaffold(value: string): string {
       "",
     )
     .replace(
-      /^(?:please\s+)?schedule\s+(?:an?\s+)?(?:automation|task|job|check|monitor|reminder)\s*(?:for\s+(?:me|us|myself)\s*)?(?:to|that)?\s*/i,
+      /^(?:please\s+)?schedule\s+(?:an?\s+)?(?:automation|task|job|check|monitor|reminder)\s*(?:for\s+(?:me|myself)\s*)?(?:to|that)?\s*/i,
       "",
     )
     .replace(/^(?:please\s+)?automate\s+(?:this|that|it)?\s*/i, "")
-    .replace(/^(?:where|that|to|che|per|dove)\s+/i, "");
+    .replace(/^(?:where|that|to|for|che|per|dove)\s+/i, "");
 
   cleaned = cleaned
     .replace(
@@ -684,7 +692,15 @@ function stripAutomationScaffold(value: string): string {
       "",
     )
     .replace(new RegExp(`\\bevery\\s+${INTERVAL_PATTERN}\\b\\s*(?:and|to|then|,)?\\s*`, "i"), "")
+    .replace(
+      new RegExp(`\\bevery\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s*(?:and|to|then|,)?\\s*`, "i"),
+      "",
+    )
     .replace(new RegExp(`\\bogni\\s+${INTERVAL_PATTERN}\\b\\s*(?:e|poi|per|,)?\\s*`, "i"), "")
+    .replace(
+      new RegExp(`\\bogni\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s*(?:e|poi|per|,)?\\s*`, "i"),
+      "",
+    )
     .replace(new RegExp(`\\bin\\s+${INTERVAL_PATTERN}\\b\\s*(?:and|to|then|,)?\\s*`, "i"), "")
     .replace(
       new RegExp(`\\b(?:tra|fra)\\s+${INTERVAL_PATTERN}\\b\\s*(?:e|poi|per|,)?\\s*`, "i"),

--- a/apps/web/src/lib/automationIntent.ts
+++ b/apps/web/src/lib/automationIntent.ts
@@ -662,7 +662,7 @@ function stripAutomationScaffold(value: string): string {
       "",
     )
     .replace(
-      /^(?:please\s+)?schedule\s+(?:an?\s+)?(?:automation|task|job|check|monitor|reminder)\s*(?:to|that)?\s*/i,
+      /^(?:please\s+)?schedule\s+(?:an?\s+)?(?:automation|task|job|check|monitor|reminder)\s*(?:for\s+(?:me|us|myself)\s*)?(?:to|that)?\s*/i,
       "",
     )
     .replace(/^(?:please\s+)?automate\s+(?:this|that|it)?\s*/i, "")

--- a/apps/web/src/lib/automationIntent.ts
+++ b/apps/web/src/lib/automationIntent.ts
@@ -452,8 +452,10 @@ function parseIntervalSchedule(searchText: string): ParsedSchedule | null {
     searchText.match(new RegExp(`\\bogni\\s+${INTERVAL_PATTERN}\\b`));
   const bareMatch =
     match == null
-      ? (searchText.match(new RegExp(`\\b(?:every|each)\\s+(${BARE_INTERVAL_UNIT_PATTERN})\\b`)) ??
-        searchText.match(new RegExp(`\\bogni\\s+(${BARE_INTERVAL_UNIT_PATTERN})\\b`)))
+      ? (searchText.match(new RegExp(`^(?:every|each)\\s+(${BARE_INTERVAL_UNIT_PATTERN})\\b`)) ??
+        searchText.match(new RegExp(`\\b(?:every|each)\\s+(${BARE_INTERVAL_UNIT_PATTERN})$`)) ??
+        searchText.match(new RegExp(`^ogni\\s+(${BARE_INTERVAL_UNIT_PATTERN})\\b`)) ??
+        searchText.match(new RegExp(`\\bogni\\s+(${BARE_INTERVAL_UNIT_PATTERN})$`)))
       : null;
   if (!match && !bareMatch) {
     return null;
@@ -662,7 +664,7 @@ function stripAutomationScaffold(value: string): string {
   let cleaned = normalizeInlineText(value);
   cleaned = cleaned
     .replace(
-      /^(?:please\s+)?(?:make|create|set up|setup|add|start|build)\s+(?:an?\s+)?automation\s*(?:for\s+(?:me|myself)\s*)?(?:where|that|to|which)?\s*/i,
+      /^(?:please\s+)?(?:make|create|set up|setup|add|start|build)\s+(?:an?\s+)?automation\s*(?:for\s+(?:me|myself)\b\s*)?(?:where|that|to|which)?\s*/i,
       "",
     )
     .replace(
@@ -670,7 +672,7 @@ function stripAutomationScaffold(value: string): string {
       "",
     )
     .replace(
-      /^(?:please\s+)?schedule\s+(?:an?\s+)?(?:automation|task|job|check|monitor|reminder)\s*(?:for\s+(?:me|myself)\s*)?(?:to|that)?\s*/i,
+      /^(?:please\s+)?schedule\s+(?:an?\s+)?(?:automation|task|job|check|monitor|reminder)\s*(?:for\s+(?:me|myself)\b\s*)?(?:to|that)?\s*/i,
       "",
     )
     .replace(/^(?:please\s+)?automate\s+(?:this|that|it)?\s*/i, "")
@@ -693,14 +695,16 @@ function stripAutomationScaffold(value: string): string {
     )
     .replace(new RegExp(`\\bevery\\s+${INTERVAL_PATTERN}\\b\\s*(?:and|to|then|,)?\\s*`, "i"), "")
     .replace(
-      new RegExp(`\\bevery\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s*(?:and|to|then|,)?\\s*`, "i"),
+      new RegExp(`^every\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s*(?:and|to|then|,)?\\s*`, "i"),
       "",
     )
+    .replace(new RegExp(`\\bevery\\s+${BARE_INTERVAL_UNIT_PATTERN}$`, "i"), "")
     .replace(new RegExp(`\\bogni\\s+${INTERVAL_PATTERN}\\b\\s*(?:e|poi|per|,)?\\s*`, "i"), "")
     .replace(
-      new RegExp(`\\bogni\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s*(?:e|poi|per|,)?\\s*`, "i"),
+      new RegExp(`^ogni\\s+${BARE_INTERVAL_UNIT_PATTERN}\\b\\s*(?:e|poi|per|,)?\\s*`, "i"),
       "",
     )
+    .replace(new RegExp(`\\bogni\\s+${BARE_INTERVAL_UNIT_PATTERN}$`, "i"), "")
     .replace(new RegExp(`\\bin\\s+${INTERVAL_PATTERN}\\b\\s*(?:and|to|then|,)?\\s*`, "i"), "")
     .replace(
       new RegExp(`\\b(?:tra|fra)\\s+${INTERVAL_PATTERN}\\b\\s*(?:e|poi|per|,)?\\s*`, "i"),

--- a/apps/web/src/lib/automationIntent.ts
+++ b/apps/web/src/lib/automationIntent.ts
@@ -654,11 +654,11 @@ function stripAutomationScaffold(value: string): string {
   let cleaned = normalizeInlineText(value);
   cleaned = cleaned
     .replace(
-      /^(?:please\s+)?(?:make|create|set up|setup|add|start|build)\s+(?:an?\s+)?automation\s*(?:where|that|to|which)?\s*/i,
+      /^(?:please\s+)?(?:make|create|set up|setup|add|start|build)\s+(?:an?\s+)?automation\s*(?:for\s+(?:me|us|myself)\s*)?(?:where|that|to|which)?\s*/i,
       "",
     )
     .replace(
-      /^(?:please\s+)?(?:crea|creare|aggiungi|imposta|fai)\s+(?:un[' ]?)?(?:automazione|task|controllo|monitoraggio)\s*(?:che|per|dove)?\s*/i,
+      /^(?:please\s+)?(?:crea|creare|aggiungi|imposta|fai)\s+(?:un[' ]?)?(?:automazione|task|controllo|monitoraggio)\s*(?:per\s+(?:me|noi)\s*)?(?:che|per|dove)?\s*/i,
       "",
     )
     .replace(

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -553,6 +553,35 @@ describe("composerAutomation", () => {
     });
   });
 
+  it("asks how often instead of accepting a defaulted manual schedule", async () => {
+    // The generator extracts the task but reports the schedule as missing; it must not be
+    // silently accepted as a manual automation — the conversational "how often?" follow-up
+    // should fire for the common "create an automation to check the build" case.
+    const generateIntent = vi.fn(async () => ({
+      isAutomation: true,
+      confidence: 0.92,
+      language: "en",
+      name: "Check the build",
+      taskPrompt: "Check the build.",
+      schedule: null,
+      mode: "heartbeat" as const,
+      completionPolicy: { type: "none" as const },
+      missingFields: ["schedule" as const],
+      needsConfirmation: false,
+      reason: null,
+    }));
+    const decision = await resolveComposerAutomationRequest({
+      message: "create an automation to check the build",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+    expect(decision).toMatchObject({
+      type: "needs-clarification",
+      missingFields: ["schedule"],
+    });
+  });
+
   it("keeps an explicit /automation setup parseable across follow-ups", async () => {
     const generateIntent = vi.fn(async () => ({
       isAutomation: true,

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -7,6 +7,7 @@ import type { ModelSelection, ProjectId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  automationClarificationPrompt,
   buildComposerAutomationDraft,
   resolveComposerAutomationRequest,
 } from "./composerAutomation";
@@ -403,5 +404,99 @@ describe("composerAutomation", () => {
       "worktree-cleanup",
     ]);
     expect(Array.from(draft.acknowledgedWarningIds)).toEqual([]);
+  });
+
+  it("asks for clarification when an automation request is missing its task and schedule", async () => {
+    const generateIntent = vi.fn(async () => ({
+      isAutomation: true,
+      confidence: 0.9,
+      language: "en",
+      name: null,
+      taskPrompt: null,
+      schedule: null,
+      mode: null,
+      completionPolicy: { type: "none" as const },
+      missingFields: ["taskPrompt" as const, "schedule" as const],
+      needsConfirmation: false,
+      reason: "Tell me what to automate.",
+    }));
+
+    const decision = await resolveComposerAutomationRequest({
+      message: "could you create an automation for me?",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+
+    expect(generateIntent).toHaveBeenCalledTimes(1);
+    expect(decision).toMatchObject({
+      type: "needs-clarification",
+      missingFields: ["taskPrompt", "schedule"],
+      reason: "Tell me what to automate.",
+    });
+  });
+
+  it("resolves to an automation once the follow-up supplies the schedule", async () => {
+    // First turn: a task with no cadence cannot be created yet.
+    const incompleteGeneration = vi.fn(async () => ({
+      isAutomation: true,
+      confidence: 0.9,
+      language: "en",
+      name: null,
+      taskPrompt: null,
+      schedule: null,
+      mode: null,
+      completionPolicy: { type: "none" as const },
+      missingFields: ["schedule" as const],
+      needsConfirmation: false,
+      reason: null,
+    }));
+    const first = await resolveComposerAutomationRequest({
+      message: "create an automation to check the build",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: incompleteGeneration,
+    });
+    expect(first.type).toBe("needs-clarification");
+
+    // Second turn: the composer folds the reply back into the original request. The
+    // deterministic parser now finds the schedule, so the automation resolves even
+    // though optional enrichment generation fails.
+    const failingEnrichment = vi.fn(async () => {
+      throw new Error("enrichment is optional once the schedule parses deterministically");
+    });
+    const combined = await resolveComposerAutomationRequest({
+      message: "create an automation to check the build\nevery 6 hours",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: failingEnrichment,
+    });
+    expect(combined).toMatchObject({
+      type: "automation",
+      resolution: {
+        source: "deterministic",
+        intent: {
+          schedule: { type: "interval", everySeconds: 21_600 },
+        },
+      },
+    });
+  });
+
+  describe("automationClarificationPrompt", () => {
+    it("asks for both the task and cadence when the task is missing", () => {
+      expect(automationClarificationPrompt(["taskPrompt", "schedule"])).toContain(
+        "what should this automation do",
+      );
+    });
+
+    it("asks only for the cadence when just the schedule is missing", () => {
+      const prompt = automationClarificationPrompt(["schedule"]);
+      expect(prompt).toContain("How often");
+      expect(prompt).not.toContain("what should this automation do");
+    });
+
+    it("defaults to asking for a cadence when nothing was reported", () => {
+      expect(automationClarificationPrompt([])).toContain("How often");
+    });
   });
 });

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -508,6 +508,25 @@ describe("composerAutomation", () => {
     });
   });
 
+  it("keeps 'please' as task content when generation is unavailable", async () => {
+    // Generation fails, so the deterministic invocation is carried forward. "please" must
+    // survive (it is real task content here), unlike "for me" possessive filler.
+    const offline = vi.fn(async () => {
+      throw new Error("generation unavailable");
+    });
+    const decision = await resolveComposerAutomationRequest({
+      message: "create an automation to remind me to say please",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(decision.type).toBe("needs-clarification");
+    if (decision.type !== "needs-clarification") {
+      throw new Error("Expected needs-clarification decision");
+    }
+    expect(decision.automationMessage).toContain("say please");
+  });
+
   describe("automationClarificationPrompt", () => {
     it("asks for both the task and cadence when the task is missing", () => {
       expect(automationClarificationPrompt(["taskPrompt", "schedule"])).toContain(

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -603,6 +603,22 @@ describe("composerAutomation", () => {
       everySeconds: 3600,
     });
 
+    const metricsSubject = await resolveComposerAutomationRequest({
+      message: "create an automation for metrics every hour",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(metricsSubject.type).toBe("automation");
+    if (metricsSubject.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    expect(metricsSubject.resolution.intent.prompt).toBe("metrics");
+    expect(metricsSubject.resolution.intent.schedule).toMatchObject({
+      type: "interval",
+      everySeconds: 3600,
+    });
+
     const punctuatedFiller = await resolveComposerAutomationRequest({
       message: "create an automation for me!",
       cwd: "/tmp/project",
@@ -788,6 +804,22 @@ describe("composerAutomation", () => {
         intent: {
           prompt: "check the build",
           schedule: { type: "interval", everySeconds: 21_600 },
+        },
+      },
+    });
+
+    const dailyWithTaskOrdinal = await resolveComposerAutomationRequest({
+      message: "/automation every day check every second item in the queue",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(dailyWithTaskOrdinal).toMatchObject({
+      type: "automation",
+      resolution: {
+        intent: {
+          prompt: "check every second item in the queue",
+          schedule: { type: "daily", timeOfDay: "09:00" },
         },
       },
     });

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -586,6 +586,45 @@ describe("composerAutomation", () => {
       throw new Error("Expected automation decision");
     }
     expect(scheduledTaskCombined.resolution.intent.prompt).toBe("check the build");
+
+    const usSubject = await resolveComposerAutomationRequest({
+      message: "create an automation for US outages every hour",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(usSubject.type).toBe("automation");
+    if (usSubject.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    expect(usSubject.resolution.intent.prompt).toBe("US outages");
+    expect(usSubject.resolution.intent.schedule).toMatchObject({
+      type: "interval",
+      everySeconds: 3600,
+    });
+
+    const punctuatedFiller = await resolveComposerAutomationRequest({
+      message: "create an automation for me!",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+    expect(punctuatedFiller).toMatchObject({
+      type: "needs-clarification",
+      automationMessage: "create an automation",
+    });
+
+    const punctuatedCombined = await resolveComposerAutomationRequest({
+      message: "create an automation\ncheck the build every 6 hours",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(punctuatedCombined.type).toBe("automation");
+    if (punctuatedCombined.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    expect(punctuatedCombined.resolution.intent.prompt).toBe("check the build");
   });
 
   it("strips Italian possessive creation filler before the task across turns", async () => {

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -619,6 +619,22 @@ describe("composerAutomation", () => {
       everySeconds: 3600,
     });
 
+    const leadingBareCadence = await resolveComposerAutomationRequest({
+      message: "every hour check metrics",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(leadingBareCadence.type).toBe("automation");
+    if (leadingBareCadence.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    expect(leadingBareCadence.resolution.intent.prompt).toBe("check metrics");
+    expect(leadingBareCadence.resolution.intent.schedule).toMatchObject({
+      type: "interval",
+      everySeconds: 3600,
+    });
+
     const punctuatedFiller = await resolveComposerAutomationRequest({
       message: "create an automation for me!",
       cwd: "/tmp/project",
@@ -685,6 +701,22 @@ describe("composerAutomation", () => {
     expect(combined.resolution.intent.schedule).toMatchObject({
       type: "interval",
       everySeconds: 21_600,
+    });
+
+    const mercatoSubject = await resolveComposerAutomationRequest({
+      message: "crea un'automazione per mercato ogni ora",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(mercatoSubject.type).toBe("automation");
+    if (mercatoSubject.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    expect(mercatoSubject.resolution.intent.prompt).toBe("mercato");
+    expect(mercatoSubject.resolution.intent.schedule).toMatchObject({
+      type: "interval",
+      everySeconds: 3600,
     });
   });
 
@@ -819,6 +851,22 @@ describe("composerAutomation", () => {
       resolution: {
         intent: {
           prompt: "check every second item in the queue",
+          schedule: { type: "daily", timeOfDay: "09:00" },
+        },
+      },
+    });
+
+    const leadingOrdinalWithDailyCadence = await resolveComposerAutomationRequest({
+      message: "/automation every second item in the queue daily",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(leadingOrdinalWithDailyCadence).toMatchObject({
+      type: "automation",
+      resolution: {
+        intent: {
+          prompt: "every second item in the queue",
           schedule: { type: "daily", timeOfDay: "09:00" },
         },
       },

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -563,6 +563,29 @@ describe("composerAutomation", () => {
       throw new Error("Expected automation decision");
     }
     expect(withoutConnector.resolution.intent.prompt).toBe("check the build");
+
+    const scheduledTask = await resolveComposerAutomationRequest({
+      message: "schedule a task for me to check the build",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+    expect(scheduledTask).toMatchObject({
+      type: "needs-clarification",
+      automationMessage: "schedule a task to check the build",
+    });
+
+    const scheduledTaskCombined = await resolveComposerAutomationRequest({
+      message: "schedule a task to check the build\nevery 6 hours",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(scheduledTaskCombined.type).toBe("automation");
+    if (scheduledTaskCombined.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    expect(scheduledTaskCombined.resolution.intent.prompt).toBe("check the build");
   });
 
   it("strips Italian possessive creation filler before the task across turns", async () => {

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -431,6 +431,9 @@ describe("composerAutomation", () => {
     expect(generateIntent).toHaveBeenCalledTimes(1);
     expect(decision).toMatchObject({
       type: "needs-clarification",
+      // The accumulated request is the cleaned invocation (politeness, "?", and "for me"
+      // filler stripped), so folding the next reply never re-parses scaffolding as the task.
+      automationMessage: "create an automation",
       missingFields: ["taskPrompt", "schedule"],
       reason: "Tell me what to automate.",
     });
@@ -479,6 +482,29 @@ describe("composerAutomation", () => {
           schedule: { type: "interval", everySeconds: 21_600 },
         },
       },
+    });
+  });
+
+  it("does not leak creation scaffolding into the task prompt across turns", async () => {
+    const offline = vi.fn(async () => {
+      throw new Error("deterministic parse should cover the combined request");
+    });
+    // Mirrors ChatView folding the cleaned, filler-stripped automationMessage
+    // ("create an automation") with the user's follow-up answer.
+    const decision = await resolveComposerAutomationRequest({
+      message: "create an automation\ncheck the build every 6 hours",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(decision.type).toBe("automation");
+    if (decision.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    expect(decision.resolution.intent.prompt).toBe("check the build");
+    expect(decision.resolution.intent.schedule).toMatchObject({
+      type: "interval",
+      everySeconds: 21_600,
     });
   });
 

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -508,6 +508,108 @@ describe("composerAutomation", () => {
     });
   });
 
+  it("strips possessive creation filler before the task across turns", async () => {
+    const generateIntent = vi.fn(async () => ({
+      isAutomation: true,
+      confidence: 0.9,
+      language: "en",
+      name: "Check build",
+      taskPrompt: "Check the build.",
+      schedule: null,
+      mode: "heartbeat" as const,
+      completionPolicy: { type: "none" as const },
+      missingFields: ["schedule" as const],
+      needsConfirmation: false,
+      reason: null,
+    }));
+    const first = await resolveComposerAutomationRequest({
+      message: "create an automation for me to check the build",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+    expect(first).toMatchObject({
+      type: "needs-clarification",
+      automationMessage: "create an automation to check the build",
+    });
+
+    const offline = vi.fn(async () => {
+      throw new Error("deterministic parse should cover the combined request");
+    });
+    const combined = await resolveComposerAutomationRequest({
+      message: "create an automation to check the build\nevery 6 hours",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(combined.type).toBe("automation");
+    if (combined.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    expect(combined.resolution.intent.prompt).toBe("check the build");
+    expect(combined.resolution.intent.schedule).toMatchObject({
+      type: "interval",
+      everySeconds: 21_600,
+    });
+
+    const withoutConnector = await resolveComposerAutomationRequest({
+      message: "create an automation for me check the build\nevery 6 hours",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(withoutConnector.type).toBe("automation");
+    if (withoutConnector.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    expect(withoutConnector.resolution.intent.prompt).toBe("check the build");
+  });
+
+  it("strips Italian possessive creation filler before the task across turns", async () => {
+    const generateIntent = vi.fn(async () => ({
+      isAutomation: true,
+      confidence: 0.9,
+      language: "it",
+      name: "Controlla build",
+      taskPrompt: "Controlla la build.",
+      schedule: null,
+      mode: "heartbeat" as const,
+      completionPolicy: { type: "none" as const },
+      missingFields: ["schedule" as const],
+      needsConfirmation: false,
+      reason: null,
+    }));
+    const first = await resolveComposerAutomationRequest({
+      message: "crea un'automazione per me che controlla la build",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+    expect(first).toMatchObject({
+      type: "needs-clarification",
+      automationMessage: "crea un'automazione che controlla la build",
+    });
+
+    const offline = vi.fn(async () => {
+      throw new Error("deterministic parse should cover the combined request");
+    });
+    const combined = await resolveComposerAutomationRequest({
+      message: "crea un'automazione che controlla la build\nogni 6 ore",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(combined.type).toBe("automation");
+    if (combined.type !== "automation") {
+      throw new Error("Expected automation decision");
+    }
+    expect(combined.resolution.intent.prompt).toBe("controlla la build");
+    expect(combined.resolution.intent.schedule).toMatchObject({
+      type: "interval",
+      everySeconds: 21_600,
+    });
+  });
+
   it("keeps 'please' as task content when generation is unavailable", async () => {
     // Generation fails, so the deterministic invocation is carried forward. "please" must
     // survive (it is real task content here), unlike "for me" possessive filler.

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -521,8 +521,57 @@ describe("composerAutomation", () => {
       expect(prompt).not.toContain("what should this automation do");
     });
 
-    it("defaults to asking for a cadence when nothing was reported", () => {
-      expect(automationClarificationPrompt([])).toContain("How often");
+    it("asks for task and cadence when nothing was reported, so setup can recover", () => {
+      // Empty missingFields (generation timed out/failed) must not loop on cadence for a
+      // bare request that has no task yet.
+      expect(automationClarificationPrompt([])).toContain("what should this automation do");
+    });
+  });
+
+  it("keeps an explicit /automation setup parseable across follow-ups", async () => {
+    const generateIntent = vi.fn(async () => ({
+      isAutomation: true,
+      confidence: 0.9,
+      language: "en",
+      name: null,
+      taskPrompt: null,
+      schedule: { type: "interval" as const, everySeconds: 21_600 },
+      mode: null,
+      completionPolicy: { type: "none" as const },
+      missingFields: ["taskPrompt" as const],
+      needsConfirmation: false,
+      reason: null,
+    }));
+    const first = await resolveComposerAutomationRequest({
+      message: "/automation every 6 hours",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent,
+    });
+    // The marker is stripped, so the carry-forward re-seeds a creation scaffold instead
+    // of leaving a cadence-only fragment that the next turn could not re-detect.
+    expect(first).toMatchObject({
+      type: "needs-clarification",
+      automationMessage: "create an automation every 6 hours",
+    });
+
+    const offline = vi.fn(async () => {
+      throw new Error("deterministic parse should cover the combined request");
+    });
+    const combined = await resolveComposerAutomationRequest({
+      message: "create an automation every 6 hours\ncheck the build",
+      cwd: "/tmp/project",
+      nowIso: NOW_ISO,
+      generateIntent: offline,
+    });
+    expect(combined).toMatchObject({
+      type: "automation",
+      resolution: {
+        intent: {
+          prompt: "check the build",
+          schedule: { type: "interval", everySeconds: 21_600 },
+        },
+      },
     });
   });
 });

--- a/apps/web/src/lib/composerAutomation.test.ts
+++ b/apps/web/src/lib/composerAutomation.test.ts
@@ -540,6 +540,12 @@ describe("composerAutomation", () => {
       expect(prompt).not.toContain("what should this automation do");
     });
 
+    it("asks only for the task when the cadence is already known", () => {
+      const prompt = automationClarificationPrompt(["taskPrompt"]);
+      expect(prompt).toContain("What should this automation do");
+      expect(prompt).not.toContain("How often");
+    });
+
     it("asks for task and cadence when nothing was reported, so setup can recover", () => {
       // Empty missingFields (generation timed out/failed) must not loop on cadence for a
       // bare request that has no task yet.

--- a/apps/web/src/lib/composerAutomation.ts
+++ b/apps/web/src/lib/composerAutomation.ts
@@ -9,6 +9,7 @@ import type {
   AutomationMode,
   ModelSelection,
   ProjectId,
+  ServerAutomationIntentMissingField,
   ServerGenerateAutomationIntentInput,
   ServerGenerateAutomationIntentResult,
   ThreadId,
@@ -49,7 +50,12 @@ const DEFAULT_GENERATE_INTENT_TIMEOUT_MS = 1_500;
 export type ComposerAutomationRequestDecision =
   | { readonly type: "normal-chat" }
   | {
-      readonly type: "missing-schedule";
+      // The message reads as an automation request but is missing required fields
+      // (a task and/or a schedule). ChatView turns this into a conversational
+      // follow-up instead of dropping the message: it keeps the raw text, asks for
+      // what's missing, and folds the user's next reply back in before re-resolving.
+      readonly type: "needs-clarification";
+      readonly missingFields: readonly ServerAutomationIntentMissingField[];
       readonly reason: string | null;
     }
   | {
@@ -68,6 +74,23 @@ export interface ComposerAutomationDraftDecision {
   };
   readonly acknowledgedWarningIds: ReadonlySet<AutomationDraftWarningId>;
   readonly needsDraftReview: boolean;
+}
+
+// Builds the follow-up question shown when an automation request is missing required
+// fields. Falls back to asking for a schedule (the dominant missing field) when the
+// generator could not report what was missing.
+export function automationClarificationPrompt(
+  missingFields: readonly ServerAutomationIntentMissingField[],
+): string {
+  const fields: readonly ServerAutomationIntentMissingField[] =
+    missingFields.length > 0 ? missingFields : ["schedule"];
+  if (fields.includes("taskPrompt")) {
+    return 'Sure, what should this automation do, and how often should it run? For example: "every weekday at 9am, summarize my open PRs."';
+  }
+  if (fields.includes("schedule")) {
+    return "How often should this automation run? For example: every 6 hours, weekdays at 9am, or daily at 18:00.";
+  }
+  return "A couple more details: what should this automation do, and how often should it run?";
 }
 
 // ─── ENTRY POINT ─────────────────────────────────────────────
@@ -170,7 +193,8 @@ export async function resolveComposerAutomationRequest(input: {
   });
   if (!automationResolution) {
     return {
-      type: "missing-schedule",
+      type: "needs-clarification",
+      missingFields: generatedAutomationIntent?.missingFields ?? [],
       reason: generatedAutomationIntent?.reason ?? null,
     };
   }

--- a/apps/web/src/lib/composerAutomation.ts
+++ b/apps/web/src/lib/composerAutomation.ts
@@ -81,14 +81,15 @@ export interface ComposerAutomationDraftDecision {
   readonly needsDraftReview: boolean;
 }
 
-// Trailing filler like "for me" / "per favore" carries no task content, but once a
-// follow-up answer is folded onto the accumulated request it would survive into the
-// parsed prompt (e.g. "for me check the build"). Strip it so multi-turn setup keeps a
-// clean task. Conservative on purpose: only first/second-person filler, never nouns.
+// Trailing "for me" filler carries no task content, but once a follow-up answer is
+// folded onto the accumulated request it would survive into the parsed prompt (e.g.
+// "for me check the build"). Strip it so multi-turn setup keeps a clean task.
+// Deliberately narrow: only the "for me/us/myself" possessive tail (and its Italian
+// form). "please" is left alone because it can be real task content ("say please").
 function stripTrailingAutomationFiller(message: string): string {
   return message
     .replace(/[?？]+\s*$/u, "")
-    .replace(/\s+(?:for\s+(?:me|us|myself)|per\s+(?:me|noi)|please|per favore)\s*$/iu, "")
+    .replace(/\s+(?:for\s+(?:me|us|myself)|per\s+(?:me|noi))\s*$/iu, "")
     .trim();
 }
 

--- a/apps/web/src/lib/composerAutomation.ts
+++ b/apps/web/src/lib/composerAutomation.ts
@@ -218,7 +218,16 @@ export async function resolveComposerAutomationRequest(input: {
     defaultMode: automationDefaultMode,
     executionScope: automationExecutionScope,
   });
-  if (!automationResolution) {
+  // The generator defaults an unspecified schedule to "manual", which would otherwise
+  // open a manual-automation review dialog for "create an automation to check the build"
+  // instead of asking "how often?". When generation reports the schedule as still
+  // missing, keep the conversational follow-up rather than accepting that default.
+  const generatedScheduleStillMissing =
+    automationResolution !== null &&
+    automationResolution.source === "generated" &&
+    (generatedAutomationIntent?.missingFields.includes("schedule") ?? false) &&
+    automationResolution.intent.schedule.type === "manual";
+  if (!automationResolution || generatedScheduleStillMissing) {
     return {
       type: "needs-clarification",
       // Strip trailing filler, then guarantee a parseable trigger survives so the next

--- a/apps/web/src/lib/composerAutomation.ts
+++ b/apps/web/src/lib/composerAutomation.ts
@@ -87,10 +87,10 @@ export interface ComposerAutomationDraftDecision {
 // real task content ("say please").
 function stripTrailingAutomationFiller(message: string): string {
   return message
-    .replace(/[?？]+\s*$/u, "")
-    .replace(/\b(automation|task|job|check|monitor|reminder)\s+for\s+(?:me|us|myself)\s+/iu, "$1 ")
+    .replace(/[.!?。！？]+\s*$/u, "")
+    .replace(/\b(automation|task|job|check|monitor|reminder)\s+for\s+(?:me|myself)\s+/iu, "$1 ")
     .replace(/\b(automazione|task|controllo|monitoraggio)\s+per\s+(?:me|noi)\s+/iu, "$1 ")
-    .replace(/\s+(?:for\s+(?:me|us|myself)|per\s+(?:me|noi))\s*$/iu, "")
+    .replace(/\s+(?:for\s+(?:me|myself)|per\s+(?:me|noi))\s*$/iu, "")
     .trim();
 }
 

--- a/apps/web/src/lib/composerAutomation.ts
+++ b/apps/web/src/lib/composerAutomation.ts
@@ -52,9 +52,13 @@ export type ComposerAutomationRequestDecision =
   | {
       // The message reads as an automation request but is missing required fields
       // (a task and/or a schedule). ChatView turns this into a conversational
-      // follow-up instead of dropping the message: it keeps the raw text, asks for
-      // what's missing, and folds the user's next reply back in before re-resolving.
+      // follow-up instead of dropping the message: it asks for what's missing and
+      // folds the user's next reply back in before re-resolving. `automationMessage`
+      // is the cleaned invocation (politeness/creation scaffold stripped) so the
+      // accumulated request never re-parses "could you create an automation for me?"
+      // scaffolding as task content.
       readonly type: "needs-clarification";
+      readonly automationMessage: string;
       readonly missingFields: readonly ServerAutomationIntentMissingField[];
       readonly reason: string | null;
     }
@@ -74,6 +78,17 @@ export interface ComposerAutomationDraftDecision {
   };
   readonly acknowledgedWarningIds: ReadonlySet<AutomationDraftWarningId>;
   readonly needsDraftReview: boolean;
+}
+
+// Trailing filler like "for me" / "per favore" carries no task content, but once a
+// follow-up answer is folded onto the accumulated request it would survive into the
+// parsed prompt (e.g. "for me check the build"). Strip it so multi-turn setup keeps a
+// clean task. Conservative on purpose: only first/second-person filler, never nouns.
+function stripTrailingAutomationFiller(message: string): string {
+  return message
+    .replace(/[?？]+\s*$/u, "")
+    .replace(/\s+(?:for\s+(?:me|us|myself)|per\s+(?:me|noi)|please|per favore)\s*$/iu, "")
+    .trim();
 }
 
 // Builds the follow-up question shown when an automation request is missing required
@@ -194,6 +209,7 @@ export async function resolveComposerAutomationRequest(input: {
   if (!automationResolution) {
     return {
       type: "needs-clarification",
+      automationMessage: stripTrailingAutomationFiller(automationMessage),
       missingFields: generatedAutomationIntent?.missingFields ?? [],
       reason: generatedAutomationIntent?.reason ?? null,
     };

--- a/apps/web/src/lib/composerAutomation.ts
+++ b/apps/web/src/lib/composerAutomation.ts
@@ -88,7 +88,7 @@ export interface ComposerAutomationDraftDecision {
 function stripTrailingAutomationFiller(message: string): string {
   return message
     .replace(/[?？]+\s*$/u, "")
-    .replace(/\b(automation)\s+for\s+(?:me|us|myself)\s+/iu, "$1 ")
+    .replace(/\b(automation|task|job|check|monitor|reminder)\s+for\s+(?:me|us|myself)\s+/iu, "$1 ")
     .replace(/\b(automazione|task|controllo|monitoraggio)\s+per\s+(?:me|noi)\s+/iu, "$1 ")
     .replace(/\s+(?:for\s+(?:me|us|myself)|per\s+(?:me|noi))\s*$/iu, "")
     .trim();

--- a/apps/web/src/lib/composerAutomation.ts
+++ b/apps/web/src/lib/composerAutomation.ts
@@ -104,10 +104,17 @@ export function automationClarificationPrompt(
   // looping on a cadence-only question that a bare "create an automation" can't answer.
   const fields: readonly ServerAutomationIntentMissingField[] =
     missingFields.length > 0 ? missingFields : ["taskPrompt", "schedule"];
-  if (fields.includes("taskPrompt")) {
+  const needsTask = fields.includes("taskPrompt");
+  const needsSchedule = fields.includes("schedule");
+  if (needsTask && needsSchedule) {
     return 'Sure, what should this automation do, and how often should it run? For example: "every weekday at 9am, summarize my open PRs."';
   }
-  if (fields.includes("schedule")) {
+  if (needsTask) {
+    // Cadence is already known, so asking for it again risks the user repeating it and
+    // leaving a duplicate schedule phrase in the saved task.
+    return "What should this automation do? For example: summarize my open PRs, or check the build.";
+  }
+  if (needsSchedule) {
     return "How often should this automation run? For example: every 6 hours, weekdays at 9am, or daily at 18:00.";
   }
   return "A couple more details: what should this automation do, and how often should it run?";

--- a/apps/web/src/lib/composerAutomation.ts
+++ b/apps/web/src/lib/composerAutomation.ts
@@ -31,6 +31,7 @@ import {
 } from "./automationDraft";
 import {
   detectChatAutomationExecutionScope,
+  ensureAutomationConversationScaffold,
   extractChatAutomationInvocation,
   extractPlainChatAutomationCreationInvocation,
   parseChatAutomationInvocation,
@@ -97,8 +98,11 @@ function stripTrailingAutomationFiller(message: string): string {
 export function automationClarificationPrompt(
   missingFields: readonly ServerAutomationIntentMissingField[],
 ): string {
+  // When the generator could not say what was missing (timeout/failure on a bare
+  // request), ask for both task and schedule so setup can still recover instead of
+  // looping on a cadence-only question that a bare "create an automation" can't answer.
   const fields: readonly ServerAutomationIntentMissingField[] =
-    missingFields.length > 0 ? missingFields : ["schedule"];
+    missingFields.length > 0 ? missingFields : ["taskPrompt", "schedule"];
   if (fields.includes("taskPrompt")) {
     return 'Sure, what should this automation do, and how often should it run? For example: "every weekday at 9am, summarize my open PRs."';
   }
@@ -209,7 +213,11 @@ export async function resolveComposerAutomationRequest(input: {
   if (!automationResolution) {
     return {
       type: "needs-clarification",
-      automationMessage: stripTrailingAutomationFiller(automationMessage),
+      // Strip trailing filler, then guarantee a parseable trigger survives so the next
+      // folded reply still resolves as an automation (markers/cadence-only would not).
+      automationMessage: ensureAutomationConversationScaffold(
+        stripTrailingAutomationFiller(automationMessage),
+      ),
       missingFields: generatedAutomationIntent?.missingFields ?? [],
       reason: generatedAutomationIntent?.reason ?? null,
     };

--- a/apps/web/src/lib/composerAutomation.ts
+++ b/apps/web/src/lib/composerAutomation.ts
@@ -81,14 +81,15 @@ export interface ComposerAutomationDraftDecision {
   readonly needsDraftReview: boolean;
 }
 
-// Trailing "for me" filler carries no task content, but once a follow-up answer is
-// folded onto the accumulated request it would survive into the parsed prompt (e.g.
-// "for me check the build"). Strip it so multi-turn setup keeps a clean task.
-// Deliberately narrow: only the "for me/us/myself" possessive tail (and its Italian
-// form). "please" is left alone because it can be real task content ("say please").
+// Possessive "for me" filler carries no task content, but once a follow-up answer
+// is folded onto the accumulated request it would survive into the parsed prompt
+// (e.g. "for me check the build"). Strip it while keeping "please", which can be
+// real task content ("say please").
 function stripTrailingAutomationFiller(message: string): string {
   return message
     .replace(/[?？]+\s*$/u, "")
+    .replace(/\b(automation)\s+for\s+(?:me|us|myself)\s+/iu, "$1 ")
+    .replace(/\b(automazione|task|controllo|monitoraggio)\s+per\s+(?:me|noi)\s+/iu, "$1 ")
     .replace(/\s+(?:for\s+(?:me|us|myself)|per\s+(?:me|noi))\s*$/iu, "")
     .trim();
 }


### PR DESCRIPTION
## Summary

Follow-up to #241, feat automations conversational setup for chat-created automations. The conversational setup flow cleaned trailing filler like for me, but possessive filler immediately after the automation scaffold could still be carried into accumulated setup text or parsed task text.

This PR keeps the setup request and parsed task clean for English and Italian creation phrasing, including bare forms like create an automation for me check the build.

## Changes

- Strip immediate automation for me and automazione per me filler from the accumulated conversational setup message.
- Teach the shared automation scaffold parser to ignore the same filler before task text.
- Add regression coverage for connector and bare English forms plus the Italian per me che form.

## Verification

- bun fmt
- bun lint, 0 errors with existing warnings only
- bun typecheck
- bun run --cwd apps/web test src/lib/composerAutomation.test.ts
- git diff --check
- Same-directory check-code review pass found the bare-filler issue; second same-directory review pass reported no actionable findings.
