### PR TITLE
fix(automation): enforce risk acknowledgement gate at dispatch, not just create/update

### DIFF
--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -807,6 +807,107 @@ layer("AutomationService", (it) => {
     }),
   );
 
+  it.effect("blocks an unacknowledged full-access run at dispatch and records a failed run", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-fullaccess-runnow");
+      // Inserted directly (e.g. via the API/DB), bypassing create-time validation.
+      yield* repository.createDefinition({
+        id: automationId,
+        input: { ...createInput("worktree"), runtimeMode: "full-access", acknowledgedRisks: [] },
+        now,
+      });
+
+      const error = yield* service.runNow({ automationId }).pipe(Effect.flip);
+
+      assert.match(error.message, /full-access/);
+      assert.strictEqual(
+        dispatchedCommands.filter((command) => command.type === "thread.create").length,
+        0,
+      );
+      const listed = yield* service.list({ projectId });
+      assert.strictEqual(
+        listed.runs.find((run) => run.automationId === automationId)?.status,
+        "failed",
+      );
+    }),
+  );
+
+  it.effect("blocks an unacknowledged full-access automation on the scheduler", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-fullaccess-scheduled");
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("worktree"),
+          runtimeMode: "full-access",
+          acknowledgedRisks: [],
+          schedule: { type: "interval", everySeconds: 300 },
+        },
+        now: "2026-06-16T10:00:00.000Z",
+      });
+
+      yield* service.runDueOnce({
+        now: "2026-06-16T10:00:00.000Z",
+        limit: 10,
+        leaseOwnerId: "test-scheduler",
+      });
+
+      assert.strictEqual(
+        dispatchedCommands.filter((command) => command.type === "thread.create").length,
+        0,
+      );
+      const listed = yield* service.list({ projectId });
+      assert.strictEqual(
+        listed.runs.find((run) => run.automationId === automationId)?.status,
+        "failed",
+      );
+    }),
+  );
+
+  it.effect("dispatches an acknowledged full-access automation", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const created = yield* service.create({
+        ...createInput("auto"),
+        runtimeMode: "full-access",
+        acknowledgedRisks: ["full-access", "local-checkout"],
+      });
+
+      yield* service.runNow({ automationId: created.id });
+
+      assert.isTrue(dispatchedCommands.some((command) => command.type === "thread.create"));
+    }),
+  );
+
+  it.effect("blocks an unacknowledged standalone local checkout at dispatch", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-local-dispatch");
+      yield* repository.createDefinition({
+        id: automationId,
+        input: { ...createInput("worktree"), worktreeMode: "local", acknowledgedRisks: [] },
+        now,
+      });
+
+      const error = yield* service.runNow({ automationId }).pipe(Effect.flip);
+
+      assert.match(error.message, /local checkout/);
+      assert.strictEqual(
+        dispatchedCommands.filter((command) => command.type === "thread.create").length,
+        0,
+      );
+    }),
+  );
+
   it.effect("runs due scheduled automations once and advances the next run", () =>
     Effect.gen(function* () {
       resetHarness();

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -908,6 +908,55 @@ layer("AutomationService", (it) => {
     }),
   );
 
+  it.effect("requires local-checkout acknowledgement for a local heartbeat", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const targetThreadId = ThreadId.makeUnsafe("local-heartbeat-ack-thread");
+      threadShell = Option.some(makeThreadShell({ id: targetThreadId }));
+
+      // A heartbeat reuses its target thread, but that thread can itself be on the local
+      // checkout, so `worktreeMode: "local"` must still require the acknowledgement.
+      const error = yield* service
+        .create({
+          ...createInput("local"),
+          mode: "heartbeat",
+          targetThreadId,
+          acknowledgedRisks: [],
+        })
+        .pipe(Effect.flip);
+
+      assert.match(error.message, /local checkout/);
+    }),
+  );
+
+  it.effect("blocks an unacknowledged fast interval run at dispatch", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-fast-interval-dispatch");
+      // Sub-minute schedule inserted directly, bypassing validateSchedulePolicy.
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("worktree"),
+          schedule: { type: "interval", everySeconds: 15 },
+          acknowledgedRisks: [],
+        },
+        now,
+      });
+
+      const error = yield* service.runNow({ automationId }).pipe(Effect.flip);
+
+      assert.match(error.message, /fast interval/);
+      assert.strictEqual(
+        dispatchedCommands.filter((command) => command.type === "thread.create").length,
+        0,
+      );
+    }),
+  );
+
   it.effect("runs due scheduled automations once and advances the next run", () =>
     Effect.gen(function* () {
       resetHarness();

--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -949,7 +949,36 @@ layer("AutomationService", (it) => {
 
       const error = yield* service.runNow({ automationId }).pipe(Effect.flip);
 
-      assert.match(error.message, /fast interval/);
+      assert.match(error.message, /at least \d+ seconds apart/);
+      assert.strictEqual(
+        dispatchedCommands.filter((command) => command.type === "thread.create").length,
+        0,
+      );
+    }),
+  );
+
+  it.effect("blocks an acknowledged but uncapped fast interval run at dispatch", () =>
+    Effect.gen(function* () {
+      resetHarness();
+      const service = yield* AutomationService;
+      const repository = yield* AutomationRepository;
+      const automationId = AutomationId.makeUnsafe("automation-fast-interval-uncapped");
+      // Acknowledged sub-minute schedule with the iteration cap removed, inserted around the
+      // create/update policy that enforces the ack + cap as a pair.
+      yield* repository.createDefinition({
+        id: automationId,
+        input: {
+          ...createInput("worktree"),
+          schedule: { type: "interval", everySeconds: 15 },
+          maxIterations: null,
+          acknowledgedRisks: ["fast-interval"],
+        },
+        now,
+      });
+
+      const error = yield* service.runNow({ automationId }).pipe(Effect.flip);
+
+      assert.match(error.message, /max iterations/);
       assert.strictEqual(
         dispatchedCommands.filter((command) => command.type === "thread.create").length,
         0,

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -299,28 +299,37 @@ function effectiveMinimumIntervalSeconds(input: {
   return input.minimumIntervalSeconds;
 }
 
-// Single source of truth for the risks an automation must acknowledge before it can run,
-// matched to what actually happens at dispatch. Enforced uniformly at create, update, and
-// run (dispatchRun) so an automation can never reach a run unacknowledged.
+// Single source of truth for the risks an automation must acknowledge before it can run.
+// Enforced uniformly at create, update, and run (dispatchRun) so an automation can never reach
+// a run unacknowledged. The `local` worktree check applies to every mode: a heartbeat reuses
+// its target thread, but that thread can itself sit on the local checkout, so continuing it
+// still runs the provider against the active project root.
 function riskAcknowledgementError(input: {
   readonly runtimeMode: AutomationDefinition["runtimeMode"];
   readonly worktreeMode: AutomationDefinition["worktreeMode"];
-  readonly mode: AutomationDefinition["mode"];
+  readonly schedule?: AutomationDefinition["schedule"];
   readonly acknowledgedRisks: readonly string[];
+  readonly now?: string;
 }): string | null {
   const acknowledgedRisks = new Set(input.acknowledgedRisks);
   if (input.runtimeMode === "full-access" && !acknowledgedRisks.has("full-access")) {
     return "Automation full-access mode requires an explicit acknowledgement.";
   }
-  // Local checkout only applies to standalone runs: heartbeat reuses the target thread and
-  // never resolves an environment, and an "auto" worktree only falls back to a local checkout
-  // at runtime (handled in resolveThreadEnvironment), so it is not required up front.
-  if (
-    input.mode === "standalone" &&
-    input.worktreeMode === "local" &&
-    !acknowledgedRisks.has("local-checkout")
-  ) {
+  if (input.worktreeMode === "local" && !acknowledgedRisks.has("local-checkout")) {
     return "Automation local checkout mode requires an explicit acknowledgement.";
+  }
+  // Sub-minute schedules can create runaway unattended runs. validateSchedulePolicy enforces
+  // this at create/update; passing schedule+now here lets the dispatch gate enforce it on the
+  // run path too, where validateSchedulePolicy never runs.
+  if (input.schedule !== undefined && input.now !== undefined) {
+    const spacingSeconds = computeAutomationScheduleSpacingSeconds(input.schedule, input.now);
+    if (
+      spacingSeconds !== null &&
+      spacingSeconds < DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS &&
+      !acknowledgedRisks.has("fast-interval")
+    ) {
+      return "Automation fast interval mode requires an explicit acknowledgement.";
+    }
   }
   return null;
 }
@@ -688,8 +697,9 @@ export const AutomationServiceLive = Layer.effect(
     const validateRiskAcknowledgements = (input: {
       readonly runtimeMode: AutomationDefinition["runtimeMode"];
       readonly worktreeMode: AutomationDefinition["worktreeMode"];
-      readonly mode: AutomationDefinition["mode"];
+      readonly schedule?: AutomationDefinition["schedule"];
       readonly acknowledgedRisks: readonly string[];
+      readonly now?: string;
     }) => {
       const message = riskAcknowledgementError(input);
       return message
@@ -839,13 +849,16 @@ export const AutomationServiceLive = Layer.effect(
 
         // Enforce the acknowledgement gate at dispatch, not just create/update, so an enabled
         // automation that reached a run unacknowledged (e.g. inserted via the API/DB without
-        // consent) cannot run on schedule or via Run now. Fails before the run is marked
-        // started; the catch at the end of dispatchRun records it as a clean failed run.
+        // consent) cannot run on schedule or via Run now. Passing schedule+now also covers the
+        // fast-interval risk here, the one run-path that validateSchedulePolicy never guards.
+        // Fails before the run is marked started; the catch at the end of dispatchRun records it
+        // as a clean failed run, and the scheduler has already advanced past this occurrence.
         yield* validateRiskAcknowledgements({
           runtimeMode: definition.runtimeMode,
           worktreeMode: definition.worktreeMode,
-          mode: definition.mode,
+          schedule: definition.schedule,
           acknowledgedRisks: definition.acknowledgedRisks,
+          now,
         });
 
         const stopIfRunCannotDispatch = (latest: AutomationRun, detail: string) =>
@@ -1864,7 +1877,6 @@ export const AutomationServiceLive = Layer.effect(
         yield* validateRiskAcknowledgements({
           runtimeMode: input.runtimeMode ?? "approval-required",
           worktreeMode: input.worktreeMode ?? "auto",
-          mode: input.mode ?? "standalone",
           acknowledgedRisks: input.acknowledgedRisks ?? [],
         });
         yield* validateHeartbeatTarget({
@@ -1901,7 +1913,6 @@ export const AutomationServiceLive = Layer.effect(
         yield* validateRiskAcknowledgements({
           runtimeMode: updated.runtimeMode,
           worktreeMode: updated.worktreeMode,
-          mode: updated.mode,
           acknowledgedRisks: updated.acknowledgedRisks,
         });
         yield* validateHeartbeatTarget(updated);

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -299,17 +299,15 @@ function effectiveMinimumIntervalSeconds(input: {
   return input.minimumIntervalSeconds;
 }
 
-// Single source of truth for the risks an automation must acknowledge before it can run.
-// Enforced uniformly at create, update, and run (dispatchRun) so an automation can never reach
-// a run unacknowledged. The `local` worktree check applies to every mode: a heartbeat reuses
-// its target thread, but that thread can itself sit on the local checkout, so continuing it
-// still runs the provider against the active project root.
+// Single source of truth for the runtime risks an automation must acknowledge before it can
+// run. Enforced uniformly at create, update, and run (dispatchRun) so an automation can never
+// reach a run unacknowledged. The `local` worktree check applies to every mode: a heartbeat
+// reuses its target thread, but that thread can itself sit on the local checkout, so continuing
+// it still runs the provider against the active project root.
 function riskAcknowledgementError(input: {
   readonly runtimeMode: AutomationDefinition["runtimeMode"];
   readonly worktreeMode: AutomationDefinition["worktreeMode"];
-  readonly schedule?: AutomationDefinition["schedule"];
   readonly acknowledgedRisks: readonly string[];
-  readonly now?: string;
 }): string | null {
   const acknowledgedRisks = new Set(input.acknowledgedRisks);
   if (input.runtimeMode === "full-access" && !acknowledgedRisks.has("full-access")) {
@@ -318,18 +316,35 @@ function riskAcknowledgementError(input: {
   if (input.worktreeMode === "local" && !acknowledgedRisks.has("local-checkout")) {
     return "Automation local checkout mode requires an explicit acknowledgement.";
   }
-  // Sub-minute schedules can create runaway unattended runs. validateSchedulePolicy enforces
-  // this at create/update; passing schedule+now here lets the dispatch gate enforce it on the
-  // run path too, where validateSchedulePolicy never runs.
-  if (input.schedule !== undefined && input.now !== undefined) {
-    const spacingSeconds = computeAutomationScheduleSpacingSeconds(input.schedule, input.now);
-    if (
-      spacingSeconds !== null &&
-      spacingSeconds < DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS &&
-      !acknowledgedRisks.has("fast-interval")
-    ) {
-      return "Automation fast interval mode requires an explicit acknowledgement.";
-    }
+  return null;
+}
+
+// Single source of truth for the fast-interval policy: a sub-minute schedule needs the
+// `fast-interval` acknowledgement AND a bounded iteration cap, treated as a pair so an
+// acknowledged loop can't run unbounded. Shared by validateSchedulePolicy (create/update) and
+// the dispatch gate (the run-path backstop). May throw if the schedule has an invalid cron or
+// timezone, so callers must wrap it (Effect.try) to surface a typed error.
+function fastIntervalPolicyError(input: {
+  readonly schedule: AutomationDefinition["schedule"];
+  readonly enabled: boolean;
+  readonly maxIterations: AutomationDefinition["maxIterations"];
+  readonly acknowledgedRisks: readonly string[];
+  readonly now: string;
+}): string | null {
+  const spacingSeconds = computeAutomationScheduleSpacingSeconds(input.schedule, input.now);
+  if (spacingSeconds === null || spacingSeconds >= DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS) {
+    return null;
+  }
+  if (!input.acknowledgedRisks.includes("fast-interval")) {
+    return `Automation schedule must run at least ${DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS} seconds apart.`;
+  }
+  const exceedsFastIterationCap =
+    input.maxIterations === null ||
+    input.maxIterations > DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS;
+  // Pausing a legacy fast loop must always remain possible; enforce the hard cap only for
+  // definitions that will continue running.
+  if (input.enabled && exceedsFastIterationCap) {
+    return `Fast interval automations must set max iterations to ${DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS} runs or fewer.`;
   }
   return null;
 }
@@ -645,25 +660,9 @@ export const AutomationServiceLive = Layer.effect(
       Effect.try({
         try: () => {
           const spacingSeconds = computeAutomationScheduleSpacingSeconds(input.schedule, input.now);
-          if (
-            spacingSeconds !== null &&
-            spacingSeconds < DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS
-          ) {
-            if (!input.acknowledgedRisks.includes("fast-interval")) {
-              throw new Error(
-                `Automation schedule must run at least ${DEFAULT_AUTOMATION_MINIMUM_INTERVAL_SECONDS} seconds apart.`,
-              );
-            }
-            const exceedsFastIterationCap =
-              input.maxIterations === null ||
-              input.maxIterations > DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS;
-            // Pausing a legacy fast loop must always remain possible; enforce the new
-            // hard cap only for definitions that will continue running.
-            if (input.enabled && exceedsFastIterationCap) {
-              throw new Error(
-                `Fast interval automations must set max iterations to ${DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS} runs or fewer.`,
-              );
-            }
+          const fastIntervalError = fastIntervalPolicyError(input);
+          if (fastIntervalError) {
+            throw new Error(fastIntervalError);
           }
           const minimumIntervalSeconds = effectiveMinimumIntervalSeconds(input);
           if (spacingSeconds !== null && spacingSeconds < minimumIntervalSeconds) {
@@ -697,9 +696,7 @@ export const AutomationServiceLive = Layer.effect(
     const validateRiskAcknowledgements = (input: {
       readonly runtimeMode: AutomationDefinition["runtimeMode"];
       readonly worktreeMode: AutomationDefinition["worktreeMode"];
-      readonly schedule?: AutomationDefinition["schedule"];
       readonly acknowledgedRisks: readonly string[];
-      readonly now?: string;
     }) => {
       const message = riskAcknowledgementError(input);
       return message
@@ -710,6 +707,26 @@ export const AutomationServiceLive = Layer.effect(
           )
         : Effect.void;
     };
+
+    // Run-path backstop for the fast-interval policy. validateSchedulePolicy enforces this at
+    // create/update; this guards the run path it never covers. Effect.try converts a throwing
+    // schedule (invalid cron/timezone in a persisted row) into a typed error so the dispatch
+    // failure path records the run as failed instead of dying on a defect.
+    const validateFastIntervalPolicy = (input: {
+      readonly schedule: AutomationDefinition["schedule"];
+      readonly enabled: boolean;
+      readonly maxIterations: AutomationDefinition["maxIterations"];
+      readonly acknowledgedRisks: readonly string[];
+      readonly now: string;
+    }) =>
+      Effect.try({
+        try: () => fastIntervalPolicyError(input),
+        catch: (cause) => new AutomationServiceError({ message: errorMessage(cause), cause }),
+      }).pipe(
+        Effect.flatMap((message) =>
+          message ? Effect.fail(new AutomationServiceError({ message })) : Effect.void,
+        ),
+      );
 
     const resolveThreadEnvironment = (
       definition: AutomationDefinition,
@@ -847,16 +864,21 @@ export const AutomationServiceLive = Layer.effect(
           );
         }
 
-        // Enforce the acknowledgement gate at dispatch, not just create/update, so an enabled
-        // automation that reached a run unacknowledged (e.g. inserted via the API/DB without
-        // consent) cannot run on schedule or via Run now. Passing schedule+now also covers the
-        // fast-interval risk here, the one run-path that validateSchedulePolicy never guards.
-        // Fails before the run is marked started; the catch at the end of dispatchRun records it
-        // as a clean failed run, and the scheduler has already advanced past this occurrence.
+        // Enforce the gate at dispatch, not just create/update, so an enabled automation that
+        // reached a run unacknowledged (e.g. inserted via the API/DB without consent) cannot run
+        // on schedule or via Run now. Reuses the same validators as create/update so the backstop
+        // stays consistent with them. Fails before the run is marked started; the catch at the end
+        // of dispatchRun records it as a clean failed run, and the scheduler has already advanced
+        // past this occurrence.
         yield* validateRiskAcknowledgements({
           runtimeMode: definition.runtimeMode,
           worktreeMode: definition.worktreeMode,
+          acknowledgedRisks: definition.acknowledgedRisks,
+        });
+        yield* validateFastIntervalPolicy({
           schedule: definition.schedule,
+          enabled: definition.enabled,
+          maxIterations: definition.maxIterations,
           acknowledgedRisks: definition.acknowledgedRisks,
           now,
         });

--- a/apps/server/src/automation/Layers/AutomationService.ts
+++ b/apps/server/src/automation/Layers/AutomationService.ts
@@ -299,16 +299,27 @@ function effectiveMinimumIntervalSeconds(input: {
   return input.minimumIntervalSeconds;
 }
 
+// Single source of truth for the risks an automation must acknowledge before it can run,
+// matched to what actually happens at dispatch. Enforced uniformly at create, update, and
+// run (dispatchRun) so an automation can never reach a run unacknowledged.
 function riskAcknowledgementError(input: {
   readonly runtimeMode: AutomationDefinition["runtimeMode"];
   readonly worktreeMode: AutomationDefinition["worktreeMode"];
+  readonly mode: AutomationDefinition["mode"];
   readonly acknowledgedRisks: readonly string[];
 }): string | null {
   const acknowledgedRisks = new Set(input.acknowledgedRisks);
   if (input.runtimeMode === "full-access" && !acknowledgedRisks.has("full-access")) {
     return "Automation full-access mode requires an explicit acknowledgement.";
   }
-  if (input.worktreeMode === "local" && !acknowledgedRisks.has("local-checkout")) {
+  // Local checkout only applies to standalone runs: heartbeat reuses the target thread and
+  // never resolves an environment, and an "auto" worktree only falls back to a local checkout
+  // at runtime (handled in resolveThreadEnvironment), so it is not required up front.
+  if (
+    input.mode === "standalone" &&
+    input.worktreeMode === "local" &&
+    !acknowledgedRisks.has("local-checkout")
+  ) {
     return "Automation local checkout mode requires an explicit acknowledgement.";
   }
   return null;
@@ -677,6 +688,7 @@ export const AutomationServiceLive = Layer.effect(
     const validateRiskAcknowledgements = (input: {
       readonly runtimeMode: AutomationDefinition["runtimeMode"];
       readonly worktreeMode: AutomationDefinition["worktreeMode"];
+      readonly mode: AutomationDefinition["mode"];
       readonly acknowledgedRisks: readonly string[];
     }) => {
       const message = riskAcknowledgementError(input);
@@ -824,6 +836,17 @@ export const AutomationServiceLive = Layer.effect(
             }),
           );
         }
+
+        // Enforce the acknowledgement gate at dispatch, not just create/update, so an enabled
+        // automation that reached a run unacknowledged (e.g. inserted via the API/DB without
+        // consent) cannot run on schedule or via Run now. Fails before the run is marked
+        // started; the catch at the end of dispatchRun records it as a clean failed run.
+        yield* validateRiskAcknowledgements({
+          runtimeMode: definition.runtimeMode,
+          worktreeMode: definition.worktreeMode,
+          mode: definition.mode,
+          acknowledgedRisks: definition.acknowledgedRisks,
+        });
 
         const stopIfRunCannotDispatch = (latest: AutomationRun, detail: string) =>
           latest.status === "running"
@@ -1841,6 +1864,7 @@ export const AutomationServiceLive = Layer.effect(
         yield* validateRiskAcknowledgements({
           runtimeMode: input.runtimeMode ?? "approval-required",
           worktreeMode: input.worktreeMode ?? "auto",
+          mode: input.mode ?? "standalone",
           acknowledgedRisks: input.acknowledgedRisks ?? [],
         });
         yield* validateHeartbeatTarget({
@@ -1877,6 +1901,7 @@ export const AutomationServiceLive = Layer.effect(
         yield* validateRiskAcknowledgements({
           runtimeMode: updated.runtimeMode,
           worktreeMode: updated.worktreeMode,
+          mode: updated.mode,
           acknowledgedRisks: updated.acknowledgedRisks,
         });
         yield* validateHeartbeatTarget(updated);


### PR DESCRIPTION
## The gap

The automation risk-acknowledgement gate was enforced **only at create and update**. But an automation actually executes through `dispatchRun`, reached by two paths — `runNow` (manual) and `runDueDefinition` (the scheduler) — and neither re-checked acknowledgements. So any definition row written *around* the service layer (raw SQLite, a future API, an agent setting one up on a user's behalf) could run **full-access** or **local-checkout** work with `acknowledged_risks = []`. The create/update "front door" was guarded; the run path was wide open.

This is the server-side root cause behind the client work in #242 (the approval banner detects the unacknowledged state, but the server never enforced it at run).

## The fix

One mode-agnostic source of truth, enforced at the single `dispatchRun` chokepoint that both run paths flow through:

- **full-access** requires its acknowledgement for any run.
- **local-checkout** is required whenever `worktreeMode === "local"`, in every mode. A heartbeat reuses its target thread, but that thread can itself sit on the local checkout, so continuing it still runs the provider against the active project root. (This is the original behavior — an earlier draft wrongly relaxed it for heartbeats; reverted after Codex P2.)
- **fast-interval** is required for sub-minute schedules. `validateSchedulePolicy` already guards this at create/update; passing `schedule`+`now` into the dispatch gate covers the one run path it never guarded.

A blocked run fails before it is marked started; the existing outer `Effect.catch` records it as a clean failed run. For scheduled runs the schedule has already advanced (done before dispatch) and the fast-interval iteration cap bounds it, so there is no tight loop.

## Supersedes #243

#243 added the fast-interval run gate by enforcing in two separate sites (`runNow` + `runDueDefinition`). This PR folds that coverage into one mode-agnostic gate at the shared `dispatchRun` chokepoint, and additionally closes the full-access / local-checkout run-path gap. Same coverage, one enforcement point.

## Tests (88 pass)

- full-access without ack blocked at dispatch via **run-now** and on the **scheduler** → recorded as failed runs, nothing dispatched
- acknowledged full-access **dispatches** normally
- local checkout without ack blocked at dispatch
- **local heartbeat** without ack rejected (P2 regression)
- **fast interval** without ack blocked at dispatch

`bun fmt`, `bun lint` (0 errors), `bun typecheck` (8/8), and the automation/schedule/repository suites all pass.

## Scope

Server-only, additive, no schema or migration changes.



## Known follow-up (from review)

**Heartbeat local checkout keyed on target-thread env (Codex P2).** For heartbeats the local-checkout risk lives in the target thread's `envMode`, not the automation's `worktreeMode` (composer leaves it `auto`). Fixing it correctly needs a coordinated client+server change (resolve the target-thread env at create/update/dispatch and surface it in the #242 approval banner); a server-only change would break the composer heartbeat flow or create a create-passes/run-fails trap. This PR is a strict improvement over `main` and does not make that case worse. Tracked as a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)