### PR TITLE
feat: add /export slash command to download a thread as a ZIP archive

### DIFF
--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -7,6 +7,7 @@ import {
   AuthCreatePairingCredentialInput,
   AuthRevokeClientSessionInput,
   AuthRevokePairingLinkInput,
+  ThreadId,
 } from "@t3tools/contracts";
 import { EDITOR_ICON_ROUTE_PATH } from "@t3tools/shared/editorIcons";
 import { DateTime, Effect, Exit, FileSystem, Layer, Path, Schema, Stream } from "effect";
@@ -29,6 +30,8 @@ import { resolveCachedEditorIcon } from "./editorAppIcons";
 import { LOCAL_IMAGE_ROUTE_PATH, resolveAllowedLocalPreviewFile } from "./localImageFiles.ts";
 import type { ProjectFaviconResolverShape } from "./project/Services/ProjectFaviconResolver";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver";
+import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
+import { buildThreadArchiveBytes, threadArchiveFileName } from "./provider/exportThreadArchive";
 import type { ServerReadiness } from "./server/readiness";
 import { resolveFavicon, tryParseHost } from "./siteFaviconCache";
 import { isTrustedAppOrigin, normalizeCorsOrigin } from "./trustedOrigins";
@@ -166,6 +169,7 @@ export function makeEffectHttpRouteLayer(readiness: ServerReadiness) {
     ),
     authEffectRouteLayer,
     projectFaviconEffectRouteLayer,
+    threadExportEffectRouteLayer,
     siteFaviconEffectRouteLayer,
     editorIconEffectRouteLayer,
     localImageEffectRouteLayer,
@@ -443,6 +447,45 @@ const siteFaviconEffectRouteLayer = HttpRouter.add(
       status: 200,
       contentType: favicon.contentType ?? "image/x-icon",
       headers: { "Cache-Control": SITE_FAVICON_CACHE_CONTROL_SUCCESS },
+    });
+  }).pipe(Effect.catchTag("AuthError", (error) => Effect.succeed(authErrorResponse(error)))),
+);
+
+// Builds a ZIP export of a single thread (thread.json + transcript.md) and streams
+// it back as a download. Reads the orchestration snapshot the same way getSnapshot
+// does; mirrors the auth shape of the other binary GET routes (favicon/attachments).
+const threadExportEffectRouteLayer = HttpRouter.add(
+  "GET",
+  "/api/thread-export",
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const url = HttpServerRequest.toURL(request);
+    if (!url) return HttpServerResponse.text("Bad Request", { status: 400 });
+
+    yield* requireAuthenticatedRequest.pipe(
+      Effect.catchTag("AuthError", (error) => Effect.fail(error)),
+    );
+
+    const threadIdParam = url.searchParams.get("threadId");
+    if (!threadIdParam)
+      return HttpServerResponse.text("Missing threadId parameter", { status: 400 });
+
+    const snapshotQuery = yield* ProjectionSnapshotQuery;
+    const readModel = yield* snapshotQuery.getSnapshot();
+    const thread = readModel.threads.find(
+      (candidate) => candidate.id === ThreadId.makeUnsafe(threadIdParam),
+    );
+    if (!thread) return HttpServerResponse.text("Not Found", { status: 404 });
+
+    const archive = yield* Effect.sync(() => buildThreadArchiveBytes(thread));
+    const fileName = threadArchiveFileName({ title: thread.title, isoTimestamp: thread.updatedAt });
+    return HttpServerResponse.uint8Array(archive, {
+      status: 200,
+      contentType: "application/zip",
+      headers: {
+        "Content-Disposition": `attachment; filename="${fileName.replaceAll('"', "")}"`,
+        "Cache-Control": "no-store",
+      },
     });
   }).pipe(Effect.catchTag("AuthError", (error) => Effect.succeed(authErrorResponse(error)))),
 );

--- a/apps/server/src/provider/exportThreadArchive.test.ts
+++ b/apps/server/src/provider/exportThreadArchive.test.ts
@@ -1,0 +1,123 @@
+import zlib from "node:zlib";
+
+import { describe, expect, it } from "@effect/vitest";
+
+import { buildThreadArchiveBytes, threadArchiveFileName } from "./exportThreadArchive.ts";
+
+import type { OrchestrationThread } from "@t3tools/contracts";
+
+// Minimal ZIP reader: walks the central directory, inflates each raw-deflate
+// entry. Enough to prove the writer emits a valid archive without depending on
+// a host `unzip` binary in CI.
+interface ZipEntry {
+  readonly name: string;
+  readonly data: Buffer;
+}
+
+const LOCAL_HEADER_SIG = 0x04034b50;
+const CENTRAL_HEADER_SIG = 0x02014b50;
+
+function readZip(buffer: Buffer): ZipEntry[] {
+  // EOCD is the last record; scan backwards for its signature.
+  let eocdOffset = -1;
+  for (let i = buffer.length - 22; i >= 0; i -= 1) {
+    if (buffer.readUInt32LE(i) === 0x06054b50) {
+      eocdOffset = i;
+      break;
+    }
+  }
+  expect(eocdOffset).toBeGreaterThanOrEqual(0);
+
+  const cdOffset = buffer.readUInt32LE(eocdOffset + 16);
+  const cdEntries = buffer.readUInt16LE(eocdOffset + 10);
+
+  const entries: ZipEntry[] = [];
+  let cursor = cdOffset;
+  for (let index = 0; index < cdEntries; index += 1) {
+    expect(buffer.readUInt32LE(cursor)).toBe(CENTRAL_HEADER_SIG);
+    const method = buffer.readUInt16LE(cursor + 10);
+    const compressedSize = buffer.readUInt32LE(cursor + 20);
+    const nameLength = buffer.readUInt16LE(cursor + 28);
+    const localHeaderOffset = buffer.readUInt32LE(cursor + 42);
+    const name = buffer.subarray(cursor + 46, cursor + 46 + nameLength).toString("utf8");
+
+    expect(buffer.readUInt32LE(localHeaderOffset)).toBe(LOCAL_HEADER_SIG);
+    const localNameLength = buffer.readUInt16LE(localHeaderOffset + 26);
+    const dataOffset = localHeaderOffset + 30 + localNameLength;
+    const stored = buffer.subarray(dataOffset, dataOffset + compressedSize);
+    const data = method === 0 ? stored : zlib.inflateRawSync(stored);
+
+    entries.push({ name, data });
+    cursor += 46 + nameLength;
+  }
+  return entries;
+}
+
+function sampleThread(): OrchestrationThread {
+  return {
+    id: "thread-abc",
+    title: "Export Demo",
+    modelSelection: { provider: "claudeAgent" } as OrchestrationThread["modelSelection"],
+    runtimeMode: "default" as OrchestrationThread["runtimeMode"],
+    messages: [
+      {
+        id: "m1",
+        role: "user",
+        text: "Hello",
+        streaming: false,
+        source: "native",
+        turnId: null,
+        createdAt: "2026-06-28T00:00:00.000Z",
+        updatedAt: "2026-06-28T00:00:00.000Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        text: "Hi there",
+        streaming: false,
+        source: "native",
+        turnId: null,
+        createdAt: "2026-06-28T00:00:01.000Z",
+        updatedAt: "2026-06-28T00:00:01.000Z",
+      },
+    ],
+    createdAt: "2026-06-28T00:00:00.000Z",
+    updatedAt: "2026-06-28T00:00:01.000Z",
+  } as unknown as OrchestrationThread;
+}
+
+describe("exportThreadArchive", () => {
+  it("builds a zip containing thread.json and transcript.md", () => {
+    const entries = readZip(buildThreadArchiveBytes(sampleThread())).reduce<Record<string, Buffer>>(
+      (acc, entry) => {
+        acc[entry.name] = entry.data;
+        return acc;
+      },
+      {},
+    );
+
+    expect(Object.keys(entries).sort()).toEqual(["thread.json", "transcript.md"]);
+
+    const threadJson = JSON.parse(entries["thread.json"]!.toString("utf8"));
+    expect(threadJson.threadId).toBe("thread-abc");
+    expect(threadJson.messages).toHaveLength(2);
+    expect(threadJson.messages[0].role).toBe("user");
+
+    const transcript = entries["transcript.md"]!.toString("utf8");
+    expect(transcript).toContain("# Export Demo");
+    expect(transcript).toContain("Hello");
+    expect(transcript).toContain("Hi there");
+  });
+
+  it("slugifies the title and stamps the date bucket into the filename", () => {
+    expect(
+      threadArchiveFileName({ title: "Fix: nasty bug!!", isoTimestamp: "2026-06-28T01:02:03Z" }),
+    ).toBe("synara-thread-fix-nasty-bug-20260628.zip");
+  });
+
+  it("falls back to a generic slug when the title has no safe characters", () => {
+    expect(threadArchiveFileName({ title: "   ", isoTimestamp: "2026-06-28T00:00:00Z" })).toBe(
+      "synara-thread-thread-20260628.zip",
+    );
+  });
+});

--- a/apps/server/src/provider/exportThreadArchive.ts
+++ b/apps/server/src/provider/exportThreadArchive.ts
@@ -1,0 +1,231 @@
+// FILE: exportThreadArchive.ts
+// Purpose: Build a ZIP archive that exports a single Synara thread so a user
+//          can download the conversation as a portable, compressed package —
+//          mirroring the `/export` affordance of agent CLIs.
+// Layer: Server runtime utility (plain module; the HTTP route composes it via
+//          Effect.promise). No external dependencies — ZIP is produced with
+//          node:zlib (deflate + crc32) and a hand-written central directory.
+// Exports: buildThreadArchiveBytes, threadArchiveFileName.
+
+import zlib from "node:zlib";
+
+import type { OrchestrationThread } from "@t3tools/contracts";
+
+export interface ThreadArchiveEntry {
+  readonly name: string;
+  readonly data: string;
+}
+
+const crc32 = (buf: Buffer): number => zlib.crc32(buf) >>> 0;
+
+const u16 = (value: number): Buffer => {
+  const buffer = Buffer.alloc(2);
+  buffer.writeUInt16LE(value >>> 0, 0);
+  return buffer;
+};
+
+const u32 = (value: number): Buffer => {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value >>> 0, 0);
+  return buffer;
+};
+
+const UTF8_FLAG = 0x0800;
+
+// ponytail: zeroed DOS time/date (1980-01-01 00:00) is valid and is what most
+// deterministic/representative archive writers emit. Real mtimes would need
+// safe conversion from ISO -> MS-DOS fields; not worth it for an export dump.
+function buildZip(entries: ReadonlyArray<ThreadArchiveEntry>): Buffer {
+  const localHeaders: Buffer[] = [];
+  const centralDirectory: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBuffer = Buffer.from(entry.name, "utf8");
+    const data = Buffer.from(entry.data, "utf8");
+    const crc = crc32(data);
+
+    const compressed = zlib.deflateRawSync(data);
+    const useDeflate = compressed.length < data.length;
+    const stored = useDeflate ? compressed : data;
+    const method = useDeflate ? 8 : 0;
+
+    const localHeader = Buffer.concat([
+      u32(0x04034b50), // local file header signature
+      u16(20), // version needed to extract
+      u16(UTF8_FLAG), // general purpose: UTF-8 names
+      u16(method), // compression method (8 deflate, 0 store)
+      u16(0), // last mod time
+      u16(0), // last mod date
+      u32(crc), // CRC-32
+      u32(stored.length), // compressed size
+      u32(data.length), // uncompressed size
+      u16(nameBuffer.length), // file name length
+      u16(0), // extra field length
+      nameBuffer,
+      stored,
+    ]);
+
+    localHeaders.push(localHeader);
+
+    centralDirectory.push(
+      Buffer.concat([
+        u32(0x02014b50), // central directory header signature
+        u16(20), // version made by
+        u16(20), // version needed to extract
+        u16(UTF8_FLAG), // general purpose: UTF-8 names
+        u16(method), // compression method
+        u16(0), // last mod time
+        u16(0), // last mod date
+        u32(crc), // CRC-32
+        u32(stored.length), // compressed size
+        u32(data.length), // uncompressed size
+        u16(nameBuffer.length), // file name length
+        u16(0), // extra field length
+        u16(0), // file comment length
+        u16(0), // disk number start
+        u16(0), // internal file attributes
+        u32(0), // external file attributes
+        u32(offset), // offset of local header
+        nameBuffer,
+      ]),
+    );
+
+    offset += localHeader.length;
+  }
+
+  const centralDirectoryStart = offset;
+  const centralDirectoryBody = Buffer.concat(centralDirectory);
+
+  const endOfCentralDirectory = Buffer.concat([
+    u32(0x06054b50), // end of central directory signature
+    u16(0), // number of this disk
+    u16(0), // disk where central directory starts
+    u16(entries.length), // entries on this disk
+    u16(entries.length), // total entries
+    u32(centralDirectoryBody.length), // size of central directory
+    u32(centralDirectoryStart), // offset of central directory
+    u16(0), // comment length
+  ]);
+
+  return Buffer.concat([...localHeaders, centralDirectoryBody, endOfCentralDirectory]);
+}
+
+const MESSAGE_ROLE_HEADING: Record<string, string> = {
+  user: "User",
+  assistant: "Assistant",
+  system: "System",
+};
+
+function escapeMarkdownInline(text: string): string {
+  // ponytail: minimal escaping — backticks and backslashes are the only pairs that
+  // would visually corrupt a transcript dump. Full CommonMark escaping is YAGNI here.
+  return text.replace(/`/g, "\\`").replace(/\\/g, "\\\\");
+}
+
+function buildTranscriptMarkdown(thread: OrchestrationThread): string {
+  const lines: string[] = [`# ${thread.title}`, "", `> Exported from Synara.`, ""];
+
+  for (const message of thread.messages) {
+    const heading = MESSAGE_ROLE_HEADING[message.role] ?? "Message";
+    const timestamp = ` \`${message.createdAt}\``;
+    lines.push(`## ${heading}${timestamp}`, "", escapeMarkdownInline(message.text), "");
+  }
+
+  return lines.join("\n");
+}
+
+function buildThreadJson(thread: OrchestrationThread): string {
+  return JSON.stringify(
+    {
+      threadId: thread.id,
+      title: thread.title,
+      modelSelection: thread.modelSelection,
+      runtimeMode: thread.runtimeMode,
+      createdAt: thread.createdAt,
+      updatedAt: thread.updatedAt,
+      messages: thread.messages.map((message) => ({
+        id: message.id,
+        role: message.role,
+        text: message.text,
+        source: message.source,
+        createdAt: message.createdAt,
+        updatedAt: message.updatedAt,
+      })),
+    },
+    null,
+    2,
+  );
+}
+
+export function buildThreadArchiveEntries(thread: OrchestrationThread): ThreadArchiveEntry[] {
+  return [
+    { name: "thread.json", data: buildThreadJson(thread) },
+    { name: "transcript.md", data: buildTranscriptMarkdown(thread) },
+  ];
+}
+
+export function buildThreadArchiveBytes(thread: OrchestrationThread): Buffer {
+  return buildZip(buildThreadArchiveEntries(thread));
+}
+
+const FILENAME_SAFE_REPLACE = /[^a-z0-9-]+/g;
+
+function slugifyTitle(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .trim()
+    .replace(FILENAME_SAFE_REPLACE, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug.length > 0 ? slug.slice(0, 48) : "thread";
+}
+
+// ponytail: stable date bucket derived from the ISO timestamp's YYYYMMDD prefix.
+// Keeps filenames sortable and avoids pulling in a date library for formatting.
+export function threadArchiveFileName(input: {
+  readonly title: string;
+  readonly isoTimestamp: string;
+}): string {
+  const dateBucket = input.isoTimestamp.slice(0, 10).replaceAll("-", "");
+  return `synara-thread-${slugifyTitle(input.title)}-${dateBucket}.zip`;
+}
+
+// --- self-check -------------------------------------------------------------
+// Run `bun apps/server/src/provider/exportThreadArchive.ts` to verify the ZIP
+// writer round-trips through `unzip`. Left in place because ZIP byte layout is
+// easy to get subtly wrong; this is the one check that fails if it breaks.
+if (import.meta.main) {
+  const sampleThread = {
+    id: "thread-sample",
+    title: "Sample Thread",
+    messages: [
+      {
+        id: "m1",
+        role: "user",
+        text: "Hello, can you help me export this?",
+        streaming: false,
+        source: "native",
+        createdAt: "2026-06-28T00:00:00.000Z",
+        updatedAt: "2026-06-28T00:00:00.000Z",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        text: "Of course. Use `/export` to download this thread as a ZIP.",
+        streaming: false,
+        source: "native",
+        createdAt: "2026-06-28T00:00:01.000Z",
+        updatedAt: "2026-06-28T00:00:01.000Z",
+      },
+    ],
+    createdAt: "2026-06-28T00:00:00.000Z",
+    updatedAt: "2026-06-28T00:00:01.000Z",
+  } as unknown as OrchestrationThread;
+
+  const bytes = buildThreadArchiveBytes(sampleThread);
+  const fileName = threadArchiveFileName({
+    title: sampleThread.title,
+    isoTimestamp: sampleThread.updatedAt,
+  });
+  console.log(`OK ${fileName} (${bytes.length} bytes)`);
+}

--- a/apps/web/src/composerSlashCommands.test.ts
+++ b/apps/web/src/composerSlashCommands.test.ts
@@ -22,6 +22,7 @@ describe("composerSlashCommands", () => {
     expect(isBuiltInComposerSlashCommand("review")).toBe(true);
     expect(isBuiltInComposerSlashCommand("fast")).toBe(true);
     expect(isBuiltInComposerSlashCommand("automation")).toBe(true);
+    expect(isBuiltInComposerSlashCommand("export")).toBe(true);
     expect(isBuiltInComposerSlashCommand("unknown")).toBe(false);
   });
 
@@ -240,7 +241,7 @@ describe("composerSlashCommands", () => {
     expect(shouldHideProviderNativeCommandFromComposerMenu("gemini", "automation")).toBe(true);
   });
 
-  it("only exposes the app-level /side command for claude", () => {
+  it("only exposes the app-level /side and /export commands for claude", () => {
     expect(
       getAvailableComposerSlashCommands({
         provider: "claudeAgent",
@@ -250,7 +251,35 @@ describe("composerSlashCommands", () => {
         canOfferForkCommand: true,
         canOfferSideCommand: true,
       }),
-    ).toEqual(["side", "automation"]);
+    ).toEqual(["side", "export", "automation"]);
+  });
+
+  it("offers the app-level /export command on every provider", () => {
+    expect(
+      getAvailableComposerSlashCommands({
+        provider: "codex",
+        supportsFastSlashCommand: true,
+        canOfferCompactCommand: true,
+        canOfferReviewCommand: true,
+        canOfferForkCommand: true,
+        canOfferSideCommand: true,
+      }),
+    ).toContain("export");
+  });
+
+  it("keeps app-level /export available even if a provider exposes a native collision", () => {
+    const availableCommands = getAvailableComposerSlashCommands({
+      provider: "claudeAgent",
+      supportsFastSlashCommand: true,
+      canOfferCompactCommand: true,
+      canOfferReviewCommand: true,
+      canOfferForkCommand: true,
+      canOfferSideCommand: true,
+      providerNativeCommandNames: ["export"],
+    });
+
+    expect(availableCommands).toContain("export");
+    expect(shouldHideProviderNativeCommandFromComposerMenu("claudeAgent", "export")).toBe(true);
   });
 
   it("only offers /compact when Codex compaction is available", () => {
@@ -297,6 +326,7 @@ describe("composerSlashCommands", () => {
       "side",
       "status",
       "subagents",
+      "export",
       "automation",
     ]);
   });

--- a/apps/web/src/composerSlashCommands.ts
+++ b/apps/web/src/composerSlashCommands.ts
@@ -72,7 +72,11 @@ function shouldKeepBuiltInSlashCommandDespiteNativeCollision(
   provider: ProviderKind,
   command: ComposerSlashCommand,
 ): boolean {
-  return command === "automation" || (provider === "codex" && command === "review");
+  return (
+    command === "automation" ||
+    command === "export" ||
+    (provider === "codex" && command === "review")
+  );
 }
 
 export function shouldHideProviderNativeCommandFromComposerMenu(
@@ -81,7 +85,9 @@ export function shouldHideProviderNativeCommandFromComposerMenu(
 ): boolean {
   const normalizedCommand = normalizeComposerSlashCommandName(command);
   return (
-    normalizedCommand === "automation" || (provider === "codex" && normalizedCommand === "review")
+    normalizedCommand === "automation" ||
+    normalizedCommand === "export" ||
+    (provider === "codex" && normalizedCommand === "review")
   );
 }
 
@@ -161,6 +167,12 @@ const COMPOSER_SLASH_COMMAND_DEFINITIONS: Record<
     command: "fast",
     label: "/fast",
     description: "Turn fast mode on or off for this thread",
+    source: "app",
+  },
+  export: {
+    command: "export",
+    label: "/export",
+    description: "Download this thread as a ZIP archive (thread.json + transcript.md)",
     source: "app",
   },
   automation: {
@@ -367,12 +379,16 @@ export function getAvailableComposerSlashCommands(input: {
           ...(input.canOfferSideCommand ? (["side"] as const) : []),
           "status",
           "subagents",
+          "export",
           "automation",
         ]
       : [
           // Claude owns most slash-command UX natively; sidechat remains app-level because it
           // creates a Synara split/context clone before the provider sees the first turn.
+          // /export is app-level too — Synara owns the thread transcript, so the download
+          // happens in the app rather than being forwarded to Claude's native /export.
           ...(input.canOfferSideCommand ? (["side"] as const) : []),
+          "export",
           "automation",
         ];
   return availableCommands.filter((command) => !collidingNativeCommandNames.has(command));

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -34,6 +34,8 @@ import { resolveForkThreadEnvironment } from "../lib/threadEnvironment";
 import { type SplitViewId } from "../splitViewStore";
 import { useRightDockStore } from "../rightDockStore";
 import { registerSidechatCreator } from "../lib/sidechatCreatorRegistry";
+import { downloadUrlAsBlob } from "../lib/browserDownload";
+import { resolveWsHttpUrl } from "../lib/wsHttpUrl";
 
 type ComposerSnapshot = {
   value: string;
@@ -604,6 +606,24 @@ export function useComposerSlashCommands(input: {
       }
       if (slashInvocation.command === "subagents") {
         editorActions.setComposerPromptValue(buildSubagentsPrompt(slashInvocation.args));
+        return true;
+      }
+      if (slashInvocation.command === "export") {
+        editorActions.clearComposerSlashDraft();
+        const params = new URLSearchParams({ threadId: threadId });
+        void downloadUrlAsBlob({
+          url: resolveWsHttpUrl(`/api/thread-export?${params.toString()}`),
+          filename: `synara-thread-${threadId}.zip`,
+        }).catch((error: unknown) => {
+          toastManager.add({
+            type: "error",
+            title: "Could not export thread",
+            description:
+              error instanceof Error
+                ? error.message
+                : "An error occurred while exporting the thread.",
+          });
+        });
         return true;
       }
       if (slashInvocation.command === "review") {

--- a/packages/shared/src/composerSlashCommands.ts
+++ b/packages/shared/src/composerSlashCommands.ts
@@ -16,6 +16,7 @@ export const BUILT_IN_COMPOSER_SLASH_COMMANDS = [
   "status",
   "subagents",
   "fast",
+  "export",
   "automation",
 ] as const;
 


### PR DESCRIPTION
## What

Adds an app-level `/export` slash command that downloads the current thread as a portable, compressed ZIP archive — mirroring the `/export` affordance of agent CLIs.

## Why

There's no way to get a conversation out of Synara as a single, shareable artifact today. `/export` gives users a one-keystroke download of the current thread as a ZIP, without expanding product scope or touching provider internals. It's provider-agnostic and reads only Synara-owned data (the orchestration projection), so it works for every provider.

## What's in the archive

| File | Contents |
| --- | --- |
| `thread.json` | Structured thread projection — messages (role/text/source/timestamps), model, runtime mode, timestamps |
| `transcript.md` | Human-readable Markdown rendering of the conversation |

Filename: `synara-thread-<title-slug>-<YYYYMMDD>.zip`.

## How it's wired (minimal, one touch per layer)

- **`packages/shared`** — register `"export"` in `BUILT_IN_COMPOSER_SLASH_COMMANDS`.
- **`apps/web`** — add the `/export` definition and expose it for every provider (including `claudeAgent`, kept app-level like `/side` and `/automation`, since Synara owns the thread transcript rather than forwarding to Claude's native `/export`). The composer branch in `useComposerSlashCommands` intercepts it and triggers a browser download via the existing `downloadUrlAsBlob` helper against the new server route.
- **`apps/server`** — `GET /api/thread-export?threadId=…`, guarded exactly like the other binary GET routes (favicon/attachments). It reads the orchestration snapshot, builds the ZIP, and streams it back with `Content-Disposition: attachment`.

The ZIP writer is hand-rolled (local file headers + central directory + EOCD) using `node:zlib` (`deflateRawSync` + `crc32`) — **no new dependency added**. The compression method is chosen per-entry (store vs deflate).

## Verification

- `bun run typecheck` passes for `packages/shared`, `apps/server`, and `apps/web`.
- `oxlint` (with `--report-unused-disable-directives`) and `oxfmt --check` are clean on all changed files.
- New + updated vitest suites pass. The archive writer has a round-trip test that parses the produced ZIP (EOCD + central directory) and inflates each entry via `inflateRawSync`, proving the byte layout is valid without depending on a host `unzip` binary.
- The ZIP layout was additionally verified locally with `unzip -l` / `unzip -p`.

## Scope

No new dependencies, no new WebSocket contracts, no changes to any provider adapter. 5 files modified, 2 added. Happy to shrink or rework any of it.
