### PR TITLE
fix(automations): keep update-only approval path

### DIFF
--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -252,9 +252,10 @@ describe("automationApprovalGaps", () => {
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
-  it("does not block an auto worktree on local-checkout", () => {
-    // worktreeMode "auto" only needs local-checkout if the server fails to create a worktree
-    // at runtime, so a normal auto run must not be flagged or have local-checkout persisted.
+  it("does not block an auto worktree but covers its fallback on approve", () => {
+    // worktreeMode "auto" is not a definite blocker, so the banner stays full-access only and
+    // Run now is not disabled for it. But approving persists local-checkout too, so the
+    // runtime worktree-creation fallback is covered once the user has approved.
     const gaps = automationApprovalGaps({
       ...base,
       runtimeMode: "full-access",
@@ -263,7 +264,7 @@ describe("automationApprovalGaps", () => {
       acknowledgedRisks: [],
     });
     expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
-    expect(gaps.acknowledgedRisks).toEqual(["full-access"]);
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
   it("needs no approval for an approval-required auto automation", () => {

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -208,8 +208,8 @@ describe("automationApprovalGaps", () => {
       runtimeMode: "full-access",
       acknowledgedRisks: [],
     });
-    expect(gaps.risks).toEqual(["full-access"]);
     expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(gaps.acknowledgedRisks).toEqual(["full-access"]);
   });
 
   it("requires local-checkout approval for a local worktree", () => {
@@ -218,7 +218,8 @@ describe("automationApprovalGaps", () => {
       worktreeMode: "local",
       acknowledgedRisks: [],
     });
-    expect(gaps.risks).toEqual(["local-checkout"]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["local-checkout"]);
+    expect(gaps.acknowledgedRisks).toEqual(["local-checkout"]);
   });
 
   it("reports both blocking risks together", () => {
@@ -228,34 +229,40 @@ describe("automationApprovalGaps", () => {
       worktreeMode: "local",
       acknowledgedRisks: [],
     });
-    expect(new Set(gaps.risks)).toEqual(new Set(["full-access", "local-checkout"]));
+    expect(new Set(gaps.warnings.map((warning) => warning.id))).toEqual(
+      new Set(["full-access", "local-checkout"]),
+    );
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
-  it("clears once the risks are acknowledged", () => {
+  it("clears the banner once the risks are acknowledged", () => {
     const gaps = automationApprovalGaps({
       ...base,
       runtimeMode: "full-access",
       worktreeMode: "local",
       acknowledgedRisks: ["full-access", "local-checkout"],
     });
-    expect(gaps.risks).toEqual([]);
     expect(gaps.warnings).toEqual([]);
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
   it("needs no approval for an approval-required worktree automation", () => {
     const gaps = automationApprovalGaps({ ...base, acknowledgedRisks: [] });
-    expect(gaps.risks).toEqual([]);
+    expect(gaps.warnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
-  it("does not treat a fast interval as a run blocker", () => {
-    // fast-interval only caps cadence; it never blocks a run, so an otherwise-approved
-    // automation needs no approval even with a sub-minute interval.
+  it("does not show a fast interval as a run blocker but persists it on approve", () => {
+    // fast-interval never blocks a run, so it is not in the banner warnings. But it must be
+    // persisted alongside full-access, or automation.update would reject the sub-minute
+    // schedule and the one-click approval would fail to save.
     const gaps = automationApprovalGaps({
       ...base,
       schedule: { type: "interval", everySeconds: 15 },
       runtimeMode: "full-access",
-      acknowledgedRisks: ["full-access"],
+      acknowledgedRisks: [],
     });
-    expect(gaps.risks).toEqual([]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "fast-interval"]));
   });
 });

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -278,17 +278,19 @@ describe("automationApprovalGaps", () => {
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
-  it("does not show a fast interval as a run blocker but persists it on approve", () => {
-    // fast-interval never blocks a run, so it is not in the banner warnings. But it must be
-    // persisted alongside full-access, or automation.update would reject the sub-minute
-    // schedule and the one-click approval would fail to save.
+  it("surfaces and persists the fast-loop risk when approving for another blocker", () => {
+    // fast-interval never blocks a run on its own, but when the banner is already shown for a
+    // run blocker, approving also persists fast-interval (or automation.update would reject
+    // the sub-minute schedule). It is therefore surfaced too, so consent is transparent.
     const gaps = automationApprovalGaps({
       ...base,
       schedule: { type: "interval", everySeconds: 15 },
       runtimeMode: "full-access",
       acknowledgedRisks: [],
     });
-    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(new Set(gaps.warnings.map((warning) => warning.id))).toEqual(
+      new Set(["full-access", "fast-recurring-interval"]),
+    );
     expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "fast-interval"]));
   });
 });

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -209,6 +209,7 @@ describe("automationApprovalGaps", () => {
       acknowledgedRisks: [],
     });
     expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(gaps.runBlockingWarnings.map((warning) => warning.id)).toEqual(["full-access"]);
     expect(gaps.acknowledgedRisks).toEqual(["full-access"]);
   });
 
@@ -219,6 +220,7 @@ describe("automationApprovalGaps", () => {
       acknowledgedRisks: [],
     });
     expect(gaps.warnings.map((warning) => warning.id)).toEqual(["local-checkout"]);
+    expect(gaps.runBlockingWarnings.map((warning) => warning.id)).toEqual(["local-checkout"]);
     expect(gaps.acknowledgedRisks).toEqual(["local-checkout"]);
   });
 
@@ -232,6 +234,9 @@ describe("automationApprovalGaps", () => {
     expect(new Set(gaps.warnings.map((warning) => warning.id))).toEqual(
       new Set(["full-access", "local-checkout"]),
     );
+    expect(new Set(gaps.runBlockingWarnings.map((warning) => warning.id))).toEqual(
+      new Set(["full-access", "local-checkout"]),
+    );
     expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
@@ -243,18 +248,20 @@ describe("automationApprovalGaps", () => {
       acknowledgedRisks: ["full-access", "local-checkout"],
     });
     expect(gaps.warnings).toEqual([]);
+    expect(gaps.runBlockingWarnings).toEqual([]);
     expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
   it("needs no approval for an approval-required worktree automation", () => {
     const gaps = automationApprovalGaps({ ...base, acknowledgedRisks: [] });
     expect(gaps.warnings).toEqual([]);
+    expect(gaps.runBlockingWarnings).toEqual([]);
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
-  it("does not block a heartbeat on local-checkout but persists it on approve", () => {
-    // Heartbeat reuses the target thread (no local env), so local-checkout never blocks the
-    // run. It is still persisted on approve so automation.update accepts a local heartbeat.
+  it("shows local-checkout approval for heartbeat updates without blocking the run", () => {
+    // Heartbeat reuses the target thread (no local env), so local-checkout never blocks
+    // dispatch. It is still surfaced so automation.update accepts a local heartbeat.
     const gaps = automationApprovalGaps({
       ...base,
       runtimeMode: "full-access",
@@ -262,25 +269,28 @@ describe("automationApprovalGaps", () => {
       mode: "heartbeat",
       acknowledgedRisks: [],
     });
-    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(new Set(gaps.warnings.map((warning) => warning.id))).toEqual(
+      new Set(["full-access", "local-checkout"]),
+    );
+    expect(gaps.runBlockingWarnings.map((warning) => warning.id)).toEqual(["full-access"]);
     expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
-  it("needs no approval for an approval-required local heartbeat", () => {
+  it("keeps an approval path for an approval-required local heartbeat", () => {
     const gaps = automationApprovalGaps({
       ...base,
       worktreeMode: "local",
       mode: "heartbeat",
       acknowledgedRisks: [],
     });
-    expect(gaps.warnings).toEqual([]);
-    expect(gaps.acknowledgedRisks).toEqual([]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["local-checkout"]);
+    expect(gaps.runBlockingWarnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual(["local-checkout"]);
   });
 
   it("does not block an auto worktree but covers its fallback on approve", () => {
-    // worktreeMode "auto" is not a definite blocker, so the banner stays full-access only and
-    // Run now is not disabled for it. But approving persists local-checkout too, so the
-    // runtime worktree-creation fallback is covered once the user has approved.
+    // worktreeMode "auto" is not a definite blocker, so Run now is blocked only by
+    // full-access. The banner still shows the local-checkout fallback risk that approval saves.
     const gaps = automationApprovalGaps({
       ...base,
       runtimeMode: "full-access",
@@ -288,7 +298,10 @@ describe("automationApprovalGaps", () => {
       mode: "standalone",
       acknowledgedRisks: [],
     });
-    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(new Set(gaps.warnings.map((warning) => warning.id))).toEqual(
+      new Set(["full-access", "local-checkout"]),
+    );
+    expect(gaps.runBlockingWarnings.map((warning) => warning.id)).toEqual(["full-access"]);
     expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
   });
 
@@ -300,6 +313,7 @@ describe("automationApprovalGaps", () => {
       acknowledgedRisks: [],
     });
     expect(gaps.warnings).toEqual([]);
+    expect(gaps.runBlockingWarnings).toEqual([]);
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
@@ -316,6 +330,18 @@ describe("automationApprovalGaps", () => {
     expect(new Set(gaps.warnings.map((warning) => warning.id))).toEqual(
       new Set(["full-access", "fast-recurring-interval"]),
     );
+    expect(gaps.runBlockingWarnings.map((warning) => warning.id)).toEqual(["full-access"]);
     expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "fast-interval"]));
+  });
+
+  it("surfaces fast-loop approval for imported definitions without blocking run now", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      schedule: { type: "interval", everySeconds: 15 },
+      acknowledgedRisks: [],
+    });
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["fast-recurring-interval"]);
+    expect(gaps.runBlockingWarnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual(["fast-interval"]);
   });
 });

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -197,6 +197,8 @@ describe("automation draft warnings", () => {
 describe("automationApprovalGaps", () => {
   const base = {
     schedule: { type: "daily" as const, timeOfDay: "09:00" },
+    enabled: true,
+    maxIterations: null,
     mode: "standalone" as const,
     runtimeMode: "approval-required" as const,
     worktreeMode: "worktree" as const,
@@ -333,6 +335,7 @@ describe("automationApprovalGaps", () => {
     );
     expect(gaps.runBlockingWarnings.map((warning) => warning.id)).toEqual(["full-access"]);
     expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "fast-interval"]));
+    expect(gaps.maxIterations).toBe(10);
   });
 
   it("surfaces fast-loop approval for imported definitions without blocking run now", () => {
@@ -344,6 +347,33 @@ describe("automationApprovalGaps", () => {
     expect(gaps.warnings.map((warning) => warning.id)).toEqual(["fast-recurring-interval"]);
     expect(gaps.runBlockingWarnings).toEqual([]);
     expect(gaps.acknowledgedRisks).toEqual(["fast-interval"]);
+    expect(gaps.maxIterations).toBe(10);
+  });
+
+  it("surfaces a cap-only fast-loop repair for legacy acknowledged definitions", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      schedule: { type: "interval", everySeconds: 15 },
+      maxIterations: 25,
+      acknowledgedRisks: ["fast-interval"],
+    });
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["fast-recurring-interval"]);
+    expect(gaps.runBlockingWarnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual(["fast-interval"]);
+    expect(gaps.maxIterations).toBe(10);
+  });
+
+  it("does not show a cap-only repair for paused legacy fast loops", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      schedule: { type: "interval", everySeconds: 15 },
+      enabled: false,
+      acknowledgedRisks: ["fast-interval"],
+    });
+    expect(gaps.warnings).toEqual([]);
+    expect(gaps.runBlockingWarnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual(["fast-interval"]);
+    expect(gaps.maxIterations).toBeUndefined();
   });
 });
 

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -11,6 +11,7 @@ import {
   automationApprovalGaps,
   buildAutomationDraftWarnings,
   hasBlockingAutomationDraftWarnings,
+  maxIterationsForFastIntervalApproval,
   warningIdsForAcknowledgedRisks,
 } from "./automationDraft";
 
@@ -343,5 +344,47 @@ describe("automationApprovalGaps", () => {
     expect(gaps.warnings.map((warning) => warning.id)).toEqual(["fast-recurring-interval"]);
     expect(gaps.runBlockingWarnings).toEqual([]);
     expect(gaps.acknowledgedRisks).toEqual(["fast-interval"]);
+  });
+});
+
+describe("maxIterationsForFastIntervalApproval", () => {
+  it("caps enabled imported fast loops without a max iteration limit", () => {
+    expect(
+      maxIterationsForFastIntervalApproval({
+        schedule: { type: "interval", everySeconds: 15 },
+        enabled: true,
+        maxIterations: null,
+      }),
+    ).toBe(10);
+  });
+
+  it("caps enabled imported fast loops above the server cap", () => {
+    expect(
+      maxIterationsForFastIntervalApproval({
+        schedule: { type: "interval", everySeconds: 15 },
+        enabled: true,
+        maxIterations: 25,
+      }),
+    ).toBe(10);
+  });
+
+  it("leaves already-bounded fast loops unchanged", () => {
+    expect(
+      maxIterationsForFastIntervalApproval({
+        schedule: { type: "interval", everySeconds: 15 },
+        enabled: true,
+        maxIterations: 3,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not cap disabled legacy fast loops during approval", () => {
+    expect(
+      maxIterationsForFastIntervalApproval({
+        schedule: { type: "interval", everySeconds: 15 },
+        enabled: false,
+        maxIterations: null,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -252,6 +252,31 @@ describe("automationApprovalGaps", () => {
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
+  it("does not block an auto worktree on local-checkout", () => {
+    // worktreeMode "auto" only needs local-checkout if the server fails to create a worktree
+    // at runtime, so a normal auto run must not be flagged or have local-checkout persisted.
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      worktreeMode: "auto",
+      mode: "standalone",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(gaps.acknowledgedRisks).toEqual(["full-access"]);
+  });
+
+  it("needs no approval for an approval-required auto automation", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      worktreeMode: "auto",
+      mode: "standalone",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.warnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual([]);
+  });
+
   it("does not show a fast interval as a run blocker but persists it on approve", () => {
     // fast-interval never blocks a run, so it is not in the banner warnings. But it must be
     // persisted alongside full-access, or automation.update would reject the sub-minute

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   acknowledgedWarningIdsForAutomaticChatAutomation,
   acknowledgedRiskIdsForDraft,
+  automationApprovalGaps,
   buildAutomationDraftWarnings,
   hasBlockingAutomationDraftWarnings,
   warningIdsForAcknowledgedRisks,
@@ -189,5 +190,72 @@ describe("automation draft warnings", () => {
 
     expect(warnings.map((warning) => warning.id)).not.toContain("local-checkout");
     expect(warnings.map((warning) => warning.id)).not.toContain("worktree-cleanup");
+  });
+});
+
+describe("automationApprovalGaps", () => {
+  const base = {
+    schedule: { type: "daily" as const, timeOfDay: "09:00" },
+    mode: "standalone" as const,
+    runtimeMode: "approval-required" as const,
+    worktreeMode: "worktree" as const,
+    prompt: "Check the build.",
+  };
+
+  it("requires full-access approval when unacknowledged", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.risks).toEqual(["full-access"]);
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+  });
+
+  it("requires local-checkout approval for a local worktree", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      worktreeMode: "local",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.risks).toEqual(["local-checkout"]);
+  });
+
+  it("reports both blocking risks together", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      worktreeMode: "local",
+      acknowledgedRisks: [],
+    });
+    expect(new Set(gaps.risks)).toEqual(new Set(["full-access", "local-checkout"]));
+  });
+
+  it("clears once the risks are acknowledged", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      worktreeMode: "local",
+      acknowledgedRisks: ["full-access", "local-checkout"],
+    });
+    expect(gaps.risks).toEqual([]);
+    expect(gaps.warnings).toEqual([]);
+  });
+
+  it("needs no approval for an approval-required worktree automation", () => {
+    const gaps = automationApprovalGaps({ ...base, acknowledgedRisks: [] });
+    expect(gaps.risks).toEqual([]);
+  });
+
+  it("does not treat a fast interval as a run blocker", () => {
+    // fast-interval only caps cadence; it never blocks a run, so an otherwise-approved
+    // automation needs no approval even with a sub-minute interval.
+    const gaps = automationApprovalGaps({
+      ...base,
+      schedule: { type: "interval", everySeconds: 15 },
+      runtimeMode: "full-access",
+      acknowledgedRisks: ["full-access"],
+    });
+    expect(gaps.risks).toEqual([]);
   });
 });

--- a/apps/web/src/lib/automationDraft.test.ts
+++ b/apps/web/src/lib/automationDraft.test.ts
@@ -252,6 +252,31 @@ describe("automationApprovalGaps", () => {
     expect(gaps.acknowledgedRisks).toEqual([]);
   });
 
+  it("does not block a heartbeat on local-checkout but persists it on approve", () => {
+    // Heartbeat reuses the target thread (no local env), so local-checkout never blocks the
+    // run. It is still persisted on approve so automation.update accepts a local heartbeat.
+    const gaps = automationApprovalGaps({
+      ...base,
+      runtimeMode: "full-access",
+      worktreeMode: "local",
+      mode: "heartbeat",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.warnings.map((warning) => warning.id)).toEqual(["full-access"]);
+    expect(new Set(gaps.acknowledgedRisks)).toEqual(new Set(["full-access", "local-checkout"]));
+  });
+
+  it("needs no approval for an approval-required local heartbeat", () => {
+    const gaps = automationApprovalGaps({
+      ...base,
+      worktreeMode: "local",
+      mode: "heartbeat",
+      acknowledgedRisks: [],
+    });
+    expect(gaps.warnings).toEqual([]);
+    expect(gaps.acknowledgedRisks).toEqual([]);
+  });
+
   it("does not block an auto worktree but covers its fallback on approve", () => {
     // worktreeMode "auto" is not a definite blocker, so the banner stays full-access only and
     // Run now is not disabled for it. But approving persists local-checkout too, so the

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -175,35 +175,45 @@ export function automationApprovalGaps(input: {
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 } {
   const acknowledged = new Set(input.acknowledgedRisks);
-  const required: AutomationAcknowledgedRiskId[] = [];
-  if (input.runtimeMode === "full-access") {
-    required.push("full-access");
+  // Definite run blockers the server enforces up front (riskAcknowledgementError): full
+  // access runtime and an explicit local checkout. These drive the banner and the Run-now
+  // disable. "auto" is not a definite blocker, so a normal auto run is never blocked here.
+  const blocking = new Set<AutomationAcknowledgedRiskId>();
+  if (input.runtimeMode === "full-access" && !acknowledged.has("full-access")) {
+    blocking.add("full-access");
   }
-  if (input.worktreeMode === "local") {
-    required.push("local-checkout");
+  if (input.worktreeMode === "local" && !acknowledged.has("local-checkout")) {
+    blocking.add("local-checkout");
+  }
+  if (blocking.size === 0) {
+    // Nothing blocks the run, so no approval is surfaced and nothing new is persisted.
+    return { warnings: [], acknowledgedRisks: input.acknowledgedRisks };
+  }
+  const warnings = buildAutomationDraftWarnings({
+    schedule: input.schedule,
+    mode: input.mode,
+    runtimeMode: input.runtimeMode,
+    worktreeMode: input.worktreeMode,
+    hasEphemeralContext: false,
+    generatedConfidence: null,
+    generatedNeedsConfirmation: false,
+    prompt: input.prompt,
+  }).filter((warning) => blocking.has(warning.id as AutomationAcknowledgedRiskId));
+  // Persist every risk the config requires so the automation is fully runnable: local
+  // checkout is included for "auto" too, so a runtime worktree-creation fallback is covered
+  // once approved, plus fast-interval for a sub-minute schedule (automation.update would
+  // otherwise reject it).
+  const required = new Set<AutomationAcknowledgedRiskId>(input.acknowledgedRisks);
+  if (input.runtimeMode === "full-access") {
+    required.add("full-access");
+  }
+  if (input.worktreeMode === "local" || input.worktreeMode === "auto") {
+    required.add("local-checkout");
   }
   if (input.schedule.type === "interval" && input.schedule.everySeconds < 60) {
-    required.push("fast-interval");
+    required.add("fast-interval");
   }
-  // Run-blocking risks (everything required except fast-interval) still needing consent.
-  const blocking = new Set(
-    required.filter((risk) => risk !== "fast-interval" && !acknowledged.has(risk)),
-  );
-  const warnings =
-    blocking.size === 0
-      ? []
-      : buildAutomationDraftWarnings({
-          schedule: input.schedule,
-          mode: input.mode,
-          runtimeMode: input.runtimeMode,
-          worktreeMode: input.worktreeMode,
-          hasEphemeralContext: false,
-          generatedConfidence: null,
-          generatedNeedsConfirmation: false,
-          prompt: input.prompt,
-        }).filter((warning) => blocking.has(warning.id as AutomationAcknowledgedRiskId));
-  const acknowledgedRisks = Array.from(new Set([...input.acknowledgedRisks, ...required]));
-  return { warnings, acknowledgedRisks };
+  return { warnings, acknowledgedRisks: Array.from(required) };
 }
 
 export function acknowledgedRiskIdsForDraft(

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -178,7 +178,9 @@ export function automationApprovalGaps(input: {
   // Definite run blockers the server enforces up front (riskAcknowledgementError): full
   // access runtime and an explicit local checkout. These drive the banner and the Run-now
   // disable. "auto" is not a definite blocker, so a normal auto run is never blocked here.
-  const blocking = new Set<AutomationAcknowledgedRiskId>();
+  // Narrowed to the two ids that are both run blockers and valid warning ids, so the set can
+  // seed the display warning ids below.
+  const blocking = new Set<"full-access" | "local-checkout">();
   if (input.runtimeMode === "full-access" && !acknowledged.has("full-access")) {
     blocking.add("full-access");
   }
@@ -189,6 +191,17 @@ export function automationApprovalGaps(input: {
     // Nothing blocks the run, so no approval is surfaced and nothing new is persisted.
     return { warnings: [], acknowledgedRisks: input.acknowledgedRisks };
   }
+  // Display the blocking risks, plus the fast-recurring-loop risk when a sub-minute schedule
+  // means approving will also acknowledge it — so the user sees everything they consent to,
+  // not just the run blockers.
+  const displayIds = new Set<AutomationDraftWarningId>(blocking);
+  if (
+    input.schedule.type === "interval" &&
+    input.schedule.everySeconds < 60 &&
+    !acknowledged.has("fast-interval")
+  ) {
+    displayIds.add("fast-recurring-interval");
+  }
   const warnings = buildAutomationDraftWarnings({
     schedule: input.schedule,
     mode: input.mode,
@@ -198,7 +211,7 @@ export function automationApprovalGaps(input: {
     generatedConfidence: null,
     generatedNeedsConfirmation: false,
     prompt: input.prompt,
-  }).filter((warning) => blocking.has(warning.id as AutomationAcknowledgedRiskId));
+  }).filter((warning) => displayIds.has(warning.id));
   // Persist every risk the config requires so the automation is fully runnable: local
   // checkout is included for "auto" too, so a runtime worktree-creation fallback is covered
   // once approved, plus fast-interval for a sub-minute schedule (automation.update would

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -161,9 +161,13 @@ const RUN_BLOCKING_WARNING_IDS: ReadonlySet<AutomationDraftWarningId> = new Set(
   "local-checkout",
 ]);
 
-// Computes the approval an existing automation still needs before it can run: the
-// run-blocking risks it carries that have not yet been acknowledged. Returns the missing
-// warnings (for display) and the risk ids to persist. Empty when nothing is required.
+// Computes the approval an existing automation still needs before it can run.
+// `warnings` are the run-blocking risks that have not been acknowledged — they drive the
+// approval banner (empty means no approval needed). `acknowledgedRisks` is the full set to
+// persist when approving: every risk the config requires, merged with what is already
+// acknowledged. It includes fast-interval when the schedule is sub-minute, because
+// automation.update revalidates the whole definition and rejects such a schedule unless
+// fast-interval is acknowledged — so a banner approval would otherwise fail to save.
 export function automationApprovalGaps(input: {
   readonly schedule: AutomationSchedule;
   readonly mode: AutomationMode;
@@ -173,10 +177,10 @@ export function automationApprovalGaps(input: {
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 }): {
   readonly warnings: readonly AutomationDraftWarning[];
-  readonly risks: readonly AutomationAcknowledgedRiskId[];
+  readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 } {
   const acknowledged = new Set(input.acknowledgedRisks);
-  const warnings = buildAutomationDraftWarnings({
+  const requiredWarnings = buildAutomationDraftWarnings({
     schedule: input.schedule,
     mode: input.mode,
     runtimeMode: input.runtimeMode,
@@ -185,17 +189,23 @@ export function automationApprovalGaps(input: {
     generatedConfidence: null,
     generatedNeedsConfirmation: false,
     prompt: input.prompt,
-  }).filter(
+  }).filter((warning) => warning.requiresAcknowledgement);
+  const warnings = requiredWarnings.filter(
     (warning) =>
-      warning.requiresAcknowledgement &&
       RUN_BLOCKING_WARNING_IDS.has(warning.id) &&
       // full-access and local-checkout warning ids map 1:1 to their risk ids.
       !acknowledged.has(warning.id as AutomationAcknowledgedRiskId),
   );
-  return {
-    warnings,
-    risks: warnings.map((warning) => warning.id as AutomationAcknowledgedRiskId),
-  };
+  const acknowledgedRisks = Array.from(
+    new Set([
+      ...input.acknowledgedRisks,
+      ...acknowledgedRiskIdsForDraft(
+        requiredWarnings,
+        new Set(requiredWarnings.map((warning) => warning.id)),
+      ),
+    ]),
+  );
+  return { warnings, acknowledgedRisks };
 }
 
 export function acknowledgedRiskIdsForDraft(

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -158,6 +158,8 @@ export function buildAutomationDraftWarnings(input: {
 // disable Run now. `acknowledgedRisks` is the full set to persist on approval.
 export function automationApprovalGaps(input: {
   readonly schedule: AutomationSchedule;
+  readonly enabled: boolean;
+  readonly maxIterations: number | null;
   readonly mode: AutomationMode;
   readonly runtimeMode: RuntimeMode;
   readonly worktreeMode: AutomationWorktreeMode;
@@ -167,9 +169,11 @@ export function automationApprovalGaps(input: {
   readonly warnings: readonly AutomationDraftWarning[];
   readonly runBlockingWarnings: readonly AutomationDraftWarning[];
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
+  readonly maxIterations: number | undefined;
 } {
   const acknowledged = new Set(input.acknowledgedRisks);
   const approvalIds = new Set<AutomationDraftWarningId>();
+  const maxIterations = maxIterationsForFastIntervalApproval(input);
   // Definite run blockers: full-access and a standalone local checkout. Heartbeats reuse
   // their target thread, so local-checkout consent is needed for updates but not dispatch.
   const runBlockingIds = new Set<AutomationDraftWarningId>();
@@ -190,6 +194,9 @@ export function automationApprovalGaps(input: {
   ) {
     approvalIds.add("fast-recurring-interval");
   }
+  if (maxIterations !== undefined) {
+    approvalIds.add("fast-recurring-interval");
+  }
   if (
     approvalIds.size > 0 &&
     input.mode === "standalone" &&
@@ -205,6 +212,7 @@ export function automationApprovalGaps(input: {
       warnings: [],
       runBlockingWarnings: [],
       acknowledgedRisks: input.acknowledgedRisks,
+      maxIterations: undefined,
     };
   }
   const warnings = buildAutomationDraftWarnings({
@@ -223,7 +231,12 @@ export function automationApprovalGaps(input: {
   for (const risk of acknowledgedRiskIdsForDraft(warnings, acknowledgedWarningIds)) {
     required.add(risk);
   }
-  return { warnings, runBlockingWarnings, acknowledgedRisks: Array.from(required) };
+  return {
+    warnings,
+    runBlockingWarnings,
+    acknowledgedRisks: Array.from(required),
+    maxIterations,
+  };
 }
 
 // Approval of an enabled legacy fast loop must also satisfy the server's hard iteration cap.

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -226,6 +226,24 @@ export function automationApprovalGaps(input: {
   return { warnings, runBlockingWarnings, acknowledgedRisks: Array.from(required) };
 }
 
+// Approval of an enabled legacy fast loop must also satisfy the server's hard iteration cap.
+export function maxIterationsForFastIntervalApproval(input: {
+  readonly schedule: AutomationSchedule;
+  readonly enabled: boolean;
+  readonly maxIterations: number | null;
+}): number | undefined {
+  if (
+    input.enabled &&
+    input.schedule.type === "interval" &&
+    input.schedule.everySeconds < 60 &&
+    (input.maxIterations === null ||
+      input.maxIterations > DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS)
+  ) {
+    return DEFAULT_AUTOMATION_FAST_INTERVAL_MAX_ITERATIONS;
+  }
+  return undefined;
+}
+
 export function acknowledgedRiskIdsForDraft(
   warnings: readonly AutomationDraftWarning[],
   acknowledgedWarningIds: ReadonlySet<AutomationDraftWarningId>,

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -153,16 +153,9 @@ export function buildAutomationDraftWarnings(input: {
   return warnings;
 }
 
-// Computes the approval an existing automation still needs before it can run, matching the
-// server gate exactly. `warnings` are the run-blocking risks not yet acknowledged and drive
-// the approval banner (empty means no approval is needed). `acknowledgedRisks` is the full
-// set to persist when approving, merged with what is already acknowledged.
-//
-// Only full-access runtime and an explicit local checkout (worktreeMode "local") block a
-// run. worktreeMode "auto" is excluded on purpose: the server needs local-checkout for auto
-// only when it cannot create a worktree at runtime (a conditional fallback), so a normal
-// auto run must not be blocked. fast-interval never blocks a run, but it is still persisted
-// on approve so automation.update (which revalidates a sub-minute schedule) accepts the save.
+// Computes the approval an existing automation still needs before it can run or update.
+// `warnings` drives the banner; `runBlockingWarnings` is the narrower subset that should
+// disable Run now. `acknowledgedRisks` is the full set to persist on approval.
 export function automationApprovalGaps(input: {
   readonly schedule: AutomationSchedule;
   readonly mode: AutomationMode;
@@ -172,41 +165,47 @@ export function automationApprovalGaps(input: {
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 }): {
   readonly warnings: readonly AutomationDraftWarning[];
+  readonly runBlockingWarnings: readonly AutomationDraftWarning[];
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 } {
   const acknowledged = new Set(input.acknowledgedRisks);
-  // Definite run blockers the server enforces up front (riskAcknowledgementError): full
-  // access runtime and an explicit local checkout. These drive the banner and the Run-now
-  // disable. "auto" is not a definite blocker, so a normal auto run is never blocked here.
-  // Narrowed to the two ids that are both run blockers and valid warning ids, so the set can
-  // seed the display warning ids below.
-  const blocking = new Set<"full-access" | "local-checkout">();
+  const approvalIds = new Set<AutomationDraftWarningId>();
+  // Definite run blockers: full-access and a standalone local checkout. Heartbeats reuse
+  // their target thread, so local-checkout consent is needed for updates but not dispatch.
+  const runBlockingIds = new Set<AutomationDraftWarningId>();
   if (input.runtimeMode === "full-access" && !acknowledged.has("full-access")) {
-    blocking.add("full-access");
+    approvalIds.add("full-access");
+    runBlockingIds.add("full-access");
   }
-  if (
-    input.worktreeMode === "local" &&
-    // Heartbeat runs reuse the target thread and never resolve a local/worktree environment,
-    // so local-checkout consent cannot block them; only standalone runs are gated at dispatch.
-    input.mode === "standalone" &&
-    !acknowledged.has("local-checkout")
-  ) {
-    blocking.add("local-checkout");
+  if (input.worktreeMode === "local" && !acknowledged.has("local-checkout")) {
+    approvalIds.add("local-checkout");
+    if (input.mode === "standalone") {
+      runBlockingIds.add("local-checkout");
+    }
   }
-  if (blocking.size === 0) {
-    // Nothing blocks the run, so no approval is surfaced and nothing new is persisted.
-    return { warnings: [], acknowledgedRisks: input.acknowledgedRisks };
-  }
-  // Display the blocking risks, plus the fast-recurring-loop risk when a sub-minute schedule
-  // means approving will also acknowledge it — so the user sees everything they consent to,
-  // not just the run blockers.
-  const displayIds = new Set<AutomationDraftWarningId>(blocking);
   if (
     input.schedule.type === "interval" &&
     input.schedule.everySeconds < 60 &&
     !acknowledged.has("fast-interval")
   ) {
-    displayIds.add("fast-recurring-interval");
+    approvalIds.add("fast-recurring-interval");
+  }
+  if (
+    approvalIds.size > 0 &&
+    input.mode === "standalone" &&
+    input.worktreeMode === "auto" &&
+    !acknowledged.has("local-checkout")
+  ) {
+    // Auto fallback is not enough to show the banner by itself, but if the user is already
+    // approving another risk, include the fallback consent instead of saving a hidden risk.
+    approvalIds.add("local-checkout");
+  }
+  if (approvalIds.size === 0) {
+    return {
+      warnings: [],
+      runBlockingWarnings: [],
+      acknowledgedRisks: input.acknowledgedRisks,
+    };
   }
   const warnings = buildAutomationDraftWarnings({
     schedule: input.schedule,
@@ -217,22 +216,14 @@ export function automationApprovalGaps(input: {
     generatedConfidence: null,
     generatedNeedsConfirmation: false,
     prompt: input.prompt,
-  }).filter((warning) => displayIds.has(warning.id));
-  // Persist every risk the config requires so the automation is fully runnable: local
-  // checkout is included for "auto" too, so a runtime worktree-creation fallback is covered
-  // once approved, plus fast-interval for a sub-minute schedule (automation.update would
-  // otherwise reject it).
+  }).filter((warning) => approvalIds.has(warning.id));
+  const runBlockingWarnings = warnings.filter((warning) => runBlockingIds.has(warning.id));
+  const acknowledgedWarningIds = new Set(warnings.map((warning) => warning.id));
   const required = new Set<AutomationAcknowledgedRiskId>(input.acknowledgedRisks);
-  if (input.runtimeMode === "full-access") {
-    required.add("full-access");
+  for (const risk of acknowledgedRiskIdsForDraft(warnings, acknowledgedWarningIds)) {
+    required.add(risk);
   }
-  if (input.worktreeMode === "local" || input.worktreeMode === "auto") {
-    required.add("local-checkout");
-  }
-  if (input.schedule.type === "interval" && input.schedule.everySeconds < 60) {
-    required.add("fast-interval");
-  }
-  return { warnings, acknowledgedRisks: Array.from(required) };
+  return { warnings, runBlockingWarnings, acknowledgedRisks: Array.from(required) };
 }
 
 export function acknowledgedRiskIdsForDraft(

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -37,7 +37,7 @@ export interface AutomationDraftWarning {
   readonly requiresAcknowledgement: boolean;
 }
 
-type AutomationAcknowledgedRiskId = "full-access" | "local-checkout" | "fast-interval";
+export type AutomationAcknowledgedRiskId = "full-access" | "local-checkout" | "fast-interval";
 
 export interface AutomationCreationDraft {
   readonly source: AutomationCreationDraftSource;
@@ -151,6 +151,51 @@ export function buildAutomationDraftWarnings(input: {
     });
   }
   return warnings;
+}
+
+// The server refuses to start a run only for these two risks (full-access runtime and a
+// local checkout); fast-interval merely caps the cadence, so it never blocks a run and is
+// intentionally excluded from approval detection.
+const RUN_BLOCKING_WARNING_IDS: ReadonlySet<AutomationDraftWarningId> = new Set([
+  "full-access",
+  "local-checkout",
+]);
+
+// Computes the approval an existing automation still needs before it can run: the
+// run-blocking risks it carries that have not yet been acknowledged. Returns the missing
+// warnings (for display) and the risk ids to persist. Empty when nothing is required.
+export function automationApprovalGaps(input: {
+  readonly schedule: AutomationSchedule;
+  readonly mode: AutomationMode;
+  readonly runtimeMode: RuntimeMode;
+  readonly worktreeMode: AutomationWorktreeMode;
+  readonly prompt: string;
+  readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
+}): {
+  readonly warnings: readonly AutomationDraftWarning[];
+  readonly risks: readonly AutomationAcknowledgedRiskId[];
+} {
+  const acknowledged = new Set(input.acknowledgedRisks);
+  const warnings = buildAutomationDraftWarnings({
+    schedule: input.schedule,
+    mode: input.mode,
+    runtimeMode: input.runtimeMode,
+    worktreeMode: input.worktreeMode,
+    hasEphemeralContext: false,
+    generatedConfidence: null,
+    generatedNeedsConfirmation: false,
+    prompt: input.prompt,
+  }).filter(
+    (warning) =>
+      warning.requiresAcknowledgement &&
+      RUN_BLOCKING_WARNING_IDS.has(warning.id) &&
+      // full-access and local-checkout warning ids map 1:1 to their risk ids.
+      !acknowledged.has(warning.id as AutomationAcknowledgedRiskId),
+  );
+  return {
+    warnings,
+    risks: warnings.map((warning) => warning.id as AutomationAcknowledgedRiskId),
+  };
 }
 
 export function acknowledgedRiskIdsForDraft(

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -153,21 +153,16 @@ export function buildAutomationDraftWarnings(input: {
   return warnings;
 }
 
-// The server refuses to start a run only for these two risks (full-access runtime and a
-// local checkout); fast-interval merely caps the cadence, so it never blocks a run and is
-// intentionally excluded from approval detection.
-const RUN_BLOCKING_WARNING_IDS: ReadonlySet<AutomationDraftWarningId> = new Set([
-  "full-access",
-  "local-checkout",
-]);
-
-// Computes the approval an existing automation still needs before it can run.
-// `warnings` are the run-blocking risks that have not been acknowledged — they drive the
-// approval banner (empty means no approval needed). `acknowledgedRisks` is the full set to
-// persist when approving: every risk the config requires, merged with what is already
-// acknowledged. It includes fast-interval when the schedule is sub-minute, because
-// automation.update revalidates the whole definition and rejects such a schedule unless
-// fast-interval is acknowledged — so a banner approval would otherwise fail to save.
+// Computes the approval an existing automation still needs before it can run, matching the
+// server gate exactly. `warnings` are the run-blocking risks not yet acknowledged and drive
+// the approval banner (empty means no approval is needed). `acknowledgedRisks` is the full
+// set to persist when approving, merged with what is already acknowledged.
+//
+// Only full-access runtime and an explicit local checkout (worktreeMode "local") block a
+// run. worktreeMode "auto" is excluded on purpose: the server needs local-checkout for auto
+// only when it cannot create a worktree at runtime (a conditional fallback), so a normal
+// auto run must not be blocked. fast-interval never blocks a run, but it is still persisted
+// on approve so automation.update (which revalidates a sub-minute schedule) accepts the save.
 export function automationApprovalGaps(input: {
   readonly schedule: AutomationSchedule;
   readonly mode: AutomationMode;
@@ -180,31 +175,34 @@ export function automationApprovalGaps(input: {
   readonly acknowledgedRisks: readonly AutomationAcknowledgedRiskId[];
 } {
   const acknowledged = new Set(input.acknowledgedRisks);
-  const requiredWarnings = buildAutomationDraftWarnings({
-    schedule: input.schedule,
-    mode: input.mode,
-    runtimeMode: input.runtimeMode,
-    worktreeMode: input.worktreeMode,
-    hasEphemeralContext: false,
-    generatedConfidence: null,
-    generatedNeedsConfirmation: false,
-    prompt: input.prompt,
-  }).filter((warning) => warning.requiresAcknowledgement);
-  const warnings = requiredWarnings.filter(
-    (warning) =>
-      RUN_BLOCKING_WARNING_IDS.has(warning.id) &&
-      // full-access and local-checkout warning ids map 1:1 to their risk ids.
-      !acknowledged.has(warning.id as AutomationAcknowledgedRiskId),
+  const required: AutomationAcknowledgedRiskId[] = [];
+  if (input.runtimeMode === "full-access") {
+    required.push("full-access");
+  }
+  if (input.worktreeMode === "local") {
+    required.push("local-checkout");
+  }
+  if (input.schedule.type === "interval" && input.schedule.everySeconds < 60) {
+    required.push("fast-interval");
+  }
+  // Run-blocking risks (everything required except fast-interval) still needing consent.
+  const blocking = new Set(
+    required.filter((risk) => risk !== "fast-interval" && !acknowledged.has(risk)),
   );
-  const acknowledgedRisks = Array.from(
-    new Set([
-      ...input.acknowledgedRisks,
-      ...acknowledgedRiskIdsForDraft(
-        requiredWarnings,
-        new Set(requiredWarnings.map((warning) => warning.id)),
-      ),
-    ]),
-  );
+  const warnings =
+    blocking.size === 0
+      ? []
+      : buildAutomationDraftWarnings({
+          schedule: input.schedule,
+          mode: input.mode,
+          runtimeMode: input.runtimeMode,
+          worktreeMode: input.worktreeMode,
+          hasEphemeralContext: false,
+          generatedConfidence: null,
+          generatedNeedsConfirmation: false,
+          prompt: input.prompt,
+        }).filter((warning) => blocking.has(warning.id as AutomationAcknowledgedRiskId));
+  const acknowledgedRisks = Array.from(new Set([...input.acknowledgedRisks, ...required]));
   return { warnings, acknowledgedRisks };
 }
 

--- a/apps/web/src/lib/automationDraft.ts
+++ b/apps/web/src/lib/automationDraft.ts
@@ -184,7 +184,13 @@ export function automationApprovalGaps(input: {
   if (input.runtimeMode === "full-access" && !acknowledged.has("full-access")) {
     blocking.add("full-access");
   }
-  if (input.worktreeMode === "local" && !acknowledged.has("local-checkout")) {
+  if (
+    input.worktreeMode === "local" &&
+    // Heartbeat runs reuse the target thread and never resolve a local/worktree environment,
+    // so local-checkout consent cannot block them; only standalone runs are gated at dispatch.
+    input.mode === "standalone" &&
+    !acknowledged.has("local-checkout")
+  ) {
     blocking.add("local-checkout");
   }
   if (blocking.size === 0) {

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -23,6 +23,7 @@ import {
   ComposerPickerMenuSubPopup,
 } from "~/components/chat/ComposerPickerMenuPopup";
 import { ProviderModelPicker } from "~/components/chat/ProviderModelPicker";
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Dialog, DialogPopup, DialogTitle } from "~/components/ui/dialog";
 import {
@@ -642,6 +643,50 @@ export function maxIterationOptions(
     return MAX_ITERATION_PRESETS;
   }
   return [{ value, label: maxIterationLabel(value) }, ...MAX_ITERATION_PRESETS];
+}
+
+// Shown at the top of an automation's detail panel when it still needs a one-time risk
+// approval before it can run. Approving persists on the automation, so it never asks again.
+export function AutomationApprovalBanner({
+  warnings,
+  busy,
+  onApprove,
+  onApproveAndRun,
+}: {
+  readonly warnings: readonly AutomationDraftWarning[];
+  readonly busy: boolean;
+  readonly onApprove: () => void;
+  readonly onApproveAndRun: () => void;
+}) {
+  if (warnings.length === 0) {
+    return null;
+  }
+  return (
+    <Alert variant="warning">
+      <AlertTitle>Approval needed to run</AlertTitle>
+      <AlertDescription>
+        <span>
+          This automation needs your approval once before it can run. It won&apos;t ask again.
+        </span>
+        <ul className="flex flex-col gap-1.5">
+          {warnings.map((warning) => (
+            <li key={warning.id} className="text-xs">
+              <span className="font-medium text-foreground/90">{warning.title}</span>
+              <span className="block">{warning.detail}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={onApprove}>
+            Approve
+          </Button>
+          <Button type="button" size="sm" disabled={busy} onClick={onApproveAndRun}>
+            Approve &amp; run now
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
 }
 
 export function AutomationModelPicker({

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -645,8 +645,8 @@ export function maxIterationOptions(
   return [{ value, label: maxIterationLabel(value) }, ...MAX_ITERATION_PRESETS];
 }
 
-// Shown at the top of an automation's detail panel when it still needs a one-time risk
-// approval before Synara can run or update every configured path without asking again.
+// Shown at the top of an automation's detail panel when saving or manual run actions need
+// one-time risk approval.
 export function AutomationApprovalBanner({
   warnings,
   busy,
@@ -666,8 +666,8 @@ export function AutomationApprovalBanner({
       <AlertTitle>Approval needed</AlertTitle>
       <AlertDescription>
         <span>
-          This automation needs your approval once before Synara can run or update it. It
-          won&apos;t ask again.
+          This automation needs your approval once before Synara can save changes. When a
+          warning blocks manual runs, Run now stays disabled until you approve it.
         </span>
         <ul className="flex flex-col gap-1.5">
           {warnings.map((warning) => (

--- a/apps/web/src/routes/-automations.shared.tsx
+++ b/apps/web/src/routes/-automations.shared.tsx
@@ -646,7 +646,7 @@ export function maxIterationOptions(
 }
 
 // Shown at the top of an automation's detail panel when it still needs a one-time risk
-// approval before it can run. Approving persists on the automation, so it never asks again.
+// approval before Synara can run or update every configured path without asking again.
 export function AutomationApprovalBanner({
   warnings,
   busy,
@@ -663,10 +663,11 @@ export function AutomationApprovalBanner({
   }
   return (
     <Alert variant="warning">
-      <AlertTitle>Approval needed to run</AlertTitle>
+      <AlertTitle>Approval needed</AlertTitle>
       <AlertDescription>
         <span>
-          This automation needs your approval once before it can run. It won&apos;t ask again.
+          This automation needs your approval once before Synara can run or update it. It
+          won&apos;t ask again.
         </span>
         <ul className="flex flex-col gap-1.5">
           {warnings.map((warning) => (

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -485,7 +485,9 @@ function AutomationDetailView() {
               <AutomationApprovalBanner
                 warnings={approvalGaps.warnings}
                 busy={approvalBusy}
-                onApprove={() => void approveAutomationRisks()}
+                // Swallow the rejection here; the mutation's onError already toasts. Without
+                // this, void-ing the rejected promise would surface an unhandled rejection.
+                onApprove={() => void approveAutomationRisks().catch(() => undefined)}
                 onApproveAndRun={() => void handleApproveAndRunNow()}
               />
               <DetailGroup title="Status">

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -268,14 +268,14 @@ function AutomationDetailView() {
     prompt: definition.prompt,
     acknowledgedRisks: definition.acknowledgedRisks,
   });
-  const approveAutomationRisks = () => {
-    const acknowledgedRisks = Array.from(
-      new Set([...definition.acknowledgedRisks, ...approvalGaps.risks]),
-    );
-    // Records consent only. Pause/resume stays a separate, explicit action so approving
-    // never silently re-enables an automation the user deliberately paused.
-    return updateMutation.mutateAsync({ id: definition.id, acknowledgedRisks });
-  };
+  const approveAutomationRisks = () =>
+    // Records consent only, persisting the full required risk set so the update validates.
+    // Pause/resume stays a separate, explicit action so approving never silently re-enables
+    // an automation the user deliberately paused.
+    updateMutation.mutateAsync({
+      id: definition.id,
+      acknowledgedRisks: approvalGaps.acknowledgedRisks,
+    });
   const handleApproveAndRunNow = async () => {
     try {
       await approveAutomationRisks();
@@ -460,7 +460,14 @@ function AutomationDetailView() {
                   type="button"
                   size="sm"
                   className="ml-1.5"
-                  disabled={runNowMutation.isPending || approvalGaps.warnings.length > 0}
+                  disabled={
+                    runNowMutation.isPending ||
+                    // Stay disabled while an approval update is in flight: the cache merges
+                    // acknowledgedRisks optimistically, so warnings clears before the server
+                    // persists and a run dispatched in that window hits the old definition.
+                    updateMutation.isPending ||
+                    approvalGaps.warnings.length > 0
+                  }
                   title={
                     approvalGaps.warnings.length > 0 ? "Approve the automation first" : undefined
                   }

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -31,6 +31,7 @@ import { SidebarInset } from "~/components/ui/sidebar";
 import {
   automationApprovalGaps,
   hasBlockingAutomationDraftWarnings,
+  maxIterationsForFastIntervalApproval,
   warningIdsForAcknowledgedRisks,
   type AutomationDraftWarning,
   type AutomationDraftWarningId,
@@ -268,13 +269,20 @@ function AutomationDetailView() {
     prompt: definition.prompt,
     acknowledgedRisks: definition.acknowledgedRisks,
   });
+  const fastIntervalMaxIterationsOnApproval = maxIterationsForFastIntervalApproval({
+    schedule: definition.schedule,
+    enabled: definition.enabled,
+    maxIterations: definition.maxIterations,
+  });
   const approveAutomationRisks = () =>
-    // Records consent only, persisting the full required risk set so the update validates.
-    // Pause/resume stays a separate, explicit action so approving never silently re-enables
-    // an automation the user deliberately paused.
+    // Records consent and any server-required fast-loop cap. Pause/resume stays separate so
+    // approving never silently re-enables an automation the user deliberately paused.
     updateMutation.mutateAsync({
       id: definition.id,
       acknowledgedRisks: approvalGaps.acknowledgedRisks,
+      ...(fastIntervalMaxIterationsOnApproval !== undefined
+        ? { maxIterations: fastIntervalMaxIterationsOnApproval }
+        : {}),
     });
   const handleApproveAndRunNow = async () => {
     try {

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -466,10 +466,12 @@ function AutomationDetailView() {
                     // acknowledgedRisks optimistically, so warnings clears before the server
                     // persists and a run dispatched in that window hits the old definition.
                     updateMutation.isPending ||
-                    approvalGaps.warnings.length > 0
+                    approvalGaps.runBlockingWarnings.length > 0
                   }
                   title={
-                    approvalGaps.warnings.length > 0 ? "Approve the automation first" : undefined
+                    approvalGaps.runBlockingWarnings.length > 0
+                      ? "Approve the automation first"
+                      : undefined
                   }
                   onClick={() => runNowMutation.mutate(definition)}
                 >

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -31,7 +31,6 @@ import { SidebarInset } from "~/components/ui/sidebar";
 import {
   automationApprovalGaps,
   hasBlockingAutomationDraftWarnings,
-  maxIterationsForFastIntervalApproval,
   warningIdsForAcknowledgedRisks,
   type AutomationDraftWarning,
   type AutomationDraftWarningId,
@@ -263,16 +262,13 @@ function AutomationDetailView() {
   // automation still needs it (e.g. created via the API). Persists on the automation.
   const approvalGaps = automationApprovalGaps({
     schedule: definition.schedule,
+    enabled: definition.enabled,
+    maxIterations: definition.maxIterations,
     mode: definition.mode,
     runtimeMode: definition.runtimeMode,
     worktreeMode: definition.worktreeMode,
     prompt: definition.prompt,
     acknowledgedRisks: definition.acknowledgedRisks,
-  });
-  const fastIntervalMaxIterationsOnApproval = maxIterationsForFastIntervalApproval({
-    schedule: definition.schedule,
-    enabled: definition.enabled,
-    maxIterations: definition.maxIterations,
   });
   const approveAutomationRisks = () =>
     // Records consent and any server-required fast-loop cap. Pause/resume stays separate so
@@ -280,8 +276,8 @@ function AutomationDetailView() {
     updateMutation.mutateAsync({
       id: definition.id,
       acknowledgedRisks: approvalGaps.acknowledgedRisks,
-      ...(fastIntervalMaxIterationsOnApproval !== undefined
-        ? { maxIterations: fastIntervalMaxIterationsOnApproval }
+      ...(approvalGaps.maxIterations !== undefined
+        ? { maxIterations: approvalGaps.maxIterations }
         : {}),
     });
   const handleApproveAndRunNow = async () => {

--- a/apps/web/src/routes/_chat.automations.$automationId.tsx
+++ b/apps/web/src/routes/_chat.automations.$automationId.tsx
@@ -29,6 +29,7 @@ import { SidebarHeaderNavigationControls } from "~/components/SidebarHeaderNavig
 import { Button } from "~/components/ui/button";
 import { SidebarInset } from "~/components/ui/sidebar";
 import {
+  automationApprovalGaps,
   hasBlockingAutomationDraftWarnings,
   warningIdsForAcknowledgedRisks,
   type AutomationDraftWarning,
@@ -55,6 +56,7 @@ import { ensureNativeApi } from "~/nativeApi";
 import { useStore } from "~/store";
 import {
   type AutomationFormState,
+  AutomationApprovalBanner,
   AutomationDialog,
   AutomationModelPicker,
   acknowledgedRiskIdsForFormWarnings,
@@ -256,6 +258,34 @@ function AutomationDetailView() {
   const patch = (input: Omit<AutomationUpdateInput, "id">) =>
     updateMutation.mutate({ id: definition.id, ...input });
 
+  // One-time risk approval surfaced at the top of the panel when an already-created
+  // automation still needs it (e.g. created via the API). Persists on the automation.
+  const approvalGaps = automationApprovalGaps({
+    schedule: definition.schedule,
+    mode: definition.mode,
+    runtimeMode: definition.runtimeMode,
+    worktreeMode: definition.worktreeMode,
+    prompt: definition.prompt,
+    acknowledgedRisks: definition.acknowledgedRisks,
+  });
+  const approveAutomationRisks = () => {
+    const acknowledgedRisks = Array.from(
+      new Set([...definition.acknowledgedRisks, ...approvalGaps.risks]),
+    );
+    // Records consent only. Pause/resume stays a separate, explicit action so approving
+    // never silently re-enables an automation the user deliberately paused.
+    return updateMutation.mutateAsync({ id: definition.id, acknowledgedRisks });
+  };
+  const handleApproveAndRunNow = async () => {
+    try {
+      await approveAutomationRisks();
+    } catch {
+      return; // update failed; the mutation already surfaced the error toast
+    }
+    runNowMutation.mutate(definition);
+  };
+  const approvalBusy = updateMutation.isPending || runNowMutation.isPending;
+
   // Applying a new model selection (model swap or a capability tweak) refreshes the saved
   // provider start options the same way the model picker does, then patches both at once.
   const applyModelSelection = (nextModelSelection: ModelSelection) => {
@@ -430,7 +460,10 @@ function AutomationDetailView() {
                   type="button"
                   size="sm"
                   className="ml-1.5"
-                  disabled={runNowMutation.isPending}
+                  disabled={runNowMutation.isPending || approvalGaps.warnings.length > 0}
+                  title={
+                    approvalGaps.warnings.length > 0 ? "Approve the automation first" : undefined
+                  }
                   onClick={() => runNowMutation.mutate(definition)}
                 >
                   <CentralIcon name="play" className="size-4" />
@@ -442,6 +475,12 @@ function AutomationDetailView() {
 
           <div className="min-h-0 flex-1 overflow-y-auto border-l border-[var(--app-surface-divider)]">
             <div className="flex flex-col gap-6 px-4 py-8">
+              <AutomationApprovalBanner
+                warnings={approvalGaps.warnings}
+                busy={approvalBusy}
+                onApprove={() => void approveAutomationRisks()}
+                onApproveAndRun={() => void handleApproveAndRunNow()}
+              />
               <DetailGroup title="Status">
                 <DetailRow label="Status">
                   <StatusValue>


### PR DESCRIPTION
Follows up #242.

## What changed
- Split automation approval gaps into visible approval warnings and run-blocking warnings.
- Kept a one-click approval path for imported/API automations whose risks block `automation.update` but not dispatch, including local heartbeat definitions and sub-minute schedules.
- Kept Run now disabled only for true run blockers or pending update/run mutations.
- Made auto-worktree fallback consent visible only when another approval is already being saved, avoiding a standalone banner for normal approval-required auto automations.

## Verification
- `bun run --cwd apps/web test automationDraft.test.ts`
- `git diff --check`
- Same-directory `/review` pass 1: no actionable issues found.
- Same-directory `/review` pass 2 after cleanup: no actionable issues found.

## Source context
- Follow-up for #242 latest-head Codex finding about local heartbeat definitions needing an approval path for update-only local-checkout consent.