### PR TITLE
Reduce idle local server polling

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -132,11 +132,9 @@ import {
 import { resolveCurrentProjectTargetId } from "../lib/projectShortcutTargets";
 import { projectDiscoverScriptsQueryOptions } from "../lib/projectReactQuery";
 import {
-  LOCAL_SERVERS_BACKGROUND_REFETCH_INTERVAL_MS,
-  LOCAL_SERVERS_VISIBLE_REFETCH_INTERVAL_MS,
   serverConfigQueryOptions,
-  serverLocalServersQueryOptions,
   serverQueryKeys,
+  sidebarLocalServersQueryOptions,
 } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
 import { isHomeChatContainerProject, prewarmHomeChatProject } from "../lib/chatProjects";
@@ -3961,20 +3959,16 @@ export default function Sidebar() {
     return commandByProjectId;
   }, [discoveredScriptTargetsByProjectId, standardProjects]);
   projectRunCommandByProjectIdRef.current = projectRunCommandByProjectId;
-  // Keep manual server attribution alive, but slow the always-on folder scan
-  // when no Synara-owned run needs near-real-time reconciliation.
+  // Keep manual server attribution alive without repeating the expensive
+  // port/process scan while no Synara-owned run needs near-real-time status.
   const hasActiveProjectRun = useMemo(
     () => Object.keys(projectRunsByProjectId).length > 0,
     [projectRunsByProjectId],
   );
-  const shouldTrackLocalServers = standardProjects.length > 0 || hasActiveProjectRun;
-  const localServersRefetchInterval = hasActiveProjectRun
-    ? LOCAL_SERVERS_VISIBLE_REFETCH_INTERVAL_MS
-    : LOCAL_SERVERS_BACKGROUND_REFETCH_INTERVAL_MS;
   const projectRunLocalServersQuery = useQuery(
-    serverLocalServersQueryOptions({
-      enabled: shouldTrackLocalServers,
-      refetchInterval: localServersRefetchInterval,
+    sidebarLocalServersQueryOptions({
+      hasActiveProjectRun,
+      hasProjects: standardProjects.length > 0,
     }),
   );
   const projectRunServerByProjectId = useMemo(() => {

--- a/apps/web/src/lib/serverReactQuery.test.ts
+++ b/apps/web/src/lib/serverReactQuery.test.ts
@@ -5,10 +5,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  LOCAL_SERVERS_BACKGROUND_REFETCH_INTERVAL_MS,
   LOCAL_SERVERS_VISIBLE_REFETCH_INTERVAL_MS,
   serverAllProviderUsageQueryOptions,
   serverLocalServersQueryOptions,
+  sidebarLocalServersQueryOptions,
 } from "./serverReactQuery";
 
 describe("serverLocalServersQueryOptions", () => {
@@ -26,13 +26,35 @@ describe("serverLocalServersQueryOptions", () => {
     expect(options.refetchInterval).toBe(false);
   });
 
-  it("allows the sidebar to use the cheaper background polling interval", () => {
-    const options = serverLocalServersQueryOptions({
-      enabled: true,
-      refetchInterval: LOCAL_SERVERS_BACKGROUND_REFETCH_INTERVAL_MS,
+  it("keeps sidebar attribution enabled without idle polling", () => {
+    const options = sidebarLocalServersQueryOptions({
+      hasActiveProjectRun: false,
+      hasProjects: true,
     });
 
-    expect(options.refetchInterval).toBe(LOCAL_SERVERS_BACKGROUND_REFETCH_INTERVAL_MS);
+    expect(options.enabled).toBe(true);
+    expect(options.refetchInterval).toBe(false);
+    expect(options.refetchOnWindowFocus).toBe(true);
+  });
+
+  it("uses visible polling while a Synara-owned project run is active", () => {
+    const options = sidebarLocalServersQueryOptions({
+      hasActiveProjectRun: true,
+      hasProjects: true,
+    });
+
+    expect(options.enabled).toBe(true);
+    expect(options.refetchInterval).toBe(LOCAL_SERVERS_VISIBLE_REFETCH_INTERVAL_MS);
+  });
+
+  it("disables sidebar attribution when no projects or project runs exist", () => {
+    const options = sidebarLocalServersQueryOptions({
+      hasActiveProjectRun: false,
+      hasProjects: false,
+    });
+
+    expect(options.enabled).toBe(false);
+    expect(options.refetchInterval).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/serverReactQuery.ts
+++ b/apps/web/src/lib/serverReactQuery.ts
@@ -115,6 +115,19 @@ export function serverLocalServersQueryOptions(
   });
 }
 
+// Sidebar project badges need a snapshot, but idle Home should not keep shelling out
+// through lsof/ps; active Synara-owned runs still poll for responsive status.
+export function sidebarLocalServersQueryOptions(input: {
+  hasActiveProjectRun: boolean;
+  hasProjects: boolean;
+}) {
+  const enabled = input.hasProjects || input.hasActiveProjectRun;
+  return serverLocalServersQueryOptions({
+    enabled,
+    refetchInterval: input.hasActiveProjectRun ? LOCAL_SERVERS_VISIBLE_REFETCH_INTERVAL_MS : false,
+  });
+}
+
 export function serverStopLocalServerMutationOptions(input: { queryClient: QueryClient }) {
   return mutationOptions({
     mutationKey: serverMutationKeys.stopLocalServer(),


### PR DESCRIPTION
## Summary
- stop the Sidebar local-server query from polling while Synara is idle
- keep local-server attribution enabled for focus/reconnect refreshes and resume fast polling when a Synara-owned project run is active
- cover the idle and active Sidebar query behavior with focused tests

Fixes #246.

## Verification
- bun run test src/lib/serverReactQuery.test.ts (from apps/web)
- git diff --check
- bun lint
- bun typecheck
- bun fmt

## Review
- First same-worktree gpt-5.5 xhigh review: no actionable issues
- Second same-worktree gpt-5.5 xhigh review: no actionable issues