### PR TITLE
Add collapsible review file tree to diff panel

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -388,8 +388,14 @@ export default function DiffPanel({
   const setRepoDiffScope = useRepoDiffScopeStore((store) => store.setScope);
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(() => new Set());
   const [fileTreeOpen, setFileTreeOpen] = useState(false);
+  // Lazy-mount the review file tree on first open so a closed diff panel never
+  // pays to filter/build/render the side tree (the common case). Keep it mounted
+  // afterward so the open/close animation plays and the filter + expand state
+  // persist across toggles.
+  const [fileTreeMounted, setFileTreeMounted] = useState(false);
   const toggleFileTree = useCallback(() => {
     setFileTreeOpen((previous) => !previous);
+    setFileTreeMounted(true);
   }, []);
   const closeFileTree = useCallback(() => {
     setFileTreeOpen(false);
@@ -1180,14 +1186,19 @@ export default function DiffPanel({
               aria-hidden={!fileTreeOpen}
               inert={!fileTreeOpen}
             >
-              <ReviewFileTreePanel
-                files={renderableFiles}
-                selectedFilePath={selectedFilePath}
-                resolvedTheme={resolvedTheme}
-                isLoading={activeReviewIsLoading}
-                onSelectFile={selectFile}
-                onClose={closeFileTree}
-              />
+              {/* Empty until first open: the wrapper stays mounted (free) so the
+                  width reveal animates, but the tree only filters/builds once the
+                  user actually opens it. */}
+              {fileTreeMounted ? (
+                <ReviewFileTreePanel
+                  files={renderableFiles}
+                  selectedFilePath={selectedFilePath}
+                  resolvedTheme={resolvedTheme}
+                  isLoading={activeReviewIsLoading}
+                  onSelectFile={selectFile}
+                  onClose={closeFileTree}
+                />
+              ) : null}
             </div>
           )}
         </div>

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -35,6 +35,7 @@ import {
   buildWhyChangedPrompt,
 } from "../lib/chatReferences";
 import { resolveDiffEnvironmentState } from "../lib/threadEnvironment";
+import { disclosureWidthClassName } from "../lib/disclosureMotion";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 import { type RepoDiffScope, useRepoDiffScopeStore } from "../repoDiffScopeStore";
 import { useStore } from "../store";
@@ -63,6 +64,7 @@ import {
 } from "./DiffPanel.logic";
 import { DiffPanelPatchViewport } from "./DiffPanelPatchViewport";
 import { DiffPanelToolbar } from "./DiffPanelToolbar";
+import { ReviewFileTreePanel } from "./ReviewFileTreePanel";
 import { ComposerPickerMenuPopup } from "./chat/ComposerPickerMenuPopup";
 import { closestThroughShadow } from "./chat/chatSelectionActions";
 import { TranscriptSelectionAction } from "./chat/TranscriptSelectionAction";
@@ -385,6 +387,13 @@ export default function DiffPanel({
   const repoDiffScope = useRepoDiffScopeStore((store) => store.scope);
   const setRepoDiffScope = useRepoDiffScopeStore((store) => store.setScope);
   const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(() => new Set());
+  const [fileTreeOpen, setFileTreeOpen] = useState(false);
+  const toggleFileTree = useCallback(() => {
+    setFileTreeOpen((previous) => !previous);
+  }, []);
+  const closeFileTree = useCallback(() => {
+    setFileTreeOpen(false);
+  }, []);
   const patchViewportRef = useRef<HTMLDivElement>(null);
   const previousDiffOpenRef = useRef(false);
   const routeThreadId = useParams({
@@ -1024,6 +1033,7 @@ export default function DiffPanel({
           timestampFormat={settings.timestampFormat}
           renderableFiles={renderableFiles}
           selectedFilePath={selectedFilePath}
+          fileTreeOpen={fileTreeOpen}
           resolvedTheme={resolvedTheme}
           diffRenderMode={diffRenderMode}
           diffWordWrap={diffWordWrap}
@@ -1036,6 +1046,7 @@ export default function DiffPanel({
           onSelectLastTurn={selectLastTurn}
           onSelectTurn={selectTurn}
           onSelectFile={selectFile}
+          onToggleFileTree={toggleFileTree}
           onDiffRenderModeChange={setDiffRenderMode}
           onDiffWordWrapChange={setDiffWordWrap}
           onDiffIgnoreWhitespaceChange={setDiffIgnoreWhitespace}
@@ -1071,6 +1082,7 @@ export default function DiffPanel({
       diffIgnoreWhitespace,
       diffRenderMode,
       diffWordWrap,
+      fileTreeOpen,
       hideHeader,
       inferredCheckpointTurnCountByTurnId,
       isDiffCopied,
@@ -1091,6 +1103,7 @@ export default function DiffPanel({
       settings.timestampFormat,
       showDiffToolbar,
       toggleCollapseAll,
+      toggleFileTree,
       turnScopeIntent,
       viewSource,
     ],
@@ -1118,47 +1131,65 @@ export default function DiffPanel({
           is ready.
         </PanelStateMessage>
       ) : (
-        <div
-          ref={patchViewportRef}
-          className="diff-panel-viewport flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
-          onMouseUp={diffSelectionAction.onContainerMouseUp}
-        >
-          <DiffPanelPatchViewport
-            renderablePatch={renderablePatch}
-            renderableFiles={renderableFiles}
-            resolvedTheme={resolvedTheme}
-            diffRenderMode={diffRenderMode}
-            diffWordWrap={diffWordWrap}
-            workspaceRoot={activeCwd ?? null}
-            collapsedFiles={collapsedFiles}
-            onToggleFileCollapsed={toggleFileCollapsed}
-            chatActions={diffFileChatActions}
-            isLoading={activeReviewIsLoading}
-            hasNoChanges={activeReviewHasNoChanges}
-            error={activeReviewError}
-            viewKind={diffViewKind}
-            loadingLabel={
-              diffViewKind === "repo"
-                ? `Loading ${REPO_DIFF_SCOPE_LABELS[repoDiffScope].toLowerCase()} diff...`
-                : "Loading checkpoint diff..."
-            }
-            emptyLabel={
-              diffViewKind === "repo"
-                ? "No changes in the selected diff source."
-                : orderedTurnDiffSummaries.length === 0
-                  ? "No turn diffs are available yet."
-                  : "No net changes in this selection."
-            }
-            unavailableLabel="No repo diff is available right now."
-          />
-          {diffSelectionAction.pendingAction ? (
-            <TranscriptSelectionAction
-              left={diffSelectionAction.pendingAction.left}
-              top={diffSelectionAction.pendingAction.top}
-              placement={diffSelectionAction.pendingAction.placement}
-              onAddToChat={diffSelectionAction.commit}
+        <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+          <div
+            ref={patchViewportRef}
+            className="diff-panel-viewport flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+            onMouseUp={diffSelectionAction.onContainerMouseUp}
+          >
+            <DiffPanelPatchViewport
+              renderablePatch={renderablePatch}
+              renderableFiles={renderableFiles}
+              resolvedTheme={resolvedTheme}
+              diffRenderMode={diffRenderMode}
+              diffWordWrap={diffWordWrap}
+              workspaceRoot={activeCwd ?? null}
+              collapsedFiles={collapsedFiles}
+              onToggleFileCollapsed={toggleFileCollapsed}
+              chatActions={diffFileChatActions}
+              isLoading={activeReviewIsLoading}
+              hasNoChanges={activeReviewHasNoChanges}
+              error={activeReviewError}
+              viewKind={diffViewKind}
+              loadingLabel={
+                diffViewKind === "repo"
+                  ? `Loading ${REPO_DIFF_SCOPE_LABELS[repoDiffScope].toLowerCase()} diff...`
+                  : "Loading checkpoint diff..."
+              }
+              emptyLabel={
+                diffViewKind === "repo"
+                  ? "No changes in the selected diff source."
+                  : orderedTurnDiffSummaries.length === 0
+                    ? "No turn diffs are available yet."
+                    : "No net changes in this selection."
+              }
+              unavailableLabel="No repo diff is available right now."
             />
-          ) : null}
+            {diffSelectionAction.pendingAction ? (
+              <TranscriptSelectionAction
+                left={diffSelectionAction.pendingAction.left}
+                top={diffSelectionAction.pendingAction.top}
+                placement={diffSelectionAction.pendingAction.placement}
+                onAddToChat={diffSelectionAction.commit}
+              />
+            ) : null}
+          </div>
+          {hideHeader ? null : (
+            <div
+              className={disclosureWidthClassName(fileTreeOpen, "w-[min(42%,28rem)]", "shrink-0")}
+              aria-hidden={!fileTreeOpen}
+              inert={!fileTreeOpen}
+            >
+              <ReviewFileTreePanel
+                files={renderableFiles}
+                selectedFilePath={selectedFilePath}
+                resolvedTheme={resolvedTheme}
+                isLoading={activeReviewIsLoading}
+                onSelectFile={selectFile}
+                onClose={closeFileTree}
+              />
+            </div>
+          )}
         </div>
       )}
     </DiffPanelShell>

--- a/apps/web/src/components/DiffPanelToolbar.tsx
+++ b/apps/web/src/components/DiffPanelToolbar.tsx
@@ -17,6 +17,7 @@ import {
   DiffIcon,
   EllipsisIcon,
   FolderIcon,
+  FolderOpenIcon,
   GitBranchIcon,
   GitCommitIcon,
   ListChecksIcon,
@@ -86,6 +87,7 @@ interface DiffPanelToolbarProps {
   timestampFormat: TimestampFormat;
   renderableFiles: ReadonlyArray<FileDiffMetadata>;
   selectedFilePath: string | null;
+  fileTreeOpen: boolean;
   resolvedTheme: "light" | "dark";
   diffRenderMode: DiffRenderMode;
   diffWordWrap: boolean;
@@ -98,6 +100,7 @@ interface DiffPanelToolbarProps {
   onSelectLastTurn: () => void;
   onSelectTurn: (turnId: TurnId | null) => void;
   onSelectFile: (filePath: string) => void;
+  onToggleFileTree: () => void;
   onDiffRenderModeChange: (mode: DiffRenderMode) => void;
   onDiffWordWrapChange: (enabled: boolean) => void;
   onDiffIgnoreWhitespaceChange: (enabled: boolean) => void;
@@ -394,6 +397,26 @@ export const DiffPanelToolbar = memo(function DiffPanelToolbar(props: DiffPanelT
             resolvedTheme={props.resolvedTheme}
             onSelectFile={props.onSelectFile}
           />
+
+          <IconButton
+            variant="ghost"
+            size="icon-xs"
+            className={cn(
+              DIFF_PANEL_TOOLBAR_ICON_BUTTON_CLASS_NAME,
+              props.fileTreeOpen &&
+                "bg-[var(--color-background-button-secondary)] text-foreground hover:text-foreground",
+            )}
+            aria-pressed={props.fileTreeOpen}
+            label={props.fileTreeOpen ? "Hide file tree" : "Show file tree"}
+            title={props.fileTreeOpen ? "Hide file tree" : "Show file tree"}
+            onClick={props.onToggleFileTree}
+          >
+            {props.fileTreeOpen ? (
+              <FolderOpenIcon className="size-3.5" />
+            ) : (
+              <FolderIcon className="size-3.5" />
+            )}
+          </IconButton>
         </div>
 
         <DiffPanelToolbarDivider />

--- a/apps/web/src/components/EditorWorkspaceView.tsx
+++ b/apps/web/src/components/EditorWorkspaceView.tsx
@@ -64,6 +64,7 @@ import {
   CHAT_SURFACE_HEADER_HEIGHT_CLASS,
 } from "./chat/chatHeaderControls";
 import { FileEntryIcon } from "./chat/FileEntryIcon";
+import { fileRowClassName, fileRowIndentStyle } from "./chat/fileRowStyles";
 import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "./ui/collapsible";
 import { DisclosureChevron } from "./ui/DisclosureChevron";
 import { DiffStat } from "./chat/DiffStatLabel";
@@ -314,14 +315,8 @@ const ExplorerRow = forwardRef<
       {...rest}
       ref={ref}
       type="button"
-      className={cn(
-        "flex h-7 w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-md pr-2 text-left text-[12px] transition-colors",
-        selected
-          ? "bg-[var(--color-background-button-secondary)] text-foreground"
-          : "text-foreground/78 hover:bg-[var(--color-background-button-secondary-hover)] hover:text-foreground",
-        className,
-      )}
-      style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
+      className={fileRowClassName(selected, cn("h-7 pr-2", className))}
+      style={fileRowIndentStyle(depth)}
       title={entry.path}
       draggable
       onDragStart={handleDragStart}
@@ -350,7 +345,7 @@ function ExplorerLoadingRows(props: { depth: number }) {
   return (
     <div
       className="space-y-1.5 py-1.5 pr-2"
-      style={{ paddingLeft: `${0.5 + props.depth * 0.75}rem` }}
+      style={fileRowIndentStyle(props.depth)}
       role="status"
       aria-label="Loading directory..."
     >
@@ -468,12 +463,7 @@ function DiffFileRow(props: {
   return (
     <button
       type="button"
-      className={cn(
-        "flex h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-2 text-left text-[12px] transition-colors",
-        props.selected
-          ? "bg-[var(--color-background-button-secondary)] text-foreground"
-          : "text-foreground/78 hover:bg-[var(--color-background-button-secondary-hover)] hover:text-foreground",
-      )}
+      className={fileRowClassName(props.selected, "h-8 px-2")}
       title={filePath}
       draggable
       onDragStart={(event) => {
@@ -664,12 +654,7 @@ function WorkspaceSearchResultRow(props: {
   return (
     <button
       type="button"
-      className={cn(
-        "flex h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-md px-2 text-left text-[12px] transition-colors",
-        props.selected
-          ? "bg-[var(--color-background-button-secondary)] text-foreground"
-          : "text-foreground/78 hover:bg-[var(--color-background-button-secondary-hover)] hover:text-foreground",
-      )}
+      className={fileRowClassName(props.selected, "h-8 px-2")}
       title={entry.path}
       draggable
       onDragStart={(event) => {

--- a/apps/web/src/components/ReviewFileTreePanel.test.tsx
+++ b/apps/web/src/components/ReviewFileTreePanel.test.tsx
@@ -43,6 +43,22 @@ describe("ReviewFileTreePanel", () => {
     expect(markup).toContain("ChatView.tsx");
   });
 
+  it("renders a same-named file and directory replacement as distinct rows", () => {
+    // Deleting `foo` while adding `foo/bar.ts` produces sibling nodes that share
+    // the path "foo"; the panel must render both without colliding React keys.
+    const markup = renderToStaticMarkup(
+      <ReviewFileTreePanel
+        files={[createFileDiff("foo"), createFileDiff("foo/bar.ts")]}
+        selectedFilePath="foo"
+        resolvedTheme="dark"
+        onSelectFile={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("foo");
+    expect(markup).toContain("bar.ts");
+  });
+
   it("shows a coherent empty state when there are no files", () => {
     const markup = renderToStaticMarkup(
       <ReviewFileTreePanel

--- a/apps/web/src/components/ReviewFileTreePanel.test.tsx
+++ b/apps/web/src/components/ReviewFileTreePanel.test.tsx
@@ -1,0 +1,73 @@
+// FILE: ReviewFileTreePanel.test.tsx
+// Purpose: Guards the compact review file-tree panel: it renders the filter
+//          input, the nested/compressed changed files, and coherent empty and
+//          loading states.
+// Layer: Component rendering tests
+
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { ReviewFileTreePanel } from "./ReviewFileTreePanel";
+
+function createFileDiff(path: string): FileDiffMetadata {
+  return {
+    cacheKey: path,
+    name: path,
+    prevName: path,
+    hunks: [{ additionLines: 2, deletionLines: 1 }],
+  } as FileDiffMetadata;
+}
+
+describe("ReviewFileTreePanel", () => {
+  it("renders the filter input and the nested, compressed changed files", () => {
+    const markup = renderToStaticMarkup(
+      <ReviewFileTreePanel
+        files={[
+          createFileDiff("apps/server/src/codex.ts"),
+          createFileDiff("apps/web/src/ChatView.tsx"),
+        ]}
+        selectedFilePath="apps/web/src/ChatView.tsx"
+        resolvedTheme="dark"
+        onSelectFile={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('placeholder="Filter files..."');
+    // Top-level directory plus the compressed single-child chains.
+    expect(markup).toContain("apps");
+    expect(markup).toContain("server/src");
+    expect(markup).toContain("web/src");
+    // Leaf file names render inside the expanded tree.
+    expect(markup).toContain("codex.ts");
+    expect(markup).toContain("ChatView.tsx");
+  });
+
+  it("shows a coherent empty state when there are no files", () => {
+    const markup = renderToStaticMarkup(
+      <ReviewFileTreePanel
+        files={[]}
+        selectedFilePath={null}
+        resolvedTheme="light"
+        onSelectFile={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("No files in this diff.");
+  });
+
+  it("shows a loading state while the diff is loading with no files yet", () => {
+    const markup = renderToStaticMarkup(
+      <ReviewFileTreePanel
+        files={[]}
+        isLoading
+        selectedFilePath={null}
+        resolvedTheme="light"
+        onSelectFile={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain("Loading changed files...");
+    expect(markup).not.toContain("No files in this diff.");
+  });
+});

--- a/apps/web/src/components/ReviewFileTreePanel.tsx
+++ b/apps/web/src/components/ReviewFileTreePanel.tsx
@@ -1,0 +1,264 @@
+// FILE: ReviewFileTreePanel.tsx
+// Purpose: Compact, searchable file-tree side panel for the review/diff panel.
+//          Renders the changed files of the active diff as a nested, collapsible
+//          tree and navigates the diff on click. Reuses the diff path helpers,
+//          file-row chrome, file icons, and disclosure motion shared with the
+//          editor explorer instead of duplicating them.
+// Layer: Diff panel UI
+
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useMemo,
+  useState,
+  type ComponentPropsWithoutRef,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from "react";
+
+import { buildFileDiffTree, type FileDiffTreeNode } from "~/lib/fileDiffTree";
+import { XIcon } from "~/lib/icons";
+import { cn } from "~/lib/utils";
+
+import { filterRenderableFilesForSearch } from "./DiffPanel.logic";
+import { FileEntryIcon } from "./chat/FileEntryIcon";
+import { fileRowClassName, fileRowIndentStyle } from "./chat/fileRowStyles";
+import { PanelStateMessage } from "./chat/PanelStateMessage";
+import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "./ui/collapsible";
+import { DisclosureChevron } from "./ui/DisclosureChevron";
+import { IconButton } from "./ui/icon-button";
+import { SearchInput } from "./ui/search-input";
+import { Skeleton } from "./ui/skeleton";
+
+// Forwards its ref and spreads incoming props so directory rows can act as the
+// Collapsible trigger (Base UI injects onClick/aria/data + ref onto this element).
+const ReviewTreeRow = forwardRef<
+  HTMLButtonElement,
+  {
+    depth: number;
+    selected: boolean;
+    leading: ReactNode;
+    label: string;
+    labelClassName?: string;
+  } & ComponentPropsWithoutRef<"button">
+>(function ReviewTreeRow(
+  { depth, selected, leading, label, labelClassName, className, ...rest },
+  ref,
+) {
+  return (
+    <button
+      {...rest}
+      ref={ref}
+      type="button"
+      className={fileRowClassName(selected, cn("h-7 pr-2", className))}
+      style={fileRowIndentStyle(depth)}
+      title={label}
+    >
+      {leading}
+      <span className={cn("min-w-0 truncate", labelClassName)}>{label}</span>
+    </button>
+  );
+});
+
+const ReviewFileTreeNodes = memo(function ReviewFileTreeNodes(props: {
+  nodes: ReadonlyArray<FileDiffTreeNode>;
+  depth: number;
+  selectedFilePath: string | null;
+  resolvedTheme: "light" | "dark";
+  isPathCollapsed: (path: string) => boolean;
+  onToggleDirectory: (path: string) => void;
+  onSelectFile: (path: string) => void;
+}) {
+  return (
+    <>
+      {props.nodes.map((node) => {
+        if (node.kind === "file") {
+          return (
+            <ReviewTreeRow
+              key={node.path}
+              depth={props.depth}
+              selected={node.path === props.selectedFilePath}
+              leading={
+                <FileEntryIcon
+                  pathValue={node.path}
+                  kind="file"
+                  theme={props.resolvedTheme}
+                  className="size-3.5 shrink-0 opacity-80"
+                />
+              }
+              label={node.name}
+              onClick={() => props.onSelectFile(node.path)}
+            />
+          );
+        }
+        const open = !props.isPathCollapsed(node.path);
+        return (
+          <Collapsible
+            key={node.path}
+            open={open}
+            onOpenChange={() => props.onToggleDirectory(node.path)}
+          >
+            <CollapsibleTrigger
+              render={
+                <ReviewTreeRow
+                  depth={props.depth}
+                  selected={false}
+                  leading={<DisclosureChevron open={open} className="opacity-75" />}
+                  label={node.name}
+                  labelClassName="font-medium text-foreground/80"
+                />
+              }
+            />
+            <CollapsiblePanel>
+              <ReviewFileTreeNodes
+                nodes={node.children}
+                depth={props.depth + 1}
+                selectedFilePath={props.selectedFilePath}
+                resolvedTheme={props.resolvedTheme}
+                isPathCollapsed={props.isPathCollapsed}
+                onToggleDirectory={props.onToggleDirectory}
+                onSelectFile={props.onSelectFile}
+              />
+            </CollapsiblePanel>
+          </Collapsible>
+        );
+      })}
+    </>
+  );
+});
+
+const REVIEW_TREE_SKELETON_ROW_WIDTHS = ["w-9/12", "w-6/12", "w-8/12", "w-5/12", "w-7/12"];
+
+function ReviewFileTreeLoadingRows() {
+  return (
+    <div className="space-y-1.5 px-1 py-1.5" role="status" aria-label="Loading changed files...">
+      {REVIEW_TREE_SKELETON_ROW_WIDTHS.map((width, index) => (
+        <div
+          key={width}
+          className="flex h-5 items-center gap-1.5"
+          style={fileRowIndentStyle(index % 2)}
+        >
+          <Skeleton className="size-3.5 shrink-0 rounded-sm" />
+          <Skeleton className={cn("h-3 rounded-full", width)} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const ReviewFileTreePanel = memo(function ReviewFileTreePanel(props: {
+  files: ReadonlyArray<FileDiffMetadata>;
+  selectedFilePath: string | null;
+  resolvedTheme: "light" | "dark";
+  isLoading?: boolean;
+  className?: string;
+  onSelectFile: (filePath: string) => void;
+  onClose?: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  // Default fully expanded (the diff file set is known upfront and usually
+  // small), so we track which directories the user has *collapsed* rather than
+  // an expanded allow-list. While searching, collapse state is ignored so every
+  // match stays visible.
+  const [collapsedPaths, setCollapsedPaths] = useState<ReadonlySet<string>>(() => new Set());
+
+  const filteredFiles = useMemo(
+    () => filterRenderableFilesForSearch(props.files, query),
+    [props.files, query],
+  );
+  const tree = useMemo(() => buildFileDiffTree(filteredFiles), [filteredFiles]);
+
+  const isSearching = query.trim().length > 0;
+  const isPathCollapsed = useCallback(
+    (path: string) => !isSearching && collapsedPaths.has(path),
+    [collapsedPaths, isSearching],
+  );
+  const handleToggleDirectory = useCallback((path: string) => {
+    setCollapsedPaths((previous) => {
+      const next = new Set(previous);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  }, []);
+  const handleSearchKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Escape" && query.length > 0) {
+        event.stopPropagation();
+        setQuery("");
+      }
+    },
+    [query.length],
+  );
+
+  const hasFiles = props.files.length > 0;
+  const showLoadingRows = (props.isLoading ?? false) && !hasFiles;
+
+  return (
+    <aside
+      className={cn(
+        "flex h-full w-full min-h-0 min-w-0 flex-col border-l border-border bg-[var(--color-background-surface)]",
+        props.className,
+      )}
+      aria-label="Review files"
+    >
+      <div className="flex shrink-0 items-center gap-1.5 border-b border-border/65 p-2">
+        <SearchInput
+          value={query}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+          placeholder="Filter files..."
+          aria-label="Filter files"
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={handleSearchKeyDown}
+        />
+        {props.onClose ? (
+          <IconButton
+            variant="ghost"
+            size="icon-xs"
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+            label="Hide file tree"
+            title="Hide file tree"
+            onClick={props.onClose}
+          >
+            <XIcon className="size-3.5" />
+          </IconButton>
+        ) : null}
+      </div>
+      <div
+        className={cn(
+          "min-h-0 flex-1 overflow-auto px-1 py-1",
+          (showLoadingRows || tree.length === 0) && "flex flex-col",
+        )}
+      >
+        {showLoadingRows ? (
+          <ReviewFileTreeLoadingRows />
+        ) : !hasFiles ? (
+          <PanelStateMessage density="compact" fill="flex">
+            <p>No files in this diff.</p>
+          </PanelStateMessage>
+        ) : tree.length === 0 ? (
+          <PanelStateMessage density="compact" fill="flex">
+            <p>No matching files.</p>
+          </PanelStateMessage>
+        ) : (
+          <ReviewFileTreeNodes
+            nodes={tree}
+            depth={0}
+            selectedFilePath={props.selectedFilePath}
+            resolvedTheme={props.resolvedTheme}
+            isPathCollapsed={isPathCollapsed}
+            onToggleDirectory={handleToggleDirectory}
+            onSelectFile={props.onSelectFile}
+          />
+        )}
+      </div>
+    </aside>
+  );
+});

--- a/apps/web/src/components/ReviewFileTreePanel.tsx
+++ b/apps/web/src/components/ReviewFileTreePanel.tsx
@@ -76,8 +76,11 @@ const ReviewFileTreeNodes = memo(function ReviewFileTreeNodes(props: {
       {props.nodes.map((node) => {
         if (node.kind === "file") {
           return (
+            // Namespace keys by kind: a diff that replaces a file with a
+            // same-named directory (delete `foo`, add `foo/bar`) yields sibling
+            // file and directory nodes sharing the same path.
             <ReviewTreeRow
-              key={node.path}
+              key={`file:${node.path}`}
               depth={props.depth}
               selected={node.path === props.selectedFilePath}
               leading={
@@ -96,7 +99,7 @@ const ReviewFileTreeNodes = memo(function ReviewFileTreeNodes(props: {
         const open = !props.isPathCollapsed(node.path);
         return (
           <Collapsible
-            key={node.path}
+            key={`dir:${node.path}`}
             open={open}
             onOpenChange={() => props.onToggleDirectory(node.path)}
           >

--- a/apps/web/src/components/chat/fileRowStyles.ts
+++ b/apps/web/src/components/chat/fileRowStyles.ts
@@ -1,0 +1,31 @@
+// FILE: fileRowStyles.ts
+// Purpose: Shared visual chrome for file/entry rows (editor explorer, diff file
+//          lists, review file tree) so every file row matches without each
+//          surface re-declaring the same Tailwind classes and indent math.
+// Layer: Chat/shared UI
+
+import { cn } from "~/lib/utils";
+
+/**
+ * Base chrome shared by every file/entry row button. Height and horizontal
+ * padding differ per surface, so callers append them (e.g. `"h-7 pr-2"`).
+ */
+export const FILE_ROW_BASE_CLASS_NAME =
+  "flex w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-md text-left text-[12px] transition-colors";
+
+/** Selected vs. resting/hover tone for a file row. */
+export function fileRowToneClassName(selected: boolean): string {
+  return selected
+    ? "bg-[var(--color-background-button-secondary)] text-foreground"
+    : "text-foreground/78 hover:bg-[var(--color-background-button-secondary-hover)] hover:text-foreground";
+}
+
+/** Full file-row button className. Pass per-surface extras (height/padding) via `className`. */
+export function fileRowClassName(selected: boolean, className?: string): string {
+  return cn(FILE_ROW_BASE_CLASS_NAME, fileRowToneClassName(selected), className);
+}
+
+/** Depth indent matching the editor explorer (0.5rem base + 0.75rem per level). */
+export function fileRowIndentStyle(depth: number): { paddingLeft: string } {
+  return { paddingLeft: `${0.5 + depth * 0.75}rem` };
+}

--- a/apps/web/src/lib/disclosureMotion.ts
+++ b/apps/web/src/lib/disclosureMotion.ts
@@ -32,6 +32,22 @@ export const DISCLOSURE_CHEVRON_MOTION_CLASS =
 export const DISCLOSURE_COLLAPSIBLE_PANEL_CLASS =
   "h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-220 ease-out motion-reduce:transition-none data-ending-style:h-0 data-starting-style:h-0 data-open:data-ending-style:[height:var(--collapsible-panel-height)]";
 
+/**
+ * Inline-axis (width) reveal for side panels that open/close along the
+ * horizontal axis. Same timing curve as the vertical disclosures so every
+ * toggle in the app stays consistent. Pair `open ? openWidthClassName : "w-0"`.
+ */
+export const DISCLOSURE_WIDTH_MOTION_CLASS =
+  "overflow-hidden transition-[width] duration-220 ease-out motion-reduce:transition-none";
+
+export function disclosureWidthClassName(
+  open: boolean,
+  openWidthClassName: string,
+  className?: string,
+) {
+  return cn(DISCLOSURE_WIDTH_MOTION_CLASS, open ? openWidthClassName : "w-0", className);
+}
+
 export function disclosureShellClassName(open: boolean, className?: string) {
   return cn(
     DISCLOSURE_SHELL_MOTION_CLASS,

--- a/apps/web/src/lib/fileDiffTree.test.ts
+++ b/apps/web/src/lib/fileDiffTree.test.ts
@@ -1,0 +1,125 @@
+// FILE: fileDiffTree.test.ts
+// Purpose: Guards flat-to-tree conversion, single-chain compression, ordering,
+//          and the search → tree pipeline used by the review file tree panel.
+// Layer: Web diff utilities tests
+
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+import { describe, expect, it } from "vitest";
+
+import { filterRenderableFilesForSearch } from "~/components/DiffPanel.logic";
+import {
+  buildFileDiffTree,
+  collectFileDiffTreeDirectoryPaths,
+  type FileDiffTreeDirectoryNode,
+  type FileDiffTreeNode,
+} from "./fileDiffTree";
+
+function createFileDiff(path: string): FileDiffMetadata {
+  return {
+    cacheKey: path,
+    name: path,
+    prevName: path,
+    hunks: [{ additionLines: 1, deletionLines: 0 }],
+  } as FileDiffMetadata;
+}
+
+function asDirectory(node: FileDiffTreeNode | undefined): FileDiffTreeDirectoryNode {
+  if (!node || node.kind !== "directory") {
+    throw new Error(`Expected a directory node, received ${node?.kind ?? "undefined"}`);
+  }
+  return node;
+}
+
+function names(nodes: ReadonlyArray<FileDiffTreeNode>): string[] {
+  return nodes.map((node) => node.name);
+}
+
+describe("buildFileDiffTree", () => {
+  it("returns an empty tree for no files", () => {
+    expect(buildFileDiffTree([])).toEqual([]);
+  });
+
+  it("groups files into nested directories with directories before files", () => {
+    const tree = buildFileDiffTree([
+      createFileDiff("apps/server/src/a.ts"),
+      createFileDiff("apps/server/src/b.ts"),
+      createFileDiff("apps/web/src/c.tsx"),
+      createFileDiff("README.md"),
+    ]);
+
+    // Top level: directory "apps" sorts before the root-level file.
+    expect(names(tree)).toEqual(["apps", "README.md"]);
+
+    const apps = asDirectory(tree[0]);
+    // "server" and "web" each have a single child "src", so they compress.
+    expect(names(apps.children)).toEqual(["server/src", "web/src"]);
+
+    const serverSrc = asDirectory(apps.children[0]);
+    expect(serverSrc.name).toBe("server/src");
+    expect(serverSrc.path).toBe("apps/server/src");
+    expect(names(serverSrc.children)).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("compresses a fully unbranched chain into a single directory row", () => {
+    const tree = buildFileDiffTree([createFileDiff("components/ui/widgets/button.tsx")]);
+    expect(tree).toHaveLength(1);
+
+    const compressed = asDirectory(tree[0]);
+    expect(compressed.name).toBe("components/ui/widgets");
+    expect(compressed.path).toBe("components/ui/widgets");
+    expect(names(compressed.children)).toEqual(["button.tsx"]);
+  });
+
+  it("stops compression at branch points", () => {
+    const tree = buildFileDiffTree([
+      createFileDiff("src/feature/one.ts"),
+      createFileDiff("src/feature/nested/two.ts"),
+    ]);
+
+    // "src/feature" compresses (single child until the branch), then forks.
+    const root = asDirectory(tree[0]);
+    expect(root.name).toBe("src/feature");
+    expect(names(root.children)).toEqual(["nested", "one.ts"]);
+  });
+
+  it("sorts entries with natural, case-insensitive ordering", () => {
+    const tree = buildFileDiffTree([
+      createFileDiff("file10.ts"),
+      createFileDiff("file2.ts"),
+      createFileDiff("File1.ts"),
+    ]);
+    expect(names(tree)).toEqual(["File1.ts", "file2.ts", "file10.ts"]);
+  });
+
+  it("collects every directory path", () => {
+    const tree = buildFileDiffTree([
+      createFileDiff("apps/server/a.ts"),
+      createFileDiff("apps/web/b.ts"),
+    ]);
+    expect(collectFileDiffTreeDirectoryPaths(tree).toSorted()).toEqual([
+      "apps",
+      "apps/server",
+      "apps/web",
+    ]);
+  });
+});
+
+describe("search → tree pipeline", () => {
+  const files = [
+    createFileDiff("apps/server/src/codex.ts"),
+    createFileDiff("apps/web/src/ChatView.tsx"),
+    createFileDiff("packages/shared/src/model.ts"),
+  ];
+
+  it("filters files by path substring before building the tree", () => {
+    const tree = buildFileDiffTree(filterRenderableFilesForSearch(files, "web"));
+    expect(names(tree)).toEqual(["apps/web/src"]);
+
+    const matched = asDirectory(tree[0]);
+    expect(names(matched.children)).toEqual(["ChatView.tsx"]);
+  });
+
+  it("returns an empty tree when nothing matches", () => {
+    expect(buildFileDiffTree(filterRenderableFilesForSearch(files, "no-such-file"))).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/fileDiffTree.test.ts
+++ b/apps/web/src/lib/fileDiffTree.test.ts
@@ -82,6 +82,21 @@ describe("buildFileDiffTree", () => {
     expect(names(root.children)).toEqual(["nested", "one.ts"]);
   });
 
+  it("keeps a same-named file and directory as distinct sibling nodes", () => {
+    // A diff that deletes file `foo` while adding `foo/bar.ts` yields a directory
+    // and a file that share the path "foo"; both must survive as siblings so the
+    // replacement renders faithfully (the panel disambiguates their React keys
+    // by node kind).
+    const tree = buildFileDiffTree([createFileDiff("foo"), createFileDiff("foo/bar.ts")]);
+    expect(tree).toHaveLength(2);
+
+    const directory = tree.find((node) => node.kind === "directory");
+    const file = tree.find((node) => node.kind === "file");
+    expect(directory?.path).toBe("foo");
+    expect(file?.path).toBe("foo");
+    expect(names(asDirectory(directory).children)).toEqual(["bar.ts"]);
+  });
+
   it("sorts entries with natural, case-insensitive ordering", () => {
     const tree = buildFileDiffTree([
       createFileDiff("file10.ts"),

--- a/apps/web/src/lib/fileDiffTree.ts
+++ b/apps/web/src/lib/fileDiffTree.ts
@@ -1,0 +1,138 @@
+// FILE: fileDiffTree.ts
+// Purpose: Build a nested, path-compressed folder/file tree from a flat list of
+//          parsed file diffs so review surfaces can render a compact explorer
+//          without each one re-implementing flat-to-tree conversion. The editor
+//          explorer lazy-fetches one directory level at a time from the backend,
+//          so it never needed this; in-memory diff lists do.
+// Layer: Web diff utilities
+// Depends on: diffRendering path helpers.
+
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+
+import { resolveFileDiffPath } from "./diffRendering";
+
+export interface FileDiffTreeFileNode {
+  kind: "file";
+  /** Leaf name (the final path segment). */
+  name: string;
+  /** Full repo-relative path, used as the selection id and React key. */
+  path: string;
+  fileDiff: FileDiffMetadata;
+}
+
+export interface FileDiffTreeDirectoryNode {
+  kind: "directory";
+  /** Display name; compressed chains render as `parent/child`. */
+  name: string;
+  /** Full repo-relative directory path (no trailing slash), used as the key. */
+  path: string;
+  children: FileDiffTreeNode[];
+}
+
+export type FileDiffTreeNode = FileDiffTreeDirectoryNode | FileDiffTreeFileNode;
+
+interface MutableDirectory {
+  name: string;
+  path: string;
+  directories: Map<string, MutableDirectory>;
+  files: FileDiffTreeFileNode[];
+}
+
+function createDirectory(name: string, path: string): MutableDirectory {
+  return { name, path, directories: new Map(), files: [] };
+}
+
+// Natural-order, case-insensitive comparison so the tree stays human-friendly
+// and stable (mirrors compareFileDiffByPath in diffRendering).
+function compareNodeName(left: string, right: string): number {
+  return left.localeCompare(right, undefined, { numeric: true, sensitivity: "base" });
+}
+
+// Collapse single-child directory chains (e.g. `server` → `src` becomes
+// `server/src`) so deep, unbranched paths stay compact — the same affordance
+// VS Code and GitHub use. Children are already finalized, so a single merge per
+// level is sufficient; the loop is defensive.
+function compressDirectory(node: FileDiffTreeDirectoryNode): FileDiffTreeDirectoryNode {
+  let current = node;
+  while (current.children.length === 1) {
+    const onlyChild = current.children[0];
+    if (!onlyChild || onlyChild.kind !== "directory") {
+      break;
+    }
+    current = {
+      kind: "directory",
+      name: `${current.name}/${onlyChild.name}`,
+      path: onlyChild.path,
+      children: onlyChild.children,
+    };
+  }
+  return current;
+}
+
+function finalizeDirectory(directory: MutableDirectory): FileDiffTreeNode[] {
+  const directories: FileDiffTreeDirectoryNode[] = [];
+  for (const child of directory.directories.values()) {
+    directories.push(
+      compressDirectory({
+        kind: "directory",
+        name: child.name,
+        path: child.path,
+        children: finalizeDirectory(child),
+      }),
+    );
+  }
+  // Directories first, then files, matching the editor explorer ordering.
+  const sortedDirectories = directories.toSorted((left, right) =>
+    compareNodeName(left.name, right.name),
+  );
+  const sortedFiles = directory.files.toSorted((left, right) =>
+    compareNodeName(left.name, right.name),
+  );
+  return [...sortedDirectories, ...sortedFiles];
+}
+
+/**
+ * Convert a flat list of parsed file diffs into a sorted, path-compressed tree
+ * of directory and file nodes. Pure and side-effect free.
+ */
+export function buildFileDiffTree(files: ReadonlyArray<FileDiffMetadata>): FileDiffTreeNode[] {
+  const root = createDirectory("", "");
+  for (const fileDiff of files) {
+    const path = resolveFileDiffPath(fileDiff);
+    const segments = path.split("/").filter((segment) => segment.length > 0);
+    if (segments.length === 0) {
+      continue;
+    }
+    const fileName = segments[segments.length - 1] as string;
+    let directory = root;
+    for (let index = 0; index < segments.length - 1; index += 1) {
+      const segment = segments[index] as string;
+      const childPath = directory.path ? `${directory.path}/${segment}` : segment;
+      let child = directory.directories.get(segment);
+      if (!child) {
+        child = createDirectory(segment, childPath);
+        directory.directories.set(segment, child);
+      }
+      directory = child;
+    }
+    directory.files.push({ kind: "file", name: fileName, path, fileDiff });
+  }
+  return finalizeDirectory(root);
+}
+
+/** Collect every directory path in the tree (useful for expand/collapse-all). */
+export function collectFileDiffTreeDirectoryPaths(
+  nodes: ReadonlyArray<FileDiffTreeNode>,
+): string[] {
+  const paths: string[] = [];
+  const walk = (current: ReadonlyArray<FileDiffTreeNode>) => {
+    for (const node of current) {
+      if (node.kind === "directory") {
+        paths.push(node.path);
+        walk(node.children);
+      }
+    }
+  };
+  walk(nodes);
+  return paths;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/desktop": {
       "name": "@t3tools/desktop",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "dependencies": {
         "effect": "catalog:",
         "electron": "40.6.0",
@@ -43,7 +43,7 @@
     },
     "apps/server": {
       "name": "t3",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "bin": {
         "t3": "./dist/index.mjs",
       },
@@ -81,7 +81,7 @@
     },
     "apps/web": {
       "name": "@t3tools/web",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@dnd-kit/core": "^6.3.1",
@@ -152,7 +152,7 @@
     },
     "packages/contracts": {
       "name": "@t3tools/contracts",
-      "version": "0.2.2",
+      "version": "0.3.1",
       "dependencies": {
         "effect": "catalog:",
       },


### PR DESCRIPTION
## Summary
- Added a searchable review file tree sidebar to the diff panel with open/close toggle controls.
- Built a shared file-diff tree utility that nests, sorts, and compresses single-child directory chains for compact rendering.
- Consolidated file-row styling into shared helpers so the editor explorer, diff lists, and review tree stay visually consistent.
- Added coverage for tree building, search filtering, and review panel rendering states.

## Testing
- Not run (not requested).
- Added/updated Vitest coverage in `apps/web/src/lib/fileDiffTree.test.ts` and `apps/web/src/components/ReviewFileTreePanel.test.tsx`.