### PR TITLE
[codex] Add provider update check setting

### DIFF
--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -223,6 +223,36 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       assert.strictEqual(codex?.message, "Provider is disabled in Synara settings.");
     });
 
+    it("suppresses cached update advisories when automatic update checks are disabled", () => {
+      const statuses = projectProviderStatusesForSettings(
+        [
+          {
+            ...cachedReadyCodexStatus,
+            version: "0.129.0",
+            versionAdvisory: {
+              status: "behind_latest",
+              currentVersion: "0.129.0",
+              latestVersion: "0.130.0",
+              updateCommand: "npm install -g @openai/codex@latest",
+              canUpdate: true,
+              checkedAt: "2026-06-16T12:00:00.000Z",
+              message: "Update available.",
+            },
+          },
+        ],
+        { ...DEFAULT_SERVER_SETTINGS, enableProviderUpdateChecks: false },
+        "2026-06-16T12:05:00.000Z",
+      );
+      const codex = statuses.find((status) => status.provider === "codex");
+
+      assert.strictEqual(codex?.available, true);
+      assert.strictEqual(codex?.version, "0.129.0");
+      assert.strictEqual(codex?.versionAdvisory?.status, "unknown");
+      assert.strictEqual(codex?.versionAdvisory?.latestVersion, null);
+      assert.strictEqual(codex?.versionAdvisory?.canUpdate, false);
+      assert.strictEqual(codex?.versionAdvisory?.updateCommand, null);
+    });
+
     it.effect("does not expose cached ready statuses for disabled providers", () =>
       Effect.gen(function* () {
         const fileSystem = yield* FileSystem.FileSystem;

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -1757,6 +1757,29 @@ function mergeProviderStatusUpdates(
   return orderProviderStatuses([...statusByProvider.values()]);
 }
 
+// Keeps local CLI version/status visible while removing network-backed update metadata.
+function makeSuppressedProviderVersionAdvisory(
+  status: ServerProviderStatus,
+  currentVersion?: string | null,
+): NonNullable<ServerProviderStatus["versionAdvisory"]> {
+  return {
+    status: "unknown",
+    currentVersion: currentVersion ?? status.version ?? null,
+    latestVersion: null,
+    updateCommand: null,
+    canUpdate: false,
+    checkedAt: status.checkedAt,
+    message: null,
+  };
+}
+
+function suppressProviderVersionAdvisory(status: ServerProviderStatus): ServerProviderStatus {
+  return {
+    ...status,
+    versionAdvisory: makeSuppressedProviderVersionAdvisory(status),
+  };
+}
+
 // Disabled providers are a settings overlay, not a probe result. Keep the raw
 // cached/probed status intact so re-enabling a provider can reuse it immediately.
 export function projectProviderStatusesForSettings(
@@ -1773,15 +1796,7 @@ export function projectProviderStatusesForSettings(
       const disabledStatus = makeDisabledProviderStatus(provider, status?.checkedAt ?? checkedAt);
       const disabledStatusWithAdvisory = {
         ...disabledStatus,
-        versionAdvisory: {
-          status: "unknown" as const,
-          currentVersion: status?.version ?? null,
-          latestVersion: null,
-          updateCommand: null,
-          canUpdate: false,
-          checkedAt: disabledStatus.checkedAt,
-          message: null,
-        },
+        versionAdvisory: makeSuppressedProviderVersionAdvisory(disabledStatus, status?.version),
       } satisfies ServerProviderStatus;
       projected.push(
         status?.updateState
@@ -1792,7 +1807,9 @@ export function projectProviderStatusesForSettings(
     }
 
     if (status && !isDisabledProviderStatusOverlay(status)) {
-      projected.push(status);
+      projected.push(
+        settings.enableProviderUpdateChecks ? status : suppressProviderVersionAdvisory(status),
+      );
     }
   }
 
@@ -1992,6 +2009,18 @@ export const ProviderHealthLive = Layer.effect(
     const enrichStatuses = Effect.fn("enrichProviderStatuses")(function* (
       statuses: ReadonlyArray<ServerProviderStatus>,
     ) {
+      const settings = yield* serverSettings.ready.pipe(
+        Effect.flatMap(() => serverSettings.getSettings),
+        Effect.catch(() => Effect.succeed(null)),
+      );
+      if (settings?.enableProviderUpdateChecks === false) {
+        return yield* Effect.forEach(
+          statuses.map(suppressProviderVersionAdvisory),
+          applyVolatileProviderState,
+          { concurrency: "unbounded" },
+        );
+      }
+
       const enriched = yield* Effect.forEach(
         statuses,
         (status) =>
@@ -2030,8 +2059,9 @@ export const ProviderHealthLive = Layer.effect(
         ? check.pipe(Effect.map(Option.some))
         : Effect.succeed(Option.none());
 
-    const loadProviderStatuses = serverSettings.getSettings
+    const loadProviderStatuses = serverSettings.ready
       .pipe(
+        Effect.flatMap(() => serverSettings.getSettings),
         Effect.flatMap((settings) =>
           Effect.all(
             [

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -28,6 +28,7 @@ describe("ServerSettingsService", () => {
     expect(settings.providers.codex.binaryPath).toBe("codex");
     expect(settings.providers.grok.binaryPath).toBe("grok");
     expect(settings.defaultThreadEnvMode).toBe("local");
+    expect(settings.enableProviderUpdateChecks).toBe(true);
   });
 
   it("persists updates and reloads them", async () => {
@@ -40,6 +41,7 @@ describe("ServerSettingsService", () => {
 
         const updated = yield* service.updateSettings({
           enableAssistantStreaming: true,
+          enableProviderUpdateChecks: false,
           providers: {
             codex: {
               binaryPath: "/usr/local/bin/codex",
@@ -53,9 +55,11 @@ describe("ServerSettingsService", () => {
     );
 
     expect(result.updated.enableAssistantStreaming).toBe(true);
+    expect(result.updated.enableProviderUpdateChecks).toBe(false);
     expect(result.updated.providers.codex.binaryPath).toBe("/usr/local/bin/codex");
     expect(result.parsed).toMatchObject({
       enableAssistantStreaming: true,
+      enableProviderUpdateChecks: false,
       providers: {
         codex: {
           binaryPath: "/usr/local/bin/codex",

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -182,6 +182,7 @@ export const AppSettingsSchema = Schema.Struct({
   showEnvironmentInstructions: Schema.Boolean.pipe(withDefaults(() => true)),
   showEnvironmentNotepad: Schema.Boolean.pipe(withDefaults(() => true)),
   enableAssistantStreaming: Schema.Boolean.pipe(withDefaults(() => false)),
+  enableProviderUpdateChecks: Schema.Boolean.pipe(withDefaults(() => true)),
   enableNativeFontSmoothing: Schema.Boolean.pipe(withDefaults(getDefaultNativeFontSmoothing)),
   enableTaskCompletionToasts: Schema.Boolean.pipe(withDefaults(() => true)),
   enableSystemTaskCompletionNotifications: Schema.Boolean.pipe(withDefaults(() => true)),
@@ -444,6 +445,7 @@ function serverSettingsToAppSettings(settings: ServerSettings): Partial<AppSetti
     cursorBinaryPath: settings.providers.cursor.binaryPath,
     defaultThreadEnvMode: settings.defaultThreadEnvMode,
     enableAssistantStreaming: settings.enableAssistantStreaming,
+    enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
     geminiBinaryPath: settings.providers.gemini.binaryPath,
     grokBinaryPath: settings.providers.grok.binaryPath,
     kiloBinaryPath: settings.providers.kilo.binaryPath,
@@ -502,6 +504,9 @@ function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): Ser
 
   if (hasOwn(patch, "enableAssistantStreaming")) {
     serverPatch.enableAssistantStreaming = Boolean(patch.enableAssistantStreaming);
+  }
+  if (hasOwn(patch, "enableProviderUpdateChecks")) {
+    serverPatch.enableProviderUpdateChecks = Boolean(patch.enableProviderUpdateChecks);
   }
   if (patch.defaultThreadEnvMode === "local" || patch.defaultThreadEnvMode === "worktree") {
     serverPatch.defaultThreadEnvMode = patch.defaultThreadEnvMode;
@@ -640,6 +645,7 @@ function buildInitialServerSettingsMigrationPatch(settings: AppSettings): Server
     "cursorBinaryPath",
     "defaultThreadEnvMode",
     "enableAssistantStreaming",
+    "enableProviderUpdateChecks",
     "geminiBinaryPath",
     "grokBinaryPath",
     "kiloBinaryPath",

--- a/apps/web/src/providerUpdates.test.ts
+++ b/apps/web/src/providerUpdates.test.ts
@@ -46,6 +46,7 @@ function serverSettings(overrides: Partial<ServerSettings["providers"]> = {}): S
 
   return {
     enableAssistantStreaming: false,
+    enableProviderUpdateChecks: true,
     defaultThreadEnvMode: "local",
     addProjectBaseDirectory: "",
     textGenerationModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
@@ -96,6 +97,15 @@ describe("getVisibleProviderUpdateStatuses", () => {
     const result = getVisibleProviderUpdateStatuses({
       providers: [providerStatus("codex")],
       serverSettings: null,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes provider updates when automatic update checks are disabled", () => {
+    const result = getVisibleProviderUpdateStatuses({
+      providers: [providerStatus("codex")],
+      serverSettings: { ...serverSettings(), enableProviderUpdateChecks: false },
     });
 
     expect(result).toEqual([]);

--- a/apps/web/src/providerUpdates.ts
+++ b/apps/web/src/providerUpdates.ts
@@ -11,7 +11,10 @@ export const PROVIDER_UPDATE_REFRESH_INTERVAL_MS = 60 * 60 * 1_000;
 type ProviderUpdateFilterInput = {
   readonly providers: ReadonlyArray<ServerProviderStatus>;
   readonly hiddenProviders?: ReadonlyArray<ProviderKind>;
-  readonly serverSettings?: Pick<ServerSettings, "providers"> | null | undefined;
+  readonly serverSettings?:
+    | Pick<ServerSettings, "providers" | "enableProviderUpdateChecks">
+    | null
+    | undefined;
   readonly oneClickOnly?: boolean;
 };
 
@@ -19,7 +22,10 @@ type ProviderUpdateVisibilityInput = {
   readonly provider: ServerProviderStatus;
   readonly hiddenProviders?: ReadonlyArray<ProviderKind>;
   readonly hiddenProviderSet?: ReadonlySet<ProviderKind>;
-  readonly serverSettings?: Pick<ServerSettings, "providers"> | null | undefined;
+  readonly serverSettings?:
+    | Pick<ServerSettings, "providers" | "enableProviderUpdateChecks">
+    | null
+    | undefined;
   readonly oneClickOnly?: boolean;
 };
 
@@ -43,6 +49,7 @@ export function shouldShowProviderUpdateStatus(input: ProviderUpdateVisibilityIn
   const hiddenProviderSet = input.hiddenProviderSet ?? new Set(input.hiddenProviders ?? []);
   if (
     !advisory ||
+    input.serverSettings?.enableProviderUpdateChecks === false ||
     advisory.status !== "behind_latest" ||
     advisory.latestVersion === null ||
     hiddenProviderSet.has(input.provider.provider) ||

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -216,6 +216,18 @@ function ProviderUpdateNotifications() {
   const { settings } = useAppSettings();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const serverSettingsQuery = useQuery(serverSettingsQueryOptions());
+  const providerUpdateServerSettings = useMemo(
+    () =>
+      serverSettingsQuery.data
+        ? {
+            ...serverSettingsQuery.data,
+            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+          }
+        : null,
+    [serverSettingsQuery.data, settings.enableProviderUpdateChecks],
+  );
+  const providerUpdateChecksEnabled =
+    serverSettingsQuery.data !== undefined && settings.enableProviderUpdateChecks;
   const [isUpdatingAll, setIsUpdatingAll] = useState(false);
   const activeToastRef = useRef<ActiveProviderUpdateToast | null>(null);
   const isUpdatingAllRef = useRef(false);
@@ -223,6 +235,7 @@ function ProviderUpdateNotifications() {
   // Provider latest-version checks are slow/network-backed, so keep this much
   // coarser than auth focus refreshes while still avoiding manual-only refreshes.
   useProviderStatusRefresh({
+    enabled: providerUpdateChecksEnabled,
     initialDelayMs: PROVIDER_UPDATE_INITIAL_REFRESH_DELAY_MS,
     intervalMs: PROVIDER_UPDATE_REFRESH_INTERVAL_MS,
   });
@@ -231,10 +244,10 @@ function ProviderUpdateNotifications() {
       getVisibleProviderUpdateStatuses({
         providers: serverConfigQuery.data?.providers ?? [],
         hiddenProviders: settings.hiddenProviders,
-        serverSettings: serverSettingsQuery.data ?? null,
+        serverSettings: providerUpdateServerSettings,
         oneClickOnly: true,
       }),
-    [serverConfigQuery.data?.providers, serverSettingsQuery.data, settings.hiddenProviders],
+    [providerUpdateServerSettings, serverConfigQuery.data?.providers, settings.hiddenProviders],
   );
   const oneClickProviders = useMemo(
     () => outdatedProviders.filter((provider) => !isProviderUpdateActive(provider)),

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -761,14 +761,24 @@ function SettingsRouteView() {
       new Map((serverConfigQuery.data?.providers ?? []).map((status) => [status.provider, status])),
     [serverConfigQuery.data?.providers],
   );
+  const providerUpdateServerSettings = useMemo(
+    () =>
+      serverSettingsQuery.data
+        ? {
+            ...serverSettingsQuery.data,
+            enableProviderUpdateChecks: settings.enableProviderUpdateChecks,
+          }
+        : null,
+    [serverSettingsQuery.data, settings.enableProviderUpdateChecks],
+  );
   const outdatedProviderStatuses = useMemo(
     () =>
       getVisibleProviderUpdateStatuses({
         providers: serverConfigQuery.data?.providers ?? [],
         hiddenProviders: settings.hiddenProviders,
-        serverSettings: serverSettingsQuery.data ?? null,
+        serverSettings: providerUpdateServerSettings,
       }),
-    [serverConfigQuery.data?.providers, serverSettingsQuery.data, settings.hiddenProviders],
+    [providerUpdateServerSettings, serverConfigQuery.data?.providers, settings.hiddenProviders],
   );
   const outdatedProviderCount = outdatedProviderStatuses.length;
   useSettingsTargetScroll(
@@ -956,6 +966,9 @@ function SettingsRouteView() {
       : []),
     ...(settings.enableAssistantStreaming !== defaults.enableAssistantStreaming
       ? ["Assistant output"]
+      : []),
+    ...(settings.enableProviderUpdateChecks !== defaults.enableProviderUpdateChecks
+      ? ["Provider update checks"]
       : []),
     ...(settings.diffWordWrap !== defaults.diffWordWrap ? ["Diff line wrapping"] : []),
     ...(settings.confirmThreadDelete !== defaults.confirmThreadDelete
@@ -2588,16 +2601,27 @@ function SettingsRouteView() {
   const renderProviderUpdatesSection = () => (
     <div ref={providerUpdatesRef} id={SETTINGS_TARGETS.providerUpdates}>
       <SettingsSection title="Updates">
+        {renderBooleanSettingRow({
+          settingKey: "enableProviderUpdateChecks",
+          title: "Automatic CLI update checks",
+          description:
+            "Check Codex, Claude, and other provider CLIs for newer versions in the background.",
+          resetLabel: "CLI update checks",
+          ariaLabel: "Automatic CLI update checks",
+        })}
+
         <SettingsRow
           title="Provider updates"
-          description="Update installed provider tools that Synara can safely update."
+          description="Review installed provider tools that Synara can safely update."
           status={
-            outdatedProviderCount > 0
-              ? `${outdatedProviderCount} ${pluralize(outdatedProviderCount, "update")} available`
-              : "No provider updates detected"
+            !settings.enableProviderUpdateChecks
+              ? "Automatic checks off"
+              : outdatedProviderCount > 0
+                ? `${outdatedProviderCount} ${pluralize(outdatedProviderCount, "update")} available`
+                : "No provider updates detected"
           }
         >
-          {outdatedProviderStatuses.length > 0 ? (
+          {settings.enableProviderUpdateChecks && outdatedProviderStatuses.length > 0 ? (
             <div className={cn("mt-4", SETTINGS_INSET_LIST_CLASS_NAME)}>
               {outdatedProviderStatuses.map((providerStatus) => {
                 const updateAdvisory = providerStatus.versionAdvisory;
@@ -2667,9 +2691,11 @@ function SettingsRouteView() {
           title="Installed CLIs"
           description="Review provider versions and update tools. Open a row only when you need binary overrides."
           status={
-            outdatedProviderCount > 0
-              ? `${outdatedProviderCount} ${pluralize(outdatedProviderCount, "update")} available`
-              : "No provider updates detected"
+            !settings.enableProviderUpdateChecks
+              ? "Automatic checks off"
+              : outdatedProviderCount > 0
+                ? `${outdatedProviderCount} ${pluralize(outdatedProviderCount, "update")} available`
+                : "No provider updates detected"
           }
           resetAction={
             isInstallSettingsDirty ? (
@@ -2760,16 +2786,21 @@ function SettingsRouteView() {
                   ? shouldShowProviderUpdateStatus({
                       provider: providerStatus,
                       hiddenProviderSet,
-                      serverSettings: serverSettingsQuery.data ?? null,
+                      serverSettings: providerUpdateServerSettings,
                     })
                   : false;
                 const providerUpdateSuppressed =
                   providerStatus?.versionAdvisory?.status === "behind_latest" &&
                   !showProviderUpdateStatus;
+                const currentProviderVersion = formatProviderVersion(providerStatus?.version);
                 const providerUpdateLabel = providerStatus
-                  ? providerUpdateSuppressed
-                    ? null
-                    : providerUpdateStatusLabel(providerStatus)
+                  ? !settings.enableProviderUpdateChecks
+                    ? currentProviderVersion
+                      ? `Current ${currentProviderVersion}`
+                      : null
+                    : providerUpdateSuppressed
+                      ? null
+                      : providerUpdateStatusLabel(providerStatus)
                   : null;
                 const updateAdvisory = providerStatus?.versionAdvisory;
                 const providerUpdateState = providerStatus?.updateState?.status;

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -258,6 +258,13 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
 
   // ── Providers ─────────────────────────────────────────────────────────────────
   {
+    id: "providers:automatic-cli-update-checks",
+    section: "providers",
+    title: "Automatic CLI update checks",
+    keywords:
+      "Check Codex Claude and other provider CLIs for newer versions in the background. updates upgrade disable nags",
+  },
+  {
     id: "providers:visible-providers",
     section: "providers",
     title: "Visible providers",

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -86,6 +86,7 @@ export type SkillsServerSettings = typeof SkillsServerSettings.Type;
 
 export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
+  enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
   defaultThreadEnvMode: ThreadEnvironmentMode.pipe(Schema.withDecodingDefault(() => "local")),
   addProjectBaseDirectory: StringSetting.pipe(Schema.withDecodingDefault(() => "")),
   textGenerationModelSelection: ModelSelection.pipe(
@@ -124,6 +125,7 @@ const ProviderSettingsBasePatch = {
 
 export const ServerSettingsPatch = Schema.Struct({
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
+  enableProviderUpdateChecks: Schema.optionalKey(Schema.Boolean),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvironmentMode),
   addProjectBaseDirectory: Schema.optionalKey(StringSetting),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),


### PR DESCRIPTION
## Summary
- add a persisted server setting for automatic provider CLI update checks
- add a Providers settings toggle and suppress update rows/toasts when disabled
- keep local provider status/version visible while clearing network-backed update advisories when checks are off

## Verification
- bun run --cwd apps/web test src/providerUpdates.test.ts
- bun run --cwd apps/server test src/serverSettings.test.ts src/provider/Layers/ProviderHealth.test.ts
- git diff --check

## Notes
This intentionally leaves provider auth/status refresh behavior intact while disabling the update-specific latest-version prompts.