### PR TITLE
Support bidi text in chat composer and transcripts

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -37,6 +37,29 @@ describe("ChatMarkdown", () => {
     expect(markup).not.toContain("text-neutral-900");
   });
 
+  it("lets markdown prose resolve text direction automatically", async () => {
+    const markup = await renderMarkdown("שלום from Synara");
+
+    expect(markup).toContain('class="chat-markdown');
+    expect(markup).toContain('dir="auto"');
+  });
+
+  it("keeps code surfaces isolated as ltr inside bidi markdown", async () => {
+    const markup = await renderMarkdown(
+      [
+        "שלום with inline `const value = 1`.",
+        "",
+        "```ts",
+        "const path = 'src/app.ts';",
+        "```",
+      ].join("\n"),
+    );
+
+    expect(markup).toContain('<code dir="ltr">const value = 1</code>');
+    expect(markup).toContain('class="chat-markdown-codeblock"');
+    expect(markup).toContain('dir="ltr"');
+  });
+
   it("renders inline math with KaTeX", async () => {
     const markup = await renderMarkdown("Euler wrote $e^{i\\\\pi} + 1 = 0$.");
 
@@ -72,7 +95,7 @@ describe("ChatMarkdown", () => {
     expect(markup).toContain(
       'href="https://example.com" target="_blank" rel="noopener noreferrer"',
     );
-    expect(markup).toContain("<code>$z$</code>");
+    expect(markup).toContain('<code dir="ltr">$z$</code>');
     expect(markup).toContain("const price = &quot;$5&quot;;");
     expect(markup.match(/class="katex"/g) ?? []).toHaveLength(1);
   });

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -36,6 +36,7 @@ import { isLocalImageMarkdownSrc } from "../lib/localImageUrls";
 import { useTheme } from "../hooks/useTheme";
 import { openWorkspaceFileReference, useWorkspaceFileOpener } from "../lib/workspaceFileOpener";
 import { resolveMarkdownFileLinkTarget, rewriteMarkdownFileUriHref } from "../markdown-links";
+import type { TextDirectionAttribute } from "../textDirection";
 import type { ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { GeneratedMarkdownImage } from "./chat/GeneratedMarkdownImage";
 import {
@@ -85,6 +86,7 @@ interface ChatMarkdownProps {
   isStreaming?: boolean;
   className?: string | undefined;
   style?: CSSProperties | undefined;
+  direction?: TextDirectionAttribute | undefined;
   onImageExpand?: ((preview: ExpandedImagePreview) => void) | undefined;
   markers?: readonly ThreadMarker[] | undefined;
   /**
@@ -813,7 +815,7 @@ function MarkdownCodeBlock({
   );
 
   return (
-    <div className="chat-markdown-codeblock" data-wrap={wrap ? "true" : "false"}>
+    <div className="chat-markdown-codeblock" data-wrap={wrap ? "true" : "false"} dir="ltr">
       <div className="chat-markdown-codeblock__header">
         <CodeBlockHeaderTitle fence={fence} />
         <div className="chat-markdown-codeblock__actions">
@@ -952,6 +954,7 @@ function ChatMarkdown({
   isStreaming = false,
   className = "text-sm leading-relaxed",
   style,
+  direction = "auto",
   onImageExpand,
   markers,
   onTaskToggle,
@@ -1056,7 +1059,7 @@ function ChatMarkdown({
           }
         }
         return (
-          <code className={className} {...props}>
+          <code className={className} dir="ltr" {...props}>
             {children}
           </code>
         );
@@ -1104,7 +1107,11 @@ function ChatMarkdown({
   );
 
   return (
-    <div className={`chat-markdown w-full min-w-0 ${className} text-foreground`} style={style}>
+    <div
+      className={`chat-markdown w-full min-w-0 text-start ${className} text-foreground`}
+      dir={direction}
+      style={style}
+    >
       <ReactMarkdown
         remarkPlugins={remarkPlugins}
         rehypePlugins={MARKDOWN_REHYPE_PLUGINS}

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1774,6 +1774,41 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("keeps Hebrew-leading composer text RTL without mirroring the chat shell", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-composer-rtl-target" as MessageId,
+        targetText: "composer rtl target",
+      }),
+    });
+
+    try {
+      const prompt = "שלום, please inspect src/App.tsx";
+      useComposerDraftStore.getState().setPrompt(THREAD_ID, prompt);
+
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditor.textContent ?? "").toContain(prompt);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      const composerParagraph = await waitForElement(
+        () => composerEditor.querySelector<HTMLParagraphElement>("p"),
+        "Unable to find composer paragraph.",
+      );
+      expect(composerParagraph.getAttribute("dir")).toBe("auto");
+      expect(getComputedStyle(composerParagraph).direction).toBe("rtl");
+      expect(getComputedStyle(composerParagraph).textAlign).toBe("start");
+      expect(composerEditor.className).toContain("text-start");
+      expect(document.documentElement.getAttribute("dir")).not.toBe("rtl");
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("sends unmarked automation questions as normal chat messages", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1130,13 +1130,14 @@ function ComposerPromptEditorInner({
           contentEditable={
             <ContentEditable
               className={cn(
-                "block max-h-[200px] w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-foreground focus:outline-none",
+                "block max-h-[200px] w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-start text-foreground focus:outline-none",
                 COMPOSER_EDITOR_TYPOGRAPHY_CLASS_NAME,
                 COMPOSER_EDITOR_MIN_HEIGHT_CLASS_NAME,
                 COMPOSER_EDITOR_CONTENT_RESET_CLASS_NAME,
                 className,
               )}
               data-testid="composer-editor"
+              dir="auto"
               aria-placeholder={placeholder}
               placeholder={<span />}
               onPaste={onPaste}
@@ -1147,9 +1148,11 @@ function ComposerPromptEditorInner({
               <div
                 className={cn(
                   "pointer-events-none absolute inset-0",
+                  "text-start",
                   COMPOSER_PLACEHOLDER_TEXT_CLASS_NAME,
                   COMPOSER_EDITOR_TYPOGRAPHY_CLASS_NAME,
                 )}
+                dir="auto"
               >
                 {placeholder}
               </div>

--- a/apps/web/src/components/chat/InlineMentionChip.tsx
+++ b/apps/web/src/components/chat/InlineMentionChip.tsx
@@ -81,6 +81,7 @@ export const InlineMentionChip = memo(function InlineMentionChip(props: InlineMe
       <a
         className={COMPOSER_INLINE_MENTION_CHIP_INTERACTIVE_CLASS_NAME}
         title={props.path}
+        dir="ltr"
         {...(href !== undefined ? { href } : {})}
         {...(handleActivate ? { onClick: handleActivate } : {})}
         {...(handleHoverPrefetch
@@ -93,7 +94,7 @@ export const InlineMentionChip = memo(function InlineMentionChip(props: InlineMe
   }
 
   return (
-    <span className={COMPOSER_INLINE_MENTION_CHIP_CLASS_NAME} title={props.path}>
+    <span className={COMPOSER_INLINE_MENTION_CHIP_CLASS_NAME} title={props.path} dir="ltr">
       {inner}
     </span>
   );

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -153,6 +153,93 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("katex-display");
   });
 
+  it("renders RTL assistant prose with transcript-scoped direction", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        hasMessages
+        isWorking={false}
+        activeTurnInProgress={false}
+        activeTurnStartedAt={null}
+        timelineEntries={[
+          {
+            id: "entry-assistant-rtl",
+            kind: "message",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            message: {
+              id: MessageId.makeUnsafe("assistant-message-rtl"),
+              role: "assistant",
+              text: "שלום, keep `const value = 1` readable.",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              streaming: false,
+            },
+          },
+        ]}
+        turnDiffSummaryByAssistantMessageId={new Map()}
+        nowIso="2026-03-17T19:12:30.000Z"
+        expandedWorkGroups={{}}
+        onToggleWorkGroup={() => {}}
+        onOpenTurnDiff={() => {}}
+        revertTurnCountByUserMessageId={new Map()}
+        onRevertUserMessage={() => {}}
+        isRevertingCheckpoint={false}
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        resolvedTheme="light"
+        timestampFormat="locale"
+        workspaceRoot={undefined}
+      />,
+    );
+
+    expect(markup).toContain('data-assistant-message-id="assistant-message-rtl"');
+    expect(markup).toContain('dir="rtl"');
+    expect(markup).toContain('<code dir="ltr">const value = 1</code>');
+  });
+
+  it("renders RTL user prose without mirroring the whole transcript row", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        hasMessages
+        isWorking={false}
+        activeTurnInProgress={false}
+        activeTurnStartedAt={null}
+        timelineEntries={[
+          {
+            id: "entry-user-rtl",
+            kind: "message",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            message: {
+              id: MessageId.makeUnsafe("message-user-rtl"),
+              role: "user",
+              text: "שלום, please inspect @src/App.tsx",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              streaming: false,
+            },
+          },
+        ]}
+        turnDiffSummaryByAssistantMessageId={new Map()}
+        nowIso="2026-03-17T19:12:30.000Z"
+        expandedWorkGroups={{}}
+        onToggleWorkGroup={() => {}}
+        onOpenTurnDiff={() => {}}
+        revertTurnCountByUserMessageId={new Map()}
+        onRevertUserMessage={() => {}}
+        isRevertingCheckpoint={false}
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        resolvedTheme="light"
+        timestampFormat="locale"
+        workspaceRoot={undefined}
+      />,
+    );
+
+    expect(markup).toContain("flex w-full justify-end");
+    expect(markup).toContain('dir="rtl"');
+    expect(markup).toContain('dir="ltr"');
+    expect(markup).toContain("src/App.tsx");
+  });
+
   it("renders user message metadata outside the bubble shell", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(
@@ -599,9 +686,8 @@ describe("MessagesTimeline", () => {
       />,
     );
 
-    expect(markup).toContain(
-      "block max-w-full min-w-0 whitespace-pre-wrap break-words font-system-ui",
-    );
+    expect(markup).toContain("block max-w-full min-w-0 whitespace-pre-wrap break-words");
+    expect(markup).toContain("font-system-ui");
     expect(markup).not.toContain("<pre");
   });
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -127,6 +127,7 @@ import {
 } from "../../lib/subagentPresentation";
 import { RiRobot3Line } from "react-icons/ri";
 import { deriveUserMessagePreviewState } from "./userMessagePreview";
+import { resolveTextDirectionForContent } from "../../textDirection";
 
 const MAX_VISIBLE_INLINE_TOOL_ENTRIES = 4;
 // Changed-files list in the per-turn card is capped so large turns stay compact;
@@ -832,6 +833,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
               expanded: expandedUserMessagesById[row.message.id] ?? false,
             },
           );
+          const userMessageDirection = resolveTextDirectionForContent(userMessagePreview.text);
           const userMessageExpanded = expandedUserMessagesById[row.message.id] ?? false;
           const showUserText =
             userMessagePreview.text.trim().length > 0 || terminalContexts.length > 0;
@@ -935,6 +937,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   >
                     <UserMessageBody
                       text={userMessagePreview.text}
+                      direction={userMessageDirection}
                       mentionReferences={row.message.mentions ?? []}
                       terminalContexts={terminalContexts}
                       chatTypographyStyle={userMessageTypographyStyle}
@@ -1165,6 +1168,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     text={messageText}
                     cwd={markdownCwd}
                     isStreaming={Boolean(row.message.streaming)}
+                    direction={resolveTextDirectionForContent(messageText)}
                     style={chatTypographyStyle}
                     onImageExpand={onImageExpand}
                     markers={messageMarkers}
@@ -1826,7 +1830,8 @@ const UserMessageEditForm = memo(function UserMessageEditForm(props: {
         disabled={props.disabled}
         rows={1}
         aria-label="Edit message"
-        className="max-h-60 min-h-0 w-full resize-none overflow-y-auto border-0 bg-transparent p-0 font-system-ui text-foreground outline-none placeholder:text-muted-foreground/45 disabled:opacity-70"
+        className="max-h-60 min-h-0 w-full resize-none overflow-y-auto border-0 bg-transparent p-0 text-start font-system-ui text-foreground outline-none placeholder:text-muted-foreground/45 disabled:opacity-70"
+        dir="auto"
         style={props.chatTypographyStyle}
         onChange={(event) => setDraft(event.target.value)}
         onKeyDown={handleKeyDown}
@@ -1859,6 +1864,7 @@ const UserMessageEditForm = memo(function UserMessageEditForm(props: {
 
 const UserMessageBody = memo(function UserMessageBody(props: {
   text: string;
+  direction: "ltr" | "rtl";
   mentionReferences: ReadonlyArray<ProviderMentionReference>;
   terminalContexts: ParsedTerminalContextEntry[];
   chatTypographyStyle: CSSProperties;
@@ -1915,7 +1921,8 @@ const UserMessageBody = memo(function UserMessageBody(props: {
 
         return (
           <div
-            className="block max-w-full min-w-0 wrap-break-word whitespace-pre-wrap font-system-ui text-foreground"
+            className="block max-w-full min-w-0 wrap-break-word whitespace-pre-wrap text-start font-system-ui text-foreground"
+            dir={props.direction}
             style={props.chatTypographyStyle}
           >
             {inlineNodes}
@@ -1953,7 +1960,8 @@ const UserMessageBody = memo(function UserMessageBody(props: {
 
     return (
       <div
-        className="block max-w-full min-w-0 wrap-break-word whitespace-pre-wrap font-system-ui text-foreground"
+        className="block max-w-full min-w-0 wrap-break-word whitespace-pre-wrap text-start font-system-ui text-foreground"
+        dir={props.direction}
         style={props.chatTypographyStyle}
       >
         {inlineNodes}
@@ -1971,7 +1979,8 @@ const UserMessageBody = memo(function UserMessageBody(props: {
   ) {
     return (
       <div
-        className="flex max-w-full min-w-0 items-center leading-none text-foreground [&>span]:translate-y-0"
+        className="flex max-w-full min-w-0 items-center text-start leading-none text-foreground [&>span]:translate-y-0"
+        dir={props.direction}
         style={props.chatTypographyStyle}
       >
         {renderUserMessageInlineText(
@@ -1986,7 +1995,8 @@ const UserMessageBody = memo(function UserMessageBody(props: {
 
   return (
     <div
-      className="block max-w-full min-w-0 whitespace-pre-wrap break-words font-system-ui text-foreground"
+      className="block max-w-full min-w-0 whitespace-pre-wrap break-words text-start font-system-ui text-foreground"
+      dir={props.direction}
       style={props.chatTypographyStyle}
     >
       {renderUserMessageInlineText(

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -708,12 +708,12 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown ul {
-  padding-left: 1.25rem;
+  padding-inline-start: 1.25rem;
   list-style-type: disc;
 }
 
 .chat-markdown ol {
-  padding-left: 1.25rem;
+  padding-inline-start: 1.25rem;
   list-style-type: decimal;
 }
 
@@ -746,7 +746,8 @@ label:has(> select#reasoning-effort) select {
 .chat-markdown .chat-markdown-task-checkbox {
   width: 0.95em;
   height: 0.95em;
-  margin: 0 0.4em 0.1em -1.4em;
+  margin-block: 0 0.1em;
+  margin-inline: -1.4em 0.4em;
   vertical-align: middle;
   accent-color: var(--primary);
 }
@@ -843,12 +844,14 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown blockquote {
-  border-left: 2px solid var(--border);
-  padding-left: 0.8rem;
+  border-inline-start: 2px solid var(--border);
+  padding-inline-start: 0.8rem;
   color: var(--muted-foreground);
 }
 
 .chat-markdown :not(pre) > code {
+  direction: ltr;
+  unicode-bidi: isolate;
   border-radius: 0.4rem;
   background: var(--app-user-message-background);
   padding: 0.1rem 0.35rem;
@@ -887,6 +890,8 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown pre {
+  direction: ltr;
+  text-align: left;
   max-width: 100%;
   overflow-x: auto;
   border-radius: 1rem;
@@ -905,6 +910,8 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown .chat-markdown-codeblock {
+  direction: ltr;
+  text-align: left;
   margin: 0.65rem 0;
   overflow: hidden;
   border-radius: 0.65rem;

--- a/apps/web/src/textDirection.test.ts
+++ b/apps/web/src/textDirection.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTextDirectionForContent } from "./textDirection";
+
+describe("resolveTextDirectionForContent", () => {
+  it("resolves rtl when the first strong letter is Hebrew", () => {
+    expect(resolveTextDirectionForContent("  123?! שלום from Synara")).toBe("rtl");
+  });
+
+  it("resolves rtl when the first strong letter is Arabic", () => {
+    expect(resolveTextDirectionForContent("\n- مرحبا with code `src/app.ts`")).toBe("rtl");
+  });
+
+  it("keeps ltr when English appears before RTL text", () => {
+    expect(resolveTextDirectionForContent("Fix this ואז תסביר בעברית")).toBe("ltr");
+  });
+
+  it("falls back to ltr when content has no strong letters", () => {
+    expect(resolveTextDirectionForContent("  123 -- ```")).toBe("ltr");
+  });
+});

--- a/apps/web/src/textDirection.ts
+++ b/apps/web/src/textDirection.ts
@@ -1,0 +1,35 @@
+export type ResolvedTextDirection = "ltr" | "rtl";
+export type TextDirectionAttribute = ResolvedTextDirection | "auto";
+
+const LETTER_PATTERN = /\p{Letter}/u;
+
+const RTL_CODE_POINT_RANGES: readonly (readonly [number, number])[] = [
+  [0x0590, 0x08ff],
+  [0xfb1d, 0xfdff],
+  [0xfe70, 0xfeff],
+  [0x10800, 0x10fff],
+  [0x1e800, 0x1eeff],
+];
+
+function isRtlCodePoint(codePoint: number): boolean {
+  return RTL_CODE_POINT_RANGES.some(([start, end]) => codePoint >= start && codePoint <= end);
+}
+
+export function resolveTextDirectionForContent(
+  text: string,
+  fallback: ResolvedTextDirection = "ltr",
+): ResolvedTextDirection {
+  for (const character of text) {
+    const codePoint = character.codePointAt(0);
+    if (codePoint === undefined) {
+      continue;
+    }
+    if (isRtlCodePoint(codePoint)) {
+      return "rtl";
+    }
+    if (LETTER_PATTERN.test(character)) {
+      return "ltr";
+    }
+  }
+  return fallback;
+}


### PR DESCRIPTION
## Summary

- Add first-strong text direction resolution for chat transcript prose.
- Let composer and chat message text align with RTL/LTR content without changing the app shell direction.
- Keep code blocks, inline code, and mention/file chips isolated as LTR so paths and snippets remain readable.
- Add unit and browser coverage for RTL assistant messages, user messages, markdown code, and Hebrew-leading composer input.

## Why

Hebrew/Arabic-leading chat content should read naturally in Synara without mirroring the entire UI. The previous layout kept most chat text in an LTR presentation, which made mixed RTL/LTR composer input and transcript prose awkward.

## Validation

- `bun run test -- textDirection ChatMarkdown MessagesTimeline`
- `bun run --cwd apps/web test:browser`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run build:desktop`
- Preload bundle output check
- Changed-file `oxfmt --check`
- `git diff --check`

Note: repo-wide `bun run fmt:check` currently reports formatting issues in unrelated upstream files outside this PR diff. The changed files in this PR pass `oxfmt --check`.
