### PR TITLE
Fix VS Code Store editor launch on Windows

### DIFF
--- a/apps/server/src/editorAppDiscovery.ts
+++ b/apps/server/src/editorAppDiscovery.ts
@@ -30,7 +30,19 @@ type ExecFileSyncLike = (
   },
 ) => string | Buffer;
 
+interface WindowsStorePowerShellLookupOptions {
+  readonly useCache?: boolean;
+  readonly now?: () => number;
+}
+
+interface CachedPowerShellAppxLookup {
+  readonly value: string | null;
+  readonly expiresAt: number;
+}
+
 const POWERSHELL_APPX_LOOKUP_TIMEOUT_MS = 1_500;
+const POWERSHELL_APPX_LOOKUP_CACHE_TTL_MS = 300_000;
+const powershellAppxLookupCache = new Map<string, CachedPowerShellAppxLookup>();
 
 export function getEditorMacApplications(editor: EditorDefinition): readonly string[] | undefined {
   return "macApplications" in editor ? editor.macApplications : undefined;
@@ -152,6 +164,21 @@ function windowsStorePackageDirMatches(
   );
 }
 
+function windowsStorePackageFamilyName(packageDef: WindowsStorePackageDefinition): string {
+  return `${packageDef.packageName}_${packageDef.publisherId}`;
+}
+
+function uniqueWindowsStorePackageDefinitions(
+  packages: readonly WindowsStorePackageDefinition[],
+): readonly WindowsStorePackageDefinition[] {
+  const byFamily = new Map<string, WindowsStorePackageDefinition>();
+  for (const packageDef of packages) {
+    byFamily.set(windowsStorePackageFamilyName(packageDef).toLowerCase(), packageDef);
+  }
+  return Array.from(byFamily.values());
+}
+
+// Scans package payload folders only. Availability still needs current-user AppX registration.
 export function resolveWindowsStorePackageDirectory(
   packages: readonly WindowsStorePackageDefinition[] | undefined,
   platform: NodeJS.Platform,
@@ -189,21 +216,74 @@ function quotePowerShellLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
+function resolvePowerShellCacheKey(
+  packages: readonly WindowsStorePackageDefinition[],
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string {
+  const families = uniqueWindowsStorePackageDefinitions(packages)
+    .map((packageDef) => windowsStorePackageFamilyName(packageDef).toLowerCase())
+    .sort();
+  return JSON.stringify({
+    platform,
+    families,
+    path: env.PATH ?? env.Path ?? env.path ?? "",
+    systemRoot: env.SystemRoot ?? env.WINDIR ?? "",
+  });
+}
+
+function readPowerShellAppxLookupCache(key: string, now: number): string | null | undefined {
+  const cached = powershellAppxLookupCache.get(key);
+  if (!cached) return undefined;
+  if (cached.expiresAt > now) return cached.value;
+  powershellAppxLookupCache.delete(key);
+  return undefined;
+}
+
+function writePowerShellAppxLookupCache(key: string, value: string | null, now: number): void {
+  powershellAppxLookupCache.set(key, {
+    value,
+    expiresAt: now + POWERSHELL_APPX_LOOKUP_CACHE_TTL_MS,
+  });
+}
+
+export function clearWindowsStorePackageDiscoveryCache(): void {
+  powershellAppxLookupCache.clear();
+}
+
 export function resolveWindowsStorePackageDirectoryFromPowerShell(
   packages: readonly WindowsStorePackageDefinition[] | undefined,
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
   execFile: ExecFileSyncLike = execFileSync,
+  options: WindowsStorePowerShellLookupOptions = {},
 ): string | null {
   if (platform !== "win32" || !packages) return null;
 
-  const packageNames = Array.from(new Set(packages.map((packageDef) => packageDef.packageName)));
-  const packageArray = `@(${packageNames.map(quotePowerShellLiteral).join(",")})`;
+  const packageDefs = uniqueWindowsStorePackageDefinitions(packages);
+  if (packageDefs.length === 0) return null;
+
+  const now = options.now?.() ?? Date.now();
+  const useCache = options.useCache ?? execFile === execFileSync;
+  const cacheKey = useCache ? resolvePowerShellCacheKey(packageDefs, platform, env) : null;
+  if (cacheKey) {
+    const cached = readPowerShellAppxLookupCache(cacheKey, now);
+    if (cached !== undefined) return cached;
+  }
+
+  const packageArray = `@(${packageDefs
+    .map(
+      (packageDef) =>
+        `@{ Name = ${quotePowerShellLiteral(packageDef.packageName)}; Family = ${quotePowerShellLiteral(
+          windowsStorePackageFamilyName(packageDef),
+        )} }`,
+    )
+    .join(",")})`;
   const script = [
-    `$packageNames = ${packageArray}`,
-    "foreach ($packageName in $packageNames) {",
-    "  $package = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | " +
-      "Select-Object -First 1",
+    `$packages = ${packageArray}`,
+    "foreach ($packageDef in $packages) {",
+    "  $package = Get-AppxPackage -Name $packageDef.Name -ErrorAction SilentlyContinue | " +
+      "Where-Object { $_.PackageFamilyName -ieq $packageDef.Family } | Select-Object -First 1",
     "  if ($null -ne $package -and $package.InstallLocation) {",
     "    Write-Output $package.InstallLocation",
     "    exit 0",
@@ -220,13 +300,15 @@ export function resolveWindowsStorePackageDirectoryFromPowerShell(
       timeout: POWERSHELL_APPX_LOOKUP_TIMEOUT_MS,
       windowsHide: true,
     });
-    return (
+    const result =
       String(stdout)
         .split(/\r?\n/)
         .map((line) => line.trim())
-        .find(Boolean) ?? null
-    );
+        .find(Boolean) ?? null;
+    if (cacheKey) writePowerShellAppxLookupCache(cacheKey, result, now);
+    return result;
   } catch {
+    if (cacheKey) writePowerShellAppxLookupCache(cacheKey, null, now);
     return null;
   }
 }
@@ -235,9 +317,14 @@ export function resolveWindowsStorePackageInstallLocation(
   packages: readonly WindowsStorePackageDefinition[] | undefined,
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
+  execFile: ExecFileSyncLike = execFileSync,
+  options: WindowsStorePowerShellLookupOptions = {},
 ): string | null {
-  return (
-    resolveWindowsStorePackageDirectory(packages, platform, env) ??
-    resolveWindowsStorePackageDirectoryFromPowerShell(packages, platform, env)
+  return resolveWindowsStorePackageDirectoryFromPowerShell(
+    packages,
+    platform,
+    env,
+    execFile,
+    options,
   );
 }

--- a/apps/server/src/editorAppDiscovery.ts
+++ b/apps/server/src/editorAppDiscovery.ts
@@ -5,6 +5,7 @@
 // Exports: app/package search helpers used by open.ts and editorAppIcons.ts
 // Depends on: EDITORS metadata plus filesystem stat checks.
 
+import { execFileSync } from "node:child_process";
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
@@ -16,6 +17,20 @@ export interface WindowsStorePackageDefinition {
   readonly packageName: string;
   readonly publisherId: string;
 }
+
+type ExecFileSyncLike = (
+  file: string,
+  args: readonly string[],
+  options: {
+    encoding: "utf8";
+    env: NodeJS.ProcessEnv;
+    stdio: ["ignore", "pipe", "ignore"];
+    timeout: number;
+    windowsHide: true;
+  },
+) => string | Buffer;
+
+const POWERSHELL_APPX_LOOKUP_TIMEOUT_MS = 1_500;
 
 export function getEditorMacApplications(editor: EditorDefinition): readonly string[] | undefined {
   return "macApplications" in editor ? editor.macApplications : undefined;
@@ -111,13 +126,11 @@ function uniqueNonEmpty(values: ReadonlyArray<string | null>): string[] {
 export function resolveWindowsStorePackageSearchRoots(
   env: NodeJS.ProcessEnv,
 ): ReadonlyArray<string> {
-  const localAppData = trimNonEmpty(env.LOCALAPPDATA);
   const programFiles = trimNonEmpty(env.ProgramFiles);
   const programW6432 = trimNonEmpty(env.ProgramW6432);
   const systemDrive = trimNonEmpty(env.SystemDrive);
 
   return uniqueNonEmpty([
-    localAppData ? join(localAppData, "Microsoft", "WindowsApps") : null,
     programFiles ? join(programFiles, "WindowsApps") : null,
     programW6432 ? join(programW6432, "WindowsApps") : null,
     systemDrive ? join(systemDrive, "Program Files", "WindowsApps") : null,
@@ -170,4 +183,61 @@ export function resolveWindowsStorePackageDirectory(
   }
 
   return null;
+}
+
+function quotePowerShellLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function resolveWindowsStorePackageDirectoryFromPowerShell(
+  packages: readonly WindowsStorePackageDefinition[] | undefined,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  execFile: ExecFileSyncLike = execFileSync,
+): string | null {
+  if (platform !== "win32" || !packages) return null;
+
+  const packageNames = Array.from(new Set(packages.map((packageDef) => packageDef.packageName)));
+  const packageArray = `@(${packageNames.map(quotePowerShellLiteral).join(",")})`;
+  const script = [
+    `$packageNames = ${packageArray}`,
+    "foreach ($packageName in $packageNames) {",
+    "  $package = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | " +
+      "Select-Object -First 1",
+    "  if ($null -ne $package -and $package.InstallLocation) {",
+    "    Write-Output $package.InstallLocation",
+    "    exit 0",
+    "  }",
+    "}",
+    "exit 1",
+  ].join("; ");
+
+  try {
+    const stdout = execFile("powershell.exe", ["-NoProfile", "-Command", script], {
+      encoding: "utf8",
+      env,
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: POWERSHELL_APPX_LOOKUP_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    return (
+      String(stdout)
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find(Boolean) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function resolveWindowsStorePackageInstallLocation(
+  packages: readonly WindowsStorePackageDefinition[] | undefined,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  return (
+    resolveWindowsStorePackageDirectory(packages, platform, env) ??
+    resolveWindowsStorePackageDirectoryFromPowerShell(packages, platform, env)
+  );
 }

--- a/apps/server/src/editorAppDiscovery.ts
+++ b/apps/server/src/editorAppDiscovery.ts
@@ -1,19 +1,34 @@
 // FILE: editorAppDiscovery.ts
-// Purpose: Shared helpers for resolving editor app bundles without duplicating
-//          macOS application search rules across launch and icon extraction.
+// Purpose: Shared helpers for resolving installed editor apps/packages without
+//          duplicating platform-specific search rules across launch and icons.
 // Layer: Server runtime utility
-// Exports: macOS app search/name helpers used by open.ts and editorAppIcons.ts
+// Exports: app/package search helpers used by open.ts and editorAppIcons.ts
 // Depends on: EDITORS metadata plus filesystem stat checks.
 
-import { statSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { EDITORS } from "@t3tools/contracts";
 
 export type EditorDefinition = (typeof EDITORS)[number];
 
+export interface WindowsStorePackageDefinition {
+  readonly packageName: string;
+  readonly publisherId: string;
+}
+
 export function getEditorMacApplications(editor: EditorDefinition): readonly string[] | undefined {
   return "macApplications" in editor ? editor.macApplications : undefined;
+}
+
+export function getEditorWindowsUriScheme(editor: EditorDefinition): string | undefined {
+  return "windowsUriScheme" in editor ? editor.windowsUriScheme : undefined;
+}
+
+export function getEditorWindowsStorePackages(
+  editor: EditorDefinition,
+): readonly WindowsStorePackageDefinition[] | undefined {
+  return "windowsStorePackages" in editor ? editor.windowsStorePackages : undefined;
 }
 
 export function normalizeMacApplicationBundleName(appName: string): string {
@@ -82,4 +97,77 @@ export function resolveAvailableMacApplication(
       }),
     ) ?? null
   );
+}
+
+function trimNonEmpty(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function uniqueNonEmpty(values: ReadonlyArray<string | null>): string[] {
+  return Array.from(new Set(values.filter((value): value is string => value !== null)));
+}
+
+export function resolveWindowsStorePackageSearchRoots(
+  env: NodeJS.ProcessEnv,
+): ReadonlyArray<string> {
+  const localAppData = trimNonEmpty(env.LOCALAPPDATA);
+  const programFiles = trimNonEmpty(env.ProgramFiles);
+  const programW6432 = trimNonEmpty(env.ProgramW6432);
+  const systemDrive = trimNonEmpty(env.SystemDrive);
+
+  return uniqueNonEmpty([
+    localAppData ? join(localAppData, "Microsoft", "WindowsApps") : null,
+    programFiles ? join(programFiles, "WindowsApps") : null,
+    programW6432 ? join(programW6432, "WindowsApps") : null,
+    systemDrive ? join(systemDrive, "Program Files", "WindowsApps") : null,
+  ]);
+}
+
+function windowsStorePackageDirMatches(
+  dirName: string,
+  packageDef: WindowsStorePackageDefinition,
+): boolean {
+  const normalizedName = dirName.toLowerCase();
+  const packageName = packageDef.packageName.toLowerCase();
+  const publisherId = packageDef.publisherId.toLowerCase();
+
+  return (
+    normalizedName === `${packageName}_${publisherId}` ||
+    (normalizedName.startsWith(`${packageName}_`) &&
+      normalizedName.endsWith(`__${publisherId}`))
+  );
+}
+
+export function resolveWindowsStorePackageDirectory(
+  packages: readonly WindowsStorePackageDefinition[] | undefined,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  if (platform !== "win32" || !packages) return null;
+
+  for (const root of resolveWindowsStorePackageSearchRoots(env)) {
+    let entries;
+    try {
+      entries = readdirSync(root, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (!packages.some((packageDef) => windowsStorePackageDirMatches(entry.name, packageDef))) {
+        continue;
+      }
+
+      const packageDir = join(root, entry.name);
+      try {
+        if (statSync(packageDir).isDirectory()) return packageDir;
+      } catch {
+        // Keep probing other package roots.
+      }
+    }
+  }
+
+  return null;
 }

--- a/apps/server/src/editorAppIcons.test.ts
+++ b/apps/server/src/editorAppIcons.test.ts
@@ -139,6 +139,7 @@ describe("resolveCachedEditorIcon", () => {
     const programFilesDir = makeTempDir("synara-editor-icon-win-program-files-");
     const cacheDir = makeTempDir("synara-editor-icon-win-cache-");
     const aliasDir = makeTempDir("synara-editor-icon-win-alias-");
+    const localAppData = makeTempDir("synara-editor-icon-win-local-appdata-");
     const bytes = new Uint8Array([137, 80, 78, 71, 20, 21, 22]);
     writeFakeWindowsStorePackageIcon({
       programFilesDir,
@@ -146,6 +147,15 @@ describe("resolveCachedEditorIcon", () => {
       iconFileName: "Square44x44Logo.targetsize-256_altform-unplated.png",
       bytes,
     });
+    fs.mkdirSync(
+      path.join(
+        localAppData,
+        "Microsoft",
+        "WindowsApps",
+        "Microsoft.VisualStudioCode_8wekyb3d8bbwe",
+      ),
+      { recursive: true },
+    );
     fs.writeFileSync(path.join(aliasDir, "code.EXE"), new Uint8Array([0, 1, 2, 3]));
 
     const icon = await resolveCachedEditorIcon({
@@ -153,7 +163,7 @@ describe("resolveCachedEditorIcon", () => {
       cacheDir,
       platform: "win32",
       env: {
-        LOCALAPPDATA: "",
+        LOCALAPPDATA: localAppData,
         PATH: aliasDir,
         PATHEXT: ".EXE",
         ProgramFiles: programFilesDir,

--- a/apps/server/src/editorAppIcons.test.ts
+++ b/apps/server/src/editorAppIcons.test.ts
@@ -71,6 +71,17 @@ function writeFakeLinuxDesktopIcon(input: {
   fs.writeFileSync(path.join(iconsDir, `${input.iconName}.png`), input.bytes);
 }
 
+function writeFakeWindowsStorePackageIcon(input: {
+  readonly programFilesDir: string;
+  readonly packageDirName: string;
+  readonly iconFileName: string;
+  readonly bytes: Uint8Array;
+}): void {
+  const assetsDir = path.join(input.programFilesDir, "WindowsApps", input.packageDirName, "Assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+  fs.writeFileSync(path.join(assetsDir, input.iconFileName), input.bytes);
+}
+
 describe("resolveCachedEditorIcon", () => {
   it("copies a macOS app PNG icon into the cache", async () => {
     const homeDir = makeTempDir("synara-editor-icon-home-");
@@ -117,6 +128,38 @@ describe("resolveCachedEditorIcon", () => {
       cacheDir,
       platform: "linux",
       env: { HOME: homeDir, PATH: "", XDG_DATA_DIRS: "" },
+    });
+
+    expect(icon?.contentType).toBe("image/png");
+    expect(icon?.path.startsWith(cacheDir)).toBe(true);
+    expect(icon ? fs.readFileSync(icon.path) : null).toEqual(Buffer.from(bytes));
+  });
+
+  it("copies a Windows Store package PNG icon for VS Code", async () => {
+    const programFilesDir = makeTempDir("synara-editor-icon-win-program-files-");
+    const cacheDir = makeTempDir("synara-editor-icon-win-cache-");
+    const aliasDir = makeTempDir("synara-editor-icon-win-alias-");
+    const bytes = new Uint8Array([137, 80, 78, 71, 20, 21, 22]);
+    writeFakeWindowsStorePackageIcon({
+      programFilesDir,
+      packageDirName: "Microsoft.VisualStudioCode_1.0.0.0_x64__8wekyb3d8bbwe",
+      iconFileName: "Square44x44Logo.targetsize-256_altform-unplated.png",
+      bytes,
+    });
+    fs.writeFileSync(path.join(aliasDir, "code.EXE"), new Uint8Array([0, 1, 2, 3]));
+
+    const icon = await resolveCachedEditorIcon({
+      editorId: "vscode",
+      cacheDir,
+      platform: "win32",
+      env: {
+        LOCALAPPDATA: "",
+        PATH: aliasDir,
+        PATHEXT: ".EXE",
+        ProgramFiles: programFilesDir,
+        ProgramW6432: "",
+        SystemDrive: "",
+      },
     });
 
     expect(icon?.contentType).toBe("image/png");

--- a/apps/server/src/editorAppIcons.test.ts
+++ b/apps/server/src/editorAppIcons.test.ts
@@ -5,11 +5,13 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { clearEditorIconInFlightCache, resolveCachedEditorIcon } from "./editorAppIcons";
+import { clearWindowsStorePackageDiscoveryCache } from "./editorAppDiscovery";
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
   clearEditorIconInFlightCache();
+  clearWindowsStorePackageDiscoveryCache();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -82,6 +84,21 @@ function writeFakeWindowsStorePackageIcon(input: {
   fs.writeFileSync(path.join(assetsDir, input.iconFileName), input.bytes);
 }
 
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function writeFakePowerShellAppxRegistration(input: {
+  readonly binDir: string;
+  readonly installLocation: string;
+}): void {
+  fs.mkdirSync(input.binDir, { recursive: true });
+  const script = `#!/bin/sh\nprintf '%s\\n' ${shellSingleQuote(input.installLocation)}\n`;
+  const scriptPath = path.join(input.binDir, "powershell.exe");
+  fs.writeFileSync(scriptPath, script);
+  fs.chmodSync(scriptPath, 0o755);
+}
+
 describe("resolveCachedEditorIcon", () => {
   it("copies a macOS app PNG icon into the cache", async () => {
     const homeDir = makeTempDir("synara-editor-icon-home-");
@@ -138,15 +155,18 @@ describe("resolveCachedEditorIcon", () => {
   it("copies a Windows Store package PNG icon for VS Code", async () => {
     const programFilesDir = makeTempDir("synara-editor-icon-win-program-files-");
     const cacheDir = makeTempDir("synara-editor-icon-win-cache-");
-    const aliasDir = makeTempDir("synara-editor-icon-win-alias-");
+    const powershellBinDir = makeTempDir("synara-editor-icon-win-powershell-");
     const localAppData = makeTempDir("synara-editor-icon-win-local-appdata-");
+    const packageDirName = "Microsoft.VisualStudioCode_1.0.0.0_x64__8wekyb3d8bbwe";
+    const installLocation = path.join(programFilesDir, "WindowsApps", packageDirName);
     const bytes = new Uint8Array([137, 80, 78, 71, 20, 21, 22]);
     writeFakeWindowsStorePackageIcon({
       programFilesDir,
-      packageDirName: "Microsoft.VisualStudioCode_1.0.0.0_x64__8wekyb3d8bbwe",
+      packageDirName,
       iconFileName: "Square44x44Logo.targetsize-256_altform-unplated.png",
       bytes,
     });
+    writeFakePowerShellAppxRegistration({ binDir: powershellBinDir, installLocation });
     fs.mkdirSync(
       path.join(
         localAppData,
@@ -156,7 +176,6 @@ describe("resolveCachedEditorIcon", () => {
       ),
       { recursive: true },
     );
-    fs.writeFileSync(path.join(aliasDir, "code.EXE"), new Uint8Array([0, 1, 2, 3]));
 
     const icon = await resolveCachedEditorIcon({
       editorId: "vscode",
@@ -164,7 +183,7 @@ describe("resolveCachedEditorIcon", () => {
       platform: "win32",
       env: {
         LOCALAPPDATA: localAppData,
-        PATH: aliasDir,
+        PATH: powershellBinDir,
         PATHEXT: ".EXE",
         ProgramFiles: programFilesDir,
         ProgramW6432: "",

--- a/apps/server/src/editorAppIcons.ts
+++ b/apps/server/src/editorAppIcons.ts
@@ -20,7 +20,7 @@ import {
   getEditorWindowsStorePackages,
   resolveMacApplicationBundlePath,
   resolveWindowsStorePackageDirectory,
-  type WindowsStorePackageDefinition,
+  resolveWindowsStorePackageDirectoryFromPowerShell,
   type EditorDefinition,
 } from "./editorAppDiscovery";
 
@@ -508,82 +508,52 @@ async function findWindowsStorePackageIcon(packageDir: string): Promise<string |
   return best?.path ?? null;
 }
 
-function quotePowerShellLiteral(value: string): string {
-  return `'${value.replaceAll("'", "''")}'`;
-}
-
-async function resolveWindowsStorePackageDirectoryFromPowerShell(input: {
-  readonly packages: readonly WindowsStorePackageDefinition[] | undefined;
-  readonly platform: NodeJS.Platform;
-  readonly env: NodeJS.ProcessEnv;
-}): Promise<string | null> {
-  if (input.platform !== "win32" || !input.packages) return null;
-
-  const packageNames = Array.from(
-    new Set(input.packages.map((packageDef) => packageDef.packageName)),
-  );
-  const packageArray = `@(${packageNames.map(quotePowerShellLiteral).join(",")})`;
-  const script = [
-    `$packageNames = ${packageArray}`,
-    "foreach ($packageName in $packageNames) {",
-    "  $package = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | " +
-      "Select-Object -First 1",
-    "  if ($null -ne $package -and $package.InstallLocation) {",
-    "    Write-Output $package.InstallLocation",
-    "    exit 0",
-    "  }",
-    "}",
-    "exit 1",
-  ].join("; ");
-
-  try {
-    const { stdout } = await execFileAsync("powershell.exe", ["-NoProfile", "-Command", script], {
-      env: input.env,
-    });
-    return (
-      String(stdout)
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .find(Boolean) ?? null
-    );
-  } catch {
-    return null;
-  }
-}
-
 async function resolveWindowsStoreEditorIconSource(input: {
   readonly editor: EditorDefinition;
   readonly platform: NodeJS.Platform;
   readonly env: NodeJS.ProcessEnv;
 }): Promise<EditorIconSource | null> {
   const packages = getEditorWindowsStorePackages(input.editor);
-  const packageDir =
-    resolveWindowsStorePackageDirectory(packages, input.platform, input.env) ??
-    (await resolveWindowsStorePackageDirectoryFromPowerShell({
-      packages,
-      platform: input.platform,
-      env: input.env,
-    }));
-  if (!packageDir) return null;
+  const triedPackageDirs = new Set<string>();
+  const findIconSource = async (packageDir: string): Promise<EditorIconSource | null> => {
+    triedPackageDirs.add(packageDir);
+    const iconPath = await findWindowsStorePackageIcon(packageDir);
+    if (!iconPath) return null;
+    const extension = path.extname(iconPath).toLowerCase();
+    if (extension === ".svg") {
+      return {
+        sourcePath: iconPath,
+        outputExtension: "svg",
+        contentType: "image/svg+xml",
+        transform: "copy",
+      };
+    }
 
-  const iconPath = await findWindowsStorePackageIcon(packageDir);
-  if (!iconPath) return null;
-  const extension = path.extname(iconPath).toLowerCase();
-  if (extension === ".svg") {
     return {
       sourcePath: iconPath,
-      outputExtension: "svg",
-      contentType: "image/svg+xml",
+      outputExtension: "png",
+      contentType: "image/png",
       transform: "copy",
     };
+  };
+
+  const packageDir = resolveWindowsStorePackageDirectory(packages, input.platform, input.env);
+  if (packageDir) {
+    const iconSource = await findIconSource(packageDir);
+    if (iconSource) return iconSource;
   }
 
-  return {
-    sourcePath: iconPath,
-    outputExtension: "png",
-    contentType: "image/png",
-    transform: "copy",
-  };
+  const appxPackageDir = resolveWindowsStorePackageDirectoryFromPowerShell(
+    packages,
+    input.platform,
+    input.env,
+  );
+  if (appxPackageDir && !triedPackageDirs.has(appxPackageDir)) {
+    const iconSource = await findIconSource(appxPackageDir);
+    if (iconSource) return iconSource;
+  }
+
+  return null;
 }
 
 async function resolveWindowsEditorIconSource(input: {

--- a/apps/server/src/editorAppIcons.ts
+++ b/apps/server/src/editorAppIcons.ts
@@ -19,8 +19,7 @@ import {
   getEditorMacApplications,
   getEditorWindowsStorePackages,
   resolveMacApplicationBundlePath,
-  resolveWindowsStorePackageDirectory,
-  resolveWindowsStorePackageDirectoryFromPowerShell,
+  resolveWindowsStorePackageInstallLocation,
   type EditorDefinition,
 } from "./editorAppDiscovery";
 
@@ -514,9 +513,7 @@ async function resolveWindowsStoreEditorIconSource(input: {
   readonly env: NodeJS.ProcessEnv;
 }): Promise<EditorIconSource | null> {
   const packages = getEditorWindowsStorePackages(input.editor);
-  const triedPackageDirs = new Set<string>();
   const findIconSource = async (packageDir: string): Promise<EditorIconSource | null> => {
-    triedPackageDirs.add(packageDir);
     const iconPath = await findWindowsStorePackageIcon(packageDir);
     if (!iconPath) return null;
     const extension = path.extname(iconPath).toLowerCase();
@@ -537,21 +534,12 @@ async function resolveWindowsStoreEditorIconSource(input: {
     };
   };
 
-  const packageDir = resolveWindowsStorePackageDirectory(packages, input.platform, input.env);
-  if (packageDir) {
-    const iconSource = await findIconSource(packageDir);
-    if (iconSource) return iconSource;
-  }
-
-  const appxPackageDir = resolveWindowsStorePackageDirectoryFromPowerShell(
+  const appxPackageDir = resolveWindowsStorePackageInstallLocation(
     packages,
     input.platform,
     input.env,
   );
-  if (appxPackageDir && !triedPackageDirs.has(appxPackageDir)) {
-    const iconSource = await findIconSource(appxPackageDir);
-    if (iconSource) return iconSource;
-  }
+  if (appxPackageDir) return findIconSource(appxPackageDir);
 
   return null;
 }

--- a/apps/server/src/editorAppIcons.ts
+++ b/apps/server/src/editorAppIcons.ts
@@ -17,7 +17,10 @@ import { EDITOR_ICON_ROUTE_PATH } from "@t3tools/shared/editorIcons";
 
 import {
   getEditorMacApplications,
+  getEditorWindowsStorePackages,
   resolveMacApplicationBundlePath,
+  resolveWindowsStorePackageDirectory,
+  type WindowsStorePackageDefinition,
   type EditorDefinition,
 } from "./editorAppDiscovery";
 
@@ -26,6 +29,7 @@ export { EDITOR_ICON_ROUTE_PATH };
 const execFileAsync = promisify(execFile);
 const MAX_DESKTOP_FILES_TO_SCAN = 1_500;
 const MAX_ICON_FILES_TO_SCAN = 8_000;
+const MAX_WINDOWS_PACKAGE_ICON_FILES_TO_SCAN = 1_200;
 // Editors installed as CLI-only (no app bundle / desktop icon) never resolve a
 // native icon. Cache that "structural" miss long enough to avoid re-running the
 // subprocess + filesystem scans on every menu open, while still picking up a
@@ -454,12 +458,143 @@ async function resolveLinuxEditorIconSource(input: {
   };
 }
 
+function scoreWindowsStoreIconPath(iconPath: string): number | null {
+  const name = path.basename(iconPath).toLowerCase();
+  const extension = path.extname(name);
+  if (extension !== ".png" && extension !== ".svg") return null;
+
+  let score = extension === ".png" ? 0 : 20;
+  if (name.includes("square44x44logo")) {
+    score += 0;
+  } else if (name.includes("appicon") || name.includes("logo")) {
+    score += 10;
+  } else {
+    score += 50;
+  }
+
+  if (name.includes("unplated")) score -= 3;
+  if (name.includes("targetsize-256") || name.includes("scale-200")) score -= 2;
+  if (name.includes("targetsize-48") || name.includes("scale-100")) score -= 1;
+  return score;
+}
+
+async function findWindowsStorePackageIcon(packageDir: string): Promise<string | null> {
+  const roots = Array.from(new Set([path.join(packageDir, "Assets"), packageDir]));
+  let best: { path: string; score: number } | null = null;
+  let scanned = 0;
+
+  for (const root of roots) {
+    if (!(await directoryExists(root))) continue;
+    const pendingDirs = [root];
+    while (pendingDirs.length > 0) {
+      const currentDir = pendingDirs.pop();
+      if (!currentDir) continue;
+      const entries = await fs.readdir(currentDir, { withFileTypes: true }).catch(() => []);
+      for (const entry of entries) {
+        if (++scanned > MAX_WINDOWS_PACKAGE_ICON_FILES_TO_SCAN) return best?.path ?? null;
+        const candidate = path.join(currentDir, entry.name);
+        if (entry.isDirectory()) {
+          pendingDirs.push(candidate);
+          continue;
+        }
+        if (!(await fileExists(candidate))) continue;
+        const score = scoreWindowsStoreIconPath(candidate);
+        if (score === null) continue;
+        if (!best || score < best.score) best = { path: candidate, score };
+      }
+    }
+  }
+
+  return best?.path ?? null;
+}
+
+function quotePowerShellLiteral(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+async function resolveWindowsStorePackageDirectoryFromPowerShell(input: {
+  readonly packages: readonly WindowsStorePackageDefinition[] | undefined;
+  readonly platform: NodeJS.Platform;
+  readonly env: NodeJS.ProcessEnv;
+}): Promise<string | null> {
+  if (input.platform !== "win32" || !input.packages) return null;
+
+  const packageNames = Array.from(
+    new Set(input.packages.map((packageDef) => packageDef.packageName)),
+  );
+  const packageArray = `@(${packageNames.map(quotePowerShellLiteral).join(",")})`;
+  const script = [
+    `$packageNames = ${packageArray}`,
+    "foreach ($packageName in $packageNames) {",
+    "  $package = Get-AppxPackage -Name $packageName -ErrorAction SilentlyContinue | " +
+      "Select-Object -First 1",
+    "  if ($null -ne $package -and $package.InstallLocation) {",
+    "    Write-Output $package.InstallLocation",
+    "    exit 0",
+    "  }",
+    "}",
+    "exit 1",
+  ].join("; ");
+
+  try {
+    const { stdout } = await execFileAsync("powershell.exe", ["-NoProfile", "-Command", script], {
+      env: input.env,
+    });
+    return (
+      String(stdout)
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .find(Boolean) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function resolveWindowsStoreEditorIconSource(input: {
+  readonly editor: EditorDefinition;
+  readonly platform: NodeJS.Platform;
+  readonly env: NodeJS.ProcessEnv;
+}): Promise<EditorIconSource | null> {
+  const packages = getEditorWindowsStorePackages(input.editor);
+  const packageDir =
+    resolveWindowsStorePackageDirectory(packages, input.platform, input.env) ??
+    (await resolveWindowsStorePackageDirectoryFromPowerShell({
+      packages,
+      platform: input.platform,
+      env: input.env,
+    }));
+  if (!packageDir) return null;
+
+  const iconPath = await findWindowsStorePackageIcon(packageDir);
+  if (!iconPath) return null;
+  const extension = path.extname(iconPath).toLowerCase();
+  if (extension === ".svg") {
+    return {
+      sourcePath: iconPath,
+      outputExtension: "svg",
+      contentType: "image/svg+xml",
+      transform: "copy",
+    };
+  }
+
+  return {
+    sourcePath: iconPath,
+    outputExtension: "png",
+    contentType: "image/png",
+    transform: "copy",
+  };
+}
+
 async function resolveWindowsEditorIconSource(input: {
   readonly editor: EditorDefinition;
   readonly platform: NodeJS.Platform;
   readonly env: NodeJS.ProcessEnv;
 }): Promise<EditorIconSource | null> {
   if (input.platform !== "win32") return null;
+  const storeSource = await resolveWindowsStoreEditorIconSource(input);
+  if (storeSource) return storeSource;
+
   const exePath = await resolveCommandPath({
     commands: input.editor.commands ?? null,
     platform: input.platform,
@@ -610,6 +745,10 @@ function iconLookupCacheKey(input: {
     env.HOME ?? "",
     env.XDG_DATA_HOME ?? "",
     env.XDG_DATA_DIRS ?? "",
+    env.LOCALAPPDATA ?? "",
+    env.ProgramFiles ?? "",
+    env.ProgramW6432 ?? "",
+    env.SystemDrive ?? "",
     resolvePathEnvironmentVariable(env),
     env.PATHEXT ?? "",
   ].join("\0");

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -11,6 +11,19 @@ import {
   resolveEditorLaunch,
   resolveWindowsEditorUriLaunch,
 } from "./open";
+import {
+  getEditorWindowsStorePackages,
+  resolveWindowsStorePackageDirectory,
+  resolveWindowsStorePackageDirectoryFromPowerShell,
+} from "./editorAppDiscovery";
+
+function encodeExpectedWindowsEditorUriPath(targetPath: string): string {
+  return targetPath
+    .replaceAll("\\", "/")
+    .split("/")
+    .map((segment) => encodeURIComponent(segment).replaceAll("%3A", ":"))
+    .join("/");
+}
 
 it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
   it.effect("returns commands for command-based editors", () =>
@@ -162,6 +175,27 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       assert.deepEqual(launch, {
         command: "C:\\Windows\\explorer.exe",
         args: ["vscode://file/C:/Users/Chris/Project%20Folder/src/open.ts:71:5"],
+      });
+    }),
+  );
+
+  it.effect("adds the VS Code URL-handler trailing slash for existing folders", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-vscode-folder-" });
+      const folderPath = path.join(dir, "Project Folder");
+      yield* fs.makeDirectory(folderPath);
+
+      const launch = yield* resolveEditorLaunch(
+        { cwd: folderPath, editor: "vscode" },
+        "win32",
+        { PATH: "", PATHEXT: ".COM;.EXE;.BAT;.CMD", SystemRoot: "C:\\Windows" },
+      );
+
+      assert.deepEqual(launch, {
+        command: "C:\\Windows\\explorer.exe",
+        args: [`vscode://file/${encodeExpectedWindowsEditorUriPath(folderPath)}/`],
       });
     }),
   );
@@ -480,4 +514,48 @@ it.layer(NodeServices.layer)("resolveAvailableEditors", (it) => {
       assert.equal(editors.includes("vscode"), true);
     }),
   );
+
+  it.effect("does not treat Windows app-execution-alias folders as package installs", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const localAppData = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-vscode-store-alias-",
+      });
+      yield* fs.makeDirectory(
+        path.join(
+          localAppData,
+          "Microsoft",
+          "WindowsApps",
+          "Microsoft.VisualStudioCode_8wekyb3d8bbwe",
+        ),
+        { recursive: true },
+      );
+      const editor = EDITORS.find((candidate) => candidate.id === "vscode");
+      assert.ok(editor);
+
+      assert.equal(
+        resolveWindowsStorePackageDirectory(getEditorWindowsStorePackages(editor), "win32", {
+          LOCALAPPDATA: localAppData,
+        }),
+        null,
+      );
+    }),
+  );
+
+  it("resolves Windows Store package locations through AppX when filesystem enumeration fails", () => {
+    const editor = EDITORS.find((candidate) => candidate.id === "vscode");
+    assert.ok(editor);
+    const installLocation =
+      "C:\\Program Files\\WindowsApps\\Microsoft.VisualStudioCode_1.0.0.0_x64__8wekyb3d8bbwe";
+
+    const result = resolveWindowsStorePackageDirectoryFromPowerShell(
+      getEditorWindowsStorePackages(editor),
+      "win32",
+      { PATH: "" },
+      () => `${installLocation}\r\n`,
+    );
+
+    assert.equal(result, installLocation);
+  });
 });

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -1,6 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import { assertSuccess } from "@effect/vitest/utils";
+import { EDITORS } from "@t3tools/contracts";
 import { FileSystem, Path, Effect } from "effect";
 
 import {
@@ -8,6 +9,7 @@ import {
   launchDetached,
   resolveAvailableEditors,
   resolveEditorLaunch,
+  resolveWindowsEditorUriLaunch,
 } from "./open";
 
 it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
@@ -148,6 +150,27 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       });
     }),
   );
+
+  it.effect("falls back to the VS Code URL handler on Windows when the CLI is absent", () =>
+    Effect.gen(function* () {
+      const launch = yield* resolveEditorLaunch(
+        { cwd: "C:\\Users\\Chris\\Project Folder\\src\\open.ts:71:5", editor: "vscode" },
+        "win32",
+        { PATH: "", PATHEXT: ".COM;.EXE;.BAT;.CMD", SystemRoot: "C:\\Windows" },
+      );
+
+      assert.deepEqual(launch, {
+        command: "C:\\Windows\\explorer.exe",
+        args: ["vscode://file/C:/Users/Chris/Project%20Folder/src/open.ts:71:5"],
+      });
+    }),
+  );
+
+  it("does not build URL-handler launches for non-Windows platforms", () => {
+    const editor = EDITORS.find((candidate) => candidate.id === "vscode");
+    assert.ok(editor);
+    assert.equal(resolveWindowsEditorUriLaunch(editor, "/tmp/workspace", "linux"), null);
+  });
 
   it.effect("opens terminal-style editors in the target working directory", () =>
     Effect.gen(function* () {
@@ -431,6 +454,30 @@ it.layer(NodeServices.layer)("resolveAvailableEditors", (it) => {
         PATHEXT: ".COM;.EXE;.BAT;.CMD",
       });
       assert.deepEqual(editors, ["cursor", "vscode-insiders", "zed", "file-manager"]);
+    }),
+  );
+
+  it.effect("returns VS Code when the Windows Store package is installed without a CLI", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const programFiles = yield* fs.makeTempDirectoryScoped({ prefix: "t3-vscode-store-" });
+      yield* fs.makeDirectory(
+        path.join(
+          programFiles,
+          "WindowsApps",
+          "Microsoft.VisualStudioCode_1.0.0.0_x64__8wekyb3d8bbwe",
+        ),
+        { recursive: true },
+      );
+
+      const editors = resolveAvailableEditors("win32", {
+        PATH: "",
+        PATHEXT: ".COM;.EXE;.BAT;.CMD",
+        ProgramFiles: programFiles,
+      });
+
+      assert.equal(editors.includes("vscode"), true);
     }),
   );
 });

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -12,9 +12,11 @@ import {
   resolveWindowsEditorUriLaunch,
 } from "./open";
 import {
+  clearWindowsStorePackageDiscoveryCache,
   getEditorWindowsStorePackages,
   resolveWindowsStorePackageDirectory,
   resolveWindowsStorePackageDirectoryFromPowerShell,
+  resolveWindowsStorePackageInstallLocation,
 } from "./editorAppDiscovery";
 
 function encodeExpectedWindowsEditorUriPath(targetPath: string): string {
@@ -23,6 +25,14 @@ function encodeExpectedWindowsEditorUriPath(targetPath: string): string {
     .split("/")
     .map((segment) => encodeURIComponent(segment).replaceAll("%3A", ":"))
     .join("/");
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function fakePowerShellAppxScript(installLocation: string): string {
+  return `#!/bin/sh\nprintf '%s\\n' ${shellSingleQuote(installLocation)}\n`;
 }
 
 it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
@@ -496,17 +506,24 @@ it.layer(NodeServices.layer)("resolveAvailableEditors", (it) => {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const programFiles = yield* fs.makeTempDirectoryScoped({ prefix: "t3-vscode-store-" });
-      yield* fs.makeDirectory(
-        path.join(
-          programFiles,
-          "WindowsApps",
-          "Microsoft.VisualStudioCode_1.0.0.0_x64__8wekyb3d8bbwe",
-        ),
-        { recursive: true },
+      const binDir = path.join(programFiles, "bin");
+      const installLocation = path.join(
+        programFiles,
+        "WindowsApps",
+        "Microsoft.VisualStudioCode_1.0.0.0_x64__8wekyb3d8bbwe",
       );
+      yield* fs.makeDirectory(installLocation, { recursive: true });
+      yield* fs.makeDirectory(binDir, { recursive: true });
+      yield* fs.writeFileString(
+        path.join(binDir, "powershell.exe"),
+        fakePowerShellAppxScript(installLocation),
+      );
+      yield* fs.chmod(path.join(binDir, "powershell.exe"), 0o755);
+
+      clearWindowsStorePackageDiscoveryCache();
 
       const editors = resolveAvailableEditors("win32", {
-        PATH: "",
+        PATH: binDir,
         PATHEXT: ".COM;.EXE;.BAT;.CMD",
         ProgramFiles: programFiles,
       });
@@ -543,19 +560,90 @@ it.layer(NodeServices.layer)("resolveAvailableEditors", (it) => {
     }),
   );
 
-  it("resolves Windows Store package locations through AppX when filesystem enumeration fails", () => {
+  it("resolves Windows Store package locations through matching AppX registration", () => {
     const editor = EDITORS.find((candidate) => candidate.id === "vscode");
     assert.ok(editor);
     const installLocation =
       "C:\\Program Files\\WindowsApps\\Microsoft.VisualStudioCode_1.0.0.0_x64__8wekyb3d8bbwe";
+    let script = "";
 
     const result = resolveWindowsStorePackageDirectoryFromPowerShell(
       getEditorWindowsStorePackages(editor),
       "win32",
       { PATH: "" },
-      () => `${installLocation}\r\n`,
+      (_file, args) => {
+        script = String(args[2]);
+        return `${installLocation}\r\n`;
+      },
     );
 
     assert.equal(result, installLocation);
+    assert.equal(script.includes("PackageFamilyName -ieq $packageDef.Family"), true);
+    assert.equal(script.includes("Microsoft.VisualStudioCode_8wekyb3d8bbwe"), true);
   });
+
+  it("caches Windows Store AppX registration probes", () => {
+    clearWindowsStorePackageDiscoveryCache();
+    const editor = EDITORS.find((candidate) => candidate.id === "vscode");
+    assert.ok(editor);
+    const installLocation =
+      "C:\\Program Files\\WindowsApps\\Microsoft.VisualStudioCode_1.0.0.0_x64__8wekyb3d8bbwe";
+    let calls = 0;
+
+    const first = resolveWindowsStorePackageDirectoryFromPowerShell(
+      getEditorWindowsStorePackages(editor),
+      "win32",
+      { PATH: "C:\\Windows\\System32" },
+      () => {
+        calls += 1;
+        return `${installLocation}\r\n`;
+      },
+      { useCache: true, now: () => 1_000 },
+    );
+    const second = resolveWindowsStorePackageDirectoryFromPowerShell(
+      getEditorWindowsStorePackages(editor),
+      "win32",
+      { PATH: "C:\\Windows\\System32" },
+      () => {
+        calls += 1;
+        return "C:\\wrong\r\n";
+      },
+      { useCache: true, now: () => 1_100 },
+    );
+
+    assert.equal(first, installLocation);
+    assert.equal(second, installLocation);
+    assert.equal(calls, 1);
+    clearWindowsStorePackageDiscoveryCache();
+  });
+
+  it.effect("does not treat filesystem-only AppX package directories as installed", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const editor = EDITORS.find((candidate) => candidate.id === "vscode");
+      assert.ok(editor);
+      const programFiles = yield* fs.makeTempDirectoryScoped({ prefix: "t3-vscode-staged-" });
+      yield* fs.makeDirectory(
+        path.join(
+          programFiles,
+          "WindowsApps",
+          "Microsoft.VisualStudioCode_1.0.0.0_x64__8wekyb3d8bbwe",
+        ),
+        { recursive: true },
+      );
+
+      const installLocation = resolveWindowsStorePackageInstallLocation(
+        getEditorWindowsStorePackages(editor),
+        "win32",
+        { PATH: "", ProgramFiles: programFiles },
+        () => {
+          throw new Error("not registered");
+        },
+        { useCache: false },
+      );
+
+      assert.equal(installLocation, null);
+    }),
+  );
 });

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -189,6 +189,21 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
     }),
   );
 
+  it.effect("preserves UNC paths in VS Code URL-handler launches", () =>
+    Effect.gen(function* () {
+      const launch = yield* resolveEditorLaunch(
+        { cwd: "\\\\server\\share\\Project Folder\\src\\open.ts:71:5", editor: "vscode" },
+        "win32",
+        { PATH: "", PATHEXT: ".COM;.EXE;.BAT;.CMD", SystemRoot: "C:\\Windows" },
+      );
+
+      assert.deepEqual(launch, {
+        command: "C:\\Windows\\explorer.exe",
+        args: ["vscode://file//server/share/Project%20Folder/src/open.ts:71:5"],
+      });
+    }),
+  );
+
   it.effect("adds the VS Code URL-handler trailing slash for existing folders", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -9,13 +9,20 @@
 import { spawn } from "node:child_process";
 import { accessSync, constants, statSync } from "node:fs";
 import { dirname, extname, join } from "node:path";
+import pathWin32 from "node:path/win32";
 
 import { EDITORS, type EditorId } from "@t3tools/contracts";
-import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
+import {
+  prepareWindowsSafeProcess,
+  resolveWindowsSystemRoot,
+} from "@t3tools/shared/windowsProcess";
 import { ServiceMap, Schema, Effect, Layer } from "effect";
 import {
   getEditorMacApplications,
+  getEditorWindowsStorePackages,
+  getEditorWindowsUriScheme,
   resolveAvailableMacApplication,
+  resolveWindowsStorePackageDirectory,
   type EditorDefinition,
 } from "./editorAppDiscovery";
 
@@ -33,7 +40,7 @@ export interface OpenInEditorInput {
   readonly editor: EditorId;
 }
 
-interface EditorLaunch {
+export interface EditorLaunch {
   readonly command: string;
   readonly args: ReadonlyArray<string>;
 }
@@ -218,6 +225,39 @@ function resolveFallbackEditorCommand(
   return editor.commands?.[0] ?? null;
 }
 
+function encodeWindowsEditorUriPath(targetPath: string): string {
+  return targetPath
+    .replaceAll("\\", "/")
+    .split("/")
+    .map((segment) => encodeURIComponent(segment).replaceAll("%3A", ":"))
+    .join("/");
+}
+
+function resolveWindowsEditorUri(scheme: string, target: string): string {
+  const parsedTarget = parseTargetPathAndPosition(target);
+  const targetPath = parsedTarget?.path ?? target;
+  const positionSuffix = parsedTarget?.line
+    ? `:${parsedTarget.line}${parsedTarget.column ? `:${parsedTarget.column}` : ""}`
+    : "";
+
+  return `${scheme}://file/${encodeWindowsEditorUriPath(targetPath)}${positionSuffix}`;
+}
+
+export function resolveWindowsEditorUriLaunch(
+  editor: EditorDefinition,
+  target: string,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): EditorLaunch | null {
+  const scheme = getEditorWindowsUriScheme(editor);
+  if (platform !== "win32" || !scheme) return null;
+
+  return {
+    command: pathWin32.join(resolveWindowsSystemRoot(env), "explorer.exe"),
+    args: [resolveWindowsEditorUri(scheme, target)],
+  };
+}
+
 function stripWrappingQuotes(value: string): string {
   return value.replace(/^"+|"+$/g, "");
 }
@@ -342,6 +382,14 @@ export function resolveAvailableEditors(
       continue;
     }
 
+    if (
+      resolveWindowsStorePackageDirectory(getEditorWindowsStorePackages(editor), platform, env) !==
+      null
+    ) {
+      available.push(editor.id);
+      continue;
+    }
+
     if (editor.id === "file-manager") {
       const command = fileManagerCommandForPlatform(platform);
       if (isCommandAvailable(command, { platform, env })) {
@@ -412,6 +460,11 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
     }
   }
 
+  const windowsUriLaunch = resolveWindowsEditorUriLaunch(editorDef, input.cwd, platform, env);
+  if (windowsUriLaunch) {
+    return windowsUriLaunch;
+  }
+
   const macApplication =
     resolveAvailableMacApplication(getEditorMacApplications(editorDef), platform, env) ??
     (platform === "darwin" ? (getEditorMacApplications(editorDef)?.[0] ?? null) : null);
@@ -439,6 +492,28 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
 
   return { command: fileManagerCommandForPlatform(platform), args: [input.cwd] };
 });
+
+function editorLaunchesEqual(left: EditorLaunch, right: EditorLaunch): boolean {
+  return left.command === right.command && left.args.join("\0") === right.args.join("\0");
+}
+
+function launchDetachedWithEditorFallback(
+  input: OpenInEditorInput,
+  launch: EditorLaunch,
+): Effect.Effect<void, OpenError> {
+  return launchDetached(launch).pipe(
+    Effect.catchAll((primaryError) => {
+      const editorDef = EDITORS.find((editor) => editor.id === input.editor);
+      const fallbackLaunch = editorDef ? resolveWindowsEditorUriLaunch(editorDef, input.cwd) : null;
+
+      if (!fallbackLaunch || editorLaunchesEqual(launch, fallbackLaunch)) {
+        return Effect.fail(primaryError);
+      }
+
+      return launchDetached(fallbackLaunch);
+    }),
+  );
+}
 
 export const launchDetached = (launch: EditorLaunch) =>
   Effect.gen(function* () {
@@ -496,7 +571,9 @@ const make = Effect.gen(function* () {
             try: () => open.default(input.cwd),
             catch: (cause) => new OpenError({ message: "Failed to open with default app", cause }),
           })
-        : Effect.flatMap(resolveEditorLaunch(input), launchDetached),
+        : Effect.flatMap(resolveEditorLaunch(input), (launch) =>
+            launchDetachedWithEditorFallback(input, launch),
+          ),
   } satisfies OpenShape;
 });
 

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -237,6 +237,8 @@ function resolveWindowsEditorUri(scheme: string, target: string): string {
   const parsedTarget = parseTargetPathAndPosition(target);
   const targetPath = parsedTarget?.path ?? target;
   const encodedPath = encodeWindowsEditorUriPath(targetPath);
+  // UNC paths normalize to //server/share; adding another slash changes the network path.
+  const filePathSeparator = encodedPath.startsWith("//") ? "" : "/";
   const directorySuffix =
     !parsedTarget && statSync(targetPath, { throwIfNoEntry: false })?.isDirectory() === true
       ? "/"
@@ -245,7 +247,7 @@ function resolveWindowsEditorUri(scheme: string, target: string): string {
     ? `:${parsedTarget.line}${parsedTarget.column ? `:${parsedTarget.column}` : ""}`
     : "";
 
-  return `${scheme}://file/${encodedPath}${directorySuffix}${positionSuffix}`;
+  return `${scheme}://file${filePathSeparator}${encodedPath}${directorySuffix}${positionSuffix}`;
 }
 
 export function resolveWindowsEditorUriLaunch(

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -22,7 +22,7 @@ import {
   getEditorWindowsStorePackages,
   getEditorWindowsUriScheme,
   resolveAvailableMacApplication,
-  resolveWindowsStorePackageDirectory,
+  resolveWindowsStorePackageInstallLocation,
   type EditorDefinition,
 } from "./editorAppDiscovery";
 
@@ -236,11 +236,16 @@ function encodeWindowsEditorUriPath(targetPath: string): string {
 function resolveWindowsEditorUri(scheme: string, target: string): string {
   const parsedTarget = parseTargetPathAndPosition(target);
   const targetPath = parsedTarget?.path ?? target;
+  const encodedPath = encodeWindowsEditorUriPath(targetPath);
+  const directorySuffix =
+    !parsedTarget && statSync(targetPath, { throwIfNoEntry: false })?.isDirectory() === true
+      ? "/"
+      : "";
   const positionSuffix = parsedTarget?.line
     ? `:${parsedTarget.line}${parsedTarget.column ? `:${parsedTarget.column}` : ""}`
     : "";
 
-  return `${scheme}://file/${encodeWindowsEditorUriPath(targetPath)}${positionSuffix}`;
+  return `${scheme}://file/${encodedPath}${directorySuffix}${positionSuffix}`;
 }
 
 export function resolveWindowsEditorUriLaunch(
@@ -383,8 +388,11 @@ export function resolveAvailableEditors(
     }
 
     if (
-      resolveWindowsStorePackageDirectory(getEditorWindowsStorePackages(editor), platform, env) !==
-      null
+      resolveWindowsStorePackageInstallLocation(
+        getEditorWindowsStorePackages(editor),
+        platform,
+        env,
+      ) !== null
     ) {
       available.push(editor.id);
       continue;

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -19,7 +19,17 @@ type EditorDefinition = {
   readonly label: string;
   readonly commands: readonly [string, ...string[]] | null;
   readonly macApplications?: readonly [string, ...string[]];
+  readonly windowsUriScheme?: string;
+  readonly windowsStorePackages?: readonly [
+    WindowsStorePackageDefinition,
+    ...WindowsStorePackageDefinition[],
+  ];
   readonly launchStyle: EditorLaunchStyle;
+};
+
+type WindowsStorePackageDefinition = {
+  readonly packageName: string;
+  readonly publisherId: string;
 };
 
 export const EDITORS = [
@@ -42,6 +52,10 @@ export const EDITORS = [
     label: "VS Code",
     commands: ["code"],
     macApplications: ["Visual Studio Code"],
+    windowsUriScheme: "vscode",
+    windowsStorePackages: [
+      { packageName: "Microsoft.VisualStudioCode", publisherId: "8wekyb3d8bbwe" },
+    ],
     launchStyle: "goto",
   },
   {
@@ -49,6 +63,7 @@ export const EDITORS = [
     label: "VS Code Insiders",
     commands: ["code-insiders"],
     macApplications: ["Visual Studio Code - Insiders"],
+    windowsUriScheme: "vscode-insiders",
     launchStyle: "goto",
   },
   {


### PR DESCRIPTION
## Summary
- Add Windows VS Code URI/package metadata so Store installs can be detected without relying only on the `code` CLI.
- Fall back to the `vscode://file/...` URL handler when the VS Code CLI is absent or a Windows alias fails to spawn.
- Prefer Windows Store package icon assets for VS Code before extracting icons from generic `code.exe` aliases.

Fixes #260

## Verification
- `bun run test src/open.test.ts src/editorAppIcons.test.ts` from `apps/server`
- `git diff --check`