### PR TITLE
[codex] Fix Cursor ACP CLI path resolution

### DIFF
--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -81,6 +81,7 @@ import {
 } from "../acp/AcpTurnIdleWatchdog.ts";
 import {
   applyCursorAcpModelSelection,
+  buildCursorCliModelListCommand,
   fetchCursorAcpModelDescriptors,
   makeCursorAcpRuntime,
   parseCursorCliModelList,
@@ -1480,12 +1481,12 @@ export function makeCursorAdapter(
       );
       const effectiveApiEndpoint = apiEndpoint || cursorSettings.apiEndpoint;
       const runCursorModelListCommand = Effect.gen(function* () {
-        const args = [
-          ...(effectiveApiEndpoint ? (["-e", effectiveApiEndpoint] as const) : []),
-          "models",
-        ];
+        const command = buildCursorCliModelListCommand({
+          binaryPath: effectiveBinaryPath,
+          ...(effectiveApiEndpoint ? { apiEndpoint: effectiveApiEndpoint } : {}),
+        });
         const env = buildCursorAgentHeadlessEnv();
-        const prepared = prepareWindowsSafeProcess(effectiveBinaryPath, args, {
+        const prepared = prepareWindowsSafeProcess(command.command, command.args, {
           env,
         });
         const child = yield* childProcessSpawner.spawn(
@@ -1508,7 +1509,7 @@ export function makeCursorAdapter(
             method: "model/list",
             detail:
               stderr.trim() ||
-              `Cursor model discovery failed because '${effectiveBinaryPath} models' exited with code ${exitCode}.`,
+              `Cursor model discovery failed because '${[command.command, ...command.args].join(" ")}' exited with code ${exitCode}.`,
           });
         }
         const models = parseCursorCliModelList(stdout);

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -1552,22 +1552,22 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       ),
     );
 
-    it.effect("uses Cursor editor launchers through the agent subcommand", () =>
+    it.effect("maps Cursor editor launchers to top-level agent commands", () =>
       Effect.gen(function* () {
         const status = yield* makeCheckCursorProviderStatus("/custom/bin/cursor");
         assert.strictEqual(status.status, "ready");
       }).pipe(
         Effect.provide(
           mockSpawnerLayer((args, command) => {
-            assert.strictEqual(command, "/custom/bin/cursor");
+            assert.strictEqual(command, "/custom/bin/agent");
             const joined = args.join(" ");
-            if (joined === "agent --version") {
+            if (joined === "--version") {
               return { stdout: "agent 2026.04.27\n", stderr: "", code: 0 };
             }
-            if (joined === "agent status") {
+            if (joined === "status") {
               return { stdout: "Logged in as user@example.com\n", stderr: "", code: 0 };
             }
-            if (joined === "agent models") {
+            if (joined === "models") {
               return { stdout: "gpt-5 - GPT-5\n", stderr: "", code: 0 };
             }
             throw new Error(`Unexpected args: ${joined}`);

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -1554,6 +1554,20 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
 
     it.effect("maps Cursor editor launchers to top-level agent commands", () =>
       Effect.gen(function* () {
+        const originalPath = process.env.PATH;
+        yield* Effect.acquireRelease(
+          Effect.sync(() => {
+            process.env.PATH = "";
+          }),
+          () =>
+            Effect.sync(() => {
+              if (originalPath !== undefined) {
+                process.env.PATH = originalPath;
+              } else {
+                delete process.env.PATH;
+              }
+            }),
+        );
         const status = yield* makeCheckCursorProviderStatus("/custom/bin/cursor");
         assert.strictEqual(status.status, "ready");
       }).pipe(

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -1552,7 +1552,7 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       ),
     );
 
-    it.effect("maps Cursor editor launchers to top-level agent commands", () =>
+    it.effect("uses configured Cursor editor launchers when no agent command is resolved", () =>
       Effect.gen(function* () {
         const originalPath = process.env.PATH;
         yield* Effect.acquireRelease(
@@ -1573,10 +1573,10 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       }).pipe(
         Effect.provide(
           mockSpawnerLayer((args, command) => {
-            assert.strictEqual(command, "/custom/bin/agent");
+            assert.strictEqual(command, "/custom/bin/cursor");
             const joined = args.join(" ");
             if (joined === "--version") {
-              return { stdout: "agent 2026.04.27\n", stderr: "", code: 0 };
+              return { stdout: "cursor 2026.04.27\n", stderr: "", code: 0 };
             }
             if (joined === "status") {
               return { stdout: "Logged in as user@example.com\n", stderr: "", code: 0 };

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -1552,7 +1552,7 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       ),
     );
 
-    it.effect("uses configured Cursor editor launchers when no agent command is resolved", () =>
+    it.effect("falls back to cursor-agent when a configured Cursor editor has no agent command", () =>
       Effect.gen(function* () {
         const originalPath = process.env.PATH;
         yield* Effect.acquireRelease(
@@ -1573,15 +1573,15 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       }).pipe(
         Effect.provide(
           mockSpawnerLayer((args, command) => {
-            assert.strictEqual(command, "/custom/bin/cursor");
+            assert.strictEqual(command, "cursor-agent");
             const joined = args.join(" ");
-            if (joined === "agent --version") {
+            if (joined === "--version") {
               return { stdout: "cursor 2026.04.27\n", stderr: "", code: 0 };
             }
-            if (joined === "agent status") {
+            if (joined === "status") {
               return { stdout: "Logged in as user@example.com\n", stderr: "", code: 0 };
             }
-            if (joined === "agent models") {
+            if (joined === "models") {
               return { stdout: "gpt-5 - GPT-5\n", stderr: "", code: 0 };
             }
             throw new Error(`Unexpected args: ${joined}`);

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -1552,6 +1552,30 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       ),
     );
 
+    it.effect("uses Cursor editor launchers through the agent subcommand", () =>
+      Effect.gen(function* () {
+        const status = yield* makeCheckCursorProviderStatus("/custom/bin/cursor");
+        assert.strictEqual(status.status, "ready");
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args, command) => {
+            assert.strictEqual(command, "/custom/bin/cursor");
+            const joined = args.join(" ");
+            if (joined === "agent --version") {
+              return { stdout: "agent 2026.04.27\n", stderr: "", code: 0 };
+            }
+            if (joined === "agent status") {
+              return { stdout: "Logged in as user@example.com\n", stderr: "", code: 0 };
+            }
+            if (joined === "agent models") {
+              return { stdout: "gpt-5 - GPT-5\n", stderr: "", code: 0 };
+            }
+            throw new Error(`Unexpected args: ${joined}`);
+          }),
+        ),
+      ),
+    );
+
     it.effect("returns unavailable when Cursor Agent is missing", () =>
       Effect.gen(function* () {
         const status = yield* checkCursorProviderStatus;

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -1575,13 +1575,13 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
           mockSpawnerLayer((args, command) => {
             assert.strictEqual(command, "/custom/bin/cursor");
             const joined = args.join(" ");
-            if (joined === "--version") {
+            if (joined === "agent --version") {
               return { stdout: "cursor 2026.04.27\n", stderr: "", code: 0 };
             }
-            if (joined === "status") {
+            if (joined === "agent status") {
               return { stdout: "Logged in as user@example.com\n", stderr: "", code: 0 };
             }
-            if (joined === "models") {
+            if (joined === "agent models") {
               return { stdout: "gpt-5 - GPT-5\n", stderr: "", code: 0 };
             }
             throw new Error(`Unexpected args: ${joined}`);

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -1552,7 +1552,7 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       ),
     );
 
-    it.effect("falls back to cursor-agent when a configured Cursor editor has no agent command", () =>
+    it.effect("falls back through configured Cursor editors when no agent command is resolved", () =>
       Effect.gen(function* () {
         const originalPath = process.env.PATH;
         yield* Effect.acquireRelease(
@@ -1573,15 +1573,15 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       }).pipe(
         Effect.provide(
           mockSpawnerLayer((args, command) => {
-            assert.strictEqual(command, "cursor-agent");
+            assert.strictEqual(command, "/custom/bin/cursor");
             const joined = args.join(" ");
-            if (joined === "--version") {
+            if (joined === "agent --version") {
               return { stdout: "cursor 2026.04.27\n", stderr: "", code: 0 };
             }
-            if (joined === "status") {
+            if (joined === "agent status") {
               return { stdout: "Logged in as user@example.com\n", stderr: "", code: 0 };
             }
-            if (joined === "models") {
+            if (joined === "agent models") {
               return { stdout: "gpt-5 - GPT-5\n", stderr: "", code: 0 };
             }
             throw new Error(`Unexpected args: ${joined}`);

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -57,6 +57,7 @@ import {
   probeGeminiCapabilities,
 } from "../geminiAcpProbe";
 import {
+  buildCursorAgentCommand,
   buildCursorAgentHeadlessEnv,
   DEFAULT_CURSOR_AGENT_BINARY,
   resolveCursorAgentBinaryPath,
@@ -796,14 +797,16 @@ const runKiloCommand = (args: ReadonlyArray<string>, executable = "kilo") =>
     ),
   );
 
-const runCursorCommand = (args: ReadonlyArray<string>, executable = DEFAULT_CURSOR_AGENT_BINARY) =>
-  runProviderCommand(executable, args, buildCursorAgentHeadlessEnv()).pipe(
+const runCursorCommand = (args: ReadonlyArray<string>, executable = DEFAULT_CURSOR_AGENT_BINARY) => {
+  const command = buildCursorAgentCommand(executable, args);
+  return runProviderCommand(command.command, command.args, buildCursorAgentHeadlessEnv()).pipe(
     Effect.flatMap((result) =>
       isWindowsShellCommandMissingResult({ code: result.code, stderr: result.stderr })
-        ? Effect.fail(new Error(`spawn ${executable} ENOENT`))
+        ? Effect.fail(new Error(`spawn ${command.command} ENOENT`))
         : Effect.succeed(result),
     ),
   );
+};
 
 function parseCursorAuthStatusFromOutput(result: CommandResult): {
   readonly status: ServerProviderStatusState;
@@ -2142,13 +2145,14 @@ export const ProviderHealthLive = Layer.effect(
           });
         }
         if (provider === "cursor") {
+          const command = buildCursorAgentCommand(getProviderBinaryPath(provider, settings), [
+            "update",
+          ]);
           return makeProviderMaintenanceCapabilities({
             provider,
             packageName: null,
-            updateExecutable: resolveCursorAgentBinaryPath(
-              getProviderBinaryPath(provider, settings),
-            ),
-            updateArgs: ["update"],
+            updateExecutable: command.command,
+            updateArgs: command.args,
             updateLockKey: "cursor-agent",
           });
         }

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -62,29 +62,30 @@ describe("buildCursorAgentCommand", () => {
         { pathExists: () => false },
       ),
     ).toEqual({
-      command: "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
-      args: ["agent", "models"],
+      command: "/Applications/Cursor.app/Contents/Resources/app/bin/agent",
+      args: ["models"],
     });
     expect(
       buildCursorAgentCommand(
         "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.cmd",
         ["--version"],
+        { pathExists: () => false },
       ),
     ).toEqual({
-      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.cmd",
-      args: ["agent", "--version"],
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.cmd",
+      args: ["--version"],
     });
   });
 
-  it("falls back to the Cursor agent subcommand when bare cursor has no cursor-agent peer", () => {
+  it("uses a sibling Cursor agent command when bare cursor has no cursor-agent peer", () => {
     expect(
       buildCursorAgentCommand("cursor", ["acp"], {
         env: { PATH: "/tools" },
-        pathExists: () => false,
+        pathExists: (path) => path === "/tools/cursor" || path === "/tools/agent",
       }),
     ).toEqual({
-      command: "cursor",
-      args: ["agent", "acp"],
+      command: "/tools/agent",
+      args: ["acp"],
     });
   });
 

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -114,6 +114,45 @@ describe("buildCursorAgentCommand", () => {
     });
   });
 
+  it("prefers PATH cursor-agent over sibling legacy agent commands", () => {
+    expect(
+      buildCursorAgentCommand("/usr/local/bin/cursor", ["acp"], {
+        env: { PATH: "/tools" },
+        pathExists: (path) => path === "/usr/local/bin/agent" || path === "/tools/cursor-agent",
+      }),
+    ).toEqual({
+      command: "cursor-agent",
+      args: ["acp"],
+    });
+  });
+
+  it("skips PowerShell sibling agent shims for Windows editor launchers", () => {
+    expect(
+      buildCursorAgentCommand(
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.ps1",
+        ["acp"],
+        {
+          pathExists: (path) =>
+            path === "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor-agent.ps1" ||
+            path === "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor-agent.cmd",
+        },
+      ),
+    ).toEqual({
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor-agent.cmd",
+      args: ["acp"],
+    });
+    expect(
+      buildCursorAgentCommand(
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.ps1",
+        ["status"],
+        { pathExists: () => false },
+      ),
+    ).toEqual({
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.cmd",
+      args: ["status"],
+    });
+  });
+
   it("prefers a sibling cursor-agent when a Cursor shim path is configured", () => {
     expect(
       buildCursorAgentCommand("/Users/me/.local/bin/cursor", ["acp"], {

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -138,6 +138,35 @@ describe("buildCursorAgentCommand", () => {
     });
   });
 
+  it("uses bundled sibling agent commands for Cursor-owned editor paths", () => {
+    const cursorPath = "/Applications/Cursor.app/Contents/Resources/app/bin/cursor";
+    const agentPath = "/Applications/Cursor.app/Contents/Resources/app/bin/agent";
+    expect(
+      buildCursorAgentCommand(cursorPath, ["acp"], {
+        env: { PATH: "" },
+        pathExists: (path) => path === agentPath,
+      }),
+    ).toEqual({
+      command: agentPath,
+      args: ["acp"],
+    });
+
+    expect(
+      buildCursorAgentCommand(
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.cmd",
+        ["status"],
+        {
+          env: { PATH: "" },
+          pathExists: (path) =>
+            path === "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.cmd",
+        },
+      ),
+    ).toEqual({
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.cmd",
+      args: ["status"],
+    });
+  });
+
   it("ignores adjacent generic agent commands for configured Cursor editor paths", () => {
     expect(
       buildCursorAgentCommand("/usr/local/bin/cursor", ["acp"], {

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -75,6 +75,19 @@ describe("buildCursorAgentCommand", () => {
       command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.cmd",
       args: ["--version"],
     });
+    expect(
+      buildCursorAgentCommand(
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.cmd",
+        ["--version"],
+        {
+          pathExists: (path) =>
+            path === "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor-agent.exe",
+        },
+      ),
+    ).toEqual({
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor-agent.exe",
+      args: ["--version"],
+    });
   });
 
   it("uses a sibling Cursor agent command when bare cursor has no cursor-agent peer", () => {
@@ -85,6 +98,18 @@ describe("buildCursorAgentCommand", () => {
       }),
     ).toEqual({
       command: "/tools/agent",
+      args: ["acp"],
+    });
+  });
+
+  it("falls back to PATH cursor-agent before inventing an agent sibling", () => {
+    expect(
+      buildCursorAgentCommand("/missing/bin/cursor", ["acp"], {
+        env: { PATH: "/tools" },
+        pathExists: (path) => path === "/tools/cursor-agent",
+      }),
+    ).toEqual({
+      command: "cursor-agent",
       args: ["acp"],
     });
   });

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -62,8 +62,8 @@ describe("buildCursorAgentCommand", () => {
         { pathExists: () => false },
       ),
     ).toEqual({
-      command: "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
-      args: ["agent", "models"],
+      command: "cursor-agent",
+      args: ["models"],
     });
     expect(
       buildCursorAgentCommand(
@@ -72,8 +72,8 @@ describe("buildCursorAgentCommand", () => {
         { pathExists: () => false },
       ),
     ).toEqual({
-      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.cmd",
-      args: ["agent", "--version"],
+      command: "cursor-agent",
+      args: ["--version"],
     });
     expect(
       buildCursorAgentCommand(
@@ -90,27 +90,27 @@ describe("buildCursorAgentCommand", () => {
     });
   });
 
-  it("uses a sibling Cursor agent command when bare cursor has no cursor-agent peer", () => {
+  it("does not use adjacent generic agent commands for bare cursor launchers", () => {
     expect(
       buildCursorAgentCommand("cursor", ["acp"], {
         env: { PATH: "/tools" },
         pathExists: (path) => path === "/tools/cursor" || path === "/tools/agent",
       }),
     ).toEqual({
-      command: "/tools/agent",
+      command: "cursor-agent",
       args: ["acp"],
     });
   });
 
-  it("uses the bare Cursor shim when no agent command can be resolved", () => {
+  it("falls back to cursor-agent when no Cursor agent command can be resolved", () => {
     expect(
       buildCursorAgentCommand("cursor", ["acp"], {
         env: { PATH: "/tools" },
         pathExists: (path) => path === "/tools/cursor",
       }),
     ).toEqual({
-      command: "cursor",
-      args: ["agent", "acp"],
+      command: "cursor-agent",
+      args: ["acp"],
     });
   });
 
@@ -131,6 +131,18 @@ describe("buildCursorAgentCommand", () => {
       buildCursorAgentCommand("/usr/local/bin/cursor", ["acp"], {
         env: { PATH: "/tools" },
         pathExists: (path) => path === "/usr/local/bin/agent" || path === "/tools/cursor-agent",
+      }),
+    ).toEqual({
+      command: "cursor-agent",
+      args: ["acp"],
+    });
+  });
+
+  it("ignores adjacent generic agent commands for configured Cursor editor paths", () => {
+    expect(
+      buildCursorAgentCommand("/usr/local/bin/cursor", ["acp"], {
+        env: { PATH: "" },
+        pathExists: (path) => path === "/usr/local/bin/agent",
       }),
     ).toEqual({
       command: "cursor-agent",
@@ -160,8 +172,8 @@ describe("buildCursorAgentCommand", () => {
         { pathExists: () => false },
       ),
     ).toEqual({
-      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.ps1",
-      args: ["agent", "status"],
+      command: "cursor-agent",
+      args: ["status"],
     });
   });
 

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -62,7 +62,7 @@ describe("buildCursorAgentCommand", () => {
         { pathExists: () => false },
       ),
     ).toEqual({
-      command: "/Applications/Cursor.app/Contents/Resources/app/bin/agent",
+      command: "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
       args: ["models"],
     });
     expect(
@@ -72,7 +72,7 @@ describe("buildCursorAgentCommand", () => {
         { pathExists: () => false },
       ),
     ).toEqual({
-      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.cmd",
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.cmd",
       args: ["--version"],
     });
     expect(
@@ -160,7 +160,7 @@ describe("buildCursorAgentCommand", () => {
         { pathExists: () => false },
       ),
     ).toEqual({
-      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.cmd",
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.ps1",
       args: ["status"],
     });
   });

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -142,6 +142,16 @@ describe("buildCursorAgentCommand", () => {
     const cursorPath = "/Applications/Cursor.app/Contents/Resources/app/bin/cursor";
     const agentPath = "/Applications/Cursor.app/Contents/Resources/app/bin/agent";
     expect(
+      buildCursorAgentCommand("cursor", ["acp"], {
+        env: { PATH: "/Applications/Cursor.app/Contents/Resources/app/bin" },
+        pathExists: (path) => path === cursorPath || path === agentPath,
+      }),
+    ).toEqual({
+      command: agentPath,
+      args: ["acp"],
+    });
+
+    expect(
       buildCursorAgentCommand(cursorPath, ["acp"], {
         env: { PATH: "" },
         pathExists: (path) => path === agentPath,
@@ -179,7 +189,7 @@ describe("buildCursorAgentCommand", () => {
     });
   });
 
-  it("skips PowerShell sibling agent shims for Windows editor launchers", () => {
+  it("prefers safer Windows shims but accepts PowerShell-only Cursor agent siblings", () => {
     expect(
       buildCursorAgentCommand(
         "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.ps1",
@@ -193,6 +203,33 @@ describe("buildCursorAgentCommand", () => {
     ).toEqual({
       command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor-agent.cmd",
       args: ["acp"],
+    });
+    expect(
+      buildCursorAgentCommand(
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.ps1",
+        ["status"],
+        {
+          pathExists: (path) =>
+            path === "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor-agent.ps1",
+        },
+      ),
+    ).toEqual({
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor-agent.ps1",
+      args: ["status"],
+    });
+    expect(
+      buildCursorAgentCommand(
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.ps1",
+        ["models"],
+        {
+          env: { PATH: "" },
+          pathExists: (path) =>
+            path === "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.ps1",
+        },
+      ),
+    ).toEqual({
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.ps1",
+      args: ["models"],
     });
     expect(
       buildCursorAgentCommand(

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -9,7 +9,11 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { buildCursorAgentHeadlessEnv, resolveCursorAgentBinaryPath } from "./CursorAcpCommand.ts";
+import {
+  buildCursorAgentCommand,
+  buildCursorAgentHeadlessEnv,
+  resolveCursorAgentBinaryPath,
+} from "./CursorAcpCommand.ts";
 
 describe("resolveCursorAgentBinaryPath", () => {
   it("defaults to cursor-agent when no binary is configured", () => {
@@ -26,6 +30,84 @@ describe("resolveCursorAgentBinaryPath", () => {
   it("honors explicit custom Cursor binary paths", () => {
     expect(resolveCursorAgentBinaryPath("cursor-agent")).toBe("cursor-agent");
     expect(resolveCursorAgentBinaryPath("/usr/local/bin/agent")).toBe("/usr/local/bin/agent");
+  });
+});
+
+describe("buildCursorAgentCommand", () => {
+  it("runs default Cursor Agent commands directly", () => {
+    expect(buildCursorAgentCommand(undefined, ["acp"])).toEqual({
+      command: "cursor-agent",
+      args: ["acp"],
+    });
+    expect(buildCursorAgentCommand("agent", ["models"])).toEqual({
+      command: "cursor-agent",
+      args: ["models"],
+    });
+  });
+
+  it("normalizes Cursor editor launchers before appending agent args", () => {
+    expect(
+      buildCursorAgentCommand("cursor", ["acp"], {
+        env: { PATH: "/tools" },
+        pathExists: (path) => path === "/tools/cursor-agent",
+      }),
+    ).toEqual({
+      command: "cursor-agent",
+      args: ["acp"],
+    });
+    expect(
+      buildCursorAgentCommand(
+        "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+        ["models"],
+        { pathExists: () => false },
+      ),
+    ).toEqual({
+      command: "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+      args: ["agent", "models"],
+    });
+    expect(
+      buildCursorAgentCommand(
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.cmd",
+        ["--version"],
+      ),
+    ).toEqual({
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.cmd",
+      args: ["agent", "--version"],
+    });
+  });
+
+  it("falls back to the Cursor agent subcommand when bare cursor has no cursor-agent peer", () => {
+    expect(
+      buildCursorAgentCommand("cursor", ["acp"], {
+        env: { PATH: "/tools" },
+        pathExists: () => false,
+      }),
+    ).toEqual({
+      command: "cursor",
+      args: ["agent", "acp"],
+    });
+  });
+
+  it("prefers a sibling cursor-agent when a Cursor shim path is configured", () => {
+    expect(
+      buildCursorAgentCommand("/Users/me/.local/bin/cursor", ["acp"], {
+        pathExists: (path) => path === "/Users/me/.local/bin/cursor-agent",
+      }),
+    ).toEqual({
+      command: "/Users/me/.local/bin/cursor-agent",
+      args: ["acp"],
+    });
+  });
+
+  it("honors explicit agent paths without adding another subcommand", () => {
+    expect(buildCursorAgentCommand("/Users/me/.local/bin/agent", ["acp"])).toEqual({
+      command: "/Users/me/.local/bin/agent",
+      args: ["acp"],
+    });
+    expect(buildCursorAgentCommand("/Users/me/.local/bin/cursor-agent", ["acp"])).toEqual({
+      command: "/Users/me/.local/bin/cursor-agent",
+      args: ["acp"],
+    });
   });
 });
 

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -63,7 +63,7 @@ describe("buildCursorAgentCommand", () => {
       ),
     ).toEqual({
       command: "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
-      args: ["models"],
+      args: ["agent", "models"],
     });
     expect(
       buildCursorAgentCommand(
@@ -73,7 +73,7 @@ describe("buildCursorAgentCommand", () => {
       ),
     ).toEqual({
       command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.cmd",
-      args: ["--version"],
+      args: ["agent", "--version"],
     });
     expect(
       buildCursorAgentCommand(
@@ -110,7 +110,7 @@ describe("buildCursorAgentCommand", () => {
       }),
     ).toEqual({
       command: "cursor",
-      args: ["acp"],
+      args: ["agent", "acp"],
     });
   });
 
@@ -161,7 +161,7 @@ describe("buildCursorAgentCommand", () => {
       ),
     ).toEqual({
       command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.ps1",
-      args: ["status"],
+      args: ["agent", "status"],
     });
   });
 

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -62,8 +62,8 @@ describe("buildCursorAgentCommand", () => {
         { pathExists: () => false },
       ),
     ).toEqual({
-      command: "cursor-agent",
-      args: ["models"],
+      command: "/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
+      args: ["agent", "models"],
     });
     expect(
       buildCursorAgentCommand(
@@ -72,8 +72,8 @@ describe("buildCursorAgentCommand", () => {
         { pathExists: () => false },
       ),
     ).toEqual({
-      command: "cursor-agent",
-      args: ["--version"],
+      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.cmd",
+      args: ["agent", "--version"],
     });
     expect(
       buildCursorAgentCommand(
@@ -97,20 +97,20 @@ describe("buildCursorAgentCommand", () => {
         pathExists: (path) => path === "/tools/cursor" || path === "/tools/agent",
       }),
     ).toEqual({
-      command: "cursor-agent",
-      args: ["acp"],
+      command: "cursor",
+      args: ["agent", "acp"],
     });
   });
 
-  it("falls back to cursor-agent when no Cursor agent command can be resolved", () => {
+  it("falls back through Cursor editor launchers when no agent command can be resolved", () => {
     expect(
       buildCursorAgentCommand("cursor", ["acp"], {
         env: { PATH: "/tools" },
         pathExists: (path) => path === "/tools/cursor",
       }),
     ).toEqual({
-      command: "cursor-agent",
-      args: ["acp"],
+      command: "cursor",
+      args: ["agent", "acp"],
     });
   });
 
@@ -141,6 +141,7 @@ describe("buildCursorAgentCommand", () => {
   it("uses bundled sibling agent commands for Cursor-owned editor paths", () => {
     const cursorPath = "/Applications/Cursor.app/Contents/Resources/app/bin/cursor";
     const agentPath = "/Applications/Cursor.app/Contents/Resources/app/bin/agent";
+    const cursorSymlinkPath = "/usr/local/bin/cursor";
     expect(
       buildCursorAgentCommand("cursor", ["acp"], {
         env: { PATH: "/Applications/Cursor.app/Contents/Resources/app/bin" },
@@ -149,6 +150,17 @@ describe("buildCursorAgentCommand", () => {
     ).toEqual({
       command: agentPath,
       args: ["acp"],
+    });
+
+    expect(
+      buildCursorAgentCommand("cursor", ["models"], {
+        env: { PATH: "/usr/local/bin" },
+        pathExists: (path) => path === cursorSymlinkPath || path === agentPath,
+        realpath: (path) => (path === cursorSymlinkPath ? cursorPath : path),
+      }),
+    ).toEqual({
+      command: agentPath,
+      args: ["models"],
     });
 
     expect(
@@ -184,8 +196,8 @@ describe("buildCursorAgentCommand", () => {
         pathExists: (path) => path === "/usr/local/bin/agent",
       }),
     ).toEqual({
-      command: "cursor-agent",
-      args: ["acp"],
+      command: "/usr/local/bin/cursor",
+      args: ["agent", "acp"],
     });
   });
 
@@ -214,8 +226,15 @@ describe("buildCursorAgentCommand", () => {
         },
       ),
     ).toEqual({
-      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor-agent.ps1",
-      args: ["status"],
+      command: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor-agent.ps1",
+        "status",
+      ],
     });
     expect(
       buildCursorAgentCommand(
@@ -228,8 +247,15 @@ describe("buildCursorAgentCommand", () => {
         },
       ),
     ).toEqual({
-      command: "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.ps1",
-      args: ["models"],
+      command: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\agent.ps1",
+        "models",
+      ],
     });
     expect(
       buildCursorAgentCommand(
@@ -238,8 +264,16 @@ describe("buildCursorAgentCommand", () => {
         { pathExists: () => false },
       ),
     ).toEqual({
-      command: "cursor-agent",
-      args: ["status"],
+      command: "powershell.exe",
+      args: [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        "C:\\Users\\me\\AppData\\Local\\Programs\\Cursor\\bin\\cursor.ps1",
+        "agent",
+        "status",
+      ],
     });
   });
 

--- a/apps/server/src/provider/acp/CursorAcpCommand.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.test.ts
@@ -102,6 +102,18 @@ describe("buildCursorAgentCommand", () => {
     });
   });
 
+  it("uses the bare Cursor shim when no agent command can be resolved", () => {
+    expect(
+      buildCursorAgentCommand("cursor", ["acp"], {
+        env: { PATH: "/tools" },
+        pathExists: (path) => path === "/tools/cursor",
+      }),
+    ).toEqual({
+      command: "cursor",
+      args: ["acp"],
+    });
+  });
+
   it("falls back to PATH cursor-agent before inventing an agent sibling", () => {
     expect(
       buildCursorAgentCommand("/missing/bin/cursor", ["acp"], {

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -45,7 +45,8 @@ interface CursorCommandPathParts {
 }
 
 const CURSOR_EXECUTABLE_EXTENSION_PATTERN = /\.(?:bat|cmd|exe|ps1)$/iu;
-const WINDOWS_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat", ".ps1"] as const;
+const WINDOWS_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat"] as const;
+const WINDOWS_BATCH_EXECUTABLE_EXTENSION = ".cmd";
 
 function splitCursorCommandPath(command: string): CursorCommandPathParts {
   const trimmed = command.trim();
@@ -84,15 +85,21 @@ function resolveCursorEditorLauncherCommand(
     return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
   }
 
-  const siblingAgent = resolveCursorSiblingAgentCommand(parts, options);
+  const siblingAgent = resolveCursorSiblingCommand(parts, DEFAULT_CURSOR_AGENT_BINARY, options);
   if (siblingAgent) {
     return siblingAgent;
   }
   if (findCommandOnPath(DEFAULT_CURSOR_AGENT_BINARY, options)) {
     return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
   }
+  const siblingLegacyAgent = resolveCursorSiblingCommand(parts, LEGACY_CURSOR_AGENT_BINARY, options);
+  if (siblingLegacyAgent) {
+    return siblingLegacyAgent;
+  }
   return {
-    command: `${parts.directory}${LEGACY_CURSOR_AGENT_BINARY}${parts.extension}`,
+    command: `${parts.directory}${LEGACY_CURSOR_AGENT_BINARY}${cursorLegacyFallbackExtension(
+      parts,
+    )}`,
     args: [],
   };
 }
@@ -102,28 +109,56 @@ function resolveCursorSiblingAgentCommand(
   options: ResolvedCursorAgentCommandOptions,
 ): CursorAgentCommand | undefined {
   // Cursor editor launchers do not host `cursor agent`; agent commands are top-level binaries.
+  return (
+    resolveCursorSiblingCommand(parts, DEFAULT_CURSOR_AGENT_BINARY, options) ??
+    resolveCursorSiblingCommand(parts, LEGACY_CURSOR_AGENT_BINARY, options)
+  );
+}
+
+function resolveCursorSiblingCommand(
+  parts: CursorCommandPathParts,
+  binary: string,
+  options: ResolvedCursorAgentCommandOptions,
+): CursorAgentCommand | undefined {
   for (const extension of cursorSiblingAgentExtensions(parts)) {
-    const siblingAgent = `${parts.directory}${DEFAULT_CURSOR_AGENT_BINARY}${extension}`;
+    const siblingAgent = `${parts.directory}${binary}${extension}`;
     if (options.pathExists(siblingAgent)) {
       return { command: siblingAgent, args: [] };
-    }
-  }
-  for (const extension of cursorSiblingAgentExtensions(parts)) {
-    const siblingLegacyAgent = `${parts.directory}${LEGACY_CURSOR_AGENT_BINARY}${extension}`;
-    if (options.pathExists(siblingLegacyAgent)) {
-      return { command: siblingLegacyAgent, args: [] };
     }
   }
   return undefined;
 }
 
 function cursorSiblingAgentExtensions(parts: CursorCommandPathParts): ReadonlyArray<string> {
-  const shouldProbeWindowsExtensions =
-    process.platform === "win32" || parts.directory.includes("\\") || parts.extension.length > 0;
+  const shouldProbeWindowsExtensions = shouldProbeWindowsExtensionsForParts(parts);
+  const preferredExtension = isWindowsSafeExecutableExtension(parts.extension)
+    ? [parts.extension]
+    : [];
   const extensions = shouldProbeWindowsExtensions
-    ? [parts.extension, ...WINDOWS_EXECUTABLE_EXTENSIONS, ""]
+    ? [...preferredExtension, ...WINDOWS_EXECUTABLE_EXTENSIONS, ""]
     : [parts.extension];
   return [...new Set(extensions)];
+}
+
+function cursorLegacyFallbackExtension(parts: CursorCommandPathParts): string {
+  if (!shouldProbeWindowsExtensionsForParts(parts)) {
+    return parts.extension;
+  }
+  return isWindowsSafeExecutableExtension(parts.extension)
+    ? parts.extension
+    : WINDOWS_BATCH_EXECUTABLE_EXTENSION;
+}
+
+function shouldProbeWindowsExtensionsForParts(parts: CursorCommandPathParts): boolean {
+  return (
+    process.platform === "win32" || parts.directory.includes("\\") || parts.extension.length > 0
+  );
+}
+
+function isWindowsSafeExecutableExtension(extension: string): boolean {
+  return WINDOWS_EXECUTABLE_EXTENSIONS.includes(
+    extension as (typeof WINDOWS_EXECUTABLE_EXTENSIONS)[number],
+  );
 }
 
 function findCommandOnPath(

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -91,6 +91,10 @@ function resolveCursorEditorLauncherCommand(
   if (findCommandOnPath(DEFAULT_CURSOR_AGENT_BINARY, options)) {
     return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
   }
+  const siblingLegacyAgent = resolveTrustedCursorLegacySiblingCommand(parts, options);
+  if (siblingLegacyAgent) {
+    return siblingLegacyAgent;
+  }
   return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
 }
 
@@ -100,6 +104,26 @@ function resolveCursorSiblingAgentCommand(
 ): CursorAgentCommand | undefined {
   // Only trust Cursor's named agent binary when deriving from an editor launcher path.
   return resolveCursorSiblingCommand(parts, DEFAULT_CURSOR_AGENT_BINARY, options);
+}
+
+function resolveTrustedCursorLegacySiblingCommand(
+  parts: CursorCommandPathParts,
+  options: ResolvedCursorAgentCommandOptions,
+): CursorAgentCommand | undefined {
+  if (!isCursorOwnedLauncherDirectory(parts.directory)) {
+    return undefined;
+  }
+  return resolveCursorSiblingCommand(parts, LEGACY_CURSOR_AGENT_BINARY, options);
+}
+
+function isCursorOwnedLauncherDirectory(directory: string): boolean {
+  const normalizedDirectory = directory.replaceAll("\\", "/").toLowerCase();
+  return (
+    normalizedDirectory.includes("/cursor.app/") ||
+    normalizedDirectory.includes("/programs/cursor/") ||
+    normalizedDirectory.includes("/cursor/resources/app/") ||
+    normalizedDirectory.includes("/cursor-agent/")
+  );
 }
 
 function resolveCursorSiblingCommand(

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -70,24 +70,53 @@ function resolveCursorEditorLauncherCommand(
   }
 
   if (!parts.hasDirectory) {
-    return commandExistsOnPath(DEFAULT_CURSOR_AGENT_BINARY, options)
-      ? { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] }
-      : { command, args: [LEGACY_CURSOR_AGENT_BINARY] };
+    if (findCommandOnPath(DEFAULT_CURSOR_AGENT_BINARY, options)) {
+      return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
+    }
+    const cursorPath = findCommandOnPath(command, options);
+    if (cursorPath) {
+      const cursorPathParts = splitCursorCommandPath(cursorPath);
+      const siblingAgent = resolveCursorSiblingAgentCommand(cursorPathParts, options);
+      if (siblingAgent) {
+        return siblingAgent;
+      }
+    }
+    return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
   }
 
-  const siblingAgent = `${parts.directory}${DEFAULT_CURSOR_AGENT_BINARY}${parts.extension}`;
-  return options.pathExists(siblingAgent)
-    ? { command: siblingAgent, args: [] }
-    : { command, args: [LEGACY_CURSOR_AGENT_BINARY] };
+  const siblingAgent = resolveCursorSiblingAgentCommand(parts, options);
+  if (siblingAgent) {
+    return siblingAgent;
+  }
+  return {
+    command: `${parts.directory}${LEGACY_CURSOR_AGENT_BINARY}${parts.extension}`,
+    args: [],
+  };
 }
 
-function commandExistsOnPath(
+function resolveCursorSiblingAgentCommand(
+  parts: CursorCommandPathParts,
+  options: ResolvedCursorAgentCommandOptions,
+): CursorAgentCommand | undefined {
+  // Cursor editor launchers do not host `cursor agent`; agent commands are top-level binaries.
+  const siblingAgent = `${parts.directory}${DEFAULT_CURSOR_AGENT_BINARY}${parts.extension}`;
+  if (options.pathExists(siblingAgent)) {
+    return { command: siblingAgent, args: [] };
+  }
+  const siblingLegacyAgent = `${parts.directory}${LEGACY_CURSOR_AGENT_BINARY}${parts.extension}`;
+  if (options.pathExists(siblingLegacyAgent)) {
+    return { command: siblingLegacyAgent, args: [] };
+  }
+  return undefined;
+}
+
+function findCommandOnPath(
   command: string,
   options: ResolvedCursorAgentCommandOptions,
-): boolean {
+): string | undefined {
   const searchPath = options.env.PATH ?? options.env.Path ?? "";
   if (!searchPath.trim()) {
-    return false;
+    return undefined;
   }
   const separator =
     options.env.Path !== undefined && options.env.PATH === undefined ? ";" : path.delimiter;
@@ -100,12 +129,13 @@ function commandExistsOnPath(
       continue;
     }
     for (const extension of extensions) {
-      if (options.pathExists(path.join(directory, `${command}${extension}`))) {
-        return true;
+      const candidate = path.join(directory, `${command}${extension}`);
+      if (options.pathExists(candidate)) {
+        return candidate;
       }
     }
   }
-  return false;
+  return undefined;
 }
 
 // Resolves persisted/default Cursor binary settings into the executable Synara should spawn.

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -27,7 +27,7 @@ export interface CursorAgentCommand {
   readonly args: ReadonlyArray<string>;
 }
 
-interface CursorAgentCommandOptions {
+export interface CursorAgentCommandOptions {
   readonly env?: NodeJS.ProcessEnv;
   readonly pathExists?: (path: string) => boolean;
 }
@@ -88,6 +88,9 @@ function resolveCursorEditorLauncherCommand(
   if (siblingAgent) {
     return siblingAgent;
   }
+  if (findCommandOnPath(DEFAULT_CURSOR_AGENT_BINARY, options)) {
+    return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
+  }
   return {
     command: `${parts.directory}${LEGACY_CURSOR_AGENT_BINARY}${parts.extension}`,
     args: [],
@@ -99,15 +102,28 @@ function resolveCursorSiblingAgentCommand(
   options: ResolvedCursorAgentCommandOptions,
 ): CursorAgentCommand | undefined {
   // Cursor editor launchers do not host `cursor agent`; agent commands are top-level binaries.
-  const siblingAgent = `${parts.directory}${DEFAULT_CURSOR_AGENT_BINARY}${parts.extension}`;
-  if (options.pathExists(siblingAgent)) {
-    return { command: siblingAgent, args: [] };
+  for (const extension of cursorSiblingAgentExtensions(parts)) {
+    const siblingAgent = `${parts.directory}${DEFAULT_CURSOR_AGENT_BINARY}${extension}`;
+    if (options.pathExists(siblingAgent)) {
+      return { command: siblingAgent, args: [] };
+    }
   }
-  const siblingLegacyAgent = `${parts.directory}${LEGACY_CURSOR_AGENT_BINARY}${parts.extension}`;
-  if (options.pathExists(siblingLegacyAgent)) {
-    return { command: siblingLegacyAgent, args: [] };
+  for (const extension of cursorSiblingAgentExtensions(parts)) {
+    const siblingLegacyAgent = `${parts.directory}${LEGACY_CURSOR_AGENT_BINARY}${extension}`;
+    if (options.pathExists(siblingLegacyAgent)) {
+      return { command: siblingLegacyAgent, args: [] };
+    }
   }
   return undefined;
+}
+
+function cursorSiblingAgentExtensions(parts: CursorCommandPathParts): ReadonlyArray<string> {
+  const shouldProbeWindowsExtensions =
+    process.platform === "win32" || parts.directory.includes("\\") || parts.extension.length > 0;
+  const extensions = shouldProbeWindowsExtensions
+    ? [parts.extension, ...WINDOWS_EXECUTABLE_EXTENSIONS, ""]
+    : [parts.extension];
+  return [...new Set(extensions)];
 }
 
 function findCommandOnPath(

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -81,7 +81,7 @@ function resolveCursorEditorLauncherCommand(
         return siblingAgent;
       }
     }
-    return { command, args: [LEGACY_CURSOR_AGENT_BINARY] };
+    return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
   }
 
   const siblingAgent = resolveCursorSiblingCommand(parts, DEFAULT_CURSOR_AGENT_BINARY, options);
@@ -91,22 +91,15 @@ function resolveCursorEditorLauncherCommand(
   if (findCommandOnPath(DEFAULT_CURSOR_AGENT_BINARY, options)) {
     return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
   }
-  const siblingLegacyAgent = resolveCursorSiblingCommand(parts, LEGACY_CURSOR_AGENT_BINARY, options);
-  if (siblingLegacyAgent) {
-    return siblingLegacyAgent;
-  }
-  return { command, args: [LEGACY_CURSOR_AGENT_BINARY] };
+  return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
 }
 
 function resolveCursorSiblingAgentCommand(
   parts: CursorCommandPathParts,
   options: ResolvedCursorAgentCommandOptions,
 ): CursorAgentCommand | undefined {
-  // Prefer real agent binaries; the launcher fallback must explicitly dispatch to its agent command.
-  return (
-    resolveCursorSiblingCommand(parts, DEFAULT_CURSOR_AGENT_BINARY, options) ??
-    resolveCursorSiblingCommand(parts, LEGACY_CURSOR_AGENT_BINARY, options)
-  );
+  // Only trust Cursor's named agent binary when deriving from an editor launcher path.
+  return resolveCursorSiblingCommand(parts, DEFAULT_CURSOR_AGENT_BINARY, options);
 }
 
 function resolveCursorSiblingCommand(

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -46,7 +46,6 @@ interface CursorCommandPathParts {
 
 const CURSOR_EXECUTABLE_EXTENSION_PATTERN = /\.(?:bat|cmd|exe|ps1)$/iu;
 const WINDOWS_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat"] as const;
-const WINDOWS_BATCH_EXECUTABLE_EXTENSION = ".cmd";
 
 function splitCursorCommandPath(command: string): CursorCommandPathParts {
   const trimmed = command.trim();
@@ -96,12 +95,7 @@ function resolveCursorEditorLauncherCommand(
   if (siblingLegacyAgent) {
     return siblingLegacyAgent;
   }
-  return {
-    command: `${parts.directory}${LEGACY_CURSOR_AGENT_BINARY}${cursorLegacyFallbackExtension(
-      parts,
-    )}`,
-    args: [],
-  };
+  return { command, args: [] };
 }
 
 function resolveCursorSiblingAgentCommand(
@@ -138,15 +132,6 @@ function cursorSiblingAgentExtensions(parts: CursorCommandPathParts): ReadonlyAr
     ? [...preferredExtension, ...WINDOWS_EXECUTABLE_EXTENSIONS, ""]
     : [parts.extension];
   return [...new Set(extensions)];
-}
-
-function cursorLegacyFallbackExtension(parts: CursorCommandPathParts): string {
-  if (!shouldProbeWindowsExtensionsForParts(parts)) {
-    return parts.extension;
-  }
-  return isWindowsSafeExecutableExtension(parts.extension)
-    ? parts.extension
-    : WINDOWS_BATCH_EXECUTABLE_EXTENSION;
 }
 
 function shouldProbeWindowsExtensionsForParts(parts: CursorCommandPathParts): boolean {

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -76,7 +76,9 @@ function resolveCursorEditorLauncherCommand(
     const cursorPath = findCommandOnPath(command, options);
     if (cursorPath) {
       const cursorPathParts = splitCursorCommandPath(cursorPath);
-      const siblingAgent = resolveCursorSiblingAgentCommand(cursorPathParts, options);
+      const siblingAgent =
+        resolveCursorSiblingAgentCommand(cursorPathParts, options) ??
+        resolveTrustedCursorLegacySiblingCommand(cursorPathParts, options);
       if (siblingAgent) {
         return siblingAgent;
       }
@@ -145,8 +147,10 @@ function cursorSiblingAgentExtensions(parts: CursorCommandPathParts): ReadonlyAr
   const preferredExtension = isWindowsSafeExecutableExtension(parts.extension)
     ? [parts.extension]
     : [];
+  const powerShellFallbackExtension =
+    parts.extension.toLowerCase() === ".ps1" ? [parts.extension] : [];
   const extensions = shouldProbeWindowsExtensions
-    ? [...preferredExtension, ...WINDOWS_EXECUTABLE_EXTENSIONS, ""]
+    ? [...preferredExtension, ...WINDOWS_EXECUTABLE_EXTENSIONS, "", ...powerShellFallbackExtension]
     : [parts.extension];
   return [...new Set(extensions)];
 }

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -6,9 +6,12 @@
  *
  * @module CursorAcpCommand
  */
+import { existsSync } from "node:fs";
+import * as path from "node:path";
 
 export const DEFAULT_CURSOR_AGENT_BINARY = "cursor-agent";
 export const LEGACY_CURSOR_AGENT_BINARY = "agent";
+export const CURSOR_EDITOR_BINARY = "cursor";
 export const CURSOR_AGENT_BROWSERLESS_ENV = {
   NO_BROWSER: "true",
   BROWSER: "www-browser",
@@ -19,12 +22,115 @@ export const CURSOR_AGENT_HEADLESS_PROBE_ENV = {
   DEBIAN_FRONTEND: "noninteractive",
 } as const satisfies Readonly<Record<string, string>>;
 
+export interface CursorAgentCommand {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+}
+
+interface CursorAgentCommandOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly pathExists?: (path: string) => boolean;
+}
+
+interface ResolvedCursorAgentCommandOptions {
+  readonly env: NodeJS.ProcessEnv;
+  readonly pathExists: (path: string) => boolean;
+}
+
+interface CursorCommandPathParts {
+  readonly directory: string;
+  readonly extension: string;
+  readonly hasDirectory: boolean;
+  readonly stem: string;
+}
+
+const CURSOR_EXECUTABLE_EXTENSION_PATTERN = /\.(?:bat|cmd|exe|ps1)$/iu;
+const WINDOWS_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat", ".ps1"] as const;
+
+function splitCursorCommandPath(command: string): CursorCommandPathParts {
+  const trimmed = command.trim();
+  const forwardSlash = trimmed.lastIndexOf("/");
+  const backslash = trimmed.lastIndexOf("\\");
+  const separatorIndex = Math.max(forwardSlash, backslash);
+  const hasDirectory = separatorIndex >= 0;
+  const directory = hasDirectory ? trimmed.slice(0, separatorIndex + 1) : "";
+  const filename = hasDirectory ? trimmed.slice(separatorIndex + 1) : trimmed;
+  const extension = filename.match(CURSOR_EXECUTABLE_EXTENSION_PATTERN)?.[0] ?? "";
+  const stem = (extension ? filename.slice(0, -extension.length) : filename).toLowerCase();
+  return { directory, extension, hasDirectory, stem };
+}
+
+function resolveCursorEditorLauncherCommand(
+  command: string,
+  options: ResolvedCursorAgentCommandOptions,
+): CursorAgentCommand | undefined {
+  const parts = splitCursorCommandPath(command);
+  if (parts.stem !== CURSOR_EDITOR_BINARY) {
+    return undefined;
+  }
+
+  if (!parts.hasDirectory) {
+    return commandExistsOnPath(DEFAULT_CURSOR_AGENT_BINARY, options)
+      ? { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] }
+      : { command, args: [LEGACY_CURSOR_AGENT_BINARY] };
+  }
+
+  const siblingAgent = `${parts.directory}${DEFAULT_CURSOR_AGENT_BINARY}${parts.extension}`;
+  return options.pathExists(siblingAgent)
+    ? { command: siblingAgent, args: [] }
+    : { command, args: [LEGACY_CURSOR_AGENT_BINARY] };
+}
+
+function commandExistsOnPath(
+  command: string,
+  options: ResolvedCursorAgentCommandOptions,
+): boolean {
+  const searchPath = options.env.PATH ?? options.env.Path ?? "";
+  if (!searchPath.trim()) {
+    return false;
+  }
+  const separator =
+    options.env.Path !== undefined && options.env.PATH === undefined ? ";" : path.delimiter;
+  const extensions =
+    process.platform === "win32" && path.extname(command) === ""
+      ? WINDOWS_EXECUTABLE_EXTENSIONS
+      : [""];
+  for (const directory of searchPath.split(separator)) {
+    if (!directory.trim()) {
+      continue;
+    }
+    for (const extension of extensions) {
+      if (options.pathExists(path.join(directory, `${command}${extension}`))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 // Resolves persisted/default Cursor binary settings into the executable Synara should spawn.
 export function resolveCursorAgentBinaryPath(binaryPath: string | null | undefined): string {
   const configuredBinaryPath = binaryPath?.trim();
   return !configuredBinaryPath || configuredBinaryPath === LEGACY_CURSOR_AGENT_BINARY
     ? DEFAULT_CURSOR_AGENT_BINARY
     : configuredBinaryPath;
+}
+
+// Builds Cursor Agent invocations from either `cursor-agent` or the `cursor` editor launcher.
+export function buildCursorAgentCommand(
+  binaryPath: string | null | undefined,
+  args: ReadonlyArray<string>,
+  options: CursorAgentCommandOptions = {},
+): CursorAgentCommand {
+  const command = resolveCursorAgentBinaryPath(binaryPath);
+  const commandOptions = {
+    env: options.env ?? process.env,
+    pathExists: options.pathExists ?? existsSync,
+  };
+  const editorLauncher = resolveCursorEditorLauncherCommand(command, commandOptions);
+  return editorLauncher
+    ? { command: editorLauncher.command, args: [...editorLauncher.args, ...args] }
+    : { command, args: [...args] };
 }
 
 // Cursor auth/status probes must stay headless so provider refreshes never open login browsers.

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -81,7 +81,7 @@ function resolveCursorEditorLauncherCommand(
         return siblingAgent;
       }
     }
-    return { command, args: [] };
+    return { command, args: [LEGACY_CURSOR_AGENT_BINARY] };
   }
 
   const siblingAgent = resolveCursorSiblingCommand(parts, DEFAULT_CURSOR_AGENT_BINARY, options);
@@ -95,14 +95,14 @@ function resolveCursorEditorLauncherCommand(
   if (siblingLegacyAgent) {
     return siblingLegacyAgent;
   }
-  return { command, args: [] };
+  return { command, args: [LEGACY_CURSOR_AGENT_BINARY] };
 }
 
 function resolveCursorSiblingAgentCommand(
   parts: CursorCommandPathParts,
   options: ResolvedCursorAgentCommandOptions,
 ): CursorAgentCommand | undefined {
-  // Cursor editor launchers do not host `cursor agent`; agent commands are top-level binaries.
+  // Prefer real agent binaries; the launcher fallback must explicitly dispatch to its agent command.
   return (
     resolveCursorSiblingCommand(parts, DEFAULT_CURSOR_AGENT_BINARY, options) ??
     resolveCursorSiblingCommand(parts, LEGACY_CURSOR_AGENT_BINARY, options)

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -6,7 +6,7 @@
  *
  * @module CursorAcpCommand
  */
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import * as path from "node:path";
 
 export const DEFAULT_CURSOR_AGENT_BINARY = "cursor-agent";
@@ -30,11 +30,13 @@ export interface CursorAgentCommand {
 export interface CursorAgentCommandOptions {
   readonly env?: NodeJS.ProcessEnv;
   readonly pathExists?: (path: string) => boolean;
+  readonly realpath?: (path: string) => string;
 }
 
 interface ResolvedCursorAgentCommandOptions {
   readonly env: NodeJS.ProcessEnv;
   readonly pathExists: (path: string) => boolean;
+  readonly realpath: (path: string) => string;
 }
 
 interface CursorCommandPathParts {
@@ -45,6 +47,7 @@ interface CursorCommandPathParts {
 }
 
 const CURSOR_EXECUTABLE_EXTENSION_PATTERN = /\.(?:bat|cmd|exe|ps1)$/iu;
+const POWERSHELL_EXECUTABLE = "powershell.exe";
 const WINDOWS_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat"] as const;
 
 function splitCursorCommandPath(command: string): CursorCommandPathParts {
@@ -75,7 +78,9 @@ function resolveCursorEditorLauncherCommand(
     }
     const cursorPath = findCommandOnPath(command, options);
     if (cursorPath) {
-      const cursorPathParts = splitCursorCommandPath(cursorPath);
+      const cursorPathParts = splitCursorCommandPath(
+        resolveRealPathForSiblingProbe(cursorPath, options),
+      );
       const siblingAgent =
         resolveCursorSiblingAgentCommand(cursorPathParts, options) ??
         resolveTrustedCursorLegacySiblingCommand(cursorPathParts, options);
@@ -83,21 +88,26 @@ function resolveCursorEditorLauncherCommand(
         return siblingAgent;
       }
     }
-    return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
+    return { command, args: [LEGACY_CURSOR_AGENT_BINARY] };
   }
 
-  const siblingAgent = resolveCursorSiblingCommand(parts, DEFAULT_CURSOR_AGENT_BINARY, options);
+  const siblingProbeParts = splitCursorCommandPath(resolveRealPathForSiblingProbe(command, options));
+  const siblingAgent = resolveCursorSiblingCommand(
+    siblingProbeParts,
+    DEFAULT_CURSOR_AGENT_BINARY,
+    options,
+  );
   if (siblingAgent) {
     return siblingAgent;
   }
   if (findCommandOnPath(DEFAULT_CURSOR_AGENT_BINARY, options)) {
     return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
   }
-  const siblingLegacyAgent = resolveTrustedCursorLegacySiblingCommand(parts, options);
+  const siblingLegacyAgent = resolveTrustedCursorLegacySiblingCommand(siblingProbeParts, options);
   if (siblingLegacyAgent) {
     return siblingLegacyAgent;
   }
-  return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
+  return { command, args: [LEGACY_CURSOR_AGENT_BINARY] };
 }
 
 function resolveCursorSiblingAgentCommand(
@@ -116,6 +126,17 @@ function resolveTrustedCursorLegacySiblingCommand(
     return undefined;
   }
   return resolveCursorSiblingCommand(parts, LEGACY_CURSOR_AGENT_BINARY, options);
+}
+
+function resolveRealPathForSiblingProbe(
+  command: string,
+  options: ResolvedCursorAgentCommandOptions,
+): string {
+  try {
+    return options.realpath(command);
+  } catch {
+    return command;
+  }
 }
 
 function isCursorOwnedLauncherDirectory(directory: string): boolean {
@@ -195,6 +216,16 @@ function findCommandOnPath(
   return undefined;
 }
 
+function wrapPowerShellCommand(command: string, args: ReadonlyArray<string>): CursorAgentCommand {
+  if (!/\.ps1$/iu.test(command)) {
+    return { command, args: [...args] };
+  }
+  return {
+    command: POWERSHELL_EXECUTABLE,
+    args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", command, ...args],
+  };
+}
+
 // Resolves persisted/default Cursor binary settings into the executable Synara should spawn.
 export function resolveCursorAgentBinaryPath(binaryPath: string | null | undefined): string {
   const configuredBinaryPath = binaryPath?.trim();
@@ -213,11 +244,13 @@ export function buildCursorAgentCommand(
   const commandOptions = {
     env: options.env ?? process.env,
     pathExists: options.pathExists ?? existsSync,
+    realpath: options.realpath ?? realpathSync.native,
   };
   const editorLauncher = resolveCursorEditorLauncherCommand(command, commandOptions);
-  return editorLauncher
+  const resolvedCommand = editorLauncher
     ? { command: editorLauncher.command, args: [...editorLauncher.args, ...args] }
     : { command, args: [...args] };
+  return wrapPowerShellCommand(resolvedCommand.command, resolvedCommand.args);
 }
 
 // Cursor auth/status probes must stay headless so provider refreshes never open login browsers.

--- a/apps/server/src/provider/acp/CursorAcpCommand.ts
+++ b/apps/server/src/provider/acp/CursorAcpCommand.ts
@@ -82,7 +82,7 @@ function resolveCursorEditorLauncherCommand(
         return siblingAgent;
       }
     }
-    return { command: DEFAULT_CURSOR_AGENT_BINARY, args: [] };
+    return { command, args: [] };
   }
 
   const siblingAgent = resolveCursorSiblingCommand(parts, DEFAULT_CURSOR_AGENT_BINARY, options);

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -112,6 +112,11 @@ const parameterizedCursorVariantConfigOptions: ReadonlyArray<EffectAcpSchema.Ses
     },
   ];
 
+const noCursorAgentCommandOptions = {
+  env: { PATH: "" },
+  pathExists: () => false,
+};
+
 describe("buildCursorAcpSpawnInput", () => {
   it("builds the default Cursor ACP command", () => {
     expect(buildCursorAcpSpawnInput(undefined, "/tmp/project")).toEqual({
@@ -138,16 +143,21 @@ describe("buildCursorAcpSpawnInput", () => {
   });
 
   it("maps Cursor editor launchers to the sibling agent command", () => {
-    expect(buildCursorAcpSpawnInput({ binaryPath: "/not-real/bin/cursor" }, "/tmp/project"))
-      .toEqual({
-        command: "/not-real/bin/agent",
-        args: ["acp"],
-        cwd: "/tmp/project",
-        env: {
-          NO_BROWSER: "true",
-          BROWSER: "www-browser",
-        },
-      });
+    expect(
+      buildCursorAcpSpawnInput(
+        { binaryPath: "/not-real/bin/cursor" },
+        "/tmp/project",
+        noCursorAgentCommandOptions,
+      ),
+    ).toEqual({
+      command: "/not-real/bin/agent",
+      args: ["acp"],
+      cwd: "/tmp/project",
+      env: {
+        NO_BROWSER: "true",
+        BROWSER: "www-browser",
+      },
+    });
   });
 
   it("includes the configured api endpoint when present", () => {
@@ -178,6 +188,7 @@ describe("buildCursorAcpSpawnInput", () => {
           apiEndpoint: "http://localhost:3000",
         },
         "/tmp/project",
+        noCursorAgentCommandOptions,
       ),
     ).toEqual({
       command: "/not-real/bin/agent",
@@ -201,10 +212,13 @@ describe("buildCursorCliModelListCommand", () => {
 
   it("uses mapped Cursor agent commands for model discovery", () => {
     expect(
-      buildCursorCliModelListCommand({
-        binaryPath: "/not-real/bin/cursor",
-        apiEndpoint: "http://localhost:3000",
-      }),
+      buildCursorCliModelListCommand(
+        {
+          binaryPath: "/not-real/bin/cursor",
+          apiEndpoint: "http://localhost:3000",
+        },
+        noCursorAgentCommandOptions,
+      ),
     ).toEqual({
       command: "/not-real/bin/agent",
       args: ["-e", "http://localhost:3000", "models"],

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -160,6 +160,25 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
+  it("uses bundled sibling agent commands for Cursor editor ACP startup", () => {
+    const cursorPath = "/Applications/Cursor.app/Contents/Resources/app/bin/cursor";
+    const agentPath = "/Applications/Cursor.app/Contents/Resources/app/bin/agent";
+    expect(
+      buildCursorAcpSpawnInput({ binaryPath: cursorPath }, "/tmp/project", {
+        env: { PATH: "" },
+        pathExists: (path) => path === agentPath,
+      }),
+    ).toEqual({
+      command: agentPath,
+      args: ["acp"],
+      cwd: "/tmp/project",
+      env: {
+        NO_BROWSER: "true",
+        BROWSER: "www-browser",
+      },
+    });
+  });
+
   it("includes the configured api endpoint when present", () => {
     expect(
       buildCursorAcpSpawnInput(

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -137,11 +137,11 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
-  it("uses the Cursor editor launcher through the agent subcommand", () => {
+  it("maps Cursor editor launchers to the sibling agent command", () => {
     expect(buildCursorAcpSpawnInput({ binaryPath: "/not-real/bin/cursor" }, "/tmp/project"))
       .toEqual({
-        command: "/not-real/bin/cursor",
-        args: ["agent", "acp"],
+        command: "/not-real/bin/agent",
+        args: ["acp"],
         cwd: "/tmp/project",
         env: {
           NO_BROWSER: "true",
@@ -170,7 +170,7 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
-  it("passes api endpoint overrides through Cursor editor launchers", () => {
+  it("passes api endpoint overrides through mapped Cursor agent commands", () => {
     expect(
       buildCursorAcpSpawnInput(
         {
@@ -180,8 +180,8 @@ describe("buildCursorAcpSpawnInput", () => {
         "/tmp/project",
       ),
     ).toEqual({
-      command: "/not-real/bin/cursor",
-      args: ["agent", "-e", "http://localhost:3000", "acp"],
+      command: "/not-real/bin/agent",
+      args: ["-e", "http://localhost:3000", "acp"],
       cwd: "/tmp/project",
       env: {
         NO_BROWSER: "true",
@@ -199,15 +199,15 @@ describe("buildCursorCliModelListCommand", () => {
     });
   });
 
-  it("uses configured Cursor editor launchers for model discovery", () => {
+  it("uses mapped Cursor agent commands for model discovery", () => {
     expect(
       buildCursorCliModelListCommand({
         binaryPath: "/not-real/bin/cursor",
         apiEndpoint: "http://localhost:3000",
       }),
     ).toEqual({
-      command: "/not-real/bin/cursor",
-      args: ["agent", "-e", "http://localhost:3000", "models"],
+      command: "/not-real/bin/agent",
+      args: ["-e", "http://localhost:3000", "models"],
     });
   });
 });

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -142,7 +142,7 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
-  it("maps Cursor editor launchers to the sibling agent command", () => {
+  it("uses configured Cursor editor launchers when no agent command is resolved", () => {
     expect(
       buildCursorAcpSpawnInput(
         { binaryPath: "/not-real/bin/cursor" },
@@ -150,7 +150,7 @@ describe("buildCursorAcpSpawnInput", () => {
         noCursorAgentCommandOptions,
       ),
     ).toEqual({
-      command: "/not-real/bin/agent",
+      command: "/not-real/bin/cursor",
       args: ["acp"],
       cwd: "/tmp/project",
       env: {
@@ -180,7 +180,7 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
-  it("passes api endpoint overrides through mapped Cursor agent commands", () => {
+  it("passes api endpoint overrides through the Cursor shim fallback", () => {
     expect(
       buildCursorAcpSpawnInput(
         {
@@ -191,7 +191,7 @@ describe("buildCursorAcpSpawnInput", () => {
         noCursorAgentCommandOptions,
       ),
     ).toEqual({
-      command: "/not-real/bin/agent",
+      command: "/not-real/bin/cursor",
       args: ["-e", "http://localhost:3000", "acp"],
       cwd: "/tmp/project",
       env: {
@@ -210,7 +210,7 @@ describe("buildCursorCliModelListCommand", () => {
     });
   });
 
-  it("uses mapped Cursor agent commands for model discovery", () => {
+  it("uses the Cursor shim fallback for model discovery", () => {
     expect(
       buildCursorCliModelListCommand(
         {
@@ -220,7 +220,7 @@ describe("buildCursorCliModelListCommand", () => {
         noCursorAgentCommandOptions,
       ),
     ).toEqual({
-      command: "/not-real/bin/agent",
+      command: "/not-real/bin/cursor",
       args: ["-e", "http://localhost:3000", "models"],
     });
   });

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -142,7 +142,7 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
-  it("uses configured Cursor editor launchers when no agent command is resolved", () => {
+  it("uses cursor-agent when a configured Cursor editor has no agent command resolved", () => {
     expect(
       buildCursorAcpSpawnInput(
         { binaryPath: "/not-real/bin/cursor" },
@@ -150,8 +150,8 @@ describe("buildCursorAcpSpawnInput", () => {
         noCursorAgentCommandOptions,
       ),
     ).toEqual({
-      command: "/not-real/bin/cursor",
-      args: ["agent", "acp"],
+      command: "cursor-agent",
+      args: ["acp"],
       cwd: "/tmp/project",
       env: {
         NO_BROWSER: "true",
@@ -180,7 +180,7 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
-  it("passes api endpoint overrides through the Cursor shim fallback", () => {
+  it("keeps api endpoint overrides when falling back to cursor-agent", () => {
     expect(
       buildCursorAcpSpawnInput(
         {
@@ -191,8 +191,8 @@ describe("buildCursorAcpSpawnInput", () => {
         noCursorAgentCommandOptions,
       ),
     ).toEqual({
-      command: "/not-real/bin/cursor",
-      args: ["agent", "-e", "http://localhost:3000", "acp"],
+      command: "cursor-agent",
+      args: ["-e", "http://localhost:3000", "acp"],
       cwd: "/tmp/project",
       env: {
         NO_BROWSER: "true",
@@ -210,7 +210,7 @@ describe("buildCursorCliModelListCommand", () => {
     });
   });
 
-  it("uses the Cursor shim fallback for model discovery", () => {
+  it("uses cursor-agent for model discovery when a configured editor has no agent resolved", () => {
     expect(
       buildCursorCliModelListCommand(
         {
@@ -220,8 +220,8 @@ describe("buildCursorCliModelListCommand", () => {
         noCursorAgentCommandOptions,
       ),
     ).toEqual({
-      command: "/not-real/bin/cursor",
-      args: ["agent", "-e", "http://localhost:3000", "models"],
+      command: "cursor-agent",
+      args: ["-e", "http://localhost:3000", "models"],
     });
   });
 });

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   applyCursorAcpModelSelection,
+  buildCursorCliModelListCommand,
   buildCursorAcpModelDescriptors,
   buildCursorAcpModelDescriptorsFromAvailableModels,
   buildCursorAcpSpawnInput,
@@ -136,6 +137,19 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
+  it("uses the Cursor editor launcher through the agent subcommand", () => {
+    expect(buildCursorAcpSpawnInput({ binaryPath: "/not-real/bin/cursor" }, "/tmp/project"))
+      .toEqual({
+        command: "/not-real/bin/cursor",
+        args: ["agent", "acp"],
+        cwd: "/tmp/project",
+        env: {
+          NO_BROWSER: "true",
+          BROWSER: "www-browser",
+        },
+      });
+  });
+
   it("includes the configured api endpoint when present", () => {
     expect(
       buildCursorAcpSpawnInput(
@@ -153,6 +167,47 @@ describe("buildCursorAcpSpawnInput", () => {
         NO_BROWSER: "true",
         BROWSER: "www-browser",
       },
+    });
+  });
+
+  it("passes api endpoint overrides through Cursor editor launchers", () => {
+    expect(
+      buildCursorAcpSpawnInput(
+        {
+          binaryPath: "/not-real/bin/cursor",
+          apiEndpoint: "http://localhost:3000",
+        },
+        "/tmp/project",
+      ),
+    ).toEqual({
+      command: "/not-real/bin/cursor",
+      args: ["agent", "-e", "http://localhost:3000", "acp"],
+      cwd: "/tmp/project",
+      env: {
+        NO_BROWSER: "true",
+        BROWSER: "www-browser",
+      },
+    });
+  });
+});
+
+describe("buildCursorCliModelListCommand", () => {
+  it("builds the default Cursor model list command", () => {
+    expect(buildCursorCliModelListCommand(undefined)).toEqual({
+      command: "cursor-agent",
+      args: ["models"],
+    });
+  });
+
+  it("uses configured Cursor editor launchers for model discovery", () => {
+    expect(
+      buildCursorCliModelListCommand({
+        binaryPath: "/not-real/bin/cursor",
+        apiEndpoint: "http://localhost:3000",
+      }),
+    ).toEqual({
+      command: "/not-real/bin/cursor",
+      args: ["agent", "-e", "http://localhost:3000", "models"],
     });
   });
 });

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -151,7 +151,7 @@ describe("buildCursorAcpSpawnInput", () => {
       ),
     ).toEqual({
       command: "/not-real/bin/cursor",
-      args: ["acp"],
+      args: ["agent", "acp"],
       cwd: "/tmp/project",
       env: {
         NO_BROWSER: "true",
@@ -192,7 +192,7 @@ describe("buildCursorAcpSpawnInput", () => {
       ),
     ).toEqual({
       command: "/not-real/bin/cursor",
-      args: ["-e", "http://localhost:3000", "acp"],
+      args: ["agent", "-e", "http://localhost:3000", "acp"],
       cwd: "/tmp/project",
       env: {
         NO_BROWSER: "true",
@@ -221,7 +221,7 @@ describe("buildCursorCliModelListCommand", () => {
       ),
     ).toEqual({
       command: "/not-real/bin/cursor",
-      args: ["-e", "http://localhost:3000", "models"],
+      args: ["agent", "-e", "http://localhost:3000", "models"],
     });
   });
 });

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -142,7 +142,7 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
-  it("uses cursor-agent when a configured Cursor editor has no agent command resolved", () => {
+  it("uses configured Cursor editor launchers when no agent command is resolved", () => {
     expect(
       buildCursorAcpSpawnInput(
         { binaryPath: "/not-real/bin/cursor" },
@@ -150,8 +150,8 @@ describe("buildCursorAcpSpawnInput", () => {
         noCursorAgentCommandOptions,
       ),
     ).toEqual({
-      command: "cursor-agent",
-      args: ["acp"],
+      command: "/not-real/bin/cursor",
+      args: ["agent", "acp"],
       cwd: "/tmp/project",
       env: {
         NO_BROWSER: "true",
@@ -199,7 +199,7 @@ describe("buildCursorAcpSpawnInput", () => {
     });
   });
 
-  it("keeps api endpoint overrides when falling back to cursor-agent", () => {
+  it("passes api endpoint overrides through the Cursor launcher fallback", () => {
     expect(
       buildCursorAcpSpawnInput(
         {
@@ -210,8 +210,8 @@ describe("buildCursorAcpSpawnInput", () => {
         noCursorAgentCommandOptions,
       ),
     ).toEqual({
-      command: "cursor-agent",
-      args: ["-e", "http://localhost:3000", "acp"],
+      command: "/not-real/bin/cursor",
+      args: ["agent", "-e", "http://localhost:3000", "acp"],
       cwd: "/tmp/project",
       env: {
         NO_BROWSER: "true",
@@ -229,7 +229,7 @@ describe("buildCursorCliModelListCommand", () => {
     });
   });
 
-  it("uses cursor-agent for model discovery when a configured editor has no agent resolved", () => {
+  it("uses the Cursor launcher fallback for model discovery", () => {
     expect(
       buildCursorCliModelListCommand(
         {
@@ -239,8 +239,8 @@ describe("buildCursorCliModelListCommand", () => {
         noCursorAgentCommandOptions,
       ),
     ).toEqual({
-      command: "cursor-agent",
-      args: ["-e", "http://localhost:3000", "models"],
+      command: "/not-real/bin/cursor",
+      args: ["agent", "-e", "http://localhost:3000", "models"],
     });
   });
 });

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -23,6 +23,7 @@ import {
   CURSOR_AGENT_BROWSERLESS_ENV,
   buildCursorAgentCommand,
   type CursorAgentCommand,
+  type CursorAgentCommandOptions,
 } from "./CursorAcpCommand.ts";
 
 export interface CursorAcpRuntimeCursorSettings {
@@ -67,11 +68,16 @@ interface CursorAcpSelectOption {
 export function buildCursorAcpSpawnInput(
   cursorSettings: CursorAcpRuntimeCursorSettings | null | undefined,
   cwd: string,
+  commandOptions?: CursorAgentCommandOptions,
 ): AcpSpawnInput {
-  const command = buildCursorAgentCommand(cursorSettings?.binaryPath, [
-    ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
-    "acp",
-  ]);
+  const command = buildCursorAgentCommand(
+    cursorSettings?.binaryPath,
+    [
+      ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
+      "acp",
+    ],
+    commandOptions,
+  );
   return {
     command: command.command,
     args: command.args,
@@ -83,11 +89,16 @@ export function buildCursorAcpSpawnInput(
 
 export function buildCursorCliModelListCommand(
   cursorSettings: CursorAcpRuntimeCursorSettings | null | undefined,
+  commandOptions?: CursorAgentCommandOptions,
 ): CursorAgentCommand {
-  return buildCursorAgentCommand(cursorSettings?.binaryPath, [
-    ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
-    "models",
-  ]);
+  return buildCursorAgentCommand(
+    cursorSettings?.binaryPath,
+    [
+      ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
+      "models",
+    ],
+    commandOptions,
+  );
 }
 
 export const makeCursorAcpRuntime = (

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -19,7 +19,11 @@ import {
   type AcpSessionRuntimeShape,
   type AcpSpawnInput,
 } from "./AcpSessionRuntime.ts";
-import { CURSOR_AGENT_BROWSERLESS_ENV, resolveCursorAgentBinaryPath } from "./CursorAcpCommand.ts";
+import {
+  CURSOR_AGENT_BROWSERLESS_ENV,
+  buildCursorAgentCommand,
+  type CursorAgentCommand,
+} from "./CursorAcpCommand.ts";
 
 export interface CursorAcpRuntimeCursorSettings {
   readonly apiEndpoint?: string;
@@ -64,16 +68,26 @@ export function buildCursorAcpSpawnInput(
   cursorSettings: CursorAcpRuntimeCursorSettings | null | undefined,
   cwd: string,
 ): AcpSpawnInput {
+  const command = buildCursorAgentCommand(cursorSettings?.binaryPath, [
+    ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
+    "acp",
+  ]);
   return {
-    command: resolveCursorAgentBinaryPath(cursorSettings?.binaryPath),
-    args: [
-      ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
-      "acp",
-    ],
+    command: command.command,
+    args: command.args,
     cwd,
     // Keep ACP startup browserless without forcing CI/noninteractive flags onto user turns.
     env: CURSOR_AGENT_BROWSERLESS_ENV,
   };
+}
+
+export function buildCursorCliModelListCommand(
+  cursorSettings: CursorAcpRuntimeCursorSettings | null | undefined,
+): CursorAgentCommand {
+  return buildCursorAgentCommand(cursorSettings?.binaryPath, [
+    ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
+    "models",
+  ]);
 }
 
 export const makeCursorAcpRuntime = (

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -398,10 +398,11 @@ const INSTALL_PROVIDER_SETTINGS: readonly InstallProviderSettings[] = [
       { label: "Config", href: "https://docs.cursor.com/en/cli/overview" },
     ],
     binaryPathKey: "cursorBinaryPath",
-    binaryPlaceholder: "Cursor Agent binary path",
+    binaryPlaceholder: "Cursor Agent or Cursor CLI path",
     binaryDescription: (
       <>
-        Leave blank to use <code>cursor-agent</code> from your PATH.
+        Leave blank to use <code>cursor-agent</code> from your PATH. Cursor editor CLI paths are
+        accepted too.
       </>
     ),
     apiEndpointKey: "cursorApiEndpoint",


### PR DESCRIPTION
## Summary

Fixes Cursor ACP startup when the configured CLI path points at the Cursor editor launcher instead of the Cursor Agent binary.

## Root Cause

Synara previously treated Cursor's configured binary path as a direct Cursor Agent executable. That made the legacy bare `agent` setting collide with Grok's `agent`, and it did not consistently translate Cursor editor launchers like `cursor` into the correct `cursor agent ...` invocation.

## Changes

- Add shared Cursor command resolution for `cursor-agent`, legacy `agent`, and Cursor editor launchers.
- Reuse the resolver for ACP startup, health checks, provider updates, and CLI model discovery.
- Prefer a sibling or PATH `cursor-agent` when available, otherwise fall back to `cursor agent ...`.
- Update Cursor settings copy to clarify that Cursor Agent and Cursor editor CLI paths are accepted.
- Add regression coverage for Cursor/Grok binary separation and Cursor launcher handling.

## Validation

- `git diff --check`
- `bun run test src/provider/acp/CursorAcpCommand.test.ts src/provider/acp/CursorAcpSupport.test.ts src/provider/Layers/ProviderHealth.test.ts` from `apps/server` — 3 files passed, 109 tests passed.

## Notes

I did not run `bun fmt`, `bun lint`, or `bun typecheck` because the repository instructions say not to run those unless explicitly requested in the current conversation.