### PR TITLE
Handle OpenCode retry warnings in work logs

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -3136,6 +3136,58 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBeNull();
   });
 
+  it("labels OpenCode retry warnings with a provider-specific summary and visible detail", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "runtime.warning",
+      eventId: asEventId("evt-opencode-retry-warning"),
+      provider: "opencode",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-opencode"),
+      payload: {
+        message: "Provider request failed; retrying.",
+        detail: {
+          attempt: 2,
+        },
+      },
+      raw: {
+        source: "opencode.sdk.event",
+        payload: {
+          type: "session.next.retried",
+        },
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.activities.some(
+        (activity: ProviderRuntimeTestActivity) => activity.id === "evt-opencode-retry-warning",
+      ),
+    );
+
+    const warning = thread.activities.find(
+      (activity: ProviderRuntimeTestActivity) => activity.id === "evt-opencode-retry-warning",
+    );
+    const payload =
+      warning?.payload && typeof warning.payload === "object"
+        ? (warning.payload as Record<string, unknown>)
+        : undefined;
+    expect(warning).toMatchObject({
+      kind: "runtime.warning",
+      summary: "OpenCode retrying",
+    });
+    expect(payload).toMatchObject({
+      message: "Provider request failed; retrying.",
+      detail: "Provider request failed; retrying.",
+      nativeEventType: "session.next.retried",
+      data: {
+        attempt: 2,
+      },
+    });
+  });
+
   it("maps session/thread lifecycle and item.started into session/activity projections", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -653,6 +653,36 @@ function runtimePayloadRecord(event: ProviderRuntimeEvent): Record<string, unkno
   return payload as Record<string, unknown>;
 }
 
+function rawRuntimeEventPayload(event: ProviderRuntimeEvent): Record<string, unknown> | undefined {
+  const raw = asObject((event as { raw?: unknown }).raw);
+  return asObject(raw?.payload);
+}
+
+function runtimeWarningSummary(event: Extract<ProviderRuntimeEvent, { type: "runtime.warning" }>) {
+  const nativeType = asString(rawRuntimeEventPayload(event)?.type);
+  if (
+    (event.provider === "opencode" || event.provider === "kilo") &&
+    (nativeType === "session.next.retried" || nativeType === "session.status")
+  ) {
+    return event.provider === "opencode" ? "OpenCode retrying" : "Kilo retrying";
+  }
+  return "Runtime warning";
+}
+
+// Runtime warning rows should show the user-visible message even when raw detail is structured.
+function runtimeWarningPayload(
+  event: Extract<ProviderRuntimeEvent, { type: "runtime.warning" }>,
+): ActivityPayload {
+  const message = truncateDetail(event.payload.message);
+  const nativeType = asString(rawRuntimeEventPayload(event)?.type);
+  return toActivityPayload({
+    message,
+    detail: message,
+    ...(nativeType ? { nativeEventType: nativeType } : {}),
+    ...activityDataField(event.payload.detail),
+  });
+}
+
 function normalizeRuntimeTurnState(
   value: string | undefined,
 ): "completed" | "failed" | "interrupted" | "cancelled" {
@@ -852,11 +882,8 @@ function runtimeEventToActivities(
           createdAt: event.createdAt,
           tone: "info",
           kind: "runtime.warning",
-          summary: "Runtime warning",
-          payload: toActivityPayload({
-            message: truncateDetail(event.payload.message),
-            ...(event.payload.detail !== undefined ? { detail: event.payload.detail } : {}),
-          }),
+          summary: runtimeWarningSummary(event),
+          payload: runtimeWarningPayload(event),
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
         },

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1013,6 +1013,50 @@ describe("deriveWorkLogEntries", () => {
     expect(entries.map((entry) => entry.id)).toEqual(["tool-complete"]);
   });
 
+  it("shows runtime warning messages and collapses repeated identical warning rows", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "opencode-retry-1",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "runtime.warning",
+        summary: "OpenCode retrying",
+        tone: "info",
+        payload: {
+          message: "Provider request failed; retrying.",
+        },
+      }),
+      makeActivity({
+        id: "opencode-retry-2",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "runtime.warning",
+        summary: "OpenCode retrying",
+        tone: "info",
+        payload: {
+          message: "Provider request failed; retrying.",
+        },
+      }),
+      makeActivity({
+        id: "opencode-retry-3",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "runtime.warning",
+        summary: "OpenCode retrying",
+        tone: "info",
+        payload: {
+          message: "Provider request failed; retrying.",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "opencode-retry-3",
+      label: "OpenCode retrying",
+      detail: "3 notices - Provider request failed; retrying.",
+      preview: "3 notices - Provider request failed; retrying.",
+    });
+  });
+
   it("omits ExitPlanMode lifecycle entries once the plan card is shown", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1057,6 +1057,40 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("does not collapse identical runtime warnings across turn boundaries", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "turn-1-retry",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "runtime.warning",
+        summary: "OpenCode retrying",
+        tone: "info",
+        turnId: "turn-1",
+        payload: {
+          message: "Provider request failed; retrying.",
+        },
+      }),
+      makeActivity({
+        id: "turn-2-retry",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "runtime.warning",
+        summary: "OpenCode retrying",
+        tone: "info",
+        turnId: "turn-2",
+        payload: {
+          message: "Provider request failed; retrying.",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+    expect(entries.map((entry) => entry.id)).toEqual(["turn-1-retry", "turn-2-retry"]);
+    expect(entries.map((entry) => entry.detail)).toEqual([
+      "Provider request failed; retrying.",
+      "Provider request failed; retrying.",
+    ]);
+  });
+
   it("omits ExitPlanMode lifecycle entries once the plan card is shown", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -118,6 +118,8 @@ interface DerivedWorkLogEntry extends WorkLogEntry {
   collapseKey?: string;
   collapseCommand?: string;
   toolName?: string;
+  runtimeWarningRepeatCount?: number;
+  runtimeWarningMessage?: string;
 }
 
 export interface PendingApproval {
@@ -830,6 +832,8 @@ export function deriveWorkLogEntries(
       activityKind: _activityKind,
       collapseCommand: _collapseCommand,
       collapseKey: _collapseKey,
+      runtimeWarningMessage: _runtimeWarningMessage,
+      runtimeWarningRepeatCount: _runtimeWarningRepeatCount,
       ...entry
     }) => entry,
   );
@@ -955,6 +959,16 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   const collabTaskOutputDetail = extractCollabTaskOutputDetail(payload);
   if (collabTaskOutputDetail) {
     entry.detail = collabTaskOutputDetail;
+  }
+  const runtimeWarningMessage =
+    activity.kind === "runtime.warning" &&
+    typeof payload?.message === "string" &&
+    payload.message.trim().length > 0
+      ? payload.message.trim()
+      : undefined;
+  if (runtimeWarningMessage) {
+    entry.detail = runtimeWarningMessage;
+    entry.runtimeWarningMessage = runtimeWarningMessage;
   }
   if (commandPreview.command) {
     entry.command = commandPreview.command;
@@ -1132,6 +1146,10 @@ function collapseDerivedWorkLogEntries(
   const collapsed: DerivedWorkLogEntry[] = [];
   for (const entry of entries) {
     const previous = collapsed.at(-1);
+    if (previous && shouldCollapseRuntimeWarningEntries(previous, entry)) {
+      collapsed[collapsed.length - 1] = mergeRuntimeWarningEntries(previous, entry);
+      continue;
+    }
     if (previous && shouldCollapseToolLifecycleEntries(previous, entry)) {
       collapsed[collapsed.length - 1] = mergeDerivedWorkLogEntries(previous, entry);
       continue;
@@ -1139,6 +1157,50 @@ function collapseDerivedWorkLogEntries(
     collapsed.push(entry);
   }
   return collapsed;
+}
+
+function shouldCollapseRuntimeWarningEntries(
+  previous: DerivedWorkLogEntry,
+  next: DerivedWorkLogEntry,
+): boolean {
+  if (previous.activityKind !== "runtime.warning" || next.activityKind !== "runtime.warning") {
+    return false;
+  }
+  return (
+    normalizeWorkLogTextForComparison(previous.label) ===
+      normalizeWorkLogTextForComparison(next.label) &&
+    normalizeWorkLogTextForComparison(
+      previous.runtimeWarningMessage ?? previous.detail ?? previous.preview ?? "",
+    ) ===
+      normalizeWorkLogTextForComparison(
+        next.runtimeWarningMessage ?? next.detail ?? next.preview ?? "",
+      )
+  );
+}
+
+function mergeRuntimeWarningEntries(
+  previous: DerivedWorkLogEntry,
+  next: DerivedWorkLogEntry,
+): DerivedWorkLogEntry {
+  const repeatCount = (previous.runtimeWarningRepeatCount ?? 1) + 1;
+  const runtimeWarningMessage =
+    next.runtimeWarningMessage ??
+    previous.runtimeWarningMessage ??
+    next.detail ??
+    next.preview ??
+    previous.detail ??
+    previous.preview;
+  const repeatPreview = runtimeWarningMessage
+    ? `${repeatCount} notices - ${runtimeWarningMessage}`
+    : `${repeatCount} notices`;
+  return {
+    ...previous,
+    ...next,
+    runtimeWarningRepeatCount: repeatCount,
+    ...(runtimeWarningMessage ? { runtimeWarningMessage } : {}),
+    detail: repeatPreview,
+    preview: repeatPreview,
+  };
 }
 
 function shouldCollapseToolLifecycleEntries(

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1166,6 +1166,9 @@ function shouldCollapseRuntimeWarningEntries(
   if (previous.activityKind !== "runtime.warning" || next.activityKind !== "runtime.warning") {
     return false;
   }
+  if (previous.turnId !== next.turnId) {
+    return false;
+  }
   return (
     normalizeWorkLogTextForComparison(previous.label) ===
       normalizeWorkLogTextForComparison(next.label) &&


### PR DESCRIPTION
Summary:
- label OpenCode/Kilo retry runtime warnings with provider-specific summaries
- surface runtime warning messages in transcript work rows
- collapse repeated identical runtime warnings into one compact notice

Verification:
- bun run test src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
- bun run test src/session-logic.test.ts
- git diff --check