### PR TITLE
[codex] Add Muxy open-in support

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -250,6 +250,16 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
         args: [`--working-directory=${path.dirname(filePath)}`],
       });
 
+      const muxyLaunch = yield* resolveEditorLaunch(
+        { cwd: `${filePath}:71:5`, editor: "muxy" },
+        "linux",
+        { PATH: "" },
+      );
+      assert.deepEqual(muxyLaunch, {
+        command: "muxy",
+        args: [path.dirname(filePath)],
+      });
+
       const binDir = path.join(dir, "bin");
       yield* fs.makeDirectory(binDir, { recursive: true });
       yield* fs.writeFileString(path.join(binDir, "konsole"), "#!/bin/sh\n");
@@ -296,6 +306,9 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       yield* fs.makeDirectory(path.join(home, "Applications", "Ghostty.app"), {
         recursive: true,
       });
+      yield* fs.makeDirectory(path.join(home, "Applications", "Muxy.app"), {
+        recursive: true,
+      });
       yield* fs.makeDirectory(path.join(home, "Applications", "WebStorm.app"), {
         recursive: true,
       });
@@ -311,6 +324,16 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       assert.deepEqual(ghosttyLaunch, {
         command: "open",
         args: ["-a", "Ghostty", "/tmp/workspace"],
+      });
+
+      const muxyLaunch = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace", editor: "muxy" },
+        "darwin",
+        { HOME: home, PATH: "" },
+      );
+      assert.deepEqual(muxyLaunch, {
+        command: "open",
+        args: ["-a", "Muxy", "/tmp/workspace"],
       });
 
       const terminalLaunch = yield* resolveEditorLaunch(
@@ -344,6 +367,7 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
 
       const availableEditors = resolveAvailableEditors("darwin", { HOME: home, PATH: "" });
       assert.equal(availableEditors.includes("ghostty"), true);
+      assert.equal(availableEditors.includes("muxy"), true);
       assert.equal(availableEditors.includes("webstorm"), true);
       assert.equal(availableEditors.includes("pycharm"), true);
     }),

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -193,6 +193,8 @@ const TERMINAL_ARGS_BY_COMMAND: Readonly<Record<string, TerminalArgsBuilder>> = 
   kitty: (workingDirectory) => ["--directory", workingDirectory],
   wezterm: (workingDirectory) => ["start", "--cwd", workingDirectory],
   ghostty: DEFAULT_TERMINAL_ARGS,
+  // Muxy's CLI opens a project from a bare path, matching its `muxy .` flow.
+  muxy: (workingDirectory) => [workingDirectory],
   warp: DEFAULT_TERMINAL_ARGS,
 };
 

--- a/apps/web/src/editorMetadata.test.ts
+++ b/apps/web/src/editorMetadata.test.ts
@@ -26,6 +26,7 @@ describe("resolveAvailableEditorOptions", () => {
         "zed",
         "idea",
         "ghostty",
+        "muxy",
         "terminal",
         "warp",
         "xcode",
@@ -52,6 +53,7 @@ describe("resolveAvailableEditorOptions", () => {
       "windsurf",
       "sublime",
       "ghostty",
+      "muxy",
       "terminal",
       "warp",
       "xcode",
@@ -72,6 +74,7 @@ describe("resolveAvailableEditorOptions", () => {
 
   it("provides dedicated icons for newly supported editor rows", () => {
     expect(resolveEditorIcon("ghostty").name).toBe("GhosttyIcon");
+    expect(resolveEditorIcon("muxy").name).toBe("TerminalAppIcon");
     expect(resolveEditorIcon("terminal").name).toBe("TerminalAppIcon");
     expect(resolveEditorIcon("xcode").name).toBe("SimpleIcon");
     expect(resolveEditorIcon("webstorm").name).toBe("SimpleIcon");

--- a/apps/web/src/editorMetadata.ts
+++ b/apps/web/src/editorMetadata.ts
@@ -53,6 +53,7 @@ const EDITOR_ICONS: Partial<Record<EditorId, Icon>> = {
   sublime: SublimeTextIcon,
   antigravity: AntigravityIcon,
   ghostty: GhosttyIcon,
+  muxy: TerminalAppIcon,
   terminal: TerminalAppIcon,
   warp: WarpIcon,
   xcode: XcodeIcon,

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -109,6 +109,13 @@ export const EDITORS = [
     launchStyle: "terminal-working-directory",
   },
   {
+    id: "muxy",
+    label: "Muxy",
+    commands: ["muxy"],
+    macApplications: ["Muxy"],
+    launchStyle: "terminal-working-directory",
+  },
+  {
     id: "terminal",
     label: "Terminal",
     commands: [


### PR DESCRIPTION
## Summary

Adds Muxy as a supported Open In terminal target.

- Adds Muxy to the shared editor catalog with `muxy` CLI and `Muxy.app` detection
- Launches Muxy with the resolved working directory as a bare path, matching the documented `muxy .` flow
- Shows Muxy in the editor picker using the existing terminal fallback icon
- Covers Linux CLI launch, macOS app-bundle launch, available-editor discovery, and web metadata ordering

Closes #270.

## Verification

- `bun run test src/open.test.ts` in `apps/server`
- `bun run test src/editorMetadata.test.ts` in `apps/web`
- `git diff --check`