### PR TITLE
Preserve archived profile stats after thread purge

### DIFF
--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -350,6 +350,13 @@ const orchestrationEngine = {
       threads: [],
       updatedAt: now,
     }),
+  refreshCommandReadModel: () =>
+    Effect.succeed({
+      snapshotSequence: 0,
+      projects: [],
+      threads: [],
+      updatedAt: now,
+    }),
   dispatch: (command: OrchestrationCommand) =>
     failDispatchType !== null && command.type === failDispatchType
       ? Effect.fail(

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -635,7 +635,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   // the command engine to own a hydrated read model.
   const getReadModel = () => Effect.sync(() => commandReadModel);
   const refreshCommandReadModel: OrchestrationEngineShape["refreshCommandReadModel"] = () =>
-    refreshCommandReadModelFromProjectionState;
+    maintenanceLock.withPermits(1)(refreshCommandReadModelFromProjectionState);
 
   const dispatch: OrchestrationEngineShape["dispatch"] = (command) =>
     Effect.gen(function* () {

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -200,7 +200,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
     return nextCommandReadModel;
   }).pipe(
     Effect.catchCause((cause) =>
-      Effect.logError("failed to refresh orchestration read model after project repair").pipe(
+      Effect.logError("failed to refresh orchestration command read model").pipe(
         Effect.annotateLogs({
           cause: Cause.pretty(cause),
         }),
@@ -210,7 +210,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
               commandId: "repair-local-state",
               commandType: ORCHESTRATION_WS_METHODS.repairState,
               detail:
-                "Project repair completed, but the refreshed local snapshot could not be loaded.",
+                "Projection state changed, but the refreshed command snapshot could not be loaded.",
             }),
           ),
         ),
@@ -634,6 +634,8 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   // code should use ProjectionSnapshotQuery directly instead of depending on
   // the command engine to own a hydrated read model.
   const getReadModel = () => Effect.sync(() => commandReadModel);
+  const refreshCommandReadModel: OrchestrationEngineShape["refreshCommandReadModel"] = () =>
+    refreshCommandReadModelFromProjectionState;
 
   const dispatch: OrchestrationEngineShape["dispatch"] = (command) =>
     Effect.gen(function* () {
@@ -779,6 +781,7 @@ const makeOrchestrationEngine = Effect.gen(function* () {
 
   return {
     getReadModel,
+    refreshCommandReadModel,
     readEvents,
     dispatch,
     repairState,

--- a/apps/server/src/orchestration/Layers/ThreadDeletionReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ThreadDeletionReactor.test.ts
@@ -2,7 +2,10 @@ import { ThreadId } from "@t3tools/contracts";
 import { Cause, Effect, Exit } from "effect";
 import { describe, expect, it } from "vitest";
 
-import { logCleanupCauseUnlessInterrupted } from "./ThreadDeletionReactor";
+import {
+  cleanupSucceededUnlessInterrupted,
+  logCleanupCauseUnlessInterrupted,
+} from "./ThreadDeletionReactor";
 
 describe("logCleanupCauseUnlessInterrupted", () => {
   const threadId = ThreadId.makeUnsafe("thread-deletion-reactor-test");
@@ -22,6 +25,49 @@ describe("logCleanupCauseUnlessInterrupted", () => {
   it("preserves interrupt causes", async () => {
     const exit = await Effect.runPromiseExit(
       logCleanupCauseUnlessInterrupted({
+        effect: Effect.interrupt,
+        message: "thread deletion cleanup skipped provider session stop",
+        threadId,
+      }),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+    }
+  });
+});
+
+describe("cleanupSucceededUnlessInterrupted", () => {
+  const threadId = ThreadId.makeUnsafe("thread-deletion-reactor-test");
+
+  it("returns true for successful cleanup", async () => {
+    const result = await Effect.runPromise(
+      cleanupSucceededUnlessInterrupted({
+        effect: Effect.void,
+        message: "thread deletion cleanup skipped provider session stop",
+        threadId,
+      }),
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false for ordinary cleanup failures", async () => {
+    const result = await Effect.runPromise(
+      cleanupSucceededUnlessInterrupted({
+        effect: Effect.fail("cleanup failed"),
+        message: "thread deletion cleanup skipped provider session stop",
+        threadId,
+      }),
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("preserves interrupt causes", async () => {
+    const exit = await Effect.runPromiseExit(
+      cleanupSucceededUnlessInterrupted({
         effect: Effect.interrupt,
         message: "thread deletion cleanup skipped provider session stop",
         threadId,

--- a/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
@@ -2,8 +2,10 @@ import type { OrchestrationEvent } from "@t3tools/contracts";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 import { Cause, Effect, Layer, Stream } from "effect";
 
+import { ProfileStatsArchive } from "../../profileStatsArchive";
 import { ProviderService } from "../../provider/Services/ProviderService";
 import { TerminalManager } from "../../terminal/Services/Manager";
+import { THREAD_RETENTION_COMMAND_ID_PREFIX } from "../../threadRetention";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine";
 import {
   ThreadDeletionReactor,
@@ -11,6 +13,10 @@ import {
 } from "../Services/ThreadDeletionReactor";
 
 type ThreadDeletedEvent = Extract<OrchestrationEvent, { type: "thread.deleted" }>;
+
+// Crash recovery / backfill: threads soft-deleted before the purge could run
+// (or before purge existed) are archived and purged shortly after startup.
+const PURGE_STARTUP_SWEEP_DELAY_MS = 60 * 1000;
 
 export const logCleanupCauseUnlessInterrupted = <R, E>({
   effect,
@@ -35,6 +41,7 @@ export const logCleanupCauseUnlessInterrupted = <R, E>({
 
 const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
+  const profileStatsArchive = yield* ProfileStatsArchive;
   const providerService = yield* ProviderService;
   const terminalManager = yield* TerminalManager;
 
@@ -52,10 +59,33 @@ const make = Effect.gen(function* () {
       threadId,
     });
 
+  // Retention deletes only hide the thread (its rows keep feeding profile
+  // stats directly). Explicit deletes snapshot the stat aggregates and then
+  // hard-delete the thread's rows so disk space is actually reclaimed.
+  const purgeThreadData = (event: ThreadDeletedEvent) => {
+    if (event.commandId?.startsWith(THREAD_RETENTION_COMMAND_ID_PREFIX)) {
+      return Effect.void;
+    }
+    return profileStatsArchive
+      .purgeThreadWithStatsSnapshot({ threadId: event.payload.threadId })
+      .pipe(
+        Effect.asVoid,
+        Effect.catch((error) =>
+          // A failed purge leaves the thread soft-deleted; the startup sweep
+          // retries it on the next boot.
+          Effect.logWarning("thread deletion cleanup skipped stats archive purge", {
+            threadId: event.payload.threadId,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        ),
+      );
+  };
+
   const processThreadDeleted = Effect.fn(function* (event: ThreadDeletedEvent) {
     const { threadId } = event.payload;
     yield* stopProviderSession(threadId);
     yield* closeThreadTerminals(threadId);
+    yield* purgeThreadData(event);
   });
 
   const processThreadDeletedSafely = (event: ThreadDeletedEvent) =>
@@ -82,6 +112,23 @@ const make = Effect.gen(function* () {
         }
         return worker.enqueue(event);
       }),
+    );
+    yield* Effect.forkScoped(
+      Effect.sleep(PURGE_STARTUP_SWEEP_DELAY_MS).pipe(
+        Effect.flatMap(() => profileStatsArchive.purgeSoftDeletedManualThreads()),
+        Effect.flatMap((purgedCount) =>
+          purgedCount > 0
+            ? Effect.logInfo("purged soft-deleted threads after stats archive snapshot", {
+                purgedCount,
+              })
+            : Effect.void,
+        ),
+        Effect.catch((error) =>
+          Effect.logWarning("startup purge sweep for deleted threads failed", {
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        ),
+      ),
     );
   });
 

--- a/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
@@ -1,9 +1,10 @@
 import type { OrchestrationEvent } from "@t3tools/contracts";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
-import { Cause, Effect, Layer, Stream } from "effect";
+import { Cause, Effect, Layer, Option, Stream } from "effect";
 
 import { ProfileStatsArchive } from "../../profileStatsArchive";
 import { ProviderService } from "../../provider/Services/ProviderService";
+import { ProviderSessionDirectory } from "../../provider/Services/ProviderSessionDirectory";
 import { TerminalManager } from "../../terminal/Services/Manager";
 import { THREAD_RETENTION_COMMAND_ID_PREFIX } from "../../threadRetention";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine";
@@ -17,6 +18,8 @@ type ThreadDeletedEvent = Extract<OrchestrationEvent, { type: "thread.deleted" }
 // Crash recovery / backfill: threads soft-deleted before the purge could run
 // (or before purge existed) are archived and purged shortly after startup.
 const PURGE_STARTUP_SWEEP_DELAY_MS = 60 * 1000;
+
+type ProviderCleanupBindingState = "present" | "absent" | "unknown";
 
 export const logCleanupCauseUnlessInterrupted = <R, E>({
   effect,
@@ -39,18 +42,69 @@ export const logCleanupCauseUnlessInterrupted = <R, E>({
     }),
   );
 
+export const cleanupSucceededUnlessInterrupted = <R, E>({
+  effect,
+  message,
+  threadId,
+}: {
+  readonly effect: Effect.Effect<void, E, R>;
+  readonly message: string;
+  readonly threadId: ThreadDeletedEvent["payload"]["threadId"];
+}): Effect.Effect<boolean, E, R> =>
+  effect.pipe(
+    Effect.as(true),
+    Effect.catchCause((cause) => {
+      if (Cause.hasInterruptsOnly(cause)) {
+        return Effect.failCause(cause);
+      }
+      return Effect.logDebug(message, {
+        threadId,
+        cause: Cause.pretty(cause),
+      }).pipe(Effect.as(false));
+    }),
+  );
+
 const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const profileStatsArchive = yield* ProfileStatsArchive;
   const providerService = yield* ProviderService;
+  const providerSessionDirectory = yield* ProviderSessionDirectory;
   const terminalManager = yield* TerminalManager;
 
-  const stopProviderSession = (threadId: ThreadDeletedEvent["payload"]["threadId"]) =>
-    logCleanupCauseUnlessInterrupted({
+  const hasProviderBindingForCleanup = (
+    threadId: ThreadDeletedEvent["payload"]["threadId"],
+  ): Effect.Effect<ProviderCleanupBindingState, unknown> =>
+    providerSessionDirectory.getBinding(threadId).pipe(
+      Effect.map((binding) =>
+        Option.isSome(binding) ? ("present" as const) : ("absent" as const),
+      ),
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause)) {
+          return Effect.failCause(cause);
+        }
+        return Effect.logWarning("thread deletion cleanup skipped provider binding lookup", {
+          threadId,
+          cause: Cause.pretty(cause),
+        }).pipe(Effect.as("unknown" as const));
+      }),
+    );
+
+  const stopProviderSession = Effect.fn(function* (
+    threadId: ThreadDeletedEvent["payload"]["threadId"],
+  ) {
+    const bindingState = yield* hasProviderBindingForCleanup(threadId);
+    if (bindingState === "unknown") {
+      return false;
+    }
+    if (bindingState === "absent") {
+      return true;
+    }
+    return yield* cleanupSucceededUnlessInterrupted({
       effect: providerService.stopSession({ threadId }),
       message: "thread deletion cleanup skipped provider session stop",
       threadId,
     });
+  });
 
   const closeThreadTerminals = (threadId: ThreadDeletedEvent["payload"]["threadId"]) =>
     logCleanupCauseUnlessInterrupted({
@@ -81,10 +135,23 @@ const make = Effect.gen(function* () {
       );
   };
 
+  const cleanupThreadBeforePurge = Effect.fn(function* (
+    threadId: ThreadDeletedEvent["payload"]["threadId"],
+  ) {
+    const providerCleanupSucceeded = yield* stopProviderSession(threadId);
+    yield* closeThreadTerminals(threadId);
+    return providerCleanupSucceeded;
+  });
+
   const processThreadDeleted = Effect.fn(function* (event: ThreadDeletedEvent) {
     const { threadId } = event.payload;
-    yield* stopProviderSession(threadId);
-    yield* closeThreadTerminals(threadId);
+    const cleanupSucceeded = yield* cleanupThreadBeforePurge(threadId);
+    if (!cleanupSucceeded) {
+      yield* Effect.logWarning("thread deletion cleanup deferred stats archive purge", {
+        threadId,
+      });
+      return;
+    }
     yield* purgeThreadData(event);
   });
 
@@ -115,7 +182,11 @@ const make = Effect.gen(function* () {
     );
     yield* Effect.forkScoped(
       Effect.sleep(PURGE_STARTUP_SWEEP_DELAY_MS).pipe(
-        Effect.flatMap(() => profileStatsArchive.purgeSoftDeletedManualThreads()),
+        Effect.flatMap(() =>
+          profileStatsArchive.purgeSoftDeletedManualThreads({
+            beforePurge: cleanupThreadBeforePurge,
+          }),
+        ),
         Effect.flatMap((purgedCount) =>
           purgedCount > 0
             ? Effect.logInfo("purged soft-deleted threads after stats archive snapshot", {

--- a/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
@@ -113,7 +113,7 @@ const make = Effect.gen(function* () {
   });
 
   const closeThreadTerminals = (threadId: ThreadDeletedEvent["payload"]["threadId"]) =>
-    logCleanupCauseUnlessInterrupted({
+    cleanupSucceededUnlessInterrupted({
       effect: terminalManager.close({ threadId, deleteHistory: true }),
       message: "thread deletion cleanup skipped terminal close",
       threadId,
@@ -147,8 +147,8 @@ const make = Effect.gen(function* () {
     threadId: ThreadDeletedEvent["payload"]["threadId"],
   ) {
     const providerCleanupSucceeded = yield* stopProviderSession(threadId);
-    yield* closeThreadTerminals(threadId);
-    return providerCleanupSucceeded;
+    const terminalCleanupSucceeded = yield* closeThreadTerminals(threadId);
+    return providerCleanupSucceeded && terminalCleanupSucceeded;
   });
 
   const processThreadDeleted = Effect.fn(function* (event: ThreadDeletedEvent) {

--- a/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
+++ b/apps/server/src/orchestration/Layers/ThreadDeletionReactor.ts
@@ -1,10 +1,9 @@
-import type { OrchestrationEvent } from "@t3tools/contracts";
+import { ThreadId, type OrchestrationEvent } from "@t3tools/contracts";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
-import { Cause, Effect, Layer, Option, Stream } from "effect";
+import { Cause, Effect, Layer, Stream } from "effect";
 
 import { ProfileStatsArchive } from "../../profileStatsArchive";
 import { ProviderService } from "../../provider/Services/ProviderService";
-import { ProviderSessionDirectory } from "../../provider/Services/ProviderSessionDirectory";
 import { TerminalManager } from "../../terminal/Services/Manager";
 import { THREAD_RETENTION_COMMAND_ID_PREFIX } from "../../threadRetention";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine";
@@ -19,7 +18,7 @@ type ThreadDeletedEvent = Extract<OrchestrationEvent, { type: "thread.deleted" }
 // (or before purge existed) are archived and purged shortly after startup.
 const PURGE_STARTUP_SWEEP_DELAY_MS = 60 * 1000;
 
-type ProviderCleanupBindingState = "present" | "absent" | "unknown";
+const MISSING_PROVIDER_BINDING_DETAIL = "no persisted provider binding exists";
 
 export const logCleanupCauseUnlessInterrupted = <R, E>({
   effect,
@@ -68,42 +67,49 @@ const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const profileStatsArchive = yield* ProfileStatsArchive;
   const providerService = yield* ProviderService;
-  const providerSessionDirectory = yield* ProviderSessionDirectory;
   const terminalManager = yield* TerminalManager;
 
-  const hasProviderBindingForCleanup = (
-    threadId: ThreadDeletedEvent["payload"]["threadId"],
-  ): Effect.Effect<ProviderCleanupBindingState, unknown> =>
-    providerSessionDirectory.getBinding(threadId).pipe(
-      Effect.map((binding) =>
-        Option.isSome(binding) ? ("present" as const) : ("absent" as const),
-      ),
+  const refreshCommandReadModelAfterPurge = (threadId: string) =>
+    orchestrationEngine.refreshCommandReadModel().pipe(
+      Effect.asVoid,
       Effect.catchCause((cause) => {
         if (Cause.hasInterruptsOnly(cause)) {
           return Effect.failCause(cause);
         }
-        return Effect.logWarning("thread deletion cleanup skipped provider binding lookup", {
+        return Effect.logWarning("thread deletion cleanup could not refresh command read model", {
           threadId,
           cause: Cause.pretty(cause),
-        }).pipe(Effect.as("unknown" as const));
+        });
       }),
     );
+
+  const stopProviderSessionWithoutBinding = (
+    threadId: ThreadDeletedEvent["payload"]["threadId"],
+    cause: Cause.Cause<unknown>,
+  ) =>
+    Effect.logDebug("thread deletion cleanup found no provider session to stop", {
+      threadId,
+      cause: Cause.pretty(cause),
+    }).pipe(Effect.as(true));
 
   const stopProviderSession = Effect.fn(function* (
     threadId: ThreadDeletedEvent["payload"]["threadId"],
   ) {
-    const bindingState = yield* hasProviderBindingForCleanup(threadId);
-    if (bindingState === "unknown") {
-      return false;
-    }
-    if (bindingState === "absent") {
-      return true;
-    }
-    return yield* cleanupSucceededUnlessInterrupted({
-      effect: providerService.stopSession({ threadId }),
-      message: "thread deletion cleanup skipped provider session stop",
-      threadId,
-    });
+    return yield* providerService.stopSession({ threadId }).pipe(
+      Effect.as(true),
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause)) {
+          return Effect.failCause(cause);
+        }
+        if (Cause.pretty(cause).includes(MISSING_PROVIDER_BINDING_DETAIL)) {
+          return stopProviderSessionWithoutBinding(threadId, cause);
+        }
+        return Effect.logDebug("thread deletion cleanup skipped provider session stop", {
+          threadId,
+          cause: Cause.pretty(cause),
+        }).pipe(Effect.as(false));
+      }),
+    );
   });
 
   const closeThreadTerminals = (threadId: ThreadDeletedEvent["payload"]["threadId"]) =>
@@ -123,7 +129,9 @@ const make = Effect.gen(function* () {
     return profileStatsArchive
       .purgeThreadWithStatsSnapshot({ threadId: event.payload.threadId })
       .pipe(
-        Effect.asVoid,
+        Effect.flatMap((purged) =>
+          purged ? refreshCommandReadModelAfterPurge(event.payload.threadId) : Effect.void,
+        ),
         Effect.catch((error) =>
           // A failed purge leaves the thread soft-deleted; the startup sweep
           // retries it on the next boot.
@@ -184,8 +192,11 @@ const make = Effect.gen(function* () {
       Effect.sleep(PURGE_STARTUP_SWEEP_DELAY_MS).pipe(
         Effect.flatMap(() =>
           profileStatsArchive.purgeSoftDeletedManualThreads({
-            beforePurge: cleanupThreadBeforePurge,
+            beforePurge: (threadId) => cleanupThreadBeforePurge(ThreadId.makeUnsafe(threadId)),
           }),
+        ),
+        Effect.tap((purgedCount) =>
+          purgedCount > 0 ? refreshCommandReadModelAfterPurge("startup-sweep") : Effect.void,
         ),
         Effect.flatMap((purgedCount) =>
           purgedCount > 0

--- a/apps/server/src/orchestration/Services/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Services/OrchestrationEngine.ts
@@ -19,7 +19,10 @@ import { ServiceMap } from "effect";
 import type { Effect, Stream } from "effect";
 
 import type { OrchestrationDispatchError } from "../Errors.ts";
-import type { OrchestrationEventStoreError } from "../../persistence/Errors.ts";
+import type {
+  OrchestrationEventStoreError,
+  ProjectionRepositoryError,
+} from "../../persistence/Errors.ts";
 
 /**
  * OrchestrationEngineShape - Service API for orchestration command and event flow.
@@ -65,6 +68,16 @@ export interface OrchestrationEngineShape {
   readonly repairState: () => Effect.Effect<
     OrchestrationReadModel,
     OrchestrationDispatchError | OrchestrationEventStoreError,
+    never
+  >;
+
+  /**
+   * Reload the command-facing read model from projection tables after
+   * maintenance code mutates projection state outside the command queue.
+   */
+  readonly refreshCommandReadModel: () => Effect.Effect<
+    OrchestrationReadModel,
+    OrchestrationDispatchError | ProjectionRepositoryError,
     never
   >;
 

--- a/apps/server/src/orchestration/commandInvariants.test.ts
+++ b/apps/server/src/orchestration/commandInvariants.test.ts
@@ -125,6 +125,29 @@ const readModel: OrchestrationReadModel = {
       checkpoints: [],
       deletedAt: null,
     },
+    {
+      id: ThreadId.makeUnsafe("thread-deleted"),
+      projectId: ProjectId.makeUnsafe("project-a"),
+      title: "Deleted Thread",
+      modelSelection: {
+        provider: "codex",
+        model: "gpt-5-codex",
+      },
+      interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+      runtimeMode: "full-access",
+      branch: null,
+      worktreePath: null,
+      createdAt: now,
+      updatedAt: now,
+      latestTurn: null,
+      handoff: null,
+      messages: [],
+      session: null,
+      activities: [],
+      proposedPlans: [],
+      checkpoints: [],
+      deletedAt: now,
+    },
   ],
 };
 
@@ -173,6 +196,16 @@ describe("commandInvariants", () => {
         }),
       ),
     ).rejects.toThrow("does not exist");
+
+    await expect(
+      Effect.runPromise(
+        requireThread({
+          readModel,
+          command: messageSendCommand,
+          threadId: ThreadId.makeUnsafe("thread-deleted"),
+        }),
+      ),
+    ).rejects.toThrow("was deleted");
   });
 
   it("requires missing thread for create flows", async () => {

--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -141,13 +141,15 @@ export function requireThread(input: {
   readonly threadId: ThreadId;
 }): Effect.Effect<OrchestrationThread, OrchestrationCommandInvariantError> {
   const thread = findThreadById(input.readModel, input.threadId);
-  if (thread) {
+  if (thread && thread.deletedAt === null) {
     return Effect.succeed(thread);
   }
   return Effect.fail(
     invariantError(
       input.command.type,
-      `Thread '${input.threadId}' does not exist for command '${input.command.type}'.`,
+      thread
+        ? `Thread '${input.threadId}' was deleted and cannot handle command '${input.command.type}'.`
+        : `Thread '${input.threadId}' does not exist for command '${input.command.type}'.`,
     ),
   );
 }

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -65,6 +65,7 @@ import Migration0046 from "./Migrations/046_AutomationCompletionPolicy.ts";
 import Migration0047 from "./Migrations/047_AutomationCompletionPolicyVersion.ts";
 import Migration0048 from "./Migrations/048_AutomationCompletionEvaluationBacklog.ts";
 import Migration0049 from "./Migrations/049_ProjectionThreadMessagesDispatchOrigin.ts";
+import Migration0050 from "./Migrations/050_ProfileStatsArchive.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -126,6 +127,7 @@ export const migrationEntries = [
   [47, "AutomationCompletionPolicyVersion", Migration0047],
   [48, "AutomationCompletionEvaluationBacklog", Migration0048],
   [49, "ProjectionThreadMessagesDispatchOrigin", Migration0049],
+  [50, "ProfileStatsArchive", Migration0050],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/050_ProfileStatsArchive.ts
+++ b/apps/server/src/persistence/Migrations/050_ProfileStatsArchive.ts
@@ -1,0 +1,87 @@
+/**
+ * Profile-stats archive tables.
+ *
+ * When a thread is purged from the database (manual delete of an archived or
+ * active thread), the aggregate numbers the Profile page needs are snapshotted
+ * into these tables first. They are intentionally NOT `projection_*` tables:
+ * projections can be reset and rebuilt from orchestration_events, while these
+ * rows must survive both rebuilds and the purge of their source events.
+ */
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  // One tombstone per purged thread; keeps totalThreads accurate.
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS profile_stats_deleted_threads (
+      thread_id TEXT PRIMARY KEY,
+      project_id TEXT,
+      deleted_at TEXT NOT NULL
+    )
+  `;
+
+  // One row per native user prompt of a purged thread. Only the timestamp is
+  // kept (no text), so day/hour bucketing stays exact for any client timezone.
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS profile_stats_deleted_prompts (
+      thread_id TEXT NOT NULL,
+      project_id TEXT,
+      created_at TEXT NOT NULL
+    )
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_profile_stats_deleted_prompts_thread
+    ON profile_stats_deleted_prompts(thread_id)
+  `;
+
+  // Pre-aggregated turn counts per provider/model/reasoning of a purged thread.
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS profile_stats_deleted_turns (
+      thread_id TEXT NOT NULL,
+      provider TEXT,
+      model TEXT,
+      reasoning TEXT,
+      turn_count INTEGER NOT NULL
+    )
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_profile_stats_deleted_turns_thread
+    ON profile_stats_deleted_turns(thread_id)
+  `;
+
+  // Pre-aggregated skill/agent usage counts of a purged thread.
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS profile_stats_deleted_skills (
+      thread_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      run_count INTEGER NOT NULL
+    )
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_profile_stats_deleted_skills_thread
+    ON profile_stats_deleted_skills(thread_id)
+  `;
+
+  // Token deltas of a purged thread, keyed by the original activity timestamp
+  // so local-day bucketing stays exact for any client UTC offset (including
+  // half-hour timezones).
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS profile_stats_deleted_tokens (
+      thread_id TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      provider TEXT,
+      tokens INTEGER NOT NULL
+    )
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_profile_stats_deleted_tokens_thread
+    ON profile_stats_deleted_tokens(thread_id)
+  `;
+});

--- a/apps/server/src/profileStats.test.ts
+++ b/apps/server/src/profileStats.test.ts
@@ -579,7 +579,7 @@ describe("ProfileStatsQuery", () => {
               'thread-manual-deleted',
               'turn-skill-manual-deleted',
               'user',
-              'Manual deleted /openai-docs should not count',
+              'Manual deleted /openai-docs should still count',
               '[{"name":"openai-docs","path":"/skills/openai-docs/SKILL.md"}]',
               NULL,
               0,
@@ -604,12 +604,15 @@ describe("ProfileStatsQuery", () => {
 
         const stats = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
 
-        expect(stats.insights.skillsExplored).toBe(4);
-        expect(stats.insights.totalSkillsUsed).toBe(7);
-        expect(stats.activity.totalPromptsSent).toBe(3);
-        expect(stats.activity.totalThreads).toBe(2);
-        expect(stats.skills.slice(0, 4)).toEqual([
+        // Retention-hidden and manually deleted threads both keep contributing:
+        // profile stats are lifetime totals and deletion is only a soft hide.
+        expect(stats.insights.skillsExplored).toBe(5);
+        expect(stats.insights.totalSkillsUsed).toBe(8);
+        expect(stats.activity.totalPromptsSent).toBe(4);
+        expect(stats.activity.totalThreads).toBe(3);
+        expect(stats.skills.slice(0, 5)).toEqual([
           { name: "check-code", displayName: "$check-code", kind: "skill", runCount: 4 },
+          { name: "openai-docs", displayName: "$openai-docs", kind: "skill", runCount: 1 },
           { name: "planner", displayName: "$planner", kind: "skill", runCount: 1 },
           { name: "refactor-code", displayName: "$refactor-code", kind: "skill", runCount: 1 },
           { name: "reviewer", displayName: "@reviewer", kind: "agent", runCount: 1 },
@@ -618,7 +621,7 @@ describe("ProfileStatsQuery", () => {
     );
   });
 
-  it("selects the live project with the most native user prompts as most worked", async () => {
+  it("keeps deleted threads and deleted projects in the most-worked ranking", async () => {
     await runProfileStatsTest(
       Effect.gen(function* () {
         const sql = yield* SqlClient.SqlClient;
@@ -801,7 +804,7 @@ describe("ProfileStatsQuery", () => {
               'thread-alpha-deleted',
               'turn-alpha-deleted',
               'user',
-              'deleted thread should not win',
+              'deleted thread still counts',
               0,
               'native',
               '2026-06-14T11:05:00.000Z',
@@ -812,7 +815,7 @@ describe("ProfileStatsQuery", () => {
               'thread-deleted-project',
               'turn-deleted-project',
               'user',
-              'deleted project should not win',
+              'deleted project still counts',
               0,
               'native',
               '2026-06-14T11:35:00.000Z',
@@ -822,16 +825,19 @@ describe("ProfileStatsQuery", () => {
 
         const stats = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
 
-        expect(stats.activity.totalPromptsSent).toBe(5);
-        expect(stats.activity.totalThreads).toBe(2);
+        // Lifetime totals: deleted threads/projects keep their contribution.
+        expect(stats.activity.totalPromptsSent).toBe(7);
+        expect(stats.activity.totalThreads).toBe(4);
+        // Alpha and Beta tie on prompts (3) and active days (2); the deleted
+        // Alpha thread's later prompt breaks the tie via lastWorkedAt.
         expect(stats.mostWorkedProject).toEqual({
-          projectId: "project-beta",
-          title: "Beta",
-          workspaceRoot: "/work/beta",
+          projectId: "project-alpha",
+          title: "Alpha",
+          workspaceRoot: "/work/alpha",
           promptCount: 3,
-          threadCount: 1,
+          threadCount: 2,
           activeDays: 2,
-          lastWorkedAt: "2026-06-14T10:35:00.000Z",
+          lastWorkedAt: "2026-06-14T11:05:00.000Z",
         });
       }),
     );

--- a/apps/server/src/profileStats.ts
+++ b/apps/server/src/profileStats.ts
@@ -1,6 +1,9 @@
 // FILE: profileStats.ts
 // Purpose: Compute Profile-page stats from Synara's local projection DB only.
 // The share card never reads provider archives or cloud services for metrics.
+// Stats are lifetime numbers: deleting a thread purges its rows but snapshots
+// the aggregates into profile_stats_deleted_* first (profileStatsArchive.ts),
+// and every query here merges live projections with those archived aggregates.
 // Layer: server stats query service (SqlClient + ServerConfig).
 
 import nodePath from "node:path";
@@ -21,7 +24,6 @@ import { ServerConfig } from "./config";
 
 const HEATMAP_WINDOW_DAYS = 274; // ~9 months, GitHub-style contribution grid.
 const SKILL_RESULT_LIMIT = 12;
-const THREAD_RETENTION_COMMAND_ID_PATTERN = "thread-retention:%";
 const PROVIDER_KINDS = new Set<ProviderKind>([
   "codex",
   "claudeAgent",
@@ -58,6 +60,13 @@ interface SkillUsageMessageRow {
   readonly text: string | null;
   readonly skillsJson: string | null;
   readonly mentionsJson: string | null;
+}
+
+// Pre-aggregated usage snapshotted from purged threads (profile_stats_deleted_skills).
+interface ArchivedSkillUsageRow {
+  readonly name: string | null;
+  readonly kind: string | null;
+  readonly runCount: number;
 }
 
 interface MostWorkedProjectRow {
@@ -232,10 +241,12 @@ function extractTextSkillNames(text: string | null): string[] {
   return names;
 }
 
-// Builds profile skill rows from every stored Synara user message. Structured
-// references stay authoritative, while text tokens backfill older or partial rows.
+// Builds profile skill rows from every stored Synara user message, plus the
+// pre-aggregated counts snapshotted from purged threads. Structured references
+// stay authoritative, while text tokens backfill older or partial rows.
 export function aggregateProfileSkillUsageRows(
   rows: ReadonlyArray<SkillUsageMessageRow>,
+  archivedRows: ReadonlyArray<ArchivedSkillUsageRow> = [],
 ): SkillUsage[] {
   const counts = new Map<string, UsageCount>();
 
@@ -308,6 +319,22 @@ export function aggregateProfileSkillUsageRows(
       } else {
         counts.set(key, { ...usage, runCount: 1 });
       }
+    }
+  }
+
+  for (const row of archivedRows) {
+    const name = normalizeUsageName(row.name);
+    const kind: UsageKind | null = row.kind === "skill" || row.kind === "agent" ? row.kind : null;
+    const runCount = Math.trunc(num(row.runCount));
+    if (!name || !kind || runCount <= 0) {
+      continue;
+    }
+    const key = usageKey(kind, name);
+    const existing = counts.get(key);
+    if (existing) {
+      existing.runCount += runCount;
+    } else {
+      counts.set(key, { name, kind, runCount });
     }
   }
 
@@ -561,8 +588,11 @@ const makeProfileStatsQuery = Effect.gen(function* () {
       ),
     );
 
-  // Retention hides old threads with `thread.delete` but intentionally keeps
-  // their rows for profile history. Manual deletes and deleted projects stay out.
+  // Profile history counts all work ever done. Retention hides are soft
+  // deletes whose rows keep feeding these queries directly; explicit deletes
+  // purge the thread's rows AFTER snapshotting the aggregates that matter into
+  // the profile_stats_deleted_* tables (see profileStatsArchive.ts), so every
+  // query below merges live projections with those archived aggregates.
   // ── SQL helpers ──────────────────────────────────────────────────────
 
   // Activity = days/hours the user actually sent a Synara prompt. One day-hour
@@ -571,26 +601,24 @@ const makeProfileStatsQuery = Effect.gen(function* () {
     legacyCompatibleQuery(
       "profileStats.promptActivity",
       sql<PromptActivityRow>`
+        WITH prompt_events AS (
+          -- The thread join (no deleted_at filter) keeps retention-hidden rows
+          -- counting while excluding orphan message rows of purged threads,
+          -- which are already counted from the archive tables.
+          SELECT m.created_at AS created_at
+          FROM projection_thread_messages m
+          JOIN projection_threads t ON t.thread_id = m.thread_id
+          WHERE m.role = 'user'
+            AND m.source = 'native'
+          UNION ALL
+          SELECT d.created_at AS created_at
+          FROM profile_stats_deleted_prompts d
+        )
         SELECT
-          STRFTIME('%Y-%m-%d', DATETIME(m.created_at, ${tz})) AS day,
-          CAST(STRFTIME('%H', DATETIME(m.created_at, ${tz})) AS INTEGER) AS hour,
+          STRFTIME('%Y-%m-%d', DATETIME(created_at, ${tz})) AS day,
+          CAST(STRFTIME('%H', DATETIME(created_at, ${tz})) AS INTEGER) AS hour,
           COUNT(*) AS count
-        FROM projection_thread_messages m
-        JOIN projection_threads t ON t.thread_id = m.thread_id
-        LEFT JOIN projection_projects p ON p.project_id = t.project_id
-        WHERE m.role = 'user'
-          AND m.source = 'native'
-          AND (
-            t.deleted_at IS NULL
-            OR EXISTS (
-              SELECT 1
-              FROM orchestration_events td
-              WHERE td.event_type = 'thread.deleted'
-                AND td.stream_id = t.thread_id
-                AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
-            )
-          )
-          AND p.deleted_at IS NULL
+        FROM prompt_events
         GROUP BY day, hour
         ORDER BY day ASC, hour ASC
       `,
@@ -620,20 +648,8 @@ const makeProfileStatsQuery = Effect.gen(function* () {
             a.activity_id AS activity_id
           FROM projection_thread_activities a
           JOIN projection_threads th ON th.thread_id = a.thread_id
-          LEFT JOIN projection_projects p ON p.project_id = th.project_id
           WHERE a.kind = 'context-window.updated'
             AND json_extract(a.payload_json, '$.totalProcessedTokens') IS NOT NULL
-            AND (
-              th.deleted_at IS NULL
-              OR EXISTS (
-                SELECT 1
-                FROM orchestration_events td
-                WHERE td.event_type = 'thread.deleted'
-                  AND td.stream_id = th.thread_id
-                  AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
-              )
-            )
-            AND p.deleted_at IS NULL
         ),
         delta AS (
           SELECT
@@ -648,9 +664,18 @@ const makeProfileStatsQuery = Effect.gen(function* () {
                 activity_id ASC
             )) AS d
           FROM ev
+        ),
+        all_tokens AS (
+          SELECT day, provider, d FROM delta
+          UNION ALL
+          SELECT
+            STRFTIME('%Y-%m-%d', DATETIME(a.created_at, ${tz})) AS day,
+            COALESCE(a.provider, 'unknown') AS provider,
+            a.tokens AS d
+          FROM profile_stats_deleted_tokens a
         )
         SELECT day, provider, SUM(d) AS tokens
-        FROM delta
+        FROM all_tokens
         GROUP BY day, provider
       `,
     );
@@ -659,20 +684,9 @@ const makeProfileStatsQuery = Effect.gen(function* () {
     legacyCompatibleQuery(
       "profileStats.totalThreads",
       sql<CountRow>`
-        SELECT COUNT(*) AS count
-        FROM projection_threads t
-        LEFT JOIN projection_projects p ON p.project_id = t.project_id
-        WHERE (
-            t.deleted_at IS NULL
-            OR EXISTS (
-              SELECT 1
-              FROM orchestration_events td
-              WHERE td.event_type = 'thread.deleted'
-                AND td.stream_id = t.thread_id
-                AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
-            )
-          )
-          AND p.deleted_at IS NULL
+        SELECT
+          (SELECT COUNT(*) FROM projection_threads)
+          + (SELECT COUNT(*) FROM profile_stats_deleted_threads) AS count
       `,
     );
 
@@ -715,22 +729,18 @@ const makeProfileStatsQuery = Effect.gen(function* () {
           FROM orchestration_events e
           JOIN projection_threads t
             ON t.thread_id = COALESCE(json_extract(e.payload_json, '$.threadId'), e.stream_id)
-          LEFT JOIN projection_projects p ON p.project_id = t.project_id
           WHERE e.event_type = 'thread.turn-start-requested'
-            AND (
-              t.deleted_at IS NULL
-              OR EXISTS (
-                SELECT 1
-                FROM orchestration_events td
-                WHERE td.event_type = 'thread.deleted'
-                  AND td.stream_id = t.thread_id
-                  AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
-              )
-            )
-            AND p.deleted_at IS NULL
+        ),
+        turn_counts AS (
+          SELECT provider, model, reasoning, COUNT(*) AS count
+          FROM per_turn
+          GROUP BY provider, model, reasoning
+          UNION ALL
+          SELECT provider, model, reasoning, turn_count AS count
+          FROM profile_stats_deleted_turns
         )
-        SELECT provider, model, reasoning, COUNT(*) AS count
-        FROM per_turn
+        SELECT provider, model, reasoning, SUM(count) AS count
+        FROM turn_counts
         GROUP BY provider, model, reasoning
         ORDER BY count DESC, provider ASC, model ASC, reasoning ASC
       `,
@@ -750,20 +760,8 @@ const makeProfileStatsQuery = Effect.gen(function* () {
         m.mentions_json AS mentionsJson
       FROM projection_thread_messages m
       JOIN projection_threads t ON t.thread_id = m.thread_id
-      LEFT JOIN projection_projects p ON p.project_id = t.project_id
       WHERE m.role = 'user'
         AND m.source = 'native'
-        AND (
-          t.deleted_at IS NULL
-          OR EXISTS (
-            SELECT 1
-            FROM orchestration_events td
-            WHERE td.event_type = 'thread.deleted'
-              AND td.stream_id = t.thread_id
-              AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
-          )
-        )
-        AND p.deleted_at IS NULL
         AND (
           (m.skills_json IS NOT NULL AND TRIM(m.skills_json) NOT IN ('', '[]'))
           OR (m.mentions_json IS NOT NULL AND TRIM(m.mentions_json) NOT IN ('', '[]'))
@@ -786,19 +784,7 @@ const makeProfileStatsQuery = Effect.gen(function* () {
                 NULL AS mentionsJson
               FROM projection_thread_messages m
               JOIN projection_threads t ON t.thread_id = m.thread_id
-              LEFT JOIN projection_projects p ON p.project_id = t.project_id
               WHERE m.role = 'user'
-                AND (
-                  t.deleted_at IS NULL
-                  OR EXISTS (
-                    SELECT 1
-                    FROM orchestration_events td
-                    WHERE td.event_type = 'thread.deleted'
-                      AND td.stream_id = t.thread_id
-                      AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
-                  )
-                )
-                AND p.deleted_at IS NULL
                 AND (
                   m.text GLOB '*$[A-Za-z0-9]*'
                   OR m.text GLOB '*/[A-Za-z0-9]*'
@@ -810,34 +796,45 @@ const makeProfileStatsQuery = Effect.gen(function* () {
       ),
     );
 
+  const queryArchivedSkillUsage = () =>
+    legacyCompatibleQuery(
+      "profileStats.archivedSkillUsage",
+      sql<ArchivedSkillUsageRow>`
+        SELECT name, kind, run_count AS runCount
+        FROM profile_stats_deleted_skills
+      `,
+    );
+
   const queryMostWorkedProject = (tz: string) =>
     legacyCompatibleQuery(
       "profileStats.mostWorkedProject",
       sql<MostWorkedProjectRow>`
+        WITH project_prompts AS (
+          SELECT
+            t.project_id AS project_id,
+            m.thread_id AS thread_id,
+            m.created_at AS created_at
+          FROM projection_thread_messages m
+          JOIN projection_threads t ON t.thread_id = m.thread_id
+          WHERE m.role = 'user'
+            AND m.source = 'native'
+          UNION ALL
+          SELECT
+            d.project_id AS project_id,
+            d.thread_id AS thread_id,
+            d.created_at AS created_at
+          FROM profile_stats_deleted_prompts d
+        )
         SELECT
           p.project_id AS projectId,
           p.title AS title,
           p.workspace_root AS workspaceRoot,
           COUNT(*) AS promptCount,
-          COUNT(DISTINCT t.thread_id) AS threadCount,
-          COUNT(DISTINCT STRFTIME('%Y-%m-%d', DATETIME(m.created_at, ${tz}))) AS activeDays,
-          MAX(m.created_at) AS lastWorkedAt
-        FROM projection_thread_messages m
-        JOIN projection_threads t ON t.thread_id = m.thread_id
-        JOIN projection_projects p ON p.project_id = t.project_id
-        WHERE m.role = 'user'
-          AND m.source = 'native'
-          AND (
-            t.deleted_at IS NULL
-            OR EXISTS (
-              SELECT 1
-              FROM orchestration_events td
-              WHERE td.event_type = 'thread.deleted'
-                AND td.stream_id = t.thread_id
-                AND td.command_id LIKE ${THREAD_RETENTION_COMMAND_ID_PATTERN}
-            )
-          )
-          AND p.deleted_at IS NULL
+          COUNT(DISTINCT e.thread_id) AS threadCount,
+          COUNT(DISTINCT STRFTIME('%Y-%m-%d', DATETIME(e.created_at, ${tz}))) AS activeDays,
+          MAX(e.created_at) AS lastWorkedAt
+        FROM project_prompts e
+        JOIN projection_projects p ON p.project_id = e.project_id
         GROUP BY p.project_id, p.title, p.workspace_root
         ORDER BY
           promptCount DESC,
@@ -861,6 +858,7 @@ const makeProfileStatsQuery = Effect.gen(function* () {
       const totalThreadRows = yield* queryTotalThreads();
       const turnInsightRows = yield* queryTurnInsights();
       const skillMessageRows = yield* querySkillUsageMessages();
+      const archivedSkillRows = yield* queryArchivedSkillUsage();
       const mostWorkedProjectRows = yield* queryMostWorkedProject(tz);
 
       // ── Activity / heatmap / streaks ──
@@ -1000,7 +998,7 @@ const makeProfileStatsQuery = Effect.gen(function* () {
           : null;
 
       // ── Skills and agent mentions ──
-      const allSkillUsages = aggregateProfileSkillUsageRows(skillMessageRows);
+      const allSkillUsages = aggregateProfileSkillUsageRows(skillMessageRows, archivedSkillRows);
       const skills = allSkillUsages.slice(0, SKILL_RESULT_LIMIT);
       const totalSkillsUsed = allSkillUsages.reduce((sum, row) => sum + row.runCount, 0);
 

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -7,14 +7,42 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, Layer } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
+import {
+  CheckpointStore,
+  type CheckpointStoreShape,
+} from "./checkpointing/Services/CheckpointStore";
 import { ServerConfig } from "./config";
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite";
 import { ProfileStatsQuery, ProfileStatsQueryLive } from "./profileStats";
 import { ProfileStatsArchive, ProfileStatsArchiveLive } from "./profileStatsArchive";
 
+interface DeletedCheckpointRefCall {
+  readonly cwd: string;
+  readonly checkpointRefs: ReadonlyArray<string>;
+}
+
+const deletedCheckpointRefCalls: DeletedCheckpointRefCall[] = [];
+
+const checkpointStoreTestLayer = Layer.succeed(CheckpointStore, {
+  isGitRepository: () => Effect.die("unused checkpoint store test method"),
+  captureCheckpoint: () => Effect.die("unused checkpoint store test method"),
+  copyCheckpointRef: () => Effect.die("unused checkpoint store test method"),
+  hasCheckpointRef: () => Effect.die("unused checkpoint store test method"),
+  restoreCheckpoint: () => Effect.die("unused checkpoint store test method"),
+  diffCheckpoints: () => Effect.die("unused checkpoint store test method"),
+  deleteCheckpointRefs: (input) =>
+    Effect.sync(() => {
+      deletedCheckpointRefCalls.push({
+        cwd: input.cwd,
+        checkpointRefs: input.checkpointRefs.map((checkpointRef) => String(checkpointRef)),
+      });
+    }),
+} satisfies CheckpointStoreShape);
+
 const testLayer = Layer.mergeAll(ProfileStatsQueryLive, ProfileStatsArchiveLive).pipe(
+  Layer.provideMerge(checkpointStoreTestLayer),
   Layer.provideMerge(SqlitePersistenceMemory),
   Layer.provide(
     ServerConfig.layerTest(process.cwd(), {
@@ -158,9 +186,40 @@ const seedTwoThreadsWithActivity = Effect.gen(function* () {
         '{"totalProcessedTokens":5000}', 2, '2026-06-13T18:45:00.000Z'
       )
   `;
+
+  yield* sql`
+    INSERT INTO projection_turns (
+      thread_id, turn_id, pending_message_id, assistant_message_id, state,
+      requested_at, started_at, completed_at, checkpoint_turn_count,
+      checkpoint_ref, checkpoint_status, checkpoint_files_json
+    )
+    VALUES
+      (
+        'thread-keep', 'turn-keep-1', NULL, NULL, 'completed',
+        '2026-06-13T08:05:00.000Z', '2026-06-13T08:05:10.000Z',
+        '2026-06-13T08:06:00.000Z', 1,
+        'refs/t3/checkpoints/thread-keep/turn/1', 'captured', '[]'
+      ),
+      (
+        'thread-purge', 'turn-purge-1', NULL, NULL, 'completed',
+        '2026-06-13T09:05:00.000Z', '2026-06-13T09:05:10.000Z',
+        '2026-06-13T09:06:00.000Z', 1,
+        'refs/t3/checkpoints/thread-purge/turn/1', 'captured', '[]'
+      ),
+      (
+        'thread-purge', 'turn-purge-2', NULL, NULL, 'completed',
+        '2026-06-14T10:05:00.000Z', '2026-06-14T10:05:10.000Z',
+        '2026-06-14T10:06:00.000Z', 2,
+        'provider-diff:event-purge-2', 'captured', '[]'
+      )
+  `;
 });
 
 describe("ProfileStatsArchive", () => {
+  beforeEach(() => {
+    deletedCheckpointRefCalls.length = 0;
+  });
+
   it("purges a thread's rows while keeping every profile stat unchanged", async () => {
     await runArchiveTest(
       Effect.gen(function* () {
@@ -183,13 +242,27 @@ describe("ProfileStatsArchive", () => {
         expect(purged).toBe(true);
 
         // Every row the purged thread owned is gone.
-        const remaining = yield* sql<{ readonly threads: number; readonly messages: number }>`
+        const remaining = yield* sql<{
+          readonly threads: number;
+          readonly messages: number;
+          readonly turns: number;
+        }>`
           SELECT
             (SELECT COUNT(*) FROM projection_threads WHERE thread_id = 'thread-purge') AS threads,
-            (SELECT COUNT(*) FROM projection_thread_messages WHERE thread_id = 'thread-purge')
-              AS messages
+            (
+              SELECT COUNT(*)
+              FROM projection_thread_messages
+              WHERE thread_id = 'thread-purge'
+            ) AS messages,
+            (SELECT COUNT(*) FROM projection_turns WHERE thread_id = 'thread-purge') AS turns
         `;
-        expect(remaining[0]).toMatchObject({ threads: 0, messages: 0 });
+        expect(remaining[0]).toMatchObject({ threads: 0, messages: 0, turns: 0 });
+        expect(deletedCheckpointRefCalls).toEqual([
+          {
+            cwd: "/work/archive",
+            checkpointRefs: ["refs/t3/checkpoints/thread-purge/turn/1"],
+          },
+        ]);
         const remainingEvents = yield* sql<{ readonly count: number }>`
           SELECT COUNT(*) AS count FROM orchestration_events WHERE stream_id = 'thread-purge'
         `;
@@ -234,6 +307,82 @@ describe("ProfileStatsArchive", () => {
         expect(purgedAgain).toBe(false);
         const statsAfterRepurge = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
         expect(statsAfterRepurge.activity).toEqual(statsBefore.activity);
+      }),
+    );
+  });
+
+  it("hard-deletes empty cleanup threads without archiving a lifetime tombstone", async () => {
+    await runArchiveTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const statsQuery = yield* ProfileStatsQuery;
+        const archive = yield* ProfileStatsArchive;
+
+        yield* sql`
+          INSERT INTO projection_projects (
+            project_id, title, workspace_root, scripts_json, created_at, updated_at, deleted_at
+          )
+          VALUES (
+            'project-empty-cleanup',
+            'Empty Cleanup',
+            '/work/empty-cleanup',
+            '{}',
+            '2026-06-12T09:00:00.000Z',
+            '2026-06-12T09:00:00.000Z',
+            NULL
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_threads (
+            thread_id, project_id, title, model_selection_json, runtime_mode,
+            interaction_mode, env_mode, created_at, updated_at, deleted_at
+          )
+          VALUES (
+            'thread-empty-cleanup',
+            'project-empty-cleanup',
+            'Empty Cleanup',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access', 'default', 'local',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:05:00.000Z'
+          )
+        `;
+        yield* sql`
+          INSERT INTO profile_stats_deleted_threads (thread_id, project_id, deleted_at)
+          VALUES (
+            'thread-empty-cleanup',
+            'project-empty-cleanup',
+            '2026-06-13T09:05:00.000Z'
+          )
+        `;
+
+        const statsBefore = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
+        expect(statsBefore.activity.totalThreads).toBe(2);
+
+        const purged = yield* archive.purgeThreadWithStatsSnapshot({
+          threadId: "thread-empty-cleanup",
+        });
+        expect(purged).toBe(true);
+
+        const rows = yield* sql<{ readonly threads: number; readonly tombstones: number }>`
+          SELECT
+            (
+              SELECT COUNT(*)
+              FROM projection_threads
+              WHERE thread_id = 'thread-empty-cleanup'
+            ) AS threads,
+            (
+              SELECT COUNT(*)
+              FROM profile_stats_deleted_threads
+              WHERE thread_id = 'thread-empty-cleanup'
+            ) AS tombstones
+        `;
+        expect(rows[0]).toEqual({ threads: 0, tombstones: 0 });
+
+        const statsAfter = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
+        expect(statsAfter.activity.totalThreads).toBe(0);
+        expect(deletedCheckpointRefCalls).toEqual([]);
       }),
     );
   });
@@ -308,6 +457,26 @@ describe("ProfileStatsArchive", () => {
         const statsBefore = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
         expect(statsBefore.activity.totalPromptsSent).toBe(2);
         expect(statsBefore.activity.totalThreads).toBe(3);
+
+        const deferredThreadIds: string[] = [];
+        const deferredCount = yield* archive.purgeSoftDeletedManualThreads({
+          beforePurge: (threadId) =>
+            Effect.sync(() => {
+              deferredThreadIds.push(threadId);
+              return false;
+            }),
+        });
+        expect(deferredCount).toBe(0);
+        expect(deferredThreadIds).toEqual(["thread-manual"]);
+
+        const threadsAfterDeferred = yield* sql<{ readonly threadId: string }>`
+          SELECT thread_id AS threadId FROM projection_threads ORDER BY thread_id ASC
+        `;
+        expect(threadsAfterDeferred.map((row) => row.threadId)).toEqual([
+          "thread-live",
+          "thread-manual",
+          "thread-retention",
+        ]);
 
         const purgedCount = yield* archive.purgeSoftDeletedManualThreads();
         expect(purgedCount).toBe(1);

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -127,25 +127,31 @@ const seedTwoThreadsWithActivity = Effect.gen(function* () {
   yield* sql`
     INSERT INTO orchestration_events (
       event_id, aggregate_kind, stream_id, stream_version, event_type,
-      occurred_at, actor_kind, payload_json, metadata_json
+      occurred_at, command_id, actor_kind, payload_json, metadata_json
     )
     VALUES
       (
         'event-keep-1', 'thread', 'thread-keep', 1, 'thread.turn-start-requested',
-        '2026-06-13T08:05:00.000Z', 'client',
+        '2026-06-13T08:05:00.000Z', 'cmd-keep-turn', 'client',
         '{"threadId":"thread-keep","modelSelection":{"provider":"claudeAgent","model":"claude-sonnet-4-6","options":{"effort":"max"}}}',
         '{}'
       ),
       (
         'event-purge-1', 'thread', 'thread-purge', 1, 'thread.turn-start-requested',
-        '2026-06-13T09:05:00.000Z', 'client',
+        '2026-06-13T09:05:00.000Z', 'cmd-purge-turn', 'client',
         '{"threadId":"thread-purge","modelSelection":{"provider":"codex","model":"gpt-5-codex","options":{"reasoningEffort":"high"}}}',
         '{}'
       ),
       (
         'event-purge-2', 'thread', 'thread-purge', 2, 'thread.turn-start-requested',
-        '2026-06-14T10:05:00.000Z', 'client',
+        '2026-06-14T10:05:00.000Z', NULL, 'client',
         '{"threadId":"thread-purge"}',
+        '{}'
+      ),
+      (
+        'event-purge-delete', 'thread', 'thread-purge', 3, 'thread.deleted',
+        '2026-06-14T10:10:00.000Z', 'cmd-purge-delete', 'user',
+        '{"threadId":"thread-purge","deletedAt":"2026-06-14T10:10:00.000Z"}',
         '{}'
       )
   `;
@@ -162,6 +168,10 @@ const seedTwoThreadsWithActivity = Effect.gen(function* () {
       (
         'cmd-purge-turn', 'thread', 'thread-purge',
         '2026-06-13T09:05:00.000Z', 2, 'accepted', NULL
+      ),
+      (
+        'cmd-purge-delete', 'thread', 'thread-purge',
+        '2026-06-14T10:10:00.000Z', 3, 'accepted', NULL
       )
   `;
 
@@ -267,13 +277,16 @@ describe("ProfileStatsArchive", () => {
           SELECT COUNT(*) AS count FROM orchestration_events WHERE stream_id = 'thread-purge'
         `;
         expect(remainingEvents[0]?.count).toBe(0);
-        const remainingReceipts = yield* sql<{ readonly aggregateId: string }>`
-          SELECT aggregate_id AS aggregateId
+        const remainingReceipts = yield* sql<{ readonly commandId: string }>`
+          SELECT command_id AS commandId
           FROM orchestration_command_receipts
-          WHERE aggregate_id IN ('thread-keep', 'thread-purge')
-          ORDER BY aggregate_id ASC
+          WHERE command_id IN ('cmd-keep-turn', 'cmd-purge-turn', 'cmd-purge-delete')
+          ORDER BY command_id ASC
         `;
-        expect(remainingReceipts.map((row) => row.aggregateId)).toEqual(["thread-keep"]);
+        expect(remainingReceipts.map((row) => row.commandId)).toEqual([
+          "cmd-keep-turn",
+          "cmd-purge-delete",
+        ]);
         const remainingActivities = yield* sql<{ readonly count: number }>`
           SELECT COUNT(*) AS count
           FROM projection_thread_activities

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -30,20 +30,25 @@ interface DeletedCheckpointRefCall {
 
 const deletedCheckpointRefCalls: DeletedCheckpointRefCall[] = [];
 
+function recordDeletedCheckpointRefs(input: Parameters<CheckpointStoreShape["deleteCheckpointRefs"]>[0]) {
+  deletedCheckpointRefCalls.push({
+    cwd: input.cwd,
+    checkpointRefs: input.checkpointRefs.map((checkpointRef) => String(checkpointRef)),
+  });
+}
+
+let isGitRepositoryImpl: CheckpointStoreShape["isGitRepository"] = () => Effect.succeed(true);
+let deleteCheckpointRefsImpl: CheckpointStoreShape["deleteCheckpointRefs"] = (input) =>
+  Effect.sync(() => recordDeletedCheckpointRefs(input));
+
 const checkpointStoreTestLayer = Layer.succeed(CheckpointStore, {
-  isGitRepository: () => Effect.die("unused checkpoint store test method"),
+  isGitRepository: (cwd) => isGitRepositoryImpl(cwd),
   captureCheckpoint: () => Effect.die("unused checkpoint store test method"),
   copyCheckpointRef: () => Effect.die("unused checkpoint store test method"),
   hasCheckpointRef: () => Effect.die("unused checkpoint store test method"),
   restoreCheckpoint: () => Effect.die("unused checkpoint store test method"),
   diffCheckpoints: () => Effect.die("unused checkpoint store test method"),
-  deleteCheckpointRefs: (input) =>
-    Effect.sync(() => {
-      deletedCheckpointRefCalls.push({
-        cwd: input.cwd,
-        checkpointRefs: input.checkpointRefs.map((checkpointRef) => String(checkpointRef)),
-      });
-    }),
+  deleteCheckpointRefs: (input) => deleteCheckpointRefsImpl(input),
 } satisfies CheckpointStoreShape);
 
 const testLayer = Layer.mergeAll(ProfileStatsQueryLive, ProfileStatsArchiveLive).pipe(
@@ -243,6 +248,8 @@ const seedTwoThreadsWithActivity = Effect.gen(function* () {
 describe("ProfileStatsArchive", () => {
   beforeEach(() => {
     deletedCheckpointRefCalls.length = 0;
+    isGitRepositoryImpl = () => Effect.succeed(true);
+    deleteCheckpointRefsImpl = (input) => Effect.sync(() => recordDeletedCheckpointRefs(input));
   });
 
   it("purges a thread's rows while keeping every profile stat unchanged", async () => {
@@ -546,6 +553,133 @@ describe("ProfileStatsArchive", () => {
             ) AS turns
         `;
         expect(remainingRows[0]).toEqual({ messages: 0, turns: 0 });
+      }),
+    );
+  });
+
+  it("purges thread rows when checkpoint cleanup workspace is stale", async () => {
+    await runArchiveTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const archive = yield* ProfileStatsArchive;
+        isGitRepositoryImpl = () => Effect.succeed(false);
+
+        yield* sql`
+          INSERT INTO projection_projects (
+            project_id, title, workspace_root, scripts_json, created_at, updated_at, deleted_at
+          )
+          VALUES (
+            'project-stale-checkpoint',
+            'Stale Checkpoint',
+            '/work/missing-checkpoint',
+            '{}',
+            '2026-06-12T09:00:00.000Z',
+            '2026-06-12T09:00:00.000Z',
+            NULL
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_threads (
+            thread_id, project_id, title, model_selection_json, runtime_mode,
+            interaction_mode, env_mode, created_at, updated_at, deleted_at
+          )
+          VALUES (
+            'thread-stale-checkpoint',
+            'project-stale-checkpoint',
+            'Stale Checkpoint',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access', 'default', 'local',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:05:00.000Z'
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_thread_messages (
+            message_id, thread_id, turn_id, role, text, is_streaming, source,
+            created_at, updated_at
+          )
+          VALUES (
+            'message-stale-checkpoint',
+            'thread-stale-checkpoint',
+            'turn-stale-checkpoint',
+            'user',
+            'stale checkpoint purge',
+            0,
+            'native',
+            '2026-06-13T09:01:00.000Z',
+            '2026-06-13T09:01:00.000Z'
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_turns (
+            thread_id, turn_id, pending_message_id, assistant_message_id, state,
+            requested_at, started_at, completed_at, checkpoint_turn_count,
+            checkpoint_ref, checkpoint_status, checkpoint_files_json
+          )
+          VALUES (
+            'thread-stale-checkpoint',
+            'turn-stale-checkpoint',
+            NULL,
+            NULL,
+            'completed',
+            '2026-06-13T09:01:00.000Z',
+            '2026-06-13T09:01:10.000Z',
+            '2026-06-13T09:02:00.000Z',
+            1,
+            'refs/t3/checkpoints/thread-stale-checkpoint/turn/1',
+            'captured',
+            '[]'
+          )
+        `;
+        yield* sql`
+          INSERT INTO checkpoint_diff_blobs (
+            thread_id, from_turn_count, to_turn_count, diff, created_at
+          )
+          VALUES (
+            'thread-stale-checkpoint',
+            0,
+            1,
+            'diff --git a/file b/file',
+            '2026-06-13T09:02:00.000Z'
+          )
+        `;
+
+        const purged = yield* archive.purgeThreadWithStatsSnapshot({
+          threadId: "thread-stale-checkpoint",
+        });
+
+        expect(purged).toBe(true);
+        expect(deletedCheckpointRefCalls).toEqual([]);
+        const rows = yield* sql<{
+          readonly threads: number;
+          readonly messages: number;
+          readonly turns: number;
+          readonly diffBlobs: number;
+        }>`
+          SELECT
+            (
+              SELECT COUNT(*)
+              FROM projection_threads
+              WHERE thread_id = 'thread-stale-checkpoint'
+            ) AS threads,
+            (
+              SELECT COUNT(*)
+              FROM projection_thread_messages
+              WHERE thread_id = 'thread-stale-checkpoint'
+            ) AS messages,
+            (
+              SELECT COUNT(*)
+              FROM projection_turns
+              WHERE thread_id = 'thread-stale-checkpoint'
+            ) AS turns,
+            (
+              SELECT COUNT(*)
+              FROM checkpoint_diff_blobs
+              WHERE thread_id = 'thread-stale-checkpoint'
+            ) AS diffBlobs
+        `;
+        expect(rows[0]).toEqual({ threads: 0, messages: 0, turns: 0, diffBlobs: 0 });
       }),
     );
   });

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -123,6 +123,21 @@ const seedTwoThreadsWithActivity = Effect.gen(function* () {
   `;
 
   yield* sql`
+    INSERT INTO orchestration_command_receipts (
+      command_id, aggregate_kind, aggregate_id, accepted_at, result_sequence, status, error
+    )
+    VALUES
+      (
+        'cmd-keep-turn', 'thread', 'thread-keep',
+        '2026-06-13T08:05:00.000Z', 1, 'accepted', NULL
+      ),
+      (
+        'cmd-purge-turn', 'thread', 'thread-purge',
+        '2026-06-13T09:05:00.000Z', 2, 'accepted', NULL
+      )
+  `;
+
+  yield* sql`
     INSERT INTO projection_thread_activities (
       activity_id, thread_id, turn_id, tone, kind, summary, payload_json, sequence, created_at
     )
@@ -179,6 +194,13 @@ describe("ProfileStatsArchive", () => {
           SELECT COUNT(*) AS count FROM orchestration_events WHERE stream_id = 'thread-purge'
         `;
         expect(remainingEvents[0]?.count).toBe(0);
+        const remainingReceipts = yield* sql<{ readonly aggregateId: string }>`
+          SELECT aggregate_id AS aggregateId
+          FROM orchestration_command_receipts
+          WHERE aggregate_id IN ('thread-keep', 'thread-purge')
+          ORDER BY aggregate_id ASC
+        `;
+        expect(remainingReceipts.map((row) => row.aggregateId)).toEqual(["thread-keep"]);
         const remainingActivities = yield* sql<{ readonly count: number }>`
           SELECT COUNT(*) AS count
           FROM projection_thread_activities

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -686,6 +686,250 @@ describe("ProfileStatsArchive", () => {
     );
   });
 
+  it("keeps checkpoint refs when the database purge transaction fails", async () => {
+    await runArchiveTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const archive = yield* ProfileStatsArchive;
+
+        yield* sql`
+          INSERT INTO projection_projects (
+            project_id, title, workspace_root, scripts_json, created_at, updated_at, deleted_at
+          )
+          VALUES (
+            'project-failed-purge',
+            'Failed Purge',
+            '/work/failed-purge',
+            '{}',
+            '2026-06-12T09:00:00.000Z',
+            '2026-06-12T09:00:00.000Z',
+            NULL
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_threads (
+            thread_id, project_id, title, model_selection_json, runtime_mode,
+            interaction_mode, env_mode, created_at, updated_at, deleted_at
+          )
+          VALUES (
+            'thread-failed-purge',
+            'project-failed-purge',
+            'Failed Purge',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access', 'default', 'local',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:05:00.000Z'
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_turns (
+            thread_id, turn_id, pending_message_id, assistant_message_id, state,
+            requested_at, started_at, completed_at, checkpoint_turn_count,
+            checkpoint_ref, checkpoint_status, checkpoint_files_json
+          )
+          VALUES (
+            'thread-failed-purge',
+            'turn-failed-purge',
+            NULL,
+            NULL,
+            'completed',
+            '2026-06-13T09:01:00.000Z',
+            '2026-06-13T09:01:10.000Z',
+            '2026-06-13T09:02:00.000Z',
+            1,
+            'refs/t3/checkpoints/thread-failed-purge/turn/1',
+            'captured',
+            '[]'
+          )
+        `;
+
+        yield* sql`DROP TABLE profile_stats_deleted_threads`;
+        const exit = yield* Effect.exit(
+          archive.purgeThreadWithStatsSnapshot({ threadId: "thread-failed-purge" }),
+        );
+
+        expect(exit._tag).toBe("Failure");
+        expect(deletedCheckpointRefCalls).toEqual([]);
+        const rows = yield* sql<{ readonly threads: number; readonly turns: number }>`
+          SELECT
+            (
+              SELECT COUNT(*)
+              FROM projection_threads
+              WHERE thread_id = 'thread-failed-purge'
+            ) AS threads,
+            (
+              SELECT COUNT(*)
+              FROM projection_turns
+              WHERE thread_id = 'thread-failed-purge'
+            ) AS turns
+        `;
+        expect(rows[0]).toEqual({ threads: 1, turns: 1 });
+      }),
+    );
+  });
+
+  it("interrupts active automation runs before deleting the thread shell", async () => {
+    await runArchiveTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const archive = yield* ProfileStatsArchive;
+
+        yield* sql`
+          INSERT INTO projection_projects (
+            project_id, title, workspace_root, scripts_json, created_at, updated_at, deleted_at
+          )
+          VALUES (
+            'project-automation-purge',
+            'Automation Purge',
+            '/work/automation-purge',
+            '{}',
+            '2026-06-12T09:00:00.000Z',
+            '2026-06-12T09:00:00.000Z',
+            NULL
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_threads (
+            thread_id, project_id, title, model_selection_json, runtime_mode,
+            interaction_mode, env_mode, created_at, updated_at, deleted_at
+          )
+          VALUES (
+            'thread-automation-purge',
+            'project-automation-purge',
+            'Automation Purge',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access', 'default', 'local',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:05:00.000Z'
+          )
+        `;
+        yield* sql`
+          INSERT INTO automation_definitions (
+            automation_id, project_id, source_thread_id, name, prompt, schedule_json,
+            enabled, next_run_at, model_selection_json, provider_options_json, runtime_mode,
+            interaction_mode, worktree_mode, mode, target_thread_id, max_iterations,
+            stop_on_error, completion_policy_json, completion_policy_version,
+            completion_policy_updated_at, minimum_interval_seconds, max_runtime_seconds,
+            retry_policy_json, misfire_policy, acknowledged_risks_json, iteration_count,
+            created_at, updated_at, archived_at
+          )
+          VALUES (
+            'automation-purge',
+            'project-automation-purge',
+            NULL,
+            'Automation Purge',
+            'run it',
+            '{"type":"manual"}',
+            1,
+            NULL,
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            NULL,
+            'full-access',
+            'default',
+            'reuse',
+            'heartbeat',
+            'thread-automation-purge',
+            NULL,
+            1,
+            '{"type":"none"}',
+            0,
+            NULL,
+            60,
+            NULL,
+            '{"type":"none"}',
+            'skip',
+            '[]',
+            1,
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:00:00.000Z',
+            NULL
+          )
+        `;
+        yield* sql`
+          INSERT INTO automation_runs (
+            run_id, automation_id, project_id, thread_id, turn_id, trigger_type, status,
+            scheduled_for, claimed_by, claimed_at, lease_expires_at, started_at, finished_at,
+            thread_create_command_id, turn_start_command_id, message_id, error, result_json,
+            permission_snapshot_json, created_at, updated_at
+          )
+          VALUES (
+            'run-automation-purge',
+            'automation-purge',
+            'project-automation-purge',
+            'thread-automation-purge',
+            NULL,
+            'scheduled',
+            'running',
+            '2026-06-13T09:00:00.000Z',
+            'worker-1',
+            '2026-06-13T09:00:05.000Z',
+            '2026-06-13T09:10:00.000Z',
+            '2026-06-13T09:00:10.000Z',
+            NULL,
+            NULL,
+            'cmd-turn',
+            'message-run',
+            NULL,
+            NULL,
+            '{}',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:00:10.000Z'
+          )
+        `;
+
+        const purged = yield* archive.purgeThreadWithStatsSnapshot({
+          threadId: "thread-automation-purge",
+        });
+
+        expect(purged).toBe(true);
+        const rows = yield* sql<{
+          readonly threads: number;
+          readonly runStatus: string;
+          readonly error: string | null;
+          readonly resultJson: string | null;
+          readonly finishedAt: string | null;
+          readonly claimedBy: string | null;
+          readonly leaseExpiresAt: string | null;
+        }>`
+          SELECT
+            (
+              SELECT COUNT(*)
+              FROM projection_threads
+              WHERE thread_id = 'thread-automation-purge'
+            ) AS threads,
+            status AS runStatus,
+            error,
+            result_json AS resultJson,
+            finished_at AS finishedAt,
+            claimed_by AS claimedBy,
+            lease_expires_at AS leaseExpiresAt
+          FROM automation_runs
+          WHERE run_id = 'run-automation-purge'
+        `;
+        const result = JSON.parse(rows[0]?.resultJson ?? "null") as {
+          readonly outcome?: string;
+          readonly severity?: string;
+          readonly summary?: string;
+        } | null;
+        expect(rows[0]).toMatchObject({
+          threads: 0,
+          runStatus: "interrupted",
+          error: "Automation run was interrupted because its thread was deleted.",
+          finishedAt: "2026-06-13T09:05:00.000Z",
+          claimedBy: null,
+          leaseExpiresAt: null,
+        });
+        expect(result).toMatchObject({
+          outcome: "needs-attention",
+          severity: "warning",
+          summary: "Automation run was interrupted because its thread was deleted.",
+        });
+      }),
+    );
+  });
+
   it("sweeps manually soft-deleted threads but leaves retention-hidden ones in place", async () => {
     await runArchiveTest(
       Effect.gen(function* () {

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -142,19 +142,25 @@ const seedTwoThreadsWithActivity = Effect.gen(function* () {
         '{}'
       ),
       (
-        'event-purge-1', 'thread', 'thread-purge', 1, 'thread.turn-start-requested',
+        'event-purge-create', 'thread', 'thread-purge', 1, 'thread.created',
+        '2026-06-13T09:00:00.000Z', 'cmd-purge-create', 'client',
+        '{"threadId":"thread-purge","projectId":"project-archive","title":"Purged Thread"}',
+        '{}'
+      ),
+      (
+        'event-purge-1', 'thread', 'thread-purge', 2, 'thread.turn-start-requested',
         '2026-06-13T09:05:00.000Z', 'cmd-purge-turn', 'client',
         '{"threadId":"thread-purge","modelSelection":{"provider":"codex","model":"gpt-5-codex","options":{"reasoningEffort":"high"}}}',
         '{}'
       ),
       (
-        'event-purge-2', 'thread', 'thread-purge', 2, 'thread.turn-start-requested',
+        'event-purge-2', 'thread', 'thread-purge', 3, 'thread.turn-start-requested',
         '2026-06-14T10:05:00.000Z', NULL, 'client',
         '{"threadId":"thread-purge"}',
         '{}'
       ),
       (
-        'event-purge-delete', 'thread', 'thread-purge', 3, 'thread.deleted',
+        'event-purge-delete', 'thread', 'thread-purge', 4, 'thread.deleted',
         '2026-06-14T10:10:00.000Z', 'cmd-purge-delete', 'user',
         '{"threadId":"thread-purge","deletedAt":"2026-06-14T10:10:00.000Z"}',
         '{}'
@@ -169,6 +175,10 @@ const seedTwoThreadsWithActivity = Effect.gen(function* () {
       (
         'cmd-keep-turn', 'thread', 'thread-keep',
         '2026-06-13T08:05:00.000Z', 1, 'accepted', NULL
+      ),
+      (
+        'cmd-purge-create', 'thread', 'thread-purge',
+        '2026-06-13T09:00:00.000Z', 2, 'accepted', NULL
       ),
       (
         'cmd-purge-turn', 'thread', 'thread-purge',
@@ -311,12 +321,19 @@ describe("ProfileStatsArchive", () => {
         const remainingReceipts = yield* sql<{ readonly commandId: string }>`
           SELECT command_id AS commandId
           FROM orchestration_command_receipts
-          WHERE command_id IN ('cmd-keep-turn', 'cmd-purge-turn', 'cmd-purge-delete')
+          WHERE command_id IN (
+            'cmd-keep-turn',
+            'cmd-purge-create',
+            'cmd-purge-turn',
+            'cmd-purge-delete'
+          )
           ORDER BY command_id ASC
         `;
         expect(remainingReceipts.map((row) => row.commandId)).toEqual([
           "cmd-keep-turn",
+          "cmd-purge-create",
           "cmd-purge-delete",
+          "cmd-purge-turn",
         ]);
         const remainingActivities = yield* sql<{ readonly count: number }>`
           SELECT COUNT(*) AS count
@@ -427,6 +444,108 @@ describe("ProfileStatsArchive", () => {
         const statsAfter = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
         expect(statsAfter.activity.totalThreads).toBe(0);
         expect(deletedCheckpointRefCalls).toEqual([]);
+      }),
+    );
+  });
+
+  it("deletes message-start checkpoint refs when no turn checkpoint row exists yet", async () => {
+    await runArchiveTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const archive = yield* ProfileStatsArchive;
+
+        yield* sql`
+          INSERT INTO projection_projects (
+            project_id, title, workspace_root, scripts_json, created_at, updated_at, deleted_at
+          )
+          VALUES (
+            'project-message-checkpoint',
+            'Message Checkpoint',
+            '/work/message-checkpoint',
+            '{}',
+            '2026-06-12T09:00:00.000Z',
+            '2026-06-12T09:00:00.000Z',
+            NULL
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_threads (
+            thread_id, project_id, title, model_selection_json, runtime_mode,
+            interaction_mode, env_mode, created_at, updated_at, deleted_at
+          )
+          VALUES (
+            'thread-message-checkpoint',
+            'project-message-checkpoint',
+            'Message Checkpoint',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'full-access', 'default', 'local',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:00:00.000Z',
+            '2026-06-13T09:05:00.000Z'
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_thread_messages (
+            message_id, thread_id, turn_id, role, text, is_streaming, source,
+            created_at, updated_at
+          )
+          VALUES (
+            'message-pending-checkpoint',
+            'thread-message-checkpoint',
+            NULL,
+            'user',
+            'pending turn',
+            0,
+            'native',
+            '2026-06-13T09:01:00.000Z',
+            '2026-06-13T09:01:00.000Z'
+          )
+        `;
+        yield* sql`
+          INSERT INTO projection_turns (
+            thread_id, turn_id, pending_message_id, assistant_message_id, state,
+            requested_at, started_at, completed_at, checkpoint_turn_count,
+            checkpoint_ref, checkpoint_status, checkpoint_files_json
+          )
+          VALUES (
+            'thread-message-checkpoint', NULL, 'message-pending-checkpoint', NULL, 'pending',
+            '2026-06-13T09:01:00.000Z', NULL, NULL, NULL,
+            NULL, NULL, '[]'
+          )
+        `;
+
+        const purged = yield* archive.purgeThreadWithStatsSnapshot({
+          threadId: "thread-message-checkpoint",
+        });
+
+        expect(purged).toBe(true);
+        expect(deletedCheckpointRefCalls).toEqual([
+          {
+            cwd: "/work/message-checkpoint",
+            checkpointRefs: [
+              String(
+                checkpointRefForThreadMessageStart(
+                  ThreadId.makeUnsafe("thread-message-checkpoint"),
+                  MessageId.makeUnsafe("message-pending-checkpoint"),
+                ),
+              ),
+            ],
+          },
+        ]);
+        const remainingRows = yield* sql<{ readonly messages: number; readonly turns: number }>`
+          SELECT
+            (
+              SELECT COUNT(*)
+              FROM projection_thread_messages
+              WHERE thread_id = 'thread-message-checkpoint'
+            ) AS messages,
+            (
+              SELECT COUNT(*)
+              FROM projection_turns
+              WHERE thread_id = 'thread-message-checkpoint'
+            ) AS turns
+        `;
+        expect(remainingRows[0]).toEqual({ messages: 0, turns: 0 });
       }),
     );
   });

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -30,7 +30,9 @@ interface DeletedCheckpointRefCall {
 
 const deletedCheckpointRefCalls: DeletedCheckpointRefCall[] = [];
 
-function recordDeletedCheckpointRefs(input: Parameters<CheckpointStoreShape["deleteCheckpointRefs"]>[0]) {
+function recordDeletedCheckpointRefs(
+  input: Parameters<CheckpointStoreShape["deleteCheckpointRefs"]>[0],
+) {
   deletedCheckpointRefCalls.push({
     cwd: input.cwd,
     checkpointRefs: input.checkpointRefs.map((checkpointRef) => String(checkpointRef)),

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -1,0 +1,309 @@
+// FILE: profileStatsArchive.test.ts
+// Purpose: Coverage for the snapshot-then-purge flow: purging a thread must
+// free its rows while leaving every Profile stat unchanged.
+// Layer: Server stats tests
+// Exports: Vitest coverage for ProfileStatsArchive.
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Effect, Layer } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { describe, expect, it } from "vitest";
+
+import { ServerConfig } from "./config";
+import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite";
+import { ProfileStatsQuery, ProfileStatsQueryLive } from "./profileStats";
+import { ProfileStatsArchive, ProfileStatsArchiveLive } from "./profileStatsArchive";
+
+const testLayer = Layer.mergeAll(ProfileStatsQueryLive, ProfileStatsArchiveLive).pipe(
+  Layer.provideMerge(SqlitePersistenceMemory),
+  Layer.provide(
+    ServerConfig.layerTest(process.cwd(), {
+      prefix: "synara-profile-stats-archive-test-",
+    }),
+  ),
+  Layer.provide(NodeServices.layer),
+);
+
+function runArchiveTest<A, E>(
+  effect: Effect.Effect<A, E, ProfileStatsQuery | ProfileStatsArchive | SqlClient.SqlClient>,
+) {
+  return effect.pipe(Effect.provide(testLayer), Effect.scoped, Effect.runPromise);
+}
+
+const seedTwoThreadsWithActivity = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    INSERT INTO projection_projects (
+      project_id, title, workspace_root, scripts_json, created_at, updated_at, deleted_at
+    )
+    VALUES (
+      'project-archive',
+      'Archive',
+      '/work/archive',
+      '{}',
+      '2026-06-12T09:00:00.000Z',
+      '2026-06-12T09:00:00.000Z',
+      NULL
+    )
+  `;
+
+  yield* sql`
+    INSERT INTO projection_threads (
+      thread_id, project_id, title, model_selection_json, runtime_mode,
+      interaction_mode, env_mode, created_at, updated_at, deleted_at
+    )
+    VALUES
+      (
+        'thread-keep',
+        'project-archive',
+        'Kept Thread',
+        '{"provider":"claudeAgent","model":"claude-sonnet-4-6","options":{"effort":"max"}}',
+        'full-access', 'default', 'local',
+        '2026-06-13T08:00:00.000Z', '2026-06-13T08:00:00.000Z', NULL
+      ),
+      (
+        'thread-purge',
+        'project-archive',
+        'Purged Thread',
+        '{"provider":"codex","model":"gpt-5-codex","options":{"reasoningEffort":"high"}}',
+        'full-access', 'default', 'local',
+        '2026-06-13T09:00:00.000Z', '2026-06-13T09:00:00.000Z', NULL
+      )
+  `;
+
+  yield* sql`
+    INSERT INTO projection_thread_messages (
+      message_id, thread_id, turn_id, role, text, skills_json, mentions_json,
+      is_streaming, source, created_at, updated_at
+    )
+    VALUES
+      (
+        'message-keep-1', 'thread-keep', 'turn-keep-1', 'user',
+        'keep one', NULL, NULL,
+        0, 'native', '2026-06-13T08:05:00.000Z', '2026-06-13T08:05:00.000Z'
+      ),
+      (
+        'message-purge-1', 'thread-purge', 'turn-purge-1', 'user',
+        'Use /check-code here',
+        '[{"name":"check-code","path":"/skills/check-code/SKILL.md"}]', NULL,
+        0, 'native', '2026-06-13T09:05:00.000Z', '2026-06-13T09:05:00.000Z'
+      ),
+      (
+        'message-purge-2', 'thread-purge', 'turn-purge-2', 'user',
+        'purge two', NULL, '[{"name":"reviewer","path":"agent://reviewer"}]',
+        0, 'native', '2026-06-14T10:05:00.000Z', '2026-06-14T10:05:00.000Z'
+      )
+  `;
+
+  yield* sql`
+    INSERT INTO orchestration_events (
+      event_id, aggregate_kind, stream_id, stream_version, event_type,
+      occurred_at, actor_kind, payload_json, metadata_json
+    )
+    VALUES
+      (
+        'event-keep-1', 'thread', 'thread-keep', 1, 'thread.turn-start-requested',
+        '2026-06-13T08:05:00.000Z', 'client',
+        '{"threadId":"thread-keep","modelSelection":{"provider":"claudeAgent","model":"claude-sonnet-4-6","options":{"effort":"max"}}}',
+        '{}'
+      ),
+      (
+        'event-purge-1', 'thread', 'thread-purge', 1, 'thread.turn-start-requested',
+        '2026-06-13T09:05:00.000Z', 'client',
+        '{"threadId":"thread-purge","modelSelection":{"provider":"codex","model":"gpt-5-codex","options":{"reasoningEffort":"high"}}}',
+        '{}'
+      ),
+      (
+        'event-purge-2', 'thread', 'thread-purge', 2, 'thread.turn-start-requested',
+        '2026-06-14T10:05:00.000Z', 'client',
+        '{"threadId":"thread-purge"}',
+        '{}'
+      )
+  `;
+
+  yield* sql`
+    INSERT INTO projection_thread_activities (
+      activity_id, thread_id, turn_id, tone, kind, summary, payload_json, sequence, created_at
+    )
+    VALUES
+      (
+        'activity-keep-1', 'thread-keep', 'turn-keep-1', 'info',
+        'context-window.updated', 'tokens updated',
+        '{"totalProcessedTokens":1000}', 1, '2026-06-13T08:06:00.000Z'
+      ),
+      (
+        'activity-purge-1', 'thread-purge', 'turn-purge-1', 'info',
+        'context-window.updated', 'tokens updated',
+        '{"totalProcessedTokens":3000}', 1, '2026-06-13T09:06:00.000Z'
+      ),
+      (
+        'activity-purge-2', 'thread-purge', 'turn-purge-2', 'info',
+        'context-window.updated', 'tokens updated',
+        '{"totalProcessedTokens":5000}', 2, '2026-06-13T18:45:00.000Z'
+      )
+  `;
+});
+
+describe("ProfileStatsArchive", () => {
+  it("purges a thread's rows while keeping every profile stat unchanged", async () => {
+    await runArchiveTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const statsQuery = yield* ProfileStatsQuery;
+        const archive = yield* ProfileStatsArchive;
+
+        yield* seedTwoThreadsWithActivity;
+
+        const statsBefore = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
+        const tokenStatsBefore = yield* statsQuery.getProfileTokenStats({ utcOffsetMinutes: 0 });
+        // Half-hour offset: the 18:45Z token activity lands on the NEXT local
+        // day for +05:30, so this catches any archive-side day re-bucketing drift.
+        const statsBeforeIst = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 330 });
+        const tokenStatsBeforeIst = yield* statsQuery.getProfileTokenStats({
+          utcOffsetMinutes: 330,
+        });
+
+        const purged = yield* archive.purgeThreadWithStatsSnapshot({ threadId: "thread-purge" });
+        expect(purged).toBe(true);
+
+        // Every row the purged thread owned is gone.
+        const remaining = yield* sql<{ readonly threads: number; readonly messages: number }>`
+          SELECT
+            (SELECT COUNT(*) FROM projection_threads WHERE thread_id = 'thread-purge') AS threads,
+            (SELECT COUNT(*) FROM projection_thread_messages WHERE thread_id = 'thread-purge')
+              AS messages
+        `;
+        expect(remaining[0]).toMatchObject({ threads: 0, messages: 0 });
+        const remainingEvents = yield* sql<{ readonly count: number }>`
+          SELECT COUNT(*) AS count FROM orchestration_events WHERE stream_id = 'thread-purge'
+        `;
+        expect(remainingEvents[0]?.count).toBe(0);
+        const remainingActivities = yield* sql<{ readonly count: number }>`
+          SELECT COUNT(*) AS count
+          FROM projection_thread_activities
+          WHERE thread_id = 'thread-purge'
+        `;
+        expect(remainingActivities[0]?.count).toBe(0);
+
+        // The Profile numbers do not move: the archive snapshot replaces the rows.
+        const statsAfter = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
+        const tokenStatsAfter = yield* statsQuery.getProfileTokenStats({ utcOffsetMinutes: 0 });
+        expect(statsAfter.activity).toEqual(statsBefore.activity);
+        expect(statsAfter.activeHours).toEqual(statsBefore.activeHours);
+        expect(statsAfter.insights).toEqual(statsBefore.insights);
+        expect(statsAfter.providerModels).toEqual(statsBefore.providerModels);
+        expect(statsAfter.skills).toEqual(statsBefore.skills);
+        expect(statsAfter.mostWorkedProject).toEqual(statsBefore.mostWorkedProject);
+        expect(tokenStatsAfter).toEqual(tokenStatsBefore);
+
+        const statsAfterIst = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 330 });
+        const tokenStatsAfterIst = yield* statsQuery.getProfileTokenStats({
+          utcOffsetMinutes: 330,
+        });
+        expect(statsAfterIst.activity).toEqual(statsBeforeIst.activity);
+        expect(statsAfterIst.activeHours).toEqual(statsBeforeIst.activeHours);
+        expect(tokenStatsAfterIst).toEqual(tokenStatsBeforeIst);
+
+        // Re-purging an already purged thread is a no-op.
+        const purgedAgain = yield* archive.purgeThreadWithStatsSnapshot({
+          threadId: "thread-purge",
+        });
+        expect(purgedAgain).toBe(false);
+        const statsAfterRepurge = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
+        expect(statsAfterRepurge.activity).toEqual(statsBefore.activity);
+      }),
+    );
+  });
+
+  it("sweeps manually soft-deleted threads but leaves retention-hidden ones in place", async () => {
+    await runArchiveTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const statsQuery = yield* ProfileStatsQuery;
+        const archive = yield* ProfileStatsArchive;
+
+        yield* sql`
+          INSERT INTO projection_threads (
+            thread_id, project_id, title, model_selection_json, runtime_mode,
+            interaction_mode, env_mode, created_at, updated_at, deleted_at
+          )
+          VALUES
+            (
+              'thread-live', 'project-sweep', 'Live', '{"provider":"codex","model":"gpt-5-codex"}',
+              'full-access', 'default', 'local',
+              '2026-06-13T09:00:00.000Z', '2026-06-13T09:00:00.000Z', NULL
+            ),
+            (
+              'thread-manual', 'project-sweep', 'Manual',
+              '{"provider":"codex","model":"gpt-5-codex"}',
+              'full-access', 'default', 'local',
+              '2026-06-13T09:00:00.000Z', '2026-06-13T09:00:00.000Z', '2026-06-15T10:00:00.000Z'
+            ),
+            (
+              'thread-retention', 'project-sweep', 'Retention',
+              '{"provider":"codex","model":"gpt-5-codex"}',
+              'full-access', 'default', 'local',
+              '2026-06-08T09:00:00.000Z', '2026-06-08T09:00:00.000Z', '2026-06-15T09:00:00.000Z'
+            )
+        `;
+
+        yield* sql`
+          INSERT INTO projection_thread_messages (
+            message_id, thread_id, turn_id, role, text, is_streaming, source,
+            created_at, updated_at
+          )
+          VALUES
+            (
+              'message-manual-1', 'thread-manual', 'turn-manual-1', 'user', 'manual work',
+              0, 'native', '2026-06-13T09:05:00.000Z', '2026-06-13T09:05:00.000Z'
+            ),
+            (
+              'message-retention-1', 'thread-retention', 'turn-retention-1', 'user',
+              'retention work',
+              0, 'native', '2026-06-08T09:05:00.000Z', '2026-06-08T09:05:00.000Z'
+            )
+        `;
+
+        yield* sql`
+          INSERT INTO orchestration_events (
+            event_id, aggregate_kind, stream_id, stream_version, event_type,
+            occurred_at, command_id, actor_kind, payload_json, metadata_json
+          )
+          VALUES
+            (
+              'event-manual-delete', 'thread', 'thread-manual', 1, 'thread.deleted',
+              '2026-06-15T10:00:00.000Z', 'manual-delete:sweep-test', 'user',
+              '{"threadId":"thread-manual","deletedAt":"2026-06-15T10:00:00.000Z"}', '{}'
+            ),
+            (
+              'event-retention-delete', 'thread', 'thread-retention', 1, 'thread.deleted',
+              '2026-06-15T09:00:00.000Z', 'thread-retention:sweep-test', 'system',
+              '{"threadId":"thread-retention","deletedAt":"2026-06-15T09:00:00.000Z"}', '{}'
+            )
+        `;
+
+        const statsBefore = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
+        expect(statsBefore.activity.totalPromptsSent).toBe(2);
+        expect(statsBefore.activity.totalThreads).toBe(3);
+
+        const purgedCount = yield* archive.purgeSoftDeletedManualThreads();
+        expect(purgedCount).toBe(1);
+
+        const threadRows = yield* sql<{ readonly threadId: string }>`
+          SELECT thread_id AS threadId FROM projection_threads ORDER BY thread_id ASC
+        `;
+        expect(threadRows.map((row) => row.threadId)).toEqual(["thread-live", "thread-retention"]);
+        const tombstones = yield* sql<{ readonly threadId: string }>`
+          SELECT thread_id AS threadId FROM profile_stats_deleted_threads
+        `;
+        expect(tombstones.map((row) => row.threadId)).toEqual(["thread-manual"]);
+
+        // Lifetime totals survive: retention rows stay live, manual work is archived.
+        const statsAfter = yield* statsQuery.getProfileStats({ utcOffsetMinutes: 0 });
+        expect(statsAfter.activity.totalPromptsSent).toBe(2);
+        expect(statsAfter.activity.totalThreads).toBe(3);
+      }),
+    );
+  });
+});

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -5,6 +5,7 @@
 // Exports: Vitest coverage for ProfileStatsArchive.
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import { MessageId, ThreadId, TurnId } from "@t3tools/contracts";
 import { Effect, Layer } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -13,6 +14,10 @@ import {
   CheckpointStore,
   type CheckpointStoreShape,
 } from "./checkpointing/Services/CheckpointStore";
+import {
+  checkpointRefForThreadMessageStart,
+  checkpointRefForThreadTurnStart,
+} from "./checkpointing/Utils";
 import { ServerConfig } from "./config";
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite";
 import { ProfileStatsQuery, ProfileStatsQueryLive } from "./profileStats";
@@ -270,7 +275,33 @@ describe("ProfileStatsArchive", () => {
         expect(deletedCheckpointRefCalls).toEqual([
           {
             cwd: "/work/archive",
-            checkpointRefs: ["refs/t3/checkpoints/thread-purge/turn/1"],
+            checkpointRefs: [
+              "refs/t3/checkpoints/thread-purge/turn/1",
+              String(
+                checkpointRefForThreadTurnStart(
+                  ThreadId.makeUnsafe("thread-purge"),
+                  TurnId.makeUnsafe("turn-purge-1"),
+                ),
+              ),
+              String(
+                checkpointRefForThreadTurnStart(
+                  ThreadId.makeUnsafe("thread-purge"),
+                  TurnId.makeUnsafe("turn-purge-2"),
+                ),
+              ),
+              String(
+                checkpointRefForThreadMessageStart(
+                  ThreadId.makeUnsafe("thread-purge"),
+                  MessageId.makeUnsafe("message-purge-1"),
+                ),
+              ),
+              String(
+                checkpointRefForThreadMessageStart(
+                  ThreadId.makeUnsafe("thread-purge"),
+                  MessageId.makeUnsafe("message-purge-2"),
+                ),
+              ),
+            ],
           },
         ]);
         const remainingEvents = yield* sql<{ readonly count: number }>`

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -5,9 +5,13 @@
 // delete actually free disk space without shrinking the Profile page numbers.
 // Layer: server maintenance service (SqlClient).
 
+import { CheckpointRef, type ThreadEnvironmentMode } from "@t3tools/contracts";
+import { resolveThreadWorkspaceCwd } from "@t3tools/shared/threadEnvironment";
 import { Effect, Layer, ServiceMap } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
+import { CheckpointStore } from "./checkpointing/Services/CheckpointStore";
+import { CHECKPOINT_REFS_PREFIX } from "./checkpointing/Utils";
 import { aggregateProfileSkillUsageRows } from "./profileStats";
 import { THREAD_RETENTION_COMMAND_ID_PREFIX } from "./threadRetention";
 
@@ -15,6 +19,10 @@ interface PurgeThreadRow {
   readonly projectId: string | null;
   readonly modelSelectionJson: string | null;
   readonly deletedAt: string | null;
+  readonly envMode: string | null;
+  readonly worktreePath: string | null;
+  readonly projectKind: string | null;
+  readonly workspaceRoot: string | null;
 }
 
 interface TurnEventRow {
@@ -31,6 +39,10 @@ interface SkillMessageRow {
   readonly text: string | null;
   readonly skillsJson: string | null;
   readonly mentionsJson: string | null;
+}
+
+interface CheckpointTurnRow {
+  readonly checkpointRef: string | null;
 }
 
 export interface ThreadTurnSnapshotRow {
@@ -82,6 +94,48 @@ function parseModelSelectionJson(json: string | null): ModelSelectionLike | null
   } catch {
     return null;
   }
+}
+
+function normalizeThreadEnvironmentMode(value: string | null): ThreadEnvironmentMode | undefined {
+  return value === "local" || value === "worktree" ? value : undefined;
+}
+
+function threadWorkspaceCwdForCheckpointCleanup(thread: PurgeThreadRow): string | null {
+  const projectCwd =
+    thread.projectKind === "chat" && thread.worktreePath === null ? null : thread.workspaceRoot;
+  return resolveThreadWorkspaceCwd({
+    projectCwd,
+    envMode: normalizeThreadEnvironmentMode(thread.envMode),
+    worktreePath: thread.worktreePath,
+  });
+}
+
+function checkpointRefsFromTurnRows(
+  rows: ReadonlyArray<CheckpointTurnRow>,
+): ReadonlyArray<CheckpointRef> {
+  const refs = new Set<string>();
+  for (const row of rows) {
+    const checkpointRef = readString(row.checkpointRef);
+    if (!checkpointRef?.startsWith(`${CHECKPOINT_REFS_PREFIX}/`)) {
+      continue;
+    }
+    refs.add(checkpointRef);
+  }
+  return [...refs].map((checkpointRef) => CheckpointRef.makeUnsafe(checkpointRef));
+}
+
+function hasProfileStatsContribution(input: {
+  readonly promptRows: ReadonlyArray<SkillMessageRow>;
+  readonly turnRows: ReadonlyArray<ThreadTurnSnapshotRow>;
+  readonly tokenRows: ReadonlyArray<ThreadTokenSnapshotRow>;
+  readonly skillRows: ReturnType<typeof aggregateProfileSkillUsageRows>;
+}): boolean {
+  return (
+    input.promptRows.length > 0 ||
+    input.turnRows.some((row) => row.turnCount > 0) ||
+    input.tokenRows.length > 0 ||
+    input.skillRows.some((row) => row.runCount > 0)
+  );
 }
 
 // Mirrors the per-turn extraction in profileStats.queryTurnInsights: the turn
@@ -165,7 +219,9 @@ export interface ProfileStatsArchiveShape {
   // Purges every soft-deleted thread that was NOT hidden by the retention
   // sweep. Catches per-thread failures so one bad thread cannot stall the
   // sweep; returns how many threads were purged.
-  readonly purgeSoftDeletedManualThreads: () => Effect.Effect<number, unknown>;
+  readonly purgeSoftDeletedManualThreads: (input?: {
+    readonly beforePurge?: (threadId: string) => Effect.Effect<boolean, unknown>;
+  }) => Effect.Effect<number, unknown>;
 }
 
 export class ProfileStatsArchive extends ServiceMap.Service<
@@ -175,16 +231,22 @@ export class ProfileStatsArchive extends ServiceMap.Service<
 
 const makeProfileStatsArchive = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
+  const checkpointStore = yield* CheckpointStore;
 
   const snapshotAndPurgeThread = (threadId: string) =>
     Effect.gen(function* () {
       const threadRows = yield* sql<PurgeThreadRow>`
         SELECT
-          project_id AS projectId,
-          model_selection_json AS modelSelectionJson,
-          deleted_at AS deletedAt
-        FROM projection_threads
-        WHERE thread_id = ${threadId}
+          t.project_id AS projectId,
+          t.model_selection_json AS modelSelectionJson,
+          t.deleted_at AS deletedAt,
+          t.env_mode AS envMode,
+          t.worktree_path AS worktreePath,
+          p.kind AS projectKind,
+          p.workspace_root AS workspaceRoot
+        FROM projection_threads t
+        LEFT JOIN projection_projects p ON p.project_id = t.project_id
+        WHERE t.thread_id = ${threadId}
       `;
       const thread = threadRows[0];
       if (!thread) {
@@ -226,55 +288,83 @@ const makeProfileStatsArchive = Effect.gen(function* () {
           AND source = 'native'
         ORDER BY created_at ASC, message_id ASC
       `;
+      const checkpointTurnRows = yield* sql<CheckpointTurnRow>`
+        SELECT checkpoint_ref AS checkpointRef
+        FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND checkpoint_ref IS NOT NULL
+      `;
 
       const turnRows = aggregateThreadTurnSnapshotRows(turnEventRows, thread.modelSelectionJson);
       const tokenProvider = parseModelSelectionJson(thread.modelSelectionJson)?.provider ?? null;
       const tokenRows = aggregateThreadTokenRows(tokenActivityRows);
       const skillRows = aggregateProfileSkillUsageRows(skillMessageRows);
+      const hasStatsContribution = hasProfileStatsContribution({
+        promptRows: skillMessageRows,
+        turnRows,
+        tokenRows,
+        skillRows,
+      });
 
       // Snapshot writes are idempotent per thread so an interrupted purge can
       // safely re-run: wipe any partial snapshot before inserting the new one.
+      yield* sql`DELETE FROM profile_stats_deleted_threads WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM profile_stats_deleted_prompts WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM profile_stats_deleted_turns WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM profile_stats_deleted_skills WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM profile_stats_deleted_tokens WHERE thread_id = ${threadId}`;
 
-      yield* sql`
-        INSERT OR REPLACE INTO profile_stats_deleted_threads (thread_id, project_id, deleted_at)
-        VALUES (${threadId}, ${projectId}, ${deletedAt})
-      `;
-      yield* sql`
-        INSERT INTO profile_stats_deleted_prompts (thread_id, project_id, created_at)
-        SELECT thread_id, ${projectId}, created_at
-        FROM projection_thread_messages
-        WHERE thread_id = ${threadId}
-          AND role = 'user'
-          AND source = 'native'
-      `;
-      yield* Effect.forEach(
-        turnRows,
-        (row) => sql`
-          INSERT INTO profile_stats_deleted_turns (thread_id, provider, model, reasoning, turn_count)
-          VALUES (${threadId}, ${row.provider}, ${row.model}, ${row.reasoning}, ${row.turnCount})
-        `,
-        { concurrency: 1, discard: true },
-      );
-      yield* Effect.forEach(
-        skillRows,
-        (row) => sql`
-          INSERT INTO profile_stats_deleted_skills (thread_id, name, kind, run_count)
-          VALUES (${threadId}, ${row.name}, ${row.kind}, ${row.runCount})
-        `,
-        { concurrency: 1, discard: true },
-      );
-      yield* Effect.forEach(
-        tokenRows,
-        (row) => sql`
-          INSERT INTO profile_stats_deleted_tokens (thread_id, created_at, provider, tokens)
-          VALUES (${threadId}, ${row.createdAt}, ${tokenProvider}, ${row.tokens})
-        `,
-        { concurrency: 1, discard: true },
-      );
+      if (hasStatsContribution) {
+        yield* sql`
+          INSERT INTO profile_stats_deleted_threads (thread_id, project_id, deleted_at)
+          VALUES (${threadId}, ${projectId}, ${deletedAt})
+        `;
+        yield* sql`
+          INSERT INTO profile_stats_deleted_prompts (thread_id, project_id, created_at)
+          SELECT thread_id, ${projectId}, created_at
+          FROM projection_thread_messages
+          WHERE thread_id = ${threadId}
+            AND role = 'user'
+            AND source = 'native'
+        `;
+        yield* Effect.forEach(
+          turnRows,
+          (row) => sql`
+            INSERT INTO profile_stats_deleted_turns (thread_id, provider, model, reasoning, turn_count)
+            VALUES (${threadId}, ${row.provider}, ${row.model}, ${row.reasoning}, ${row.turnCount})
+          `,
+          { concurrency: 1, discard: true },
+        );
+        yield* Effect.forEach(
+          skillRows,
+          (row) => sql`
+            INSERT INTO profile_stats_deleted_skills (thread_id, name, kind, run_count)
+            VALUES (${threadId}, ${row.name}, ${row.kind}, ${row.runCount})
+          `,
+          { concurrency: 1, discard: true },
+        );
+        yield* Effect.forEach(
+          tokenRows,
+          (row) => sql`
+            INSERT INTO profile_stats_deleted_tokens (thread_id, created_at, provider, tokens)
+            VALUES (${threadId}, ${row.createdAt}, ${tokenProvider}, ${row.tokens})
+          `,
+          { concurrency: 1, discard: true },
+        );
+      }
+
+      const checkpointRefs = checkpointRefsFromTurnRows(checkpointTurnRows);
+      if (checkpointRefs.length > 0) {
+        const cwd = threadWorkspaceCwdForCheckpointCleanup(thread);
+        if (cwd === null) {
+          return yield* Effect.fail(
+            new Error(
+              `Cannot purge checkpoint refs for thread ${threadId} because its workspace is unavailable.`,
+            ),
+          );
+        }
+        yield* checkpointStore.deleteCheckpointRefs({ cwd, checkpointRefs });
+      }
 
       // Hard delete: every table that stores rows for this thread. The event
       // delete mirrors the snapshot scope above (stream id OR payload threadId,
@@ -310,7 +400,7 @@ const makeProfileStatsArchive = Effect.gen(function* () {
   ) => sql.withTransaction(snapshotAndPurgeThread(input.threadId));
 
   const purgeSoftDeletedManualThreads: ProfileStatsArchiveShape["purgeSoftDeletedManualThreads"] =
-    () =>
+    (input) =>
       Effect.gen(function* () {
         // Classify by the LATEST thread.deleted event: only threads whose most
         // recent delete came from retention stay hidden-but-kept. Soft-deleted
@@ -337,14 +427,20 @@ const makeProfileStatsArchive = Effect.gen(function* () {
         yield* Effect.forEach(
           candidates,
           (candidate) =>
-            purgeThreadWithStatsSnapshot({ threadId: candidate.threadId }).pipe(
-              Effect.flatMap((purged) =>
-                Effect.sync(() => {
-                  if (purged) {
-                    purgedCount += 1;
-                  }
-                }),
-              ),
+            Effect.gen(function* () {
+              const shouldPurge = input?.beforePurge
+                ? yield* input.beforePurge(candidate.threadId)
+                : true;
+              if (!shouldPurge) {
+                return;
+              }
+              const purged = yield* purgeThreadWithStatsSnapshot({
+                threadId: candidate.threadId,
+              });
+              if (purged) {
+                purgedCount += 1;
+              }
+            }).pipe(
               Effect.catch((error) =>
                 Effect.logWarning("profile stats archive failed to purge soft-deleted thread", {
                   threadId: candidate.threadId,

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -272,6 +272,13 @@ export class ProfileStatsArchive extends ServiceMap.Service<
 const makeProfileStatsArchive = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
   const checkpointStore = yield* CheckpointStore;
+  const threadDeletedAutomationRunResultJson = JSON.stringify({
+    outcome: "needs-attention",
+    summary: "Automation run was interrupted because its thread was deleted.",
+    severity: "warning",
+    unread: true,
+    archivedAt: null,
+  });
 
   const loadThreadCheckpointCleanup = (threadId: string) =>
     Effect.gen(function* () {
@@ -376,6 +383,27 @@ const makeProfileStatsArchive = Effect.gen(function* () {
       });
     });
   };
+
+  const deleteCheckpointRefsAfterCommittedPurge = (input: {
+    readonly threadId: string;
+    readonly cwd: string | null;
+    readonly checkpointRefs: ReadonlyArray<CheckpointRef>;
+  }) =>
+    deleteCheckpointRefsForPurge(input).pipe(
+      Effect.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause)) {
+          return Effect.failCause(cause);
+        }
+        return Effect.logWarning(
+          "profile stats archive could not delete checkpoint refs after purge",
+          {
+            threadId: input.threadId,
+            checkpointRefCount: input.checkpointRefs.length,
+            cause: Cause.pretty(cause),
+          },
+        );
+      }),
+    );
 
   const snapshotAndPurgeThread = (threadId: string) =>
     Effect.gen(function* () {
@@ -513,6 +541,18 @@ const makeProfileStatsArchive = Effect.gen(function* () {
       yield* sql`DELETE FROM projection_thread_proposed_plans WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM projection_thread_sessions WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM projection_turns WHERE thread_id = ${threadId}`;
+      yield* sql`
+        UPDATE automation_runs
+        SET status = 'interrupted',
+            error = 'Automation run was interrupted because its thread was deleted.',
+            result_json = ${threadDeletedAutomationRunResultJson},
+            finished_at = COALESCE(finished_at, ${deletedAt}),
+            updated_at = ${deletedAt},
+            lease_expires_at = NULL,
+            claimed_by = NULL
+        WHERE thread_id = ${threadId}
+          AND status NOT IN ('succeeded', 'failed', 'cancelled', 'interrupted', 'skipped')
+      `;
       yield* sql`DELETE FROM projection_threads WHERE thread_id = ${threadId}`;
 
       return true;
@@ -526,12 +566,15 @@ const makeProfileStatsArchive = Effect.gen(function* () {
       if (checkpointCleanup === null) {
         return false;
       }
-      yield* deleteCheckpointRefsForPurge({
-        threadId: input.threadId,
-        cwd: checkpointCleanup.cwd,
-        checkpointRefs: checkpointCleanup.checkpointRefs,
-      });
-      return yield* sql.withTransaction(snapshotAndPurgeThread(input.threadId));
+      const purged = yield* sql.withTransaction(snapshotAndPurgeThread(input.threadId));
+      if (purged) {
+        yield* deleteCheckpointRefsAfterCommittedPurge({
+          threadId: input.threadId,
+          cwd: checkpointCleanup.cwd,
+          checkpointRefs: checkpointCleanup.checkpointRefs,
+        });
+      }
+      return purged;
     });
 
   const purgeSoftDeletedManualThreads: ProfileStatsArchiveShape["purgeSoftDeletedManualThreads"] = (

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -287,6 +287,11 @@ const makeProfileStatsArchive = Effect.gen(function* () {
             OR json_extract(payload_json, '$.threadId') = ${threadId}
           )
       `;
+      yield* sql`
+        DELETE FROM orchestration_command_receipts
+        WHERE aggregate_kind = 'thread'
+          AND aggregate_id = ${threadId}
+      `;
       yield* sql`DELETE FROM checkpoint_diff_blobs WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM provider_session_runtime WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM projection_pending_approvals WHERE thread_id = ${threadId}`;

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -366,9 +366,28 @@ const makeProfileStatsArchive = Effect.gen(function* () {
         yield* checkpointStore.deleteCheckpointRefs({ cwd, checkpointRefs });
       }
 
-      // Hard delete: every table that stores rows for this thread. The event
-      // delete mirrors the snapshot scope above (stream id OR payload threadId,
-      // thread aggregate only) so no snapshotted event can survive the purge.
+      // Hard delete: every table that stores rows for this thread. The delete
+      // command receipts must survive because they are the retry idempotency
+      // record after the thread row and its delete event are gone.
+      yield* sql`
+        DELETE FROM orchestration_command_receipts
+        WHERE aggregate_kind = 'thread'
+          AND aggregate_id = ${threadId}
+          AND command_id NOT IN (
+            SELECT command_id
+            FROM orchestration_events
+            WHERE aggregate_kind = 'thread'
+              AND event_type = 'thread.deleted'
+              AND command_id IS NOT NULL
+              AND (
+                stream_id = ${threadId}
+                OR json_extract(payload_json, '$.threadId') = ${threadId}
+              )
+          )
+      `;
+      // The event delete mirrors the snapshot scope above (stream id OR
+      // payload threadId, thread aggregate only) so no snapshotted event can
+      // survive the purge.
       yield* sql`
         DELETE FROM orchestration_events
         WHERE aggregate_kind = 'thread'
@@ -376,11 +395,6 @@ const makeProfileStatsArchive = Effect.gen(function* () {
             stream_id = ${threadId}
             OR json_extract(payload_json, '$.threadId') = ${threadId}
           )
-      `;
-      yield* sql`
-        DELETE FROM orchestration_command_receipts
-        WHERE aggregate_kind = 'thread'
-          AND aggregate_id = ${threadId}
       `;
       yield* sql`DELETE FROM checkpoint_diff_blobs WHERE thread_id = ${threadId}`;
       yield* sql`DELETE FROM provider_session_runtime WHERE thread_id = ${threadId}`;
@@ -399,14 +413,15 @@ const makeProfileStatsArchive = Effect.gen(function* () {
     input,
   ) => sql.withTransaction(snapshotAndPurgeThread(input.threadId));
 
-  const purgeSoftDeletedManualThreads: ProfileStatsArchiveShape["purgeSoftDeletedManualThreads"] =
-    (input) =>
-      Effect.gen(function* () {
-        // Classify by the LATEST thread.deleted event: only threads whose most
-        // recent delete came from retention stay hidden-but-kept. Soft-deleted
-        // threads without any recorded delete event (legacy imports) count as
-        // manual deletes and get purged too.
-        const candidates = yield* sql<{ readonly threadId: string }>`
+  const purgeSoftDeletedManualThreads: ProfileStatsArchiveShape["purgeSoftDeletedManualThreads"] = (
+    input,
+  ) =>
+    Effect.gen(function* () {
+      // Classify by the LATEST thread.deleted event: only threads whose most
+      // recent delete came from retention stay hidden-but-kept. Soft-deleted
+      // threads without any recorded delete event (legacy imports) count as
+      // manual deletes and get purged too.
+      const candidates = yield* sql<{ readonly threadId: string }>`
           SELECT t.thread_id AS threadId
           FROM projection_threads t
           WHERE t.deleted_at IS NOT NULL
@@ -423,35 +438,35 @@ const makeProfileStatsArchive = Effect.gen(function* () {
             ) NOT LIKE ${`${THREAD_RETENTION_COMMAND_ID_PREFIX}%`}
         `;
 
-        let purgedCount = 0;
-        yield* Effect.forEach(
-          candidates,
-          (candidate) =>
-            Effect.gen(function* () {
-              const shouldPurge = input?.beforePurge
-                ? yield* input.beforePurge(candidate.threadId)
-                : true;
-              if (!shouldPurge) {
-                return;
-              }
-              const purged = yield* purgeThreadWithStatsSnapshot({
+      let purgedCount = 0;
+      yield* Effect.forEach(
+        candidates,
+        (candidate) =>
+          Effect.gen(function* () {
+            const shouldPurge = input?.beforePurge
+              ? yield* input.beforePurge(candidate.threadId)
+              : true;
+            if (!shouldPurge) {
+              return;
+            }
+            const purged = yield* purgeThreadWithStatsSnapshot({
+              threadId: candidate.threadId,
+            });
+            if (purged) {
+              purgedCount += 1;
+            }
+          }).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("profile stats archive failed to purge soft-deleted thread", {
                 threadId: candidate.threadId,
-              });
-              if (purged) {
-                purgedCount += 1;
-              }
-            }).pipe(
-              Effect.catch((error) =>
-                Effect.logWarning("profile stats archive failed to purge soft-deleted thread", {
-                  threadId: candidate.threadId,
-                  error: error instanceof Error ? error.message : String(error),
-                }),
-              ),
+                error: error instanceof Error ? error.message : String(error),
+              }),
             ),
-          { concurrency: 1, discard: true },
-        );
-        return purgedCount;
-      });
+          ),
+        { concurrency: 1, discard: true },
+      );
+      return purgedCount;
+    });
 
   return {
     purgeThreadWithStatsSnapshot,

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -1,0 +1,361 @@
+// FILE: profileStatsArchive.ts
+// Purpose: Snapshot a thread's profile-stat aggregates into the durable
+// profile_stats_deleted_* tables, then hard-delete every row the thread owns
+// (projections, events, checkpoints, session runtime). This is what lets a
+// delete actually free disk space without shrinking the Profile page numbers.
+// Layer: server maintenance service (SqlClient).
+
+import { Effect, Layer, ServiceMap } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { aggregateProfileSkillUsageRows } from "./profileStats";
+import { THREAD_RETENTION_COMMAND_ID_PREFIX } from "./threadRetention";
+
+interface PurgeThreadRow {
+  readonly projectId: string | null;
+  readonly modelSelectionJson: string | null;
+  readonly deletedAt: string | null;
+}
+
+interface TurnEventRow {
+  readonly payloadJson: string | null;
+}
+
+interface TokenActivityRow {
+  readonly totalProcessedTokens: number | bigint | null;
+  readonly createdAt: string | null;
+}
+
+interface SkillMessageRow {
+  readonly messageId: string | null;
+  readonly text: string | null;
+  readonly skillsJson: string | null;
+  readonly mentionsJson: string | null;
+}
+
+export interface ThreadTurnSnapshotRow {
+  readonly provider: string | null;
+  readonly model: string | null;
+  readonly reasoning: string | null;
+  readonly turnCount: number;
+}
+
+export interface ThreadTokenSnapshotRow {
+  readonly createdAt: string;
+  readonly tokens: number;
+}
+
+// ── Pure helpers ───────────────────────────────────────────────────────
+
+interface ModelSelectionLike {
+  readonly provider: string | null;
+  readonly model: string | null;
+  readonly reasoning: string | null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function parseModelSelection(value: unknown): ModelSelectionLike | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as { provider?: unknown; model?: unknown; options?: unknown };
+  const options =
+    record.options !== null && typeof record.options === "object"
+      ? (record.options as { reasoningEffort?: unknown; effort?: unknown })
+      : null;
+  return {
+    provider: readString(record.provider),
+    model: readString(record.model),
+    reasoning: readString(options?.reasoningEffort) ?? readString(options?.effort),
+  };
+}
+
+function parseModelSelectionJson(json: string | null): ModelSelectionLike | null {
+  if (json === null || json.trim().length === 0) {
+    return null;
+  }
+  try {
+    return parseModelSelection(JSON.parse(json));
+  } catch {
+    return null;
+  }
+}
+
+// Mirrors the per-turn extraction in profileStats.queryTurnInsights: the turn
+// event's own modelSelection wins, otherwise the thread's selection applies.
+export function aggregateThreadTurnSnapshotRows(
+  events: ReadonlyArray<TurnEventRow>,
+  threadModelSelectionJson: string | null,
+): ThreadTurnSnapshotRow[] {
+  const threadSelection = parseModelSelectionJson(threadModelSelectionJson);
+  const counts = new Map<
+    string,
+    { provider: string | null; model: string | null; reasoning: string | null; turnCount: number }
+  >();
+
+  for (const event of events) {
+    let eventSelection: ModelSelectionLike | null = null;
+    if (event.payloadJson !== null) {
+      try {
+        const payload: unknown = JSON.parse(event.payloadJson);
+        if (payload !== null && typeof payload === "object") {
+          eventSelection = parseModelSelection(
+            (payload as { modelSelection?: unknown }).modelSelection,
+          );
+        }
+      } catch {
+        // Malformed payload rows still count as a turn with the thread fallback.
+      }
+    }
+    const selection = eventSelection ?? threadSelection;
+    const provider = selection?.provider ?? null;
+    const model = selection?.model ?? null;
+    const reasoning = selection?.reasoning ?? null;
+    const key = `${provider ?? ""}\u0000${model ?? ""}\u0000${reasoning ?? ""}`;
+    const existing = counts.get(key);
+    if (existing) {
+      existing.turnCount += 1;
+    } else {
+      counts.set(key, { provider, model, reasoning, turnCount: 1 });
+    }
+  }
+
+  return [...counts.values()];
+}
+
+// Mirrors the LAG-based delta in profileStats.queryTokenActivity: rows must be
+// ordered the same way that query orders them, and the first total counts fully.
+// Deltas keep the original activity timestamp (raw, unparsed) so read-time
+// DATETIME(created_at, tz) bucketing stays identical to the live query for any
+// client UTC offset.
+export function aggregateThreadTokenRows(
+  rows: ReadonlyArray<TokenActivityRow>,
+): ThreadTokenSnapshotRow[] {
+  const tokensByTimestamp = new Map<string, number>();
+  let previousTotal = 0;
+  for (const row of rows) {
+    const total =
+      typeof row.totalProcessedTokens === "bigint"
+        ? Number(row.totalProcessedTokens)
+        : row.totalProcessedTokens;
+    if (total === null || !Number.isFinite(total)) {
+      continue;
+    }
+    const delta = Math.max(0, total - previousTotal);
+    previousTotal = total;
+    if (delta <= 0 || row.createdAt === null) {
+      continue;
+    }
+    tokensByTimestamp.set(row.createdAt, (tokensByTimestamp.get(row.createdAt) ?? 0) + delta);
+  }
+  return [...tokensByTimestamp.entries()].map(([createdAt, tokens]) => ({ createdAt, tokens }));
+}
+
+// ── Service ────────────────────────────────────────────────────────────
+
+export interface ProfileStatsArchiveShape {
+  // Snapshots the thread's stat aggregates and hard-deletes all of its rows in
+  // one transaction. Returns false when the thread row is already gone.
+  readonly purgeThreadWithStatsSnapshot: (input: {
+    readonly threadId: string;
+  }) => Effect.Effect<boolean, unknown>;
+  // Purges every soft-deleted thread that was NOT hidden by the retention
+  // sweep. Catches per-thread failures so one bad thread cannot stall the
+  // sweep; returns how many threads were purged.
+  readonly purgeSoftDeletedManualThreads: () => Effect.Effect<number, unknown>;
+}
+
+export class ProfileStatsArchive extends ServiceMap.Service<
+  ProfileStatsArchive,
+  ProfileStatsArchiveShape
+>()("synara/profileStats/ProfileStatsArchive") {}
+
+const makeProfileStatsArchive = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const snapshotAndPurgeThread = (threadId: string) =>
+    Effect.gen(function* () {
+      const threadRows = yield* sql<PurgeThreadRow>`
+        SELECT
+          project_id AS projectId,
+          model_selection_json AS modelSelectionJson,
+          deleted_at AS deletedAt
+        FROM projection_threads
+        WHERE thread_id = ${threadId}
+      `;
+      const thread = threadRows[0];
+      if (!thread) {
+        return false;
+      }
+      const deletedAt = thread.deletedAt ?? new Date().toISOString();
+      const projectId = thread.projectId ?? null;
+
+      const turnEventRows = yield* sql<TurnEventRow>`
+        SELECT payload_json AS payloadJson
+        FROM orchestration_events
+        WHERE event_type = 'thread.turn-start-requested'
+          AND COALESCE(json_extract(payload_json, '$.threadId'), stream_id) = ${threadId}
+      `;
+      const tokenActivityRows = yield* sql<TokenActivityRow>`
+        SELECT
+          CAST(json_extract(payload_json, '$.totalProcessedTokens') AS INTEGER)
+            AS totalProcessedTokens,
+          created_at AS createdAt
+        FROM projection_thread_activities
+        WHERE thread_id = ${threadId}
+          AND kind = 'context-window.updated'
+          AND json_extract(payload_json, '$.totalProcessedTokens') IS NOT NULL
+        ORDER BY
+          CASE WHEN sequence IS NULL THEN 0 ELSE 1 END ASC,
+          sequence ASC,
+          created_at ASC,
+          activity_id ASC
+      `;
+      const skillMessageRows = yield* sql<SkillMessageRow>`
+        SELECT
+          message_id AS messageId,
+          text,
+          skills_json AS skillsJson,
+          mentions_json AS mentionsJson
+        FROM projection_thread_messages
+        WHERE thread_id = ${threadId}
+          AND role = 'user'
+          AND source = 'native'
+        ORDER BY created_at ASC, message_id ASC
+      `;
+
+      const turnRows = aggregateThreadTurnSnapshotRows(turnEventRows, thread.modelSelectionJson);
+      const tokenProvider = parseModelSelectionJson(thread.modelSelectionJson)?.provider ?? null;
+      const tokenRows = aggregateThreadTokenRows(tokenActivityRows);
+      const skillRows = aggregateProfileSkillUsageRows(skillMessageRows);
+
+      // Snapshot writes are idempotent per thread so an interrupted purge can
+      // safely re-run: wipe any partial snapshot before inserting the new one.
+      yield* sql`DELETE FROM profile_stats_deleted_prompts WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM profile_stats_deleted_turns WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM profile_stats_deleted_skills WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM profile_stats_deleted_tokens WHERE thread_id = ${threadId}`;
+
+      yield* sql`
+        INSERT OR REPLACE INTO profile_stats_deleted_threads (thread_id, project_id, deleted_at)
+        VALUES (${threadId}, ${projectId}, ${deletedAt})
+      `;
+      yield* sql`
+        INSERT INTO profile_stats_deleted_prompts (thread_id, project_id, created_at)
+        SELECT thread_id, ${projectId}, created_at
+        FROM projection_thread_messages
+        WHERE thread_id = ${threadId}
+          AND role = 'user'
+          AND source = 'native'
+      `;
+      yield* Effect.forEach(
+        turnRows,
+        (row) => sql`
+          INSERT INTO profile_stats_deleted_turns (thread_id, provider, model, reasoning, turn_count)
+          VALUES (${threadId}, ${row.provider}, ${row.model}, ${row.reasoning}, ${row.turnCount})
+        `,
+        { concurrency: 1, discard: true },
+      );
+      yield* Effect.forEach(
+        skillRows,
+        (row) => sql`
+          INSERT INTO profile_stats_deleted_skills (thread_id, name, kind, run_count)
+          VALUES (${threadId}, ${row.name}, ${row.kind}, ${row.runCount})
+        `,
+        { concurrency: 1, discard: true },
+      );
+      yield* Effect.forEach(
+        tokenRows,
+        (row) => sql`
+          INSERT INTO profile_stats_deleted_tokens (thread_id, created_at, provider, tokens)
+          VALUES (${threadId}, ${row.createdAt}, ${tokenProvider}, ${row.tokens})
+        `,
+        { concurrency: 1, discard: true },
+      );
+
+      // Hard delete: every table that stores rows for this thread. The event
+      // delete mirrors the snapshot scope above (stream id OR payload threadId,
+      // thread aggregate only) so no snapshotted event can survive the purge.
+      yield* sql`
+        DELETE FROM orchestration_events
+        WHERE aggregate_kind = 'thread'
+          AND (
+            stream_id = ${threadId}
+            OR json_extract(payload_json, '$.threadId') = ${threadId}
+          )
+      `;
+      yield* sql`DELETE FROM checkpoint_diff_blobs WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM provider_session_runtime WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM projection_pending_approvals WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM projection_thread_activities WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM projection_thread_messages WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM projection_thread_proposed_plans WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM projection_thread_sessions WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM projection_turns WHERE thread_id = ${threadId}`;
+      yield* sql`DELETE FROM projection_threads WHERE thread_id = ${threadId}`;
+
+      return true;
+    });
+
+  const purgeThreadWithStatsSnapshot: ProfileStatsArchiveShape["purgeThreadWithStatsSnapshot"] = (
+    input,
+  ) => sql.withTransaction(snapshotAndPurgeThread(input.threadId));
+
+  const purgeSoftDeletedManualThreads: ProfileStatsArchiveShape["purgeSoftDeletedManualThreads"] =
+    () =>
+      Effect.gen(function* () {
+        // Classify by the LATEST thread.deleted event: only threads whose most
+        // recent delete came from retention stay hidden-but-kept. Soft-deleted
+        // threads without any recorded delete event (legacy imports) count as
+        // manual deletes and get purged too.
+        const candidates = yield* sql<{ readonly threadId: string }>`
+          SELECT t.thread_id AS threadId
+          FROM projection_threads t
+          WHERE t.deleted_at IS NOT NULL
+            AND COALESCE(
+              (
+                SELECT td.command_id
+                FROM orchestration_events td
+                WHERE td.event_type = 'thread.deleted'
+                  AND td.stream_id = t.thread_id
+                ORDER BY td.sequence DESC
+                LIMIT 1
+              ),
+              ''
+            ) NOT LIKE ${`${THREAD_RETENTION_COMMAND_ID_PREFIX}%`}
+        `;
+
+        let purgedCount = 0;
+        yield* Effect.forEach(
+          candidates,
+          (candidate) =>
+            purgeThreadWithStatsSnapshot({ threadId: candidate.threadId }).pipe(
+              Effect.flatMap((purged) =>
+                Effect.sync(() => {
+                  if (purged) {
+                    purgedCount += 1;
+                  }
+                }),
+              ),
+              Effect.catch((error) =>
+                Effect.logWarning("profile stats archive failed to purge soft-deleted thread", {
+                  threadId: candidate.threadId,
+                  error: error instanceof Error ? error.message : String(error),
+                }),
+              ),
+            ),
+          { concurrency: 1, discard: true },
+        );
+        return purgedCount;
+      });
+
+  return {
+    purgeThreadWithStatsSnapshot,
+    purgeSoftDeletedManualThreads,
+  } satisfies ProfileStatsArchiveShape;
+});
+
+export const ProfileStatsArchiveLive = Layer.effect(ProfileStatsArchive, makeProfileStatsArchive);

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -60,6 +60,11 @@ interface CheckpointMessageRow {
   readonly messageId: string | null;
 }
 
+interface ThreadCheckpointCleanup {
+  readonly cwd: string | null;
+  readonly checkpointRefs: ReadonlyArray<CheckpointRef>;
+}
+
 export interface ThreadTurnSnapshotRow {
   readonly provider: string | null;
   readonly model: string | null;
@@ -268,6 +273,68 @@ const makeProfileStatsArchive = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
   const checkpointStore = yield* CheckpointStore;
 
+  const loadThreadCheckpointCleanup = (threadId: string) =>
+    Effect.gen(function* () {
+      const threadRows = yield* sql<PurgeThreadRow>`
+        SELECT
+          t.project_id AS projectId,
+          t.model_selection_json AS modelSelectionJson,
+          t.deleted_at AS deletedAt,
+          t.env_mode AS envMode,
+          t.worktree_path AS worktreePath,
+          p.kind AS projectKind,
+          p.workspace_root AS workspaceRoot
+        FROM projection_threads t
+        LEFT JOIN projection_projects p ON p.project_id = t.project_id
+        WHERE t.thread_id = ${threadId}
+      `;
+      const thread = threadRows[0];
+      if (!thread) {
+        return null;
+      }
+
+      const checkpointTurnRows = yield* sql<CheckpointTurnRow>`
+        SELECT
+          turn_id AS turnId,
+          checkpoint_ref AS checkpointRef
+        FROM projection_turns
+        WHERE thread_id = ${threadId}
+          AND (
+            turn_id IS NOT NULL
+            OR checkpoint_ref IS NOT NULL
+          )
+        ORDER BY row_id ASC
+      `;
+      const checkpointMessageRows = yield* sql<CheckpointMessageRow>`
+        SELECT message_id AS messageId
+        FROM projection_thread_messages
+        WHERE thread_id = ${threadId}
+          AND message_id IS NOT NULL
+        ORDER BY message_id ASC
+      `;
+
+      const cwd = threadWorkspaceCwdForCheckpointCleanup(thread);
+      const hasPersistedCheckpointRef = checkpointTurnRows.some((row) =>
+        readString(row.checkpointRef)?.startsWith(`${CHECKPOINT_REFS_PREFIX}/`),
+      );
+      const checkpointRefs =
+        cwd !== null || hasPersistedCheckpointRef
+          ? checkpointRefsForThreadPurge(threadId, checkpointTurnRows, checkpointMessageRows)
+          : [];
+      if (checkpointRefs.length > 0 && cwd === null) {
+        return yield* Effect.fail(
+          new Error(
+            `Cannot purge checkpoint refs for thread ${threadId} because its workspace is unavailable.`,
+          ),
+        );
+      }
+
+      return {
+        cwd,
+        checkpointRefs,
+      } satisfies ThreadCheckpointCleanup;
+    });
+
   const snapshotAndPurgeThread = (threadId: string) =>
     Effect.gen(function* () {
       const threadRows = yield* sql<PurgeThreadRow>`
@@ -323,28 +390,6 @@ const makeProfileStatsArchive = Effect.gen(function* () {
           AND source = 'native'
         ORDER BY created_at ASC, message_id ASC
       `;
-      const checkpointTurnRows = yield* sql<CheckpointTurnRow>`
-        SELECT
-          turn_id AS turnId,
-          checkpoint_ref AS checkpointRef
-        FROM projection_turns
-        WHERE thread_id = ${threadId}
-          AND (
-            turn_id IS NOT NULL
-            OR checkpoint_ref IS NOT NULL
-          )
-        ORDER BY row_id ASC
-      `;
-      let checkpointMessageRows: ReadonlyArray<CheckpointMessageRow> = [];
-      if (checkpointTurnRows.length > 0) {
-        checkpointMessageRows = yield* sql<CheckpointMessageRow>`
-          SELECT message_id AS messageId
-          FROM projection_thread_messages
-          WHERE thread_id = ${threadId}
-            AND message_id IS NOT NULL
-          ORDER BY message_id ASC
-        `;
-      }
 
       const turnRows = aggregateThreadTurnSnapshotRows(turnEventRows, thread.modelSelectionJson);
       const tokenProvider = parseModelSelectionJson(thread.modelSelectionJson)?.provider ?? null;
@@ -404,42 +449,9 @@ const makeProfileStatsArchive = Effect.gen(function* () {
         );
       }
 
-      const checkpointRefs = checkpointRefsForThreadPurge(
-        threadId,
-        checkpointTurnRows,
-        checkpointMessageRows,
-      );
-      if (checkpointRefs.length > 0) {
-        const cwd = threadWorkspaceCwdForCheckpointCleanup(thread);
-        if (cwd === null) {
-          return yield* Effect.fail(
-            new Error(
-              `Cannot purge checkpoint refs for thread ${threadId} because its workspace is unavailable.`,
-            ),
-          );
-        }
-        yield* checkpointStore.deleteCheckpointRefs({ cwd, checkpointRefs });
-      }
-
       // Hard delete: every table that stores rows for this thread. The delete
-      // command receipts must survive because they are the retry idempotency
-      // record after the thread row and its delete event are gone.
-      yield* sql`
-        DELETE FROM orchestration_command_receipts
-        WHERE aggregate_kind = 'thread'
-          AND aggregate_id = ${threadId}
-          AND command_id NOT IN (
-            SELECT command_id
-            FROM orchestration_events
-            WHERE aggregate_kind = 'thread'
-              AND event_type = 'thread.deleted'
-              AND command_id IS NOT NULL
-              AND (
-                stream_id = ${threadId}
-                OR json_extract(payload_json, '$.threadId') = ${threadId}
-              )
-          )
-      `;
+      // receipts stay as tiny idempotency tombstones for command retries after
+      // the bulky event/projection rows are gone.
       // The event delete mirrors the snapshot scope above (stream id OR
       // payload threadId, thread aggregate only) so no snapshotted event can
       // survive the purge.
@@ -466,7 +478,28 @@ const makeProfileStatsArchive = Effect.gen(function* () {
 
   const purgeThreadWithStatsSnapshot: ProfileStatsArchiveShape["purgeThreadWithStatsSnapshot"] = (
     input,
-  ) => sql.withTransaction(snapshotAndPurgeThread(input.threadId));
+  ) =>
+    Effect.gen(function* () {
+      const checkpointCleanup = yield* loadThreadCheckpointCleanup(input.threadId);
+      if (checkpointCleanup === null) {
+        return false;
+      }
+      if (checkpointCleanup.checkpointRefs.length > 0) {
+        const cwd = checkpointCleanup.cwd;
+        if (cwd === null) {
+          return yield* Effect.fail(
+            new Error(
+              `Cannot purge checkpoint refs for thread ${input.threadId} because its workspace is unavailable.`,
+            ),
+          );
+        }
+        yield* checkpointStore.deleteCheckpointRefs({
+          cwd,
+          checkpointRefs: checkpointCleanup.checkpointRefs,
+        });
+      }
+      return yield* sql.withTransaction(snapshotAndPurgeThread(input.threadId));
+    });
 
   const purgeSoftDeletedManualThreads: ProfileStatsArchiveShape["purgeSoftDeletedManualThreads"] = (
     input,

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -5,13 +5,23 @@
 // delete actually free disk space without shrinking the Profile page numbers.
 // Layer: server maintenance service (SqlClient).
 
-import { CheckpointRef, type ThreadEnvironmentMode } from "@t3tools/contracts";
+import {
+  CheckpointRef,
+  MessageId,
+  ThreadId,
+  TurnId,
+  type ThreadEnvironmentMode,
+} from "@t3tools/contracts";
 import { resolveThreadWorkspaceCwd } from "@t3tools/shared/threadEnvironment";
 import { Effect, Layer, ServiceMap } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { CheckpointStore } from "./checkpointing/Services/CheckpointStore";
-import { CHECKPOINT_REFS_PREFIX } from "./checkpointing/Utils";
+import {
+  checkpointRefForThreadMessageStart,
+  checkpointRefForThreadTurnStart,
+  CHECKPOINT_REFS_PREFIX,
+} from "./checkpointing/Utils";
 import { aggregateProfileSkillUsageRows } from "./profileStats";
 import { THREAD_RETENTION_COMMAND_ID_PREFIX } from "./threadRetention";
 
@@ -42,7 +52,12 @@ interface SkillMessageRow {
 }
 
 interface CheckpointTurnRow {
+  readonly turnId: string | null;
   readonly checkpointRef: string | null;
+}
+
+interface CheckpointMessageRow {
+  readonly messageId: string | null;
 }
 
 export interface ThreadTurnSnapshotRow {
@@ -110,17 +125,37 @@ function threadWorkspaceCwdForCheckpointCleanup(thread: PurgeThreadRow): string 
   });
 }
 
-function checkpointRefsFromTurnRows(
-  rows: ReadonlyArray<CheckpointTurnRow>,
+function checkpointRefsForThreadPurge(
+  threadId: string,
+  turnRows: ReadonlyArray<CheckpointTurnRow>,
+  messageRows: ReadonlyArray<CheckpointMessageRow>,
 ): ReadonlyArray<CheckpointRef> {
   const refs = new Set<string>();
-  for (const row of rows) {
-    const checkpointRef = readString(row.checkpointRef);
-    if (!checkpointRef?.startsWith(`${CHECKPOINT_REFS_PREFIX}/`)) {
-      continue;
+
+  const addRef = (checkpointRef: CheckpointRef | string | null | undefined) => {
+    const raw = readString(checkpointRef);
+    if (raw?.startsWith(`${CHECKPOINT_REFS_PREFIX}/`)) {
+      refs.add(raw);
     }
-    refs.add(checkpointRef);
+  };
+
+  const typedThreadId = ThreadId.makeUnsafe(threadId);
+  for (const row of turnRows) {
+    const checkpointRef = readString(row.checkpointRef);
+    addRef(checkpointRef);
+
+    const turnId = readString(row.turnId);
+    if (turnId) {
+      addRef(checkpointRefForThreadTurnStart(typedThreadId, TurnId.makeUnsafe(turnId)));
+    }
   }
+  for (const row of messageRows) {
+    const messageId = readString(row.messageId);
+    if (messageId) {
+      addRef(checkpointRefForThreadMessageStart(typedThreadId, MessageId.makeUnsafe(messageId)));
+    }
+  }
+
   return [...refs].map((checkpointRef) => CheckpointRef.makeUnsafe(checkpointRef));
 }
 
@@ -289,11 +324,27 @@ const makeProfileStatsArchive = Effect.gen(function* () {
         ORDER BY created_at ASC, message_id ASC
       `;
       const checkpointTurnRows = yield* sql<CheckpointTurnRow>`
-        SELECT checkpoint_ref AS checkpointRef
+        SELECT
+          turn_id AS turnId,
+          checkpoint_ref AS checkpointRef
         FROM projection_turns
         WHERE thread_id = ${threadId}
-          AND checkpoint_ref IS NOT NULL
+          AND (
+            turn_id IS NOT NULL
+            OR checkpoint_ref IS NOT NULL
+          )
+        ORDER BY row_id ASC
       `;
+      let checkpointMessageRows: ReadonlyArray<CheckpointMessageRow> = [];
+      if (checkpointTurnRows.length > 0) {
+        checkpointMessageRows = yield* sql<CheckpointMessageRow>`
+          SELECT message_id AS messageId
+          FROM projection_thread_messages
+          WHERE thread_id = ${threadId}
+            AND message_id IS NOT NULL
+          ORDER BY message_id ASC
+        `;
+      }
 
       const turnRows = aggregateThreadTurnSnapshotRows(turnEventRows, thread.modelSelectionJson);
       const tokenProvider = parseModelSelectionJson(thread.modelSelectionJson)?.provider ?? null;
@@ -353,7 +404,11 @@ const makeProfileStatsArchive = Effect.gen(function* () {
         );
       }
 
-      const checkpointRefs = checkpointRefsFromTurnRows(checkpointTurnRows);
+      const checkpointRefs = checkpointRefsForThreadPurge(
+        threadId,
+        checkpointTurnRows,
+        checkpointMessageRows,
+      );
       if (checkpointRefs.length > 0) {
         const cwd = threadWorkspaceCwdForCheckpointCleanup(thread);
         if (cwd === null) {

--- a/apps/server/src/profileStatsArchive.ts
+++ b/apps/server/src/profileStatsArchive.ts
@@ -13,7 +13,7 @@ import {
   type ThreadEnvironmentMode,
 } from "@t3tools/contracts";
 import { resolveThreadWorkspaceCwd } from "@t3tools/shared/threadEnvironment";
-import { Effect, Layer, ServiceMap } from "effect";
+import { Cause, Effect, Layer, ServiceMap } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { CheckpointStore } from "./checkpointing/Services/CheckpointStore";
@@ -321,19 +321,61 @@ const makeProfileStatsArchive = Effect.gen(function* () {
         cwd !== null || hasPersistedCheckpointRef
           ? checkpointRefsForThreadPurge(threadId, checkpointTurnRows, checkpointMessageRows)
           : [];
-      if (checkpointRefs.length > 0 && cwd === null) {
-        return yield* Effect.fail(
-          new Error(
-            `Cannot purge checkpoint refs for thread ${threadId} because its workspace is unavailable.`,
-          ),
-        );
-      }
 
       return {
         cwd,
         checkpointRefs,
       } satisfies ThreadCheckpointCleanup;
     });
+
+  // Stale/missing workspaces cannot contain reachable refs for us to delete; keep
+  // the DB purge moving, but fail normally once a usable Git repo is confirmed.
+  const deleteCheckpointRefsForPurge = (input: {
+    readonly threadId: string;
+    readonly cwd: string | null;
+    readonly checkpointRefs: ReadonlyArray<CheckpointRef>;
+  }) => {
+    if (input.checkpointRefs.length === 0) {
+      return Effect.void;
+    }
+    const cwd = input.cwd;
+    if (cwd === null) {
+      return Effect.logWarning(
+        "profile stats archive skipped checkpoint ref cleanup because workspace is unavailable",
+        { threadId: input.threadId, checkpointRefCount: input.checkpointRefs.length },
+      );
+    }
+
+    return Effect.gen(function* () {
+      const isGitRepository = yield* checkpointStore.isGitRepository(cwd).pipe(
+        Effect.catchCause((cause) => {
+          if (Cause.hasInterruptsOnly(cause)) {
+            return Effect.failCause(cause);
+          }
+          return Effect.logWarning(
+            "profile stats archive could not verify checkpoint cleanup workspace",
+            {
+              threadId: input.threadId,
+              cwd,
+              cause: Cause.pretty(cause),
+            },
+          ).pipe(Effect.as(false));
+        }),
+      );
+      if (!isGitRepository) {
+        yield* Effect.logWarning(
+          "profile stats archive skipped checkpoint ref cleanup because workspace is not a git repository",
+          { threadId: input.threadId, cwd },
+        );
+        return;
+      }
+
+      yield* checkpointStore.deleteCheckpointRefs({
+        cwd,
+        checkpointRefs: input.checkpointRefs,
+      });
+    });
+  };
 
   const snapshotAndPurgeThread = (threadId: string) =>
     Effect.gen(function* () {
@@ -484,20 +526,11 @@ const makeProfileStatsArchive = Effect.gen(function* () {
       if (checkpointCleanup === null) {
         return false;
       }
-      if (checkpointCleanup.checkpointRefs.length > 0) {
-        const cwd = checkpointCleanup.cwd;
-        if (cwd === null) {
-          return yield* Effect.fail(
-            new Error(
-              `Cannot purge checkpoint refs for thread ${input.threadId} because its workspace is unavailable.`,
-            ),
-          );
-        }
-        yield* checkpointStore.deleteCheckpointRefs({
-          cwd,
-          checkpointRefs: checkpointCleanup.checkpointRefs,
-        });
-      }
+      yield* deleteCheckpointRefsForPurge({
+        threadId: input.threadId,
+        cwd: checkpointCleanup.cwd,
+        checkpointRefs: checkpointCleanup.checkpointRefs,
+      });
       return yield* sql.withTransaction(snapshotAndPurgeThread(input.threadId));
     });
 

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -26,6 +26,7 @@ import { ServerAuthPolicyLive } from "./auth/Layers/ServerAuthPolicy";
 import { ServerSecretStoreLive } from "./auth/Layers/ServerSecretStore";
 import { SessionCredentialServiceLive } from "./auth/Layers/SessionCredentialService";
 import { ProfileStatsQueryLive } from "./profileStats";
+import { ProfileStatsArchiveLive } from "./profileStatsArchive";
 import { ServerLifecycleEventsLive } from "./serverLifecycleEvents";
 import { ServerRuntimeStartupLive } from "./serverRuntimeStartup";
 import { ServerSettingsLive } from "./serverSettings";
@@ -69,6 +70,7 @@ export function makeServerRuntimeServicesLayer() {
     Layer.provideMerge(checkpointReactorLayer),
   );
   const threadDeletionReactorLayer = ThreadDeletionReactorLive.pipe(
+    Layer.provideMerge(ProfileStatsArchiveLive),
     Layer.provideMerge(OrchestrationLayerLive),
     Layer.provideMerge(TerminalLayerLive),
   );

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -64,13 +64,16 @@ export function makeServerRuntimeServicesLayer() {
   const checkpointReactorLayer = CheckpointReactorLive.pipe(
     Layer.provideMerge(runtimeServicesLayer),
   );
+  const profileStatsArchiveLayer = ProfileStatsArchiveLive.pipe(
+    Layer.provideMerge(checkpointStoreLayer),
+  );
   const orchestrationReactorLayer = OrchestrationReactorLive.pipe(
     Layer.provideMerge(runtimeIngestionLayer),
     Layer.provideMerge(providerCommandReactorLayer),
     Layer.provideMerge(checkpointReactorLayer),
   );
   const threadDeletionReactorLayer = ThreadDeletionReactorLive.pipe(
-    Layer.provideMerge(ProfileStatsArchiveLive),
+    Layer.provideMerge(profileStatsArchiveLayer),
     Layer.provideMerge(OrchestrationLayerLive),
     Layer.provideMerge(TerminalLayerLive),
   );

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -120,6 +120,7 @@ export function makeServerRuntimeServicesLayer() {
     automationServiceLayer,
     automationSchedulerLayer,
     automationRunReactorLayer,
+    AutomationRepositoryLive,
     orchestrationReactorLayer,
     threadDeletionReactorLayer,
     devServerManagerLayer,

--- a/apps/server/src/threadRetention.test.ts
+++ b/apps/server/src/threadRetention.test.ts
@@ -106,4 +106,25 @@ describe("thread retention", () => {
       getInactiveThreadIdsForRetention(makeReadModel([pinnedThread, unpinnedThread]), nowMs),
     ).toEqual([unpinnedThread.id]);
   });
+
+  it("does not select enabled heartbeat automation target threads", () => {
+    const nowMs = Date.parse("2026-04-20T00:00:00.000Z");
+    const oldActivityAt = new Date(nowMs - THREAD_RETENTION_UNUSED_MS - 1).toISOString();
+    const heartbeatTarget = makeReadModelThread({
+      id: ThreadId.makeUnsafe("thread-heartbeat-target"),
+      latestUserMessageAt: oldActivityAt,
+    });
+    const ordinaryThread = makeReadModelThread({
+      id: ThreadId.makeUnsafe("thread-ordinary"),
+      latestUserMessageAt: oldActivityAt,
+    });
+
+    expect(
+      getInactiveThreadIdsForRetention(
+        makeReadModel([heartbeatTarget, ordinaryThread]),
+        nowMs,
+        new Set([heartbeatTarget.id]),
+      ),
+    ).toEqual([ordinaryThread.id]);
+  });
 });

--- a/apps/server/src/threadRetention.ts
+++ b/apps/server/src/threadRetention.ts
@@ -14,6 +14,10 @@ import { randomUUID } from "node:crypto";
 
 import type { OrchestrationEngineShape } from "./orchestration/Services/OrchestrationEngine";
 import type { ProjectionSnapshotQueryShape } from "./orchestration/Services/ProjectionSnapshotQuery";
+import {
+  AutomationRepository,
+  type AutomationRepositoryShape,
+} from "./persistence/Services/AutomationRepository";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents";
 
 // Marks thread.delete commands issued by the retention sweep. Retention only
@@ -61,6 +65,26 @@ function isThreadBusy(thread: RetentionThread): boolean {
     return true;
   }
   return false;
+}
+
+function listRetentionProtectedThreadIds(
+  automationRepository: AutomationRepositoryShape,
+): Effect.Effect<ReadonlySet<ThreadId>, unknown> {
+  return automationRepository.list({ includeArchived: false }).pipe(
+    Effect.map((result) => {
+      const protectedThreadIds = new Set<ThreadId>();
+      for (const definition of result.definitions) {
+        if (
+          definition.enabled &&
+          definition.mode === "heartbeat" &&
+          definition.targetThreadId !== null
+        ) {
+          protectedThreadIds.add(definition.targetThreadId);
+        }
+      }
+      return protectedThreadIds;
+    }),
+  );
 }
 
 function chunkThreadIds(
@@ -115,12 +139,14 @@ const publishRetentionMaintenance = Effect.fn("publishRetentionMaintenance")(fun
 export function getInactiveThreadIdsForRetention(
   readModel: Pick<OrchestrationReadModel, "threads"> | Pick<OrchestrationShellSnapshot, "threads">,
   nowMs = Date.now(),
+  protectedThreadIds: ReadonlySet<ThreadId> = new Set(),
 ): ThreadId[] {
   const cutoffMs = nowMs - THREAD_RETENTION_UNUSED_MS;
   const inactiveThreadIds: ThreadId[] = [];
 
   for (const thread of readModel.threads) {
     if ("deletedAt" in thread && thread.deletedAt !== null) continue;
+    if (protectedThreadIds.has(thread.id)) continue;
     if (thread.isPinned === true) continue;
     if (isThreadBusy(thread)) continue;
     const lastActivityMs = getThreadLastActivityMs(thread);
@@ -134,9 +160,15 @@ export function getInactiveThreadIdsForRetention(
 export const runThreadRetentionSweep = Effect.fn("runThreadRetentionSweep")(function* (
   orchestrationEngine: OrchestrationEngineShape,
   projectionSnapshotQuery: ProjectionSnapshotQueryShape,
+  automationRepository: AutomationRepositoryShape,
 ) {
   const shellSnapshot = yield* projectionSnapshotQuery.getShellSnapshot();
-  const inactiveThreadIds = getInactiveThreadIdsForRetention(shellSnapshot);
+  const protectedThreadIds = yield* listRetentionProtectedThreadIds(automationRepository);
+  const inactiveThreadIds = getInactiveThreadIdsForRetention(
+    shellSnapshot,
+    Date.now(),
+    protectedThreadIds,
+  );
   const totalCandidateCount = inactiveThreadIds.length;
   let deletedCount = 0;
 
@@ -204,14 +236,25 @@ export const startThreadRetentionJob = Effect.fn("startThreadRetentionJob")(func
   orchestrationEngine: OrchestrationEngineShape,
   projectionSnapshotQuery: ProjectionSnapshotQueryShape,
 ) {
+  const automationRepository = yield* AutomationRepository;
   // Give startup/projection bootstrap a short settling window, then run one
   // hide pass promptly so desktop installs do not need to stay open for 24 hours.
   yield* Effect.gen(function* () {
     yield* Effect.sleep(THREAD_RETENTION_INITIAL_SWEEP_DELAY_MS);
-    yield* runThreadRetentionSweep(orchestrationEngine, projectionSnapshotQuery);
+    yield* runThreadRetentionSweep(
+      orchestrationEngine,
+      projectionSnapshotQuery,
+      automationRepository,
+    );
     yield* Effect.forever(
       Effect.sleep(THREAD_RETENTION_SWEEP_INTERVAL_MS).pipe(
-        Effect.flatMap(() => runThreadRetentionSweep(orchestrationEngine, projectionSnapshotQuery)),
+        Effect.flatMap(() =>
+          runThreadRetentionSweep(
+            orchestrationEngine,
+            projectionSnapshotQuery,
+            automationRepository,
+          ),
+        ),
       ),
       { disableYield: true },
     );

--- a/apps/server/src/threadRetention.ts
+++ b/apps/server/src/threadRetention.ts
@@ -16,6 +16,11 @@ import type { OrchestrationEngineShape } from "./orchestration/Services/Orchestr
 import type { ProjectionSnapshotQueryShape } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents";
 
+// Marks thread.delete commands issued by the retention sweep. Retention only
+// hides threads from the app; deletion flows use this prefix to tell retention
+// hides apart from explicit user deletes (which purge the thread's data).
+export const THREAD_RETENTION_COMMAND_ID_PREFIX = "thread-retention:";
+
 export const THREAD_RETENTION_UNUSED_MS = 7 * 24 * 60 * 60 * 1000;
 export const THREAD_RETENTION_INITIAL_SWEEP_DELAY_MS = 5 * 60 * 1000;
 export const THREAD_RETENTION_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -154,7 +159,9 @@ export const runThreadRetentionSweep = Effect.fn("runThreadRetentionSweep")(func
           orchestrationEngine
             .dispatch({
               type: "thread.delete",
-              commandId: CommandId.makeUnsafe(`thread-retention:${randomUUID()}`),
+              commandId: CommandId.makeUnsafe(
+                `${THREAD_RETENTION_COMMAND_ID_PREFIX}${randomUUID()}`,
+              ),
               threadId,
             })
             .pipe(

--- a/packages/contracts/src/stats.ts
+++ b/packages/contracts/src/stats.ts
@@ -2,6 +2,8 @@
 // Purpose: Schemas for the local profile-stats RPCs that power the Profile page and
 // the shareable activity card. All metrics are backed by Synara's local DB
 // projections; no provider archive or cloud data is part of this contract.
+// Metrics are lifetime totals: deleting a thread or project from the app never
+// subtracts the work it already contributed to the profile.
 // Layer: shared contracts (schema-only, no runtime logic)
 
 import { Schema } from "effect";


### PR DESCRIPTION
## Summary
- Add a profile-stats archive so purged threads can be hard-deleted without losing lifetime metrics.
- Update profile stats queries to merge live projection data with archived rows for prompts, tokens, turns, skills, and most-worked project rankings.
- Add startup cleanup logic for old soft-deleted threads and migration support for the new archive tables.
- Expand coverage for archive/purge flows, retention-hidden threads, and deleted-project behavior.

## Testing
- Not run (PR content only).
- Covered by new tests in `apps/server/src/profileStatsArchive.test.ts` and updates to `apps/server/src/profileStats.test.ts`.
- Added migration coverage through `apps/server/src/persistence/Migrations/050_ProfileStatsArchive.ts`.