### PR TITLE
fix(claude): keep macOS Claude OAuth token fresh to stop ~8h 'not logged in'

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -25,6 +25,7 @@ import { Open } from "./open";
 import * as SqlitePersistence from "./persistence/Layers/Sqlite";
 import { makeServerProviderLayer, makeServerRuntimeServicesLayer } from "./serverLayers";
 import { startServerMemoryDiagnostics } from "./memoryDiagnostics";
+import { startClaudeCredentialKeepalive } from "./provider/claudeCredentialKeepalive";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ProviderHealthLive } from "./provider/Layers/ProviderHealth";
 import { ProviderSessionReaperLive } from "./provider/Layers/ProviderSessionReaper";
@@ -289,6 +290,13 @@ const makeServerProgram = (input: CliInput) =>
 
     const config = yield* ServerConfig;
     yield* Effect.sync(() => startServerMemoryDiagnostics({ mode: config.mode }));
+    // Keep the macOS Claude OAuth token fresh so sessions don't report "not logged in"
+    // every ~8h when the Keychain access token expires (see claudeCredentialKeepalive.ts).
+    yield* Effect.sync(() =>
+      startClaudeCredentialKeepalive({
+        log: (message) => Effect.runFork(Effect.logInfo(message)),
+      }),
+    );
 
     if (!config.devUrl && !config.staticDir) {
       yield* Effect.logWarning(

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -31,6 +31,7 @@ import { ProviderHealthLive } from "./provider/Layers/ProviderHealth";
 import { ProviderSessionReaperLive } from "./provider/Layers/ProviderSessionReaper";
 import { Server } from "./effectServer";
 import { ServerLoggerLive } from "./serverLogger";
+import { ServerSettingsService } from "./serverSettings";
 import { formatHostForUrl, isWildcardHost } from "./startupAccess";
 import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService";
 import { AnalyticsService } from "./telemetry/Services/AnalyticsService";
@@ -286,17 +287,11 @@ const makeServerProgram = (input: CliInput) =>
     const cliConfig = yield* CliConfig;
     const { start, stopSignal } = yield* Server;
     const openDeps = yield* Open;
+    const serverSettings = yield* ServerSettingsService;
     yield* cliConfig.fixPath;
 
     const config = yield* ServerConfig;
     yield* Effect.sync(() => startServerMemoryDiagnostics({ mode: config.mode }));
-    // Keep the macOS Claude OAuth token fresh so sessions don't report "not logged in"
-    // every ~8h when the Keychain access token expires (see claudeCredentialKeepalive.ts).
-    yield* Effect.sync(() =>
-      startClaudeCredentialKeepalive({
-        log: (message) => Effect.runFork(Effect.logInfo(message)),
-      }),
-    );
 
     if (!config.devUrl && !config.staticDir) {
       yield* Effect.logWarning(
@@ -308,6 +303,16 @@ const makeServerProgram = (input: CliInput) =>
     }
 
     yield* start;
+    const settings = yield* serverSettings.getSettings;
+    // Keep the macOS Claude OAuth token fresh using the same configured CLI binary
+    // that normal Claude Agent sessions use.
+    yield* Effect.sync(() =>
+      startClaudeCredentialKeepalive({
+        binaryPath: settings.providers.claudeAgent.binaryPath,
+        log: (message) => Effect.runFork(Effect.logInfo(message)),
+      }),
+    );
+
     const orchestrationEngine = yield* OrchestrationEngineService;
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
     // Start the retention loop after the server is live so startup can serve

--- a/apps/server/src/provider/claudeCredentialKeepalive.test.ts
+++ b/apps/server/src/provider/claudeCredentialKeepalive.test.ts
@@ -1,0 +1,56 @@
+// FILE: claudeCredentialKeepalive.test.ts
+// Purpose: Regression tests for the macOS Claude credential keepalive helper.
+// Layer: Provider utility tests.
+// Exports: Vitest coverage for apps/server/src/provider/claudeCredentialKeepalive.ts.
+import { describe, it, assert } from "@effect/vitest";
+
+import {
+  CLAUDE_CREDENTIAL_KEEPALIVE_AUTH_STATUS_ARGS,
+  CLAUDE_CREDENTIAL_KEEPALIVE_MAX_INTERVAL_MS,
+  resolveClaudeCredentialKeepaliveBinaryPath,
+  resolveClaudeCredentialKeepaliveIntervalMs,
+} from "./claudeCredentialKeepalive.ts";
+
+describe("claudeCredentialKeepalive", () => {
+  it("uses the documented Claude auth status command", () => {
+    assert.deepEqual([...CLAUDE_CREDENTIAL_KEEPALIVE_AUTH_STATUS_ARGS], ["auth", "status"]);
+  });
+
+  it("resolves configured Claude binary paths with a safe default", () => {
+    assert.equal(
+      resolveClaudeCredentialKeepaliveBinaryPath("/opt/homebrew/bin/claude"),
+      "/opt/homebrew/bin/claude",
+    );
+    assert.equal(
+      resolveClaudeCredentialKeepaliveBinaryPath("  /custom/bin/claude  "),
+      "/custom/bin/claude",
+    );
+    assert.equal(resolveClaudeCredentialKeepaliveBinaryPath("   "), "claude");
+    assert.equal(resolveClaudeCredentialKeepaliveBinaryPath(undefined), "claude");
+  });
+
+  it("clamps keepalive intervals to Node's maximum timer delay", () => {
+    assert.equal(
+      resolveClaudeCredentialKeepaliveIntervalMs({
+        T3CODE_CLAUDE_KEEPALIVE_MINUTES: "60",
+      }),
+      60 * 60 * 1000,
+    );
+    assert.equal(
+      resolveClaudeCredentialKeepaliveIntervalMs({
+        T3CODE_CLAUDE_KEEPALIVE_MINUTES: "999999999",
+      }),
+      CLAUDE_CREDENTIAL_KEEPALIVE_MAX_INTERVAL_MS,
+    );
+  });
+
+  it("falls back to the default interval for invalid tuning values", () => {
+    assert.equal(
+      resolveClaudeCredentialKeepaliveIntervalMs({
+        T3CODE_CLAUDE_KEEPALIVE_MINUTES: "0",
+      }),
+      30 * 60 * 1000,
+    );
+    assert.equal(resolveClaudeCredentialKeepaliveIntervalMs({}), 30 * 60 * 1000);
+  });
+});

--- a/apps/server/src/provider/claudeCredentialKeepalive.ts
+++ b/apps/server/src/provider/claudeCredentialKeepalive.ts
@@ -1,0 +1,111 @@
+// FILE: claudeCredentialKeepalive.ts
+// Purpose: Keep the macOS Claude Code OAuth token fresh so long-lived provider sessions
+//   don't intermittently report "not logged in" roughly every ~8 hours.
+// Layer: server background job (best-effort, never throws).
+//
+// Why this exists
+// ---------------
+// On macOS, Claude Code stores its OAuth credentials in the login Keychain item
+// "Claude Code-credentials" (accessToken + refreshToken + expiresAt). The access token has
+// an ~8h TTL and is meant to be refreshed via the refresh token. The Claude auth path here
+// (`claudeProcessEnv.ts`) only inspects the FILE `~/.claude/.credentials.json`, which does NOT
+// exist on macOS (creds live in the Keychain), so the expiry is never observed and a refresh
+// is never triggered. A long-lived Claude Agent SDK session then rides a token that lapses
+// after ~8h -> the user sees "not logged in" until they re-login interactively.
+//
+// Fix: periodically invoke the official `claude` CLI, which validates and refreshes its own
+// Keychain token (using its own Keychain ACL, so there is no auth prompt and no risk of this
+// process mishandling refresh-token rotation). This keeps the Keychain token perpetually
+// fresh, so the SDK session always reads a valid token.
+//
+// Opt out:  T3CODE_CLAUDE_KEEPALIVE=0
+// Tune:     T3CODE_CLAUDE_KEEPALIVE_MINUTES=<n>   (default 30)
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_INTERVAL_MINUTES = 30;
+const COMMAND_TIMEOUT_MS = 20_000;
+
+function envFlagDisabled(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return (
+    normalized === "0" || normalized === "false" || normalized === "off" || normalized === "no"
+  );
+}
+
+function resolveIntervalMs(env: NodeJS.ProcessEnv): number {
+  const raw = env.T3CODE_CLAUDE_KEEPALIVE_MINUTES?.trim();
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  const minutes = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_INTERVAL_MINUTES;
+  return minutes * 60 * 1000;
+}
+
+// `claude auth status` validates the stored OAuth token and refreshes it via the refresh
+// token when at/near expiry, persisting the new token back to the Keychain. It is a cheap,
+// local operation that never consumes inference quota.
+async function nudgeClaudeTokenRefresh(binaryPath: string): Promise<void> {
+  await execFileAsync(binaryPath, ["auth", "status", "--json"], {
+    timeout: COMMAND_TIMEOUT_MS,
+  });
+}
+
+export interface ClaudeCredentialKeepaliveHandle {
+  readonly stop: () => void;
+}
+
+export function startClaudeCredentialKeepalive(input?: {
+  readonly platform?: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly binaryPath?: string;
+  readonly log?: (message: string) => void;
+}): ClaudeCredentialKeepaliveHandle {
+  const platform = input?.platform ?? process.platform;
+  const env = input?.env ?? process.env;
+  const binaryPath = input?.binaryPath ?? "claude";
+  const log = input?.log ?? (() => {});
+
+  // Only macOS exhibits the Keychain/short-TTL behavior that causes the bug; other platforms
+  // use the credentials file the SDK already manages, so the keepalive is a no-op there.
+  if (platform !== "darwin" || envFlagDisabled(env.T3CODE_CLAUDE_KEEPALIVE)) {
+    return { stop: () => {} };
+  }
+
+  const intervalMs = resolveIntervalMs(env);
+  let inFlight = false;
+
+  const tick = async (): Promise<void> => {
+    if (inFlight) {
+      return;
+    }
+    inFlight = true;
+    try {
+      await nudgeClaudeTokenRefresh(binaryPath);
+    } catch (cause) {
+      // Best-effort: a missing binary, a genuinely logged-out user, or a transient failure
+      // must never crash the server. Keep it quiet since it self-heals on the next tick.
+      log(
+        `[claude-keepalive] token refresh nudge failed (non-fatal): ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  const timer = setInterval(() => void tick(), intervalMs);
+  // Never keep the process alive solely for this background timer.
+  if (typeof timer.unref === "function") {
+    timer.unref();
+  }
+  // Refresh once shortly after startup so an already-stale token recovers promptly.
+  void tick();
+
+  log(`[claude-keepalive] started (every ${intervalMs / 60_000}m, macOS)`);
+  return {
+    stop: () => clearInterval(timer),
+  };
+}

--- a/apps/server/src/provider/claudeCredentialKeepalive.ts
+++ b/apps/server/src/provider/claudeCredentialKeepalive.ts
@@ -28,6 +28,8 @@ const execFileAsync = promisify(execFile);
 
 const DEFAULT_INTERVAL_MINUTES = 30;
 const COMMAND_TIMEOUT_MS = 20_000;
+export const CLAUDE_CREDENTIAL_KEEPALIVE_MAX_INTERVAL_MS = 2_147_483_647;
+export const CLAUDE_CREDENTIAL_KEEPALIVE_AUTH_STATUS_ARGS = ["auth", "status"] as const;
 
 function envFlagDisabled(value: string | undefined): boolean {
   const normalized = value?.trim().toLowerCase();
@@ -36,18 +38,26 @@ function envFlagDisabled(value: string | undefined): boolean {
   );
 }
 
-function resolveIntervalMs(env: NodeJS.ProcessEnv): number {
+// Mirrors the Claude Agent adapter default while honoring persisted custom CLI paths.
+export function resolveClaudeCredentialKeepaliveBinaryPath(
+  binaryPath: string | undefined,
+): string {
+  return binaryPath?.trim() || "claude";
+}
+
+// Caps the tuning knob before setInterval can overflow into Node's 1ms clamp behavior.
+export function resolveClaudeCredentialKeepaliveIntervalMs(env: NodeJS.ProcessEnv): number {
   const raw = env.T3CODE_CLAUDE_KEEPALIVE_MINUTES?.trim();
   const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
   const minutes = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_INTERVAL_MINUTES;
-  return minutes * 60 * 1000;
+  return Math.min(minutes * 60 * 1000, CLAUDE_CREDENTIAL_KEEPALIVE_MAX_INTERVAL_MS);
 }
 
 // `claude auth status` validates the stored OAuth token and refreshes it via the refresh
 // token when at/near expiry, persisting the new token back to the Keychain. It is a cheap,
 // local operation that never consumes inference quota.
 async function nudgeClaudeTokenRefresh(binaryPath: string): Promise<void> {
-  await execFileAsync(binaryPath, ["auth", "status", "--json"], {
+  await execFileAsync(binaryPath, [...CLAUDE_CREDENTIAL_KEEPALIVE_AUTH_STATUS_ARGS], {
     timeout: COMMAND_TIMEOUT_MS,
   });
 }
@@ -64,7 +74,7 @@ export function startClaudeCredentialKeepalive(input?: {
 }): ClaudeCredentialKeepaliveHandle {
   const platform = input?.platform ?? process.platform;
   const env = input?.env ?? process.env;
-  const binaryPath = input?.binaryPath ?? "claude";
+  const binaryPath = resolveClaudeCredentialKeepaliveBinaryPath(input?.binaryPath);
   const log = input?.log ?? (() => {});
 
   // Only macOS exhibits the Keychain/short-TTL behavior that causes the bug; other platforms
@@ -73,7 +83,7 @@ export function startClaudeCredentialKeepalive(input?: {
     return { stop: () => {} };
   }
 
-  const intervalMs = resolveIntervalMs(env);
+  const intervalMs = resolveClaudeCredentialKeepaliveIntervalMs(env);
   let inFlight = false;
 
   const tick = async (): Promise<void> => {


### PR DESCRIPTION
## Problem

On macOS, the Claude provider intermittently reports **"not logged in"** roughly every ~8 hours, even though `claude auth status` shows the user is logged in. Re-logging in fixes it for another ~8h.

**Root cause:** On macOS, Claude Code stores OAuth credentials in the login **Keychain** item `Claude Code-credentials` (`accessToken` + `refreshToken` + `expiresAt`), and the access token has an **~8h TTL**. The Claude auth path (`apps/server/src/provider/claudeProcessEnv.ts`) only inspects the **file** `~/.claude/.credentials.json`, which **does not exist on macOS**. So the expiry is never observed, no refresh is triggered, and a long-lived Claude Agent SDK session rides a token that lapses after ~8h.

(Confirmed empirically: a freshly issued token reports ~7.8h of remaining lifetime, matching the observed cycle.)

## Fix

A small, defensive background job that periodically runs the official **`claude` CLI** (`claude auth status`), which validates and refreshes its **own** Keychain token via its **own** Keychain ACL — so there's no auth prompt and no refresh-token-rotation logic to get wrong here. This keeps the Keychain token perpetually fresh, so the SDK session always reads a valid token.

Deliberately **not** reading/writing the Keychain or implementing the OAuth refresh in-app, to avoid Keychain prompts and refresh-token-rotation hazards — it delegates entirely to the official CLI.

- macOS-only (no-op elsewhere; other platforms use the file the SDK already manages)
- Never throws (best-effort; self-heals on the next tick)
- Opt out: `T3CODE_CLAUDE_KEEPALIVE=0`
- Tune interval: `T3CODE_CLAUDE_KEEPALIVE_MINUTES` (default 30)

## Files
- `apps/server/src/provider/claudeCredentialKeepalive.ts` — new background job
- `apps/server/src/main.ts` — 1 import + 1 startup hook next to `startServerMemoryDiagnostics`

## Notes
- The one thing not provable without waiting out a full ~8h cycle is that `claude auth status` performs the refresh at the exact near-expiry moment; it must validate the token to report status, and the job self-heals on the next tick if a cycle is missed. If preferred, the trigger could be swapped for a minimal `claude -p` ping.
