### PR TITLE
fix(acp): prevent assistant message ID collisions across runtime restarts

### DIFF
--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -103,6 +103,46 @@ describe("AcpSessionRuntime", () => {
     ),
   );
 
+  it.effect(
+    "assigns distinct fallback assistant item ids across separate runtime instances",
+    () => {
+      const runtimeLayer = AcpSessionRuntime.layer({
+        spawn: {
+          command: bunExe,
+          args: [mockAgentPath],
+        },
+        cwd: process.cwd(),
+        resumeSessionId: "mock-session-1",
+        clientInfo: { name: "t3-test", version: "0.0.0" },
+        authMethodId: "test",
+      });
+
+      const collectFallbackAssistantItemId = Effect.gen(function* () {
+        const runtime = yield* AcpSessionRuntime;
+        yield* runtime.start();
+        const eventsFiber = yield* Stream.runCollect(Stream.take(runtime.getEvents(), 4)).pipe(
+          Effect.forkChild,
+        );
+        yield* runtime.prompt({
+          prompt: [{ type: "text", text: "hi" }],
+        });
+        const notes = Array.from(yield* Fiber.join(eventsFiber));
+        const delta = notes.find((note) => note._tag === "ContentDelta");
+        expect(delta?._tag).toBe("ContentDelta");
+        return delta?._tag === "ContentDelta" ? delta.itemId : undefined;
+      }).pipe(Effect.provide(runtimeLayer), Effect.scoped, Effect.provide(NodeServices.layer));
+
+      return Effect.gen(function* () {
+        const firstItemId = yield* collectFallbackAssistantItemId;
+        const secondItemId = yield* collectFallbackAssistantItemId;
+        const fallbackIdPattern = /^assistant:mock-session-1:[0-9a-f]{8}:segment:0$/;
+        expect(firstItemId).toMatch(fallbackIdPattern);
+        expect(secondItemId).toMatch(fallbackIdPattern);
+        expect(firstItemId).not.toBe(secondItemId);
+      });
+    },
+  );
+
   it.effect("starts a session, prompts, and emits normalized events against the mock agent", () =>
     Effect.gen(function* () {
       const runtime = yield* AcpSessionRuntime;

--- a/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { assistantItemId } from "./AcpSessionRuntime.ts";
+
+describe("assistantItemId", () => {
+  it("produces distinct ids across runtime instances with the same session id and segment index", () => {
+    const sessionId = "session-1";
+    const a = assistantItemId(sessionId, "aaaa1111", 0);
+    const b = assistantItemId(sessionId, "bbbb2222", 0);
+    expect(a).not.toBe(b);
+    expect(a).toBe("assistant:session-1:aaaa1111:segment:0");
+    expect(b).toBe("assistant:session-1:bbbb2222:segment:0");
+  });
+});

--- a/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import { assistantItemId } from "./AcpSessionRuntime.ts";
 
 describe("assistantItemId", () => {
+  // Format contract only — distinct runtimeInstanceId wiring is covered by
+  // AcpJsonRpcConnection.test.ts ("assigns distinct fallback assistant item ids...").
   it("produces distinct ids across runtime instances with the same session id and segment index", () => {
     const sessionId = "session-1";
     const a = assistantItemId(sessionId, "aaaa1111", 0);

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { prepareWindowsSafeProcess } from "@t3tools/shared/windowsProcess";
 import {
   Cause,
@@ -177,6 +178,9 @@ const makeAcpSessionRuntime = (
     const modeStateRef = yield* Ref.make<AcpSessionModeState | undefined>(undefined);
     const toolCallsRef = yield* Ref.make(new Map<string, AcpToolCallState>());
     const assistantSegmentRef = yield* Ref.make<AcpAssistantSegmentState>({ nextSegmentIndex: 0 });
+    // Unique per runtime instance so assistant message ids never collide across
+    // server restarts or session resumes (segment index resets to 0 each time).
+    const runtimeInstanceId = randomUUID().slice(0, 8);
     const configOptionsRef = yield* Ref.make(sessionConfigOptionsFromSetup(undefined));
     const startStateRef = yield* Ref.make<AcpStartState>({ _tag: "NotStarted" });
     // session/load can replay a large history before the consumer attaches; drop
@@ -282,6 +286,7 @@ const makeAcpSessionRuntime = (
               modeStateRef,
               toolCallsRef,
               assistantSegmentRef,
+              runtimeInstanceId,
               params: notification,
             })
           : Effect.void,
@@ -669,12 +674,14 @@ const handleSessionUpdate = ({
   modeStateRef,
   toolCallsRef,
   assistantSegmentRef,
+  runtimeInstanceId,
   params,
 }: {
   readonly offer: (event: AcpParsedSessionEvent) => Effect.Effect<void>;
   readonly modeStateRef: Ref.Ref<AcpSessionModeState | undefined>;
   readonly toolCallsRef: Ref.Ref<Map<string, AcpToolCallState>>;
   readonly assistantSegmentRef: Ref.Ref<AcpAssistantSegmentState>;
+  readonly runtimeInstanceId: string;
   readonly params: EffectAcpSchema.SessionNotification;
 }): Effect.Effect<void> =>
   Effect.gen(function* () {
@@ -726,6 +733,7 @@ const handleSessionUpdate = ({
           offer,
           assistantSegmentRef,
           sessionId: params.sessionId,
+          runtimeInstanceId,
           requestedItemId: event.itemId,
         });
         yield* offer({
@@ -770,18 +778,23 @@ function shouldEmitToolCallUpdate(
   return previous.detail !== next.detail;
 }
 
-const assistantItemId = (sessionId: string, segmentIndex: number) =>
-  `assistant:${sessionId}:segment:${segmentIndex}`;
+export const assistantItemId = (
+  sessionId: string,
+  runtimeInstanceId: string,
+  segmentIndex: number,
+) => `assistant:${sessionId}:${runtimeInstanceId}:segment:${segmentIndex}`;
 
 const ensureActiveAssistantSegment = ({
   offer,
   assistantSegmentRef,
   sessionId,
+  runtimeInstanceId,
   requestedItemId,
 }: {
   readonly offer: (event: AcpParsedSessionEvent) => Effect.Effect<void>;
   readonly assistantSegmentRef: Ref.Ref<AcpAssistantSegmentState>;
   readonly sessionId: string;
+  readonly runtimeInstanceId: string;
   readonly requestedItemId?: string | undefined;
 }) =>
   Ref.modify<AcpAssistantSegmentState, EnsureActiveAssistantSegmentResult>(
@@ -795,7 +808,8 @@ const ensureActiveAssistantSegment = ({
       }
       // Cursor can provide stable message ids for chunks that resume after tool calls.
       // Keep those ids so projection appends the pieces instead of displaying broken segments.
-      const itemId = requestedItemId ?? assistantItemId(sessionId, current.nextSegmentIndex);
+      const itemId =
+        requestedItemId ?? assistantItemId(sessionId, runtimeInstanceId, current.nextSegmentIndex);
       const completedEvent = current.activeItemId
         ? ({
             _tag: "AssistantItemCompleted",


### PR DESCRIPTION
## Summary

- Assistant message IDs were built as `assistant:{sessionId}:segment:{N}`, where the segment index resets to 0 on every `AcpSessionRuntime` creation (server restart or session resume).
- When a session was resumed with the same `sessionId`, post-restart assistant segments collided with pre-restart ones. The projection's `ON CONFLICT DO UPDATE` then overwrote earlier messages in the middle of the transcript instead of appending new ones, making assistant replies silently disappear.
- Add a per-runtime-instance UUID (8 chars) to the ID so segments from different runtime instances never collide, even when the `sessionId` and segment index are identical.

Affects **Cursor** when the provider does not supply stable `itemId`s and the runtime uses the fallback ID path. Grok already scopes fallback item IDs by turn via `scopeGrokRuntimeItemIdForTurn` (`grok:{turnId}:{itemId}`), and turn IDs are unique across restarts, so Grok was not susceptible to this collision. Non-ACP providers (Codex, Claude, Gemini, OpenCode, Pi) use their own ID generation and are unaffected.

**Known behavior change:** if the server restarts mid-stream, post-restart continuation appears as a new message rather than overwriting the partial one. That is strictly better than silent data loss.

#### Test plan
- [x] Unit test: `assistantItemId` format contract (distinct IDs for different runtime instance IDs)
- [x] Integration test: two separate `AcpSessionRuntime` spawns with the same resumed session produce distinct fallback assistant item IDs
- [x] All existing tests pass
- [x] `bun fmt`, `bun lint`, `bun typecheck` all pass

Generated with [Devin](https://devin.ai)