### PR TITLE
feat(pi): surface subagent activity

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -25,9 +25,9 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.154",
     "@anthropic-ai/sdk": "^0.100.0",
-    "@earendil-works/pi-agent-core": "^0.74.0",
-    "@earendil-works/pi-ai": "^0.74.0",
-    "@earendil-works/pi-coding-agent": "^0.74.0",
+    "@earendil-works/pi-agent-core": "^0.79.0",
+    "@earendil-works/pi-ai": "^0.79.0",
+    "@earendil-works/pi-coding-agent": "^0.79.0",
     "@effect/platform-node": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
     "@opencode-ai/sdk": "^1.15.13",

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -1901,6 +1901,75 @@ it.layer(BaseTestLayer)("OrchestrationProjectionPipeline", (it) => {
     }),
   );
 
+  it.effect("does not append replayed streaming text to finalized projected messages", () =>
+    Effect.gen(function* () {
+      const projectionPipeline = yield* OrchestrationProjectionPipeline;
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const now = new Date().toISOString();
+
+      yield* sql`
+        INSERT INTO projection_thread_messages (
+          message_id,
+          thread_id,
+          turn_id,
+          role,
+          text,
+          is_streaming,
+          source,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          'assistant-replay',
+          'thread-replay',
+          NULL,
+          'assistant',
+          'Child answer.',
+          0,
+          'native',
+          ${now},
+          ${now}
+        )
+      `;
+
+      yield* eventStore.append({
+        type: "thread.message-sent",
+        eventId: EventId.makeUnsafe("evt-replay-streaming-duplicate"),
+        aggregateKind: "thread",
+        aggregateId: ThreadId.makeUnsafe("thread-replay"),
+        occurredAt: now,
+        commandId: CommandId.makeUnsafe("cmd-replay-streaming-duplicate"),
+        causationEventId: null,
+        correlationId: CorrelationId.makeUnsafe("cmd-replay-streaming-duplicate"),
+        metadata: {},
+        payload: {
+          threadId: ThreadId.makeUnsafe("thread-replay"),
+          messageId: MessageId.makeUnsafe("assistant-replay"),
+          role: "assistant",
+          text: "Child answer.",
+          turnId: null,
+          streaming: true,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+
+      yield* projectionPipeline.bootstrap;
+
+      const messageRows = yield* sql<{ readonly text: string; readonly isStreaming: unknown }>`
+        SELECT
+          text,
+          is_streaming AS "isStreaming"
+        FROM projection_thread_messages
+        WHERE message_id = 'assistant-replay'
+      `;
+      assert.equal(messageRows.length, 1);
+      assert.equal(messageRows[0]?.text, "Child answer.");
+      assert.isFalse(Boolean(messageRows[0]?.isStreaming));
+    }),
+  );
+
   it.effect(
     "resolves turn-count conflicts when checkpoint completion rewrites provisional turns",
     () =>

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -80,6 +80,10 @@ import {
   toSafeThreadAttachmentSegment,
 } from "../../attachmentStore.ts";
 import { deriveThreadSummaryState } from "@t3tools/shared/threadSummary";
+import {
+  mergeProjectedMessageStreaming,
+  mergeProjectedMessageText,
+} from "../messageProjectionMerge.ts";
 
 export const ORCHESTRATION_PROJECTOR_NAMES = {
   projects: "projection.projects",
@@ -1076,12 +1080,14 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
           const existingMessage = yield* projectionThreadMessageRepository.getByMessageId({
             messageId: event.payload.messageId,
           });
-          const nextText =
-            Option.isSome(existingMessage) && event.payload.streaming
-              ? `${existingMessage.value.text}${event.payload.text}`
-              : Option.isSome(existingMessage) && event.payload.text.length === 0
-                ? existingMessage.value.text
-                : event.payload.text;
+          const nextText = mergeProjectedMessageText({
+            existingText: Option.isSome(existingMessage) ? existingMessage.value.text : undefined,
+            existingStreaming: Option.isSome(existingMessage)
+              ? existingMessage.value.isStreaming
+              : undefined,
+            incomingText: event.payload.text,
+            incomingStreaming: event.payload.streaming,
+          });
           const nextAttachments =
             event.payload.attachments !== undefined
               ? yield* materializeAttachmentsForProjection({
@@ -1108,7 +1114,12 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
             ...(event.payload.dispatchOrigin !== undefined
               ? { dispatchOrigin: event.payload.dispatchOrigin }
               : {}),
-            isStreaming: event.payload.streaming,
+            isStreaming: mergeProjectedMessageStreaming({
+              existingStreaming: Option.isSome(existingMessage)
+                ? existingMessage.value.isStreaming
+                : undefined,
+              incomingStreaming: event.payload.streaming,
+            }),
             source: event.payload.source,
             createdAt:
               (Option.isSome(existingMessage) ? existingMessage.value.createdAt : null) ??

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -4166,6 +4166,73 @@ describe("ProviderRuntimeIngestion", () => {
     ).toBe(false);
   });
 
+  it("imports provider user-message lifecycle events into subagent child threads", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-child-user-message"),
+      provider: "pi",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      itemId: asItemId("pi-subagent-prompt-child-provider-1"),
+      providerRefs: {
+        providerThreadId: "child-provider-1",
+        providerParentThreadId: "parent-provider-1",
+      },
+      payload: {
+        itemType: "user_message",
+        status: "completed",
+        title: "Subagent prompt",
+        detail: "Run a deterministic child-thread prompt smoke test.",
+      },
+    });
+
+    const childThread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.id === "subagent:thread-1:child-provider-1" &&
+        entry.messages.some(
+          (message: { role: string; text: string }) =>
+            message.role === "user" &&
+            message.text === "Run a deterministic child-thread prompt smoke test.",
+        ),
+      2000,
+      asThreadId("subagent:thread-1:child-provider-1"),
+    );
+
+    expect(childThread.messages.map((message) => ({ role: message.role, text: message.text }))).toEqual([
+      { role: "user", text: "Run a deterministic child-thread prompt smoke test." },
+    ]);
+  });
+
+  it("does not import parent-thread provider user-message lifecycle events", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-parent-user-message"),
+      provider: "pi",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      itemId: asItemId("parent-prompt-1"),
+      payload: {
+        itemType: "user_message",
+        status: "completed",
+        title: "User message",
+        detail: "This parent prompt should not be imported a second time.",
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const parentThread = readModel.threads.find((entry) => entry.id === "thread-1");
+
+    expect(parentThread?.messages).toEqual([]);
+  });
+
   it("handles collab receiver and child provider refs on the same event without duplicate thread creation", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -4188,6 +4188,24 @@ describe("ProviderRuntimeIngestion", () => {
         detail: "Run a deterministic child-thread prompt smoke test.",
       },
     });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-child-user-message-replayed"),
+      provider: "pi",
+      createdAt: new Date().toISOString(),
+      threadId: asThreadId("thread-1"),
+      itemId: asItemId("pi-subagent-prompt-child-provider-1"),
+      providerRefs: {
+        providerThreadId: "child-provider-1",
+        providerParentThreadId: "parent-provider-1",
+      },
+      payload: {
+        itemType: "user_message",
+        status: "completed",
+        title: "Subagent prompt",
+        detail: "Run a deterministic child-thread prompt smoke test.",
+      },
+    });
 
     const childThread = await waitForThread(
       harness.engine,
@@ -4205,6 +4223,95 @@ describe("ProviderRuntimeIngestion", () => {
     expect(childThread.messages.map((message) => ({ role: message.role, text: message.text }))).toEqual([
       { role: "user", text: "Run a deterministic child-thread prompt smoke test." },
     ]);
+  });
+
+  it("does not append duplicate child assistant text when synthetic transcript events replay", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-child-replay-streaming-mode"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("message-child-replay-streaming-mode"),
+          role: "user",
+          text: "stream child transcript please",
+          attachments: [],
+        },
+        assistantDeliveryMode: "streaming",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await harness.drain();
+
+    const providerRefs = {
+      providerThreadId: "child-provider-1",
+      providerParentThreadId: "parent-provider-1",
+    };
+    const emitChildAssistantTranscript = (): void => {
+      harness.emit({
+        type: "content.delta",
+        eventId: asEventId("evt-child-assistant-delta-replay"),
+        provider: "pi",
+        createdAt: now,
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-child-replay"),
+        itemId: asItemId("item-child-assistant-replay"),
+        providerRefs,
+        payload: {
+          streamKind: "assistant_text",
+          delta: "Child answer.",
+        },
+      });
+      harness.emit({
+        type: "item.completed",
+        eventId: asEventId("evt-child-assistant-completed-replay"),
+        provider: "pi",
+        createdAt: now,
+        threadId: asThreadId("thread-1"),
+        turnId: asTurnId("turn-child-replay"),
+        itemId: asItemId("item-child-assistant-replay"),
+        providerRefs,
+        payload: {
+          itemType: "assistant_message",
+          status: "completed",
+          detail: "Child answer.",
+        },
+      });
+    };
+
+    emitChildAssistantTranscript();
+
+    await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-child-assistant-replay" &&
+            message.text === "Child answer." &&
+            !message.streaming,
+        ),
+      2000,
+      asThreadId("subagent:thread-1:child-provider-1"),
+    );
+
+    emitChildAssistantTranscript();
+    await harness.drain();
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const childThread = readModel.threads.find(
+      (entry) => entry.id === "subagent:thread-1:child-provider-1",
+    );
+    const childMessage = childThread?.messages.find(
+      (entry) => entry.id === "assistant:item-child-assistant-replay",
+    );
+
+    expect(childMessage?.text).toBe("Child answer.");
+    expect(childMessage?.streaming).toBe(false);
   });
 
   it("does not import parent-thread provider user-message lifecycle events", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -4220,9 +4220,9 @@ describe("ProviderRuntimeIngestion", () => {
       asThreadId("subagent:thread-1:child-provider-1"),
     );
 
-    expect(childThread.messages.map((message) => ({ role: message.role, text: message.text }))).toEqual([
-      { role: "user", text: "Run a deterministic child-thread prompt smoke test." },
-    ]);
+    expect(
+      childThread.messages.map((message) => ({ role: message.role, text: message.text })),
+    ).toEqual([{ role: "user", text: "Run a deterministic child-thread prompt smoke test." }]);
   });
 
   it("does not append duplicate child assistant text when synthetic transcript events replay", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -2325,6 +2325,30 @@ const make = Effect.gen(function* () {
       const proposedPlanDelta =
         event.type === "turn.proposed.delta" ? event.payload.delta : undefined;
 
+      if (
+        isChildThreadEvent &&
+        event.type === "item.completed" &&
+        event.payload.itemType === "user_message" &&
+        event.payload.detail &&
+        event.itemId
+      ) {
+        yield* orchestrationEngine.dispatch({
+          type: "thread.messages.import",
+          commandId: providerCommandId(event, "user-message-import"),
+          threadId: thread.id,
+          messages: [
+            {
+              messageId: MessageId.makeUnsafe(`user:${event.itemId}`),
+              role: "user",
+              text: event.payload.detail,
+              createdAt: event.createdAt,
+              updatedAt: event.createdAt,
+            },
+          ],
+          createdAt: event.createdAt,
+        });
+      }
+
       if (assistantDelta && assistantDelta.length > 0) {
         const assistantMessageId = MessageId.makeUnsafe(
           `assistant:${event.itemId ?? event.turnId ?? event.eventId}`,

--- a/apps/server/src/orchestration/messageProjectionMerge.ts
+++ b/apps/server/src/orchestration/messageProjectionMerge.ts
@@ -1,0 +1,34 @@
+// FILE: messageProjectionMerge.ts
+// Purpose: Shares replay-safe projected message merge rules across live and persisted projections.
+// Layer: Orchestration projection helper
+// Exports: mergeProjectedMessageText, mergeProjectedMessageStreaming
+
+export function mergeProjectedMessageText(input: {
+  readonly existingText?: string | undefined;
+  readonly existingStreaming?: boolean | undefined;
+  readonly incomingText: string;
+  readonly incomingStreaming: boolean;
+}): string {
+  if (input.existingText === undefined) {
+    return input.incomingText;
+  }
+  if (input.incomingStreaming) {
+    if (input.existingStreaming) {
+      return `${input.existingText}${input.incomingText}`;
+    }
+    return input.incomingText.length > 0 && !input.existingText.includes(input.incomingText)
+      ? `${input.existingText}${input.incomingText}`
+      : input.existingText;
+  }
+  return input.incomingText.length > 0 ? input.incomingText : input.existingText;
+}
+
+export function mergeProjectedMessageStreaming(input: {
+  readonly existingStreaming?: boolean | undefined;
+  readonly incomingStreaming: boolean;
+}): boolean {
+  if (input.existingStreaming === undefined) {
+    return input.incomingStreaming;
+  }
+  return input.existingStreaming ? input.incomingStreaming : false;
+}

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -21,6 +21,10 @@ import { Effect, Schema } from "effect";
 
 import { toProjectorDecodeError, type OrchestrationProjectorDecodeError } from "./Errors.ts";
 import {
+  mergeProjectedMessageStreaming,
+  mergeProjectedMessageText,
+} from "./messageProjectionMerge.ts";
+import {
   MessageSentPayloadSchema,
   ProjectCreatedPayload,
   ProjectDeletedPayload,
@@ -715,17 +719,16 @@ export function projectEvent(
               entry.id === message.id
                 ? {
                     ...entry,
-                    // Late streaming deltas can be real append-only metadata (generated images)
-                    // or a replay of finalized assistant text. Only append unseen text.
-                    text:
-                      message.streaming && entry.streaming
-                        ? `${entry.text}${message.text}`
-                        : message.streaming && !entry.text.includes(message.text)
-                          ? `${entry.text}${message.text}`
-                        : !message.streaming && message.text.length > 0
-                          ? message.text
-                          : entry.text,
-                    streaming: entry.streaming ? message.streaming : false,
+                    text: mergeProjectedMessageText({
+                      existingText: entry.text,
+                      existingStreaming: entry.streaming,
+                      incomingText: message.text,
+                      incomingStreaming: message.streaming,
+                    }),
+                    streaming: mergeProjectedMessageStreaming({
+                      existingStreaming: entry.streaming,
+                      incomingStreaming: message.streaming,
+                    }),
                     source: message.source,
                     updatedAt: message.updatedAt,
                     turnId: resolveStableMessageTurnId({

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -715,12 +715,17 @@ export function projectEvent(
               entry.id === message.id
                 ? {
                     ...entry,
-                    text: message.streaming
-                      ? `${entry.text}${message.text}`
-                      : message.text.length > 0
-                        ? message.text
-                        : entry.text,
-                    streaming: message.streaming,
+                    // Late streaming deltas can be real append-only metadata (generated images)
+                    // or a replay of finalized assistant text. Only append unseen text.
+                    text:
+                      message.streaming && entry.streaming
+                        ? `${entry.text}${message.text}`
+                        : message.streaming && !entry.text.includes(message.text)
+                          ? `${entry.text}${message.text}`
+                        : !message.streaming && message.text.length > 0
+                          ? message.text
+                          : entry.text,
+                    streaming: entry.streaming ? message.streaming : false,
                     source: message.source,
                     updatedAt: message.updatedAt,
                     turnId: resolveStableMessageTurnId({

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -9,6 +9,7 @@ import {
   ensurePiSubagentChildLauncherEnv,
   getPiSupportedThinkingOptions,
   makePiSubagentPromptItemId,
+  makePiSubagentSourceKey,
   makePiUserInputOptions,
   PLAIN_PI_EXTENSION_THEME,
 } from "./PiAdapter";
@@ -107,12 +108,91 @@ describe("Pi subagent child launcher env", () => {
 });
 
 describe("Pi subagent transcript helpers", () => {
-  it("uses distinct prompt item ids for repeated prompts to the same child thread", () => {
-    const first = makePiSubagentPromptItemId("child-provider-1");
-    const second = makePiSubagentPromptItemId("child-provider-1");
+  it("keys prompt item ids by child thread and transcript source", () => {
+    const sourceKey = makePiSubagentSourceKey({
+      kind: "subagent_result",
+      parentThreadId: "thread-1",
+      providerThreadId: "child-provider-1",
+      sessionFile: "/tmp/pi-child.jsonl",
+    });
+    const laterSourceKey = makePiSubagentSourceKey({
+      kind: "subagent_result",
+      parentThreadId: "thread-1",
+      providerThreadId: "child-provider-1",
+      sessionFile: "/tmp/pi-child-later.jsonl",
+    });
+    const first = makePiSubagentPromptItemId({
+      providerThreadId: "child-provider-1",
+      sourceKey,
+    });
+    const replay = makePiSubagentPromptItemId({
+      providerThreadId: "child-provider-1",
+      sourceKey,
+    });
+    const laterPrompt = makePiSubagentPromptItemId({
+      providerThreadId: "child-provider-1",
+      sourceKey: laterSourceKey,
+    });
 
-    expect(first).not.toBe(second);
-    expect(first).toMatch(/^pi-subagent-prompt-child-provider-1-/);
-    expect(second).toMatch(/^pi-subagent-prompt-child-provider-1-/);
+    expect(replay).toBe(first);
+    expect(laterPrompt).not.toBe(first);
+    expect(first).toMatch(/^pi-subagent-prompt-[a-f0-9]{24}$/);
+  });
+
+  it("uses the same session transcript source across Pi import surfaces", () => {
+    const messageSurface = makePiSubagentSourceKey({
+      kind: "subagent_result",
+      parentThreadId: "thread-1",
+      providerThreadId: "child-provider-1",
+      sessionFile: "/tmp/pi-child.jsonl",
+    });
+    const toolSurface = makePiSubagentSourceKey({
+      kind: "subagent",
+      parentThreadId: "thread-1",
+      providerThreadId: "child-provider-1",
+      sessionFile: "/tmp/pi-child.jsonl",
+      toolCallId: "call-1",
+    });
+
+    expect(toolSurface).toBe(messageSurface);
+    expect(
+      makePiSubagentPromptItemId({
+        providerThreadId: "child-provider-1",
+        sourceKey: toolSurface,
+      }),
+    ).toBe(
+      makePiSubagentPromptItemId({
+        providerThreadId: "child-provider-1",
+        sourceKey: messageSurface,
+      }),
+    );
+  });
+
+  it("scopes session transcript ids to the parent Synara thread", () => {
+    const firstParent = makePiSubagentSourceKey({
+      kind: "subagent_result",
+      parentThreadId: "thread-1",
+      providerThreadId: "child-provider-1",
+      sessionFile: "/tmp/pi-child.jsonl",
+    });
+    const secondParent = makePiSubagentSourceKey({
+      kind: "subagent_result",
+      parentThreadId: "thread-2",
+      providerThreadId: "child-provider-1",
+      sessionFile: "/tmp/pi-child.jsonl",
+    });
+
+    expect(secondParent).not.toBe(firstParent);
+    expect(
+      makePiSubagentPromptItemId({
+        providerThreadId: "child-provider-1",
+        sourceKey: secondParent,
+      }),
+    ).not.toBe(
+      makePiSubagentPromptItemId({
+        providerThreadId: "child-provider-1",
+        sourceKey: firstParent,
+      }),
+    );
   });
 });

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -123,6 +123,15 @@ describe("Pi subagent child launcher env", () => {
 
     expect(env.PI_SUBAGENT_PI_COMMAND).toBe("/opt/pi/bin/pi");
   });
+
+  it("resets an adapter-owned configured Pi binary for later default sessions", () => {
+    const env: { PI_SUBAGENT_PI_COMMAND?: string } = {};
+
+    ensurePiSubagentChildLauncherEnv(env, "/opt/pi/bin/pi");
+    ensurePiSubagentChildLauncherEnv(env);
+
+    expect(env.PI_SUBAGENT_PI_COMMAND).toBe("pi");
+  });
 });
 
 describe("Pi subagent prompt expansion", () => {
@@ -136,7 +145,7 @@ describe("Pi subagent prompt expansion", () => {
     ]);
 
     expect(prompt).toContain('Launch the "scout" subagent from the project agent scope');
-    expect(prompt).toContain('scope/source "project"');
+    expect(prompt).toContain('using scope/source "project"');
     expect(prompt).toContain("inspect the repo");
   });
 });

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -6,7 +6,9 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
+  ensurePiSubagentChildLauncherEnv,
   getPiSupportedThinkingOptions,
+  makePiSubagentPromptItemId,
   makePiUserInputOptions,
   PLAIN_PI_EXTENSION_THEME,
 } from "./PiAdapter";
@@ -83,5 +85,34 @@ describe("Pi extension UI helpers", () => {
     expect(PLAIN_PI_EXTENSION_THEME.fg("accent", "ready")).toBe("ready");
     expect(PLAIN_PI_EXTENSION_THEME.bold("done")).toBe("done");
     expect(PLAIN_PI_EXTENSION_THEME.getThinkingBorderColor("medium")("thinking")).toBe("thinking");
+  });
+});
+
+describe("Pi subagent child launcher env", () => {
+  it("defaults embedded subagent launches to the Pi CLI", () => {
+    const env: { PI_SUBAGENT_PI_COMMAND?: string } = {};
+
+    ensurePiSubagentChildLauncherEnv(env);
+
+    expect(env.PI_SUBAGENT_PI_COMMAND).toBe("pi");
+  });
+
+  it("preserves an explicit subagent launcher override", () => {
+    const env = { PI_SUBAGENT_PI_COMMAND: "custom-pi-wrapper pi" };
+
+    ensurePiSubagentChildLauncherEnv(env);
+
+    expect(env.PI_SUBAGENT_PI_COMMAND).toBe("custom-pi-wrapper pi");
+  });
+});
+
+describe("Pi subagent transcript helpers", () => {
+  it("uses distinct prompt item ids for repeated prompts to the same child thread", () => {
+    const first = makePiSubagentPromptItemId("child-provider-1");
+    const second = makePiSubagentPromptItemId("child-provider-1");
+
+    expect(first).not.toBe(second);
+    expect(first).toMatch(/^pi-subagent-prompt-child-provider-1-/);
+    expect(second).toMatch(/^pi-subagent-prompt-child-provider-1-/);
   });
 });

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -1,17 +1,19 @@
 // FILE: PiAdapter.test.ts
-// Purpose: Verifies Pi adapter model discovery exposes only SDK-supported thinking levels.
+// Purpose: Verifies Pi adapter discovery, subagent prompt, and transcript helper behavior.
 // Layer: Provider adapter tests
 // Depends on: PiAdapter discovery helpers and Pi model metadata shapes.
 
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
+  buildPiSubagentPrompt,
   ensurePiSubagentChildLauncherEnv,
   getPiSupportedThinkingOptions,
   makePiSubagentPromptItemId,
   makePiSubagentSourceKey,
   makePiUserInputOptions,
   PLAIN_PI_EXTENSION_THEME,
+  recordPiSubagentSessionTranscriptEmission,
 } from "./PiAdapter";
 
 function makePiModel(input: {
@@ -101,13 +103,74 @@ describe("Pi subagent child launcher env", () => {
   it("preserves an explicit subagent launcher override", () => {
     const env = { PI_SUBAGENT_PI_COMMAND: "custom-pi-wrapper pi" };
 
-    ensurePiSubagentChildLauncherEnv(env);
+    ensurePiSubagentChildLauncherEnv(env, "/opt/pi/bin/pi");
 
     expect(env.PI_SUBAGENT_PI_COMMAND).toBe("custom-pi-wrapper pi");
+  });
+
+  it("uses the configured Pi binary when no launcher override exists", () => {
+    const env: { PI_SUBAGENT_PI_COMMAND?: string } = {};
+
+    ensurePiSubagentChildLauncherEnv(env, "/opt/pi/bin/pi");
+
+    expect(env.PI_SUBAGENT_PI_COMMAND).toBe("/opt/pi/bin/pi");
+  });
+
+  it("replaces the adapter default when a configured Pi binary appears later", () => {
+    const env = { PI_SUBAGENT_PI_COMMAND: "pi" };
+
+    ensurePiSubagentChildLauncherEnv(env, "/opt/pi/bin/pi");
+
+    expect(env.PI_SUBAGENT_PI_COMMAND).toBe("/opt/pi/bin/pi");
+  });
+});
+
+describe("Pi subagent prompt expansion", () => {
+  it("includes project scope for project-local inline agent mentions", () => {
+    const prompt = buildPiSubagentPrompt("Please @scout(inspect the repo).", [
+      {
+        name: "scout",
+        displayName: "Scout",
+        scope: "project",
+      },
+    ]);
+
+    expect(prompt).toContain('Launch the "scout" subagent from the project agent scope');
+    expect(prompt).toContain('scope/source "project"');
+    expect(prompt).toContain("inspect the repo");
   });
 });
 
 describe("Pi subagent transcript helpers", () => {
+  it("suppresses exact session transcript replays while allowing appended content", () => {
+    const emittedTranscripts = new Map<string, string>();
+
+    expect(
+      recordPiSubagentSessionTranscriptEmission({
+        emittedTranscripts,
+        providerThreadId: "child-provider-1",
+        sessionFile: "/tmp/pi-child.jsonl",
+        sessionContent: '{"type":"message","id":"one"}\n',
+      }),
+    ).toBe(true);
+    expect(
+      recordPiSubagentSessionTranscriptEmission({
+        emittedTranscripts,
+        providerThreadId: "child-provider-1",
+        sessionFile: "/tmp/pi-child.jsonl",
+        sessionContent: '{"type":"message","id":"one"}\n',
+      }),
+    ).toBe(false);
+    expect(
+      recordPiSubagentSessionTranscriptEmission({
+        emittedTranscripts,
+        providerThreadId: "child-provider-1",
+        sessionFile: "/tmp/pi-child.jsonl",
+        sessionContent: '{"type":"message","id":"one"}\n{"type":"message","id":"two"}\n',
+      }),
+    ).toBe(true);
+  });
+
   it("keys prompt item ids by child thread and transcript source", () => {
     const sourceKey = makePiSubagentSourceKey({
       kind: "subagent_result",

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -9,10 +9,14 @@ import {
   buildPiSubagentPrompt,
   ensurePiSubagentChildLauncherEnv,
   getPiSupportedThinkingOptions,
+  makePiSubagentTurnCompletedPayload,
   makePiSubagentPromptItemId,
   makePiSubagentSourceKey,
   makePiUserInputOptions,
   PLAIN_PI_EXTENSION_THEME,
+  piSubagentPromptTextForReceiver,
+  piSubagentReceiverAgents,
+  recordPiSubagentParentTurnIds,
   recordPiSubagentSessionTranscriptEmission,
 } from "./PiAdapter";
 
@@ -151,6 +155,77 @@ describe("Pi subagent prompt expansion", () => {
 });
 
 describe("Pi subagent transcript helpers", () => {
+  it("records parent turn ids for async subagent launch acknowledgements", () => {
+    const parentTurnIds = new Map<string, string>();
+
+    recordPiSubagentParentTurnIds({
+      parentTurnId: "turn-parent-1",
+      subagentParentTurnIds: parentTurnIds,
+      transcriptTargets: [{ threadId: "child-provider-1" }, { threadId: "" }, {}],
+    });
+
+    expect(parentTurnIds.get("child-provider-1")).toBe("turn-parent-1");
+    expect(parentTurnIds.size).toBe(1);
+  });
+
+  it("uses each multi-subagent child's own prompt and session file", () => {
+    const args = {
+      children: [
+        { agent: "scout", task: "Inspect the repo" },
+        { agent: "writer", task: "Draft the summary" },
+      ],
+    };
+    const details = {
+      children: [
+        { threadId: "child-provider-1", sessionFile: "/tmp/pi-scout.jsonl" },
+        { threadId: "child-provider-2", sessionFile: "/tmp/pi-writer.jsonl" },
+      ],
+    };
+
+    const receiverAgents = piSubagentReceiverAgents({ args, details });
+
+    expect(receiverAgents).toMatchObject([
+      {
+        threadId: "child-provider-1",
+        agentId: "scout",
+        prompt: "Inspect the repo",
+        sessionFile: "/tmp/pi-scout.jsonl",
+      },
+      {
+        threadId: "child-provider-2",
+        agentId: "writer",
+        prompt: "Draft the summary",
+        sessionFile: "/tmp/pi-writer.jsonl",
+      },
+    ]);
+    expect(
+      piSubagentPromptTextForReceiver({
+        args,
+        details,
+        receiverAgent: receiverAgents[0],
+      }),
+    ).toBe("Inspect the repo");
+    expect(
+      piSubagentPromptTextForReceiver({
+        args,
+        details,
+        receiverAgent: receiverAgents[1],
+      }),
+    ).toBe("Draft the summary");
+  });
+
+  it("carries failed state into session transcript turn completions", () => {
+    expect(makePiSubagentTurnCompletedPayload(false)).toEqual({
+      state: "completed",
+      stopReason: null,
+    });
+    expect(makePiSubagentTurnCompletedPayload(true)).toEqual({
+      state: "failed",
+      stopReason: null,
+      errorMessage: "Subagent failed",
+    });
+  });
+
   it("suppresses exact session transcript replays while allowing appended content", () => {
     const emittedTranscripts = new Map<string, string>();
 

--- a/apps/server/src/provider/Layers/PiAdapter.test.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.test.ts
@@ -18,6 +18,7 @@ import {
   piSubagentReceiverAgents,
   recordPiSubagentParentTurnIds,
   recordPiSubagentSessionTranscriptEmission,
+  shouldEmitPiSubagentFallbackTranscript,
 } from "./PiAdapter";
 
 function makePiModel(input: {
@@ -236,7 +237,7 @@ describe("Pi subagent transcript helpers", () => {
         sessionFile: "/tmp/pi-child.jsonl",
         sessionContent: '{"type":"message","id":"one"}\n',
       }),
-    ).toBe(true);
+    ).toBe("recorded");
     expect(
       recordPiSubagentSessionTranscriptEmission({
         emittedTranscripts,
@@ -244,7 +245,7 @@ describe("Pi subagent transcript helpers", () => {
         sessionFile: "/tmp/pi-child.jsonl",
         sessionContent: '{"type":"message","id":"one"}\n',
       }),
-    ).toBe(false);
+    ).toBe("replayed");
     expect(
       recordPiSubagentSessionTranscriptEmission({
         emittedTranscripts,
@@ -252,7 +253,34 @@ describe("Pi subagent transcript helpers", () => {
         sessionFile: "/tmp/pi-child.jsonl",
         sessionContent: '{"type":"message","id":"one"}\n{"type":"message","id":"two"}\n',
       }),
+    ).toBe("recorded");
+  });
+
+  it("only falls back to synthetic transcripts when session import is unavailable", () => {
+    expect(
+      shouldEmitPiSubagentFallbackTranscript({
+        transcriptResult: "unavailable",
+        messageText: "Final child answer",
+      }),
     ).toBe(true);
+    expect(
+      shouldEmitPiSubagentFallbackTranscript({
+        transcriptResult: "replayed",
+        messageText: "Final child answer",
+      }),
+    ).toBe(false);
+    expect(
+      shouldEmitPiSubagentFallbackTranscript({
+        transcriptResult: "emitted",
+        messageText: "Final child answer",
+      }),
+    ).toBe(false);
+    expect(
+      shouldEmitPiSubagentFallbackTranscript({
+        transcriptResult: "unavailable",
+        messageText: "",
+      }),
+    ).toBe(false);
   });
 
   it("keys prompt item ids by child thread and transcript source", () => {

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -455,8 +455,62 @@ function parseJsonLineRecord(line: string): Record<string, unknown> | undefined 
   }
 }
 
-export function makePiSubagentPromptItemId(providerThreadId: string): RuntimeItemId {
-  return RuntimeItemId.makeUnsafe(`pi-subagent-prompt-${providerThreadId}-${crypto.randomUUID()}`);
+// Synthetic child-thread transcript events must replay with the same ids so
+// imported messages and activity rows upsert instead of duplicating.
+function stablePiSubagentHash(parts: ReadonlyArray<unknown>): string {
+  return crypto.createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, 24);
+}
+
+export function makePiSubagentSourceKey(input: {
+  readonly kind: string;
+  readonly parentThreadId: string;
+  readonly providerThreadId: string;
+  readonly sessionFile?: string | undefined;
+  readonly toolCallId?: string | undefined;
+  readonly messageIdentity?: string | undefined;
+  readonly promptText?: string | undefined;
+  readonly messageText?: string | undefined;
+}): string {
+  if (input.sessionFile) {
+    return `session:${input.parentThreadId}:${input.providerThreadId}:${input.sessionFile}`;
+  }
+  if (input.toolCallId) {
+    return `tool:${input.parentThreadId}:${input.providerThreadId}:${input.kind}:${input.toolCallId}`;
+  }
+  if (input.messageIdentity) {
+    return `message:${input.parentThreadId}:${input.providerThreadId}:${input.kind}:${input.messageIdentity}`;
+  }
+  return `${input.kind}:content:${stablePiSubagentHash([
+    input.parentThreadId,
+    input.providerThreadId,
+    input.promptText,
+    input.messageText,
+  ])}`;
+}
+
+function makePiSubagentEventId(sourceKey: string, eventKind: string): EventId {
+  return EventId.makeUnsafe(`pi-subagent-event-${stablePiSubagentHash([sourceKey, eventKind])}`);
+}
+
+function makePiSubagentTurnId(sourceKey: string): TurnId {
+  return TurnId.makeUnsafe(`pi-subagent-turn-${stablePiSubagentHash([sourceKey, "turn"])}`);
+}
+
+function makePiSubagentRuntimeItemId(
+  sourceKey: string,
+  itemKind: string,
+  itemParts: ReadonlyArray<unknown> = [],
+): RuntimeItemId {
+  return RuntimeItemId.makeUnsafe(
+    `pi-subagent-${itemKind}-${stablePiSubagentHash([sourceKey, itemKind, ...itemParts])}`,
+  );
+}
+
+export function makePiSubagentPromptItemId(input: {
+  readonly providerThreadId: string;
+  readonly sourceKey: string;
+}): RuntimeItemId {
+  return makePiSubagentRuntimeItemId(input.sourceKey, "prompt", [input.providerThreadId]);
 }
 
 function readBoundedPiSubagentSessionFile(sessionFile: string): string | undefined {
@@ -1233,16 +1287,17 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
     const emitPiSubagentChildTranscript = (input: {
       readonly context: PiSessionContext;
       readonly providerThreadId: string;
+      readonly sourceKey: string;
       readonly name?: string | undefined;
       readonly promptText?: string | undefined;
       readonly messageText: string;
       readonly failed: boolean;
       readonly raw: ProviderRuntimeEvent["raw"];
     }): void => {
-      const childTurnId = TurnId.makeUnsafe(`pi-subagent-turn-${crypto.randomUUID()}`);
-      const assistantItemId = RuntimeItemId.makeUnsafe(
-        `pi-subagent-assistant-${crypto.randomUUID()}`,
-      );
+      const childTurnId = makePiSubagentTurnId(input.sourceKey);
+      const assistantItemId = makePiSubagentRuntimeItemId(input.sourceKey, "assistant", [
+        input.providerThreadId,
+      ]);
       const providerRefs = {
         providerThreadId: input.providerThreadId,
         providerParentThreadId: input.context.session.threadId,
@@ -1251,7 +1306,11 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       if (input.promptText) {
         offerRuntimeEvent({
           ...makeEventBase(input.context, { includeTurnId: false }),
-          itemId: makePiSubagentPromptItemId(input.providerThreadId),
+          eventId: makePiSubagentEventId(input.sourceKey, "prompt-completed"),
+          itemId: makePiSubagentPromptItemId({
+            providerThreadId: input.providerThreadId,
+            sourceKey: input.sourceKey,
+          }),
           providerRefs,
           type: "item.completed",
           payload: {
@@ -1266,6 +1325,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
 
       offerRuntimeEvent({
         ...makeEventBase(input.context, { includeTurnId: false }),
+        eventId: makePiSubagentEventId(input.sourceKey, "turn-started"),
         turnId: childTurnId,
         providerRefs,
         type: "turn.started",
@@ -1274,6 +1334,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       } satisfies ProviderRuntimeEvent);
       offerRuntimeEvent({
         ...makeEventBase(input.context, { includeTurnId: false }),
+        eventId: makePiSubagentEventId(input.sourceKey, "assistant-delta"),
         turnId: childTurnId,
         itemId: assistantItemId,
         providerRefs,
@@ -1283,6 +1344,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       } satisfies ProviderRuntimeEvent);
       offerRuntimeEvent({
         ...makeEventBase(input.context, { includeTurnId: false }),
+        eventId: makePiSubagentEventId(input.sourceKey, "assistant-completed"),
         turnId: childTurnId,
         itemId: assistantItemId,
         providerRefs,
@@ -1297,6 +1359,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       } satisfies ProviderRuntimeEvent);
       offerRuntimeEvent({
         ...makeEventBase(input.context, { includeTurnId: false }),
+        eventId: makePiSubagentEventId(input.sourceKey, "turn-completed"),
         turnId: childTurnId,
         providerRefs,
         type: "turn.completed",
@@ -1312,6 +1375,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
     const emitPiSubagentSessionTranscript = (input: {
       readonly context: PiSessionContext;
       readonly providerThreadId: string;
+      readonly sourceKey: string;
       readonly sessionFile: string;
       readonly promptText?: string | undefined;
       readonly raw: ProviderRuntimeEvent["raw"];
@@ -1326,7 +1390,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         return true;
       }
 
-      const childTurnId = TurnId.makeUnsafe(`pi-subagent-turn-${crypto.randomUUID()}`);
+      const childTurnId = makePiSubagentTurnId(input.sourceKey);
       const providerRefs = {
         providerThreadId: input.providerThreadId,
         providerParentThreadId: input.context.session.threadId,
@@ -1365,8 +1429,12 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       if (input.promptText) {
         offerRuntimeEvent({
           ...makeEventBase(input.context, { includeTurnId: false }),
+          eventId: makePiSubagentEventId(input.sourceKey, "prompt-completed"),
           ...(sessionStartedAt ? { createdAt: sessionStartedAt } : {}),
-          itemId: makePiSubagentPromptItemId(input.providerThreadId),
+          itemId: makePiSubagentPromptItemId({
+            providerThreadId: input.providerThreadId,
+            sourceKey: input.sourceKey,
+          }),
           providerRefs,
           type: "item.completed",
           payload: {
@@ -1381,17 +1449,19 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
 
       offerRuntimeEvent({
         ...childBase(sessionStartedAt),
+        eventId: makePiSubagentEventId(input.sourceKey, "turn-started"),
         type: "turn.started",
         payload: {},
         raw: transcriptRaw,
       } satisfies ProviderRuntimeEvent);
 
-      for (const entry of sessionEntries) {
+      for (const [entryIndex, entry] of sessionEntries.entries()) {
         if (entry?.type !== "message") continue;
         const message = toolRecord(entry.message);
         const role = message?.role;
         const content = Array.isArray(message?.content) ? message.content : [];
         const createdAt = timestampFromUnknown(entry.timestamp) ?? timestampFromUnknown(message?.timestamp);
+        const entryIdentity = firstStringValue(entry, ["id"]) ?? stablePiSubagentHash([entryIndex, entry]);
 
         if (role === "assistant") {
           for (const [index, part] of content.entries()) {
@@ -1400,12 +1470,17 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             if (partRecord.type === "text" && typeof partRecord.text === "string") {
               const text = partRecord.text;
               if (text.length === 0) continue;
-              const itemId = RuntimeItemId.makeUnsafe(
-                `pi-subagent-session-assistant-${entry.id ?? crypto.randomUUID()}-${index}`,
-              );
+              const itemId = makePiSubagentRuntimeItemId(input.sourceKey, "session-assistant", [
+                entryIdentity,
+                index,
+              ]);
               emittedRenderableEvent = true;
               offerRuntimeEvent({
                 ...childBase(createdAt),
+                eventId: makePiSubagentEventId(
+                  input.sourceKey,
+                  `session-assistant-delta:${entryIdentity}:${index}`,
+                ),
                 itemId,
                 type: "content.delta",
                 payload: { streamKind: "assistant_text", delta: text },
@@ -1413,6 +1488,10 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
               } satisfies ProviderRuntimeEvent);
               offerRuntimeEvent({
                 ...childBase(createdAt),
+                eventId: makePiSubagentEventId(
+                  input.sourceKey,
+                  `session-assistant-completed:${entryIdentity}:${index}`,
+                ),
                 itemId,
                 type: "item.completed",
                 payload: {
@@ -1428,12 +1507,17 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             if (partRecord.type === "thinking" && typeof partRecord.thinking === "string") {
               const thinking = partRecord.thinking;
               if (thinking.length === 0) continue;
-              const itemId = RuntimeItemId.makeUnsafe(
-                `pi-subagent-session-thinking-${entry.id ?? crypto.randomUUID()}-${index}`,
-              );
+              const itemId = makePiSubagentRuntimeItemId(input.sourceKey, "session-thinking", [
+                entryIdentity,
+                index,
+              ]);
               emittedRenderableEvent = true;
               offerRuntimeEvent({
                 ...childBase(createdAt),
+                eventId: makePiSubagentEventId(
+                  input.sourceKey,
+                  `session-thinking-delta:${entryIdentity}:${index}`,
+                ),
                 itemId,
                 type: "content.delta",
                 payload: { streamKind: "reasoning_text", delta: thinking },
@@ -1441,6 +1525,10 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
               } satisfies ProviderRuntimeEvent);
               offerRuntimeEvent({
                 ...childBase(createdAt),
+                eventId: makePiSubagentEventId(
+                  input.sourceKey,
+                  `session-thinking-completed:${entryIdentity}:${index}`,
+                ),
                 itemId,
                 type: "item.completed",
                 payload: {
@@ -1458,11 +1546,17 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
               const toolName = firstStringValue(partRecord, ["name"]) ?? "tool";
               if (!toolCallId) continue;
               const args = partRecord.arguments;
-              const itemId = RuntimeItemId.makeUnsafe(`pi-subagent-session-tool-${toolCallId}`);
+              const itemId = makePiSubagentRuntimeItemId(input.sourceKey, "session-tool", [
+                toolCallId,
+              ]);
               pendingTools.set(toolCallId, { toolName, args, itemId });
               emittedRenderableEvent = true;
               offerRuntimeEvent({
                 ...childBase(createdAt),
+                eventId: makePiSubagentEventId(
+                  input.sourceKey,
+                  `session-tool-started:${toolCallId}`,
+                ),
                 itemId,
                 providerRefs: {
                   ...providerRefs,
@@ -1492,11 +1586,13 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           const result = { content };
           const detail = textFromToolResult(result);
           const itemId =
-            pending?.itemId ?? RuntimeItemId.makeUnsafe(`pi-subagent-session-tool-${toolCallId}`);
+            pending?.itemId ??
+            makePiSubagentRuntimeItemId(input.sourceKey, "session-tool", [toolCallId]);
           pendingTools.delete(toolCallId);
           emittedRenderableEvent = true;
           offerRuntimeEvent({
             ...childBase(createdAt),
+            eventId: makePiSubagentEventId(input.sourceKey, `session-tool-completed:${toolCallId}`),
             itemId,
             providerRefs: {
               ...providerRefs,
@@ -1523,6 +1619,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
 
       offerRuntimeEvent({
         ...childBase(),
+        eventId: makePiSubagentEventId(input.sourceKey, "turn-completed"),
         type: "turn.completed",
         payload: { state: "completed", stopReason: null },
         raw: transcriptRaw,
@@ -1548,6 +1645,18 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       const promptText = task;
       const failed = status === "failed" || status === "cancelled";
       const messageText = customMessageText(record?.content);
+      const messageIdentity =
+        firstStringValue(record, ["id", "messageId", "eventId"]) ??
+        firstStringValue(details, ["messageId", "eventId"]);
+      const sourceKey = makePiSubagentSourceKey({
+        kind: customType,
+        parentThreadId: context.session.threadId,
+        providerThreadId,
+        ...(sessionFile ? { sessionFile } : {}),
+        ...(messageIdentity ? { messageIdentity } : {}),
+        ...(promptText ? { promptText } : {}),
+        ...(messageText ? { messageText } : {}),
+      });
       const receiverAgent = {
         threadId: providerThreadId,
         ...(agent ? { agentId: agent, agentRole: agent } : {}),
@@ -1562,7 +1671,8 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
 
       offerRuntimeEvent({
         ...makeEventBase(context, { includeTurnId: false }),
-        itemId: RuntimeItemId.makeUnsafe(`pi-subagent-message-${crypto.randomUUID()}`),
+        eventId: makePiSubagentEventId(sourceKey, "result-activity-completed"),
+        itemId: makePiSubagentRuntimeItemId(sourceKey, "message", [providerThreadId]),
         type: "item.completed",
         payload: {
           itemType: "collab_agent_tool_call",
@@ -1581,12 +1691,20 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       if (!messageText) return true;
 
       const emittedSessionTranscript = sessionFile
-        ? emitPiSubagentSessionTranscript({ context, providerThreadId, sessionFile, promptText, raw })
+        ? emitPiSubagentSessionTranscript({
+            context,
+            providerThreadId,
+            sourceKey,
+            sessionFile,
+            promptText,
+            raw,
+          })
         : false;
       if (!emittedSessionTranscript) {
         emitPiSubagentChildTranscript({
           context,
           providerThreadId,
+          sourceKey,
           ...(name ? { name } : {}),
           ...(promptText ? { promptText } : {}),
           messageText,
@@ -2148,10 +2266,20 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             for (const receiverAgent of transcriptTargets) {
               const providerThreadId = firstStringValue(receiverAgent, ["threadId"]);
               if (!providerThreadId) continue;
+              const sourceKey = makePiSubagentSourceKey({
+                kind: event.toolName,
+                parentThreadId: context.session.threadId,
+                providerThreadId,
+                toolCallId: event.toolCallId,
+                ...(sessionFile ? { sessionFile } : {}),
+                ...(promptText ? { promptText } : {}),
+                ...(detail ? { messageText: detail } : {}),
+              });
               const emittedSessionTranscript = sessionFile
                 ? emitPiSubagentSessionTranscript({
                     context,
                     providerThreadId,
+                    sourceKey,
                     sessionFile,
                     promptText,
                     raw,
@@ -2166,6 +2294,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
                 emitPiSubagentChildTranscript({
                   context,
                   providerThreadId,
+                  sourceKey,
                   ...(childName ? { name: childName } : {}),
                   ...(promptText ? { promptText } : {}),
                   messageText: detail,

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -76,6 +76,7 @@ const PI_DEFAULT_SUPPORTED_THINKING_LEVELS = new Set<ThinkingLevel>([
 ]);
 const DEFAULT_PI_SUBAGENT_PI_COMMAND = "pi";
 const MAX_PI_SUBAGENT_SESSION_TRANSCRIPT_BYTES = 1_000_000;
+const adapterOwnedPiLauncherEnvValues = new WeakMap<object, string>();
 
 type PiModelRegistry = Pick<ModelRegistry, "find" | "getAll" | "getAvailable">;
 type PiCodingAgentModule = typeof import("@earendil-works/pi-coding-agent");
@@ -95,6 +96,7 @@ interface PiSessionContext {
   activeToolItems: Map<string, PiTrackedToolCall>;
   pendingUserInputs: Map<ApprovalRequestId, PiPendingUserInput>;
   emittedSubagentSessionTranscripts: Map<string, string>;
+  subagentParentTurnIds: Map<string, TurnId>;
   stopped: boolean;
   lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
   unsubscribe: (() => void) | undefined;
@@ -111,6 +113,7 @@ interface PiTrackedToolCall {
   readonly toolName: string;
   readonly args: unknown;
   readonly itemId: RuntimeItemId;
+  readonly parentTurnId?: TurnId | undefined;
   readonly itemType:
     | "command_execution"
     | "file_change"
@@ -151,10 +154,22 @@ export function ensurePiSubagentChildLauncherEnv(
 ): void {
   const configuredCommand = trimToUndefined(binaryPath);
   const existingCommand = trimToUndefined(env.PI_SUBAGENT_PI_COMMAND);
-  if (existingCommand && (!configuredCommand || existingCommand !== DEFAULT_PI_SUBAGENT_PI_COMMAND)) {
+  const envObject = env as object;
+  const adapterOwnedCommand = adapterOwnedPiLauncherEnvValues.get(envObject);
+  const existingIsAdapterOwned =
+    existingCommand !== undefined && existingCommand === adapterOwnedCommand;
+
+  if (
+    existingCommand &&
+    existingCommand !== DEFAULT_PI_SUBAGENT_PI_COMMAND &&
+    !existingIsAdapterOwned
+  ) {
     return;
   }
-  env.PI_SUBAGENT_PI_COMMAND = configuredCommand ?? DEFAULT_PI_SUBAGENT_PI_COMMAND;
+
+  const nextCommand = configuredCommand ?? DEFAULT_PI_SUBAGENT_PI_COMMAND;
+  env.PI_SUBAGENT_PI_COMMAND = nextCommand;
+  adapterOwnedPiLauncherEnvValues.set(envObject, nextCommand);
 }
 
 function isPiThinkingLevel(value: string | null | undefined): value is ThinkingLevel {
@@ -580,10 +595,10 @@ function readBalancedInlineTask(
 
 function piSubagentPromptScopeClause(agent: ProviderAgentDescriptor): string {
   if (agent.scope === "project") {
-    return ' from the project agent scope (pass scope/source "project" if the subagent tool accepts it)';
+    return ' from the project agent scope using scope/source "project"';
   }
   if (agent.scope === "global") {
-    return ' from the global agent scope (pass scope/source "global" if the subagent tool accepts it)';
+    return ' from the global agent scope using scope/source "global"';
   }
   return "";
 }
@@ -775,6 +790,11 @@ function piSubagentReceiverAgents(input: {
       const title = firstStringValue(childRecord, ["title"]);
       const model = firstStringValue(childRecord, ["model"]);
       const task = firstStringValue(childRecord, ["task"]);
+      const sessionFile = firstStringValue(childDetails, [
+        "sessionFile",
+        "sessionPath",
+        "session_file",
+      ]);
       return [
         {
           threadId: providerThreadId,
@@ -782,6 +802,7 @@ function piSubagentReceiverAgents(input: {
           ...(name ? { agentNickname: name } : title ? { agentNickname: title } : {}),
           ...(model ? { model } : {}),
           ...(task ? { prompt: task } : {}),
+          ...(sessionFile ? { sessionFile } : {}),
         },
       ];
     });
@@ -794,6 +815,11 @@ function piSubagentReceiverAgents(input: {
   const title = firstStringValue(input.details, ["title"]);
   const task = firstStringValue(input.details, ["task"]);
   const model = firstStringValue(input.details, ["model"]);
+  const sessionFile = firstStringValue(input.details, [
+    "sessionFile",
+    "sessionPath",
+    "session_file",
+  ]);
   return [
     {
       threadId: providerThreadId,
@@ -801,6 +827,7 @@ function piSubagentReceiverAgents(input: {
       ...(name ? { agentNickname: name } : title ? { agentNickname: title } : {}),
       ...(model ? { model } : {}),
       ...(task ? { prompt: task } : {}),
+      ...(sessionFile ? { sessionFile } : {}),
     },
   ];
 }
@@ -825,6 +852,9 @@ function hasRenderablePiSubagentSessionEntry(entry: Record<string, unknown>): bo
   const message = toolRecord(entry.message);
   const role = message?.role;
   const content = Array.isArray(message?.content) ? message.content : [];
+  if (role === "user") {
+    return textFromContent(content as (TextContent | ImageContent)[]).trim().length > 0;
+  }
   if (role === "assistant") {
     return content.some((part) => {
       const partRecord = toolRecord(part);
@@ -1436,6 +1466,15 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       if (!sessionEntries.some(hasRenderablePiSubagentSessionEntry)) {
         return false;
       }
+      const hasTranscriptUserMessage = sessionEntries.some((entry) => {
+        if (entry?.type !== "message") return false;
+        const message = toolRecord(entry.message);
+        const content = Array.isArray(message?.content) ? message.content : [];
+        return (
+          message?.role === "user" &&
+          textFromContent(content as (TextContent | ImageContent)[]).trim().length > 0
+        );
+      });
       if (
         !recordPiSubagentSessionTranscriptEmission({
           emittedTranscripts: input.context.emittedSubagentSessionTranscripts,
@@ -1468,7 +1507,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         providerRefs,
       });
 
-      if (input.promptText) {
+      if (input.promptText && !hasTranscriptUserMessage) {
         offerRuntimeEvent({
           ...makeEventBase(input.context, { includeTurnId: false }),
           eventId: makePiSubagentEventId(input.sourceKey, "prompt-completed"),
@@ -1504,6 +1543,29 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         const content = Array.isArray(message?.content) ? message.content : [];
         const createdAt = timestampFromUnknown(entry.timestamp) ?? timestampFromUnknown(message?.timestamp);
         const entryIdentity = firstStringValue(entry, ["id"]) ?? stablePiSubagentHash([entryIndex, entry]);
+
+        if (role === "user") {
+          const text = textFromContent(content as (TextContent | ImageContent)[]).trim();
+          if (text.length === 0) continue;
+          const itemId = makePiSubagentRuntimeItemId(input.sourceKey, "session-user", [
+            entryIdentity,
+          ]);
+          emittedRenderableEvent = true;
+          offerRuntimeEvent({
+            ...childBase(createdAt),
+            eventId: makePiSubagentEventId(input.sourceKey, `session-user:${entryIdentity}`),
+            itemId,
+            type: "item.completed",
+            payload: {
+              itemType: "user_message",
+              status: "completed",
+              title: "User message",
+              detail: text,
+            },
+            raw: transcriptRaw,
+          } satisfies ProviderRuntimeEvent);
+          continue;
+        }
 
         if (role === "assistant") {
           for (const [index, part] of content.entries()) {
@@ -1705,7 +1767,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         ...(name ? { agentNickname: name } : {}),
         ...(task ? { prompt: task } : {}),
       };
-      const parentTurnId = context.activeTurnId;
+      const parentTurnId = context.subagentParentTurnIds.get(providerThreadId);
       const raw = {
         source: "pi.sdk.event",
         messageType: "message_end",
@@ -2190,6 +2252,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             toolName: event.toolName,
             args: event.args,
             itemId,
+            ...(context.activeTurnId ? { parentTurnId: context.activeTurnId } : {}),
             itemType: toolItemType(event.toolName),
           };
           context.activeToolItems.set(event.toolCallId, tracked);
@@ -2256,6 +2319,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             toolName: event.toolName,
             args: undefined,
             itemId: RuntimeItemId.makeUnsafe(`pi-tool-${event.toolCallId}`),
+            // Missing start events cannot be tied to the current active turn; it may be newer.
             itemType: toolItemType(event.toolName),
           };
           context.activeToolItems.delete(event.toolCallId);
@@ -2314,21 +2378,27 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             for (const receiverAgent of transcriptTargets) {
               const providerThreadId = firstStringValue(receiverAgent, ["threadId"]);
               if (!providerThreadId) continue;
+              if (tracked.parentTurnId) {
+                context.subagentParentTurnIds.set(providerThreadId, tracked.parentTurnId);
+              }
+              const childSessionFile =
+                firstStringValue(receiverAgent, ["sessionFile", "sessionPath", "session_file"]) ??
+                sessionFile;
               const sourceKey = makePiSubagentSourceKey({
                 kind: event.toolName,
                 parentThreadId: context.session.threadId,
                 providerThreadId,
                 toolCallId: event.toolCallId,
-                ...(sessionFile ? { sessionFile } : {}),
+                ...(childSessionFile ? { sessionFile: childSessionFile } : {}),
                 ...(promptText ? { promptText } : {}),
                 ...(detail ? { messageText: detail } : {}),
               });
-              const emittedSessionTranscript = sessionFile
+              const emittedSessionTranscript = childSessionFile
                 ? emitPiSubagentSessionTranscript({
                     context,
                     providerThreadId,
                     sourceKey,
-                    sessionFile,
+                    sessionFile: childSessionFile,
                     promptText,
                     raw,
                   })
@@ -2588,6 +2658,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           activeToolItems: new Map(),
           pendingUserInputs: new Map(),
           emittedSubagentSessionTranscripts: new Map(),
+          subagentParentTurnIds: new Map(),
           stopped: false,
           lastKnownTokenUsage: undefined,
           unsubscribe: undefined,
@@ -2672,17 +2743,20 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       },
     ) =>
       Effect.gen(function* () {
-        const text =
-          appendFileAttachmentsPromptBlock({
-            text: input.input,
-            attachments: input.attachments,
-            attachmentsDir: serverConfig.attachmentsDir,
-            include: "all-files",
-          }) ?? "";
         const piSubagentAgents = listPiSubagentDefinitions({
           agentDir: context.agentDir,
           cwd: context.session.cwd ?? serverConfig.cwd,
         });
+        // Inline @agent(...) directives are command syntax, so parse only the user's
+        // typed prompt before appending passive file attachment text.
+        const userPromptText = buildPiSubagentPrompt(input.input ?? "", piSubagentAgents);
+        const text =
+          appendFileAttachmentsPromptBlock({
+            text: userPromptText,
+            attachments: input.attachments,
+            attachmentsDir: serverConfig.attachmentsDir,
+            include: "all-files",
+          }) ?? "";
         const images = yield* Effect.forEach(
           input.attachments ?? [],
           (attachment) =>
@@ -2719,7 +2793,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           { concurrency: 1 },
         );
         return {
-          text: buildPiSubagentPrompt(text, piSubagentAgents),
+          text,
           images: images.filter((image): image is ImageContent => image !== undefined),
         };
       });

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -771,7 +771,7 @@ function isPiSubagentTool(toolName: string): boolean {
   return toolName === "subagent" || toolName === "subagent_resume";
 }
 
-function piSubagentReceiverAgents(input: {
+export function piSubagentReceiverAgents(input: {
   readonly args: unknown;
   readonly details: Record<string, unknown> | undefined;
 }): ReadonlyArray<Record<string, unknown>> {
@@ -832,9 +832,50 @@ function piSubagentReceiverAgents(input: {
   ];
 }
 
-function piSubagentPromptText(args: unknown, details?: Record<string, unknown>): string | undefined {
+export function piSubagentPromptText(
+  args: unknown,
+  details?: Record<string, unknown>,
+): string | undefined {
   const argsRecord = toolRecord(args);
-  return firstStringValue(argsRecord, ["task", "prompt", "message"]) ?? firstStringValue(details, ["task"]);
+  return (
+    firstStringValue(argsRecord, ["task", "prompt", "message"]) ??
+    firstStringValue(details, ["task"])
+  );
+}
+
+export function piSubagentPromptTextForReceiver(input: {
+  readonly args: unknown;
+  readonly details?: Record<string, unknown> | undefined;
+  readonly receiverAgent?: Record<string, unknown> | undefined;
+}): string | undefined {
+  return (
+    firstStringValue(input.receiverAgent, ["prompt", "task", "message"]) ??
+    piSubagentPromptText(input.args, input.details)
+  );
+}
+
+// Async launch acknowledgements can return before any transcript import happens,
+// so keep their eventual custom result rows tied to the originating parent turn.
+export function recordPiSubagentParentTurnIds<ParentTurnId>(input: {
+  readonly parentTurnId?: ParentTurnId | undefined;
+  readonly subagentParentTurnIds: Map<string, ParentTurnId>;
+  readonly transcriptTargets: ReadonlyArray<Record<string, unknown>>;
+}): void {
+  if (input.parentTurnId === undefined) return;
+  for (const target of input.transcriptTargets) {
+    const providerThreadId = firstStringValue(target, ["threadId"]);
+    if (providerThreadId) {
+      input.subagentParentTurnIds.set(providerThreadId, input.parentTurnId);
+    }
+  }
+}
+
+export function makePiSubagentTurnCompletedPayload(failed: boolean) {
+  return {
+    state: failed ? "failed" : "completed",
+    stopReason: null,
+    ...(failed ? { errorMessage: "Subagent failed" } : {}),
+  } as const;
 }
 
 function isPiSubagentLaunchAcknowledgement(details: Record<string, unknown> | undefined): boolean {
@@ -859,7 +900,8 @@ function hasRenderablePiSubagentSessionEntry(entry: Record<string, unknown>): bo
     return content.some((part) => {
       const partRecord = toolRecord(part);
       if (!partRecord) return false;
-      if (partRecord.type === "text") return typeof partRecord.text === "string" && partRecord.text.length > 0;
+      if (partRecord.type === "text")
+        return typeof partRecord.text === "string" && partRecord.text.length > 0;
       if (partRecord.type === "thinking") {
         return typeof partRecord.thinking === "string" && partRecord.thinking.length > 0;
       }
@@ -904,7 +946,9 @@ function piSubagentLifecycleItem(input: {
     type: "collabAgentToolCall",
     tool: input.toolName,
     toolName: input.toolName,
-    ...(input.args !== undefined ? { input: input.args, args: input.args, rawInput: input.args } : {}),
+    ...(input.args !== undefined
+      ? { input: input.args, args: input.args, rawInput: input.args }
+      : {}),
     ...(agent ? { agent, agentId: agent, agentRole: agent } : {}),
     ...(name ? { name, agentNickname: name } : {}),
     ...(title ? { title } : {}),
@@ -1431,11 +1475,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         turnId: childTurnId,
         providerRefs,
         type: "turn.completed",
-        payload: {
-          state: input.failed ? "failed" : "completed",
-          stopReason: null,
-          ...(input.failed ? { errorMessage: "Subagent failed" } : {}),
-        },
+        payload: makePiSubagentTurnCompletedPayload(input.failed),
         raw: input.raw,
       } satisfies ProviderRuntimeEvent);
     };
@@ -1446,6 +1486,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       readonly sourceKey: string;
       readonly sessionFile: string;
       readonly promptText?: string | undefined;
+      readonly failed: boolean;
       readonly raw: ProviderRuntimeEvent["raw"];
     }): boolean => {
       const sessionContent = readBoundedPiSubagentSessionFile(input.sessionFile);
@@ -1483,7 +1524,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           sessionContent,
         })
       ) {
-        return true;
+        return false;
       }
 
       const sessionStartedAt = sessionLines
@@ -1541,8 +1582,10 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         const message = toolRecord(entry.message);
         const role = message?.role;
         const content = Array.isArray(message?.content) ? message.content : [];
-        const createdAt = timestampFromUnknown(entry.timestamp) ?? timestampFromUnknown(message?.timestamp);
-        const entryIdentity = firstStringValue(entry, ["id"]) ?? stablePiSubagentHash([entryIndex, entry]);
+        const createdAt =
+          timestampFromUnknown(entry.timestamp) ?? timestampFromUnknown(message?.timestamp);
+        const entryIdentity =
+          firstStringValue(entry, ["id"]) ?? stablePiSubagentHash([entryIndex, entry]);
 
         if (role === "user") {
           const text = textFromContent(content as (TextContent | ImageContent)[]).trim();
@@ -1725,7 +1768,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         ...childBase(),
         eventId: makePiSubagentEventId(input.sourceKey, "turn-completed"),
         type: "turn.completed",
-        payload: { state: "completed", stopReason: null },
+        payload: makePiSubagentTurnCompletedPayload(input.failed),
         raw: transcriptRaw,
       } satisfies ProviderRuntimeEvent);
 
@@ -1739,8 +1782,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
 
       const details = toolRecord(record?.details);
       const providerThreadId =
-        firstStringValue(details, ["id", "name"]) ??
-        `subagent-message-${crypto.randomUUID()}`;
+        firstStringValue(details, ["id", "name"]) ?? `subagent-message-${crypto.randomUUID()}`;
       const agent = firstStringValue(details, ["agent"]);
       const name = firstStringValue(details, ["name"]);
       const task = firstStringValue(details, ["task"]);
@@ -1807,6 +1849,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             sourceKey,
             sessionFile,
             promptText,
+            failed,
             raw,
           })
         : false;
@@ -2353,11 +2396,8 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             },
             raw,
           } satisfies ProviderRuntimeEvent);
-          if (isPiSubagentTool(event.toolName) && detail) {
+          if (isPiSubagentTool(event.toolName)) {
             const outputDetails = toolRecord(toolRawOutput(event.result)?.details);
-            if (isPiSubagentLaunchAcknowledgement(outputDetails)) {
-              return;
-            }
             const receiverAgents = piSubagentReceiverAgents({
               args: tracked.args,
               details: outputDetails,
@@ -2368,29 +2408,38 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
               "sessionPath",
               "session_file",
             ]);
-            const promptText = piSubagentPromptText(tracked.args, outputDetails);
             const transcriptTargets =
               receiverAgents.length > 0
                 ? receiverAgents
                 : fallbackThreadId
                   ? [{ threadId: fallbackThreadId }]
                   : [];
+            recordPiSubagentParentTurnIds({
+              parentTurnId: tracked.parentTurnId,
+              subagentParentTurnIds: context.subagentParentTurnIds,
+              transcriptTargets,
+            });
+            if (isPiSubagentLaunchAcknowledgement(outputDetails)) {
+              return;
+            }
             for (const receiverAgent of transcriptTargets) {
               const providerThreadId = firstStringValue(receiverAgent, ["threadId"]);
               if (!providerThreadId) continue;
-              if (tracked.parentTurnId) {
-                context.subagentParentTurnIds.set(providerThreadId, tracked.parentTurnId);
-              }
               const childSessionFile =
                 firstStringValue(receiverAgent, ["sessionFile", "sessionPath", "session_file"]) ??
                 sessionFile;
+              const childPromptText = piSubagentPromptTextForReceiver({
+                args: tracked.args,
+                details: outputDetails,
+                receiverAgent,
+              });
               const sourceKey = makePiSubagentSourceKey({
                 kind: event.toolName,
                 parentThreadId: context.session.threadId,
                 providerThreadId,
                 toolCallId: event.toolCallId,
                 ...(childSessionFile ? { sessionFile: childSessionFile } : {}),
-                ...(promptText ? { promptText } : {}),
+                ...(childPromptText ? { promptText: childPromptText } : {}),
                 ...(detail ? { messageText: detail } : {}),
               });
               const emittedSessionTranscript = childSessionFile
@@ -2399,11 +2448,12 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
                     providerThreadId,
                     sourceKey,
                     sessionFile: childSessionFile,
-                    promptText,
+                    promptText: childPromptText,
+                    failed: event.isError,
                     raw,
                   })
                 : false;
-              if (!emittedSessionTranscript) {
+              if (!emittedSessionTranscript && detail) {
                 const childName = firstStringValue(receiverAgent, [
                   "agentNickname",
                   "name",
@@ -2414,7 +2464,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
                   providerThreadId,
                   sourceKey,
                   ...(childName ? { name: childName } : {}),
-                  ...(promptText ? { promptText } : {}),
+                  ...(childPromptText ? { promptText: childPromptText } : {}),
                   messageText: detail,
                   failed: event.isError,
                   raw,

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
 import type {
@@ -16,7 +17,9 @@ import {
   ApprovalRequestId,
   type ChatAttachment,
   EventId,
+  type ProviderAgentDescriptor,
   type ProviderComposerCapabilities,
+  type ProviderListAgentsResult,
   type ProviderListCommandsResult,
   type ProviderListModelsResult,
   type ProviderListSkillsResult,
@@ -45,6 +48,7 @@ import { PiAdapter, type PiAdapterShape } from "../Services/PiAdapter.ts";
 import type { ProviderThreadSnapshot } from "../Services/ProviderAdapter.ts";
 import { appendFileAttachmentsPromptBlock } from "../attachmentProjection.ts";
 import { classifyPiTurnFailure } from "../piTurnFailure.ts";
+import { listPiSubagentDefinitions } from "../piSubagentDefinitions.ts";
 import { clampUsagePercent, nonNegativeFiniteNumber, positiveFiniteNumber } from "../tokenUsage.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 
@@ -70,6 +74,8 @@ const PI_DEFAULT_SUPPORTED_THINKING_LEVELS = new Set<ThinkingLevel>([
   "medium",
   "high",
 ]);
+const DEFAULT_PI_SUBAGENT_PI_COMMAND = "pi";
+const MAX_PI_SUBAGENT_SESSION_TRANSCRIPT_BYTES = 1_000_000;
 
 type PiModelRegistry = Pick<ModelRegistry, "find" | "getAll" | "getAvailable">;
 type PiCodingAgentModule = typeof import("@earendil-works/pi-coding-agent");
@@ -81,12 +87,14 @@ interface PiSessionContext {
   runtime: PiAgentRuntime;
   modelRegistry: PiModelRegistry;
   session: ProviderSession;
+  agentDir: string;
   turns: PiStoredTurn[];
   activeTurnId: TurnId | undefined;
   activeAssistantItemId: RuntimeItemId | undefined;
   activeReasoningItemId: RuntimeItemId | undefined;
   activeToolItems: Map<string, PiTrackedToolCall>;
   pendingUserInputs: Map<ApprovalRequestId, PiPendingUserInput>;
+  emittedSubagentSessionTranscripts: Set<string>;
   stopped: boolean;
   lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
   unsubscribe: (() => void) | undefined;
@@ -103,7 +111,12 @@ interface PiTrackedToolCall {
   readonly toolName: string;
   readonly args: unknown;
   readonly itemId: RuntimeItemId;
-  readonly itemType: "command_execution" | "file_change" | "dynamic_tool_call" | "web_search";
+  readonly itemType:
+    | "command_execution"
+    | "file_change"
+    | "dynamic_tool_call"
+    | "collab_agent_tool_call"
+    | "web_search";
 }
 
 interface PiPendingUserInput {
@@ -130,6 +143,13 @@ function toMessage(cause: unknown, fallback: string): string {
 function trimToUndefined(value: string | null | undefined): string | undefined {
   const trimmed = typeof value === "string" ? value.trim() : "";
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function ensurePiSubagentChildLauncherEnv(
+  env: Pick<NodeJS.ProcessEnv, "PI_SUBAGENT_PI_COMMAND"> = process.env,
+): void {
+  if (trimToUndefined(env.PI_SUBAGENT_PI_COMMAND)) return;
+  env.PI_SUBAGENT_PI_COMMAND = DEFAULT_PI_SUBAGENT_PI_COMMAND;
 }
 
 function isPiThinkingLevel(value: string | null | undefined): value is ThinkingLevel {
@@ -416,6 +436,110 @@ function textFromContent(content: string | (TextContent | ImageContent)[]): stri
     .join("\n\n");
 }
 
+function timestampFromUnknown(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  return undefined;
+}
+
+function parseJsonLineRecord(line: string): Record<string, unknown> | undefined {
+  if (!line.trim()) return undefined;
+  try {
+    return toolRecord(JSON.parse(line));
+  } catch {
+    return undefined;
+  }
+}
+
+export function makePiSubagentPromptItemId(providerThreadId: string): RuntimeItemId {
+  return RuntimeItemId.makeUnsafe(`pi-subagent-prompt-${providerThreadId}-${crypto.randomUUID()}`);
+}
+
+function readBoundedPiSubagentSessionFile(sessionFile: string): string | undefined {
+  try {
+    if (!existsSync(sessionFile)) return undefined;
+    if (statSync(sessionFile).size > MAX_PI_SUBAGENT_SESSION_TRANSCRIPT_BYTES) return undefined;
+    return readFileSync(sessionFile, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function isInlineAgentAliasChar(char: string | undefined): boolean {
+  return typeof char === "string" && /[a-zA-Z0-9._-]/.test(char);
+}
+
+function isInlineAgentMentionBoundary(char: string | undefined): boolean {
+  return char === undefined || /\s/.test(char);
+}
+
+function readBalancedInlineTask(
+  text: string,
+  openParenIndex: number,
+): { task: string; end: number } | null {
+  let depth = 1;
+  let cursor = openParenIndex + 1;
+  while (cursor < text.length) {
+    const char = text[cursor];
+    if (char === "(") depth += 1;
+    else if (char === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return { task: text.slice(openParenIndex + 1, cursor).trim(), end: cursor + 1 };
+      }
+    }
+    cursor += 1;
+  }
+  return null;
+}
+
+function buildPiSubagentPrompt(
+  text: string,
+  agents: ReadonlyArray<ProviderAgentDescriptor>,
+): string {
+  if (agents.length === 0 || !text.includes("@")) return text;
+  const agentNames = new Set(agents.map((agent) => agent.name));
+  const directives: Array<{ alias: string; task: string }> = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] !== "@" || !isInlineAgentMentionBoundary(text[index - 1])) continue;
+    let aliasEnd = index + 1;
+    while (isInlineAgentAliasChar(text[aliasEnd])) aliasEnd += 1;
+    const alias = text.slice(index + 1, aliasEnd);
+    if (!agentNames.has(alias) || text[aliasEnd] !== "(") continue;
+    const taskMatch = readBalancedInlineTask(text, aliasEnd);
+    if (!taskMatch) continue;
+    directives.push({ alias, task: taskMatch.task });
+    index = taskMatch.end - 1;
+  }
+
+  if (directives.length === 0) return text;
+
+  const directiveLines = directives
+    .map(
+      (directive, index) =>
+        `${index + 1}. Launch the "${directive.alias}" subagent for this task:\n${directive.task}`,
+    )
+    .join("\n\n");
+
+  return [
+    "The user included inline Pi subagent directives in the form @agent(task).",
+    "Execute each directive explicitly with the subagent tool using the named agent below.",
+    "After delegated work completes or reports back, continue with the overall request and synthesize the results.",
+    "Do not echo the literal @agent(task) syntax back to the user unless it is directly relevant.",
+    "",
+    "Inline directives:",
+    directiveLines,
+    "",
+    "Original user prompt:",
+    text,
+  ].join("\n");
+}
+
 function toolRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -536,7 +660,150 @@ function toolEditEntries(args: unknown): ReadonlyArray<Record<string, unknown>> 
   return undefined;
 }
 
+function isPiSubagentTool(toolName: string): boolean {
+  return toolName === "subagent" || toolName === "subagent_resume";
+}
+
+function piSubagentReceiverAgents(input: {
+  readonly args: unknown;
+  readonly details: Record<string, unknown> | undefined;
+}): ReadonlyArray<Record<string, unknown>> {
+  const argsRecord = toolRecord(input.args);
+  const children = Array.isArray(argsRecord?.children) ? argsRecord.children : undefined;
+  if (children && children.length > 0) {
+    return children.flatMap((child, index) => {
+      const childRecord = toolRecord(child);
+      if (!childRecord) return [];
+      const detailsChildren = Array.isArray(input.details?.children) ? input.details.children : [];
+      const childDetails = toolRecord(detailsChildren[index]);
+      const providerThreadId = firstStringValue(childDetails, ["id", "threadId"]);
+      if (!providerThreadId) return [];
+      const agent = firstStringValue(childRecord, ["agent"]);
+      const name = firstStringValue(childRecord, ["name"]);
+      const title = firstStringValue(childRecord, ["title"]);
+      const model = firstStringValue(childRecord, ["model"]);
+      const task = firstStringValue(childRecord, ["task"]);
+      return [
+        {
+          threadId: providerThreadId,
+          ...(agent ? { agentId: agent, agentRole: agent } : {}),
+          ...(name ? { agentNickname: name } : title ? { agentNickname: title } : {}),
+          ...(model ? { model } : {}),
+          ...(task ? { prompt: task } : {}),
+        },
+      ];
+    });
+  }
+
+  const providerThreadId = firstStringValue(input.details, ["id", "threadId"]);
+  if (!providerThreadId) return [];
+  const agent = firstStringValue(input.details, ["agent"]);
+  const name = firstStringValue(input.details, ["name"]);
+  const title = firstStringValue(input.details, ["title"]);
+  const task = firstStringValue(input.details, ["task"]);
+  const model = firstStringValue(input.details, ["model"]);
+  return [
+    {
+      threadId: providerThreadId,
+      ...(agent ? { agentId: agent, agentRole: agent } : {}),
+      ...(name ? { agentNickname: name } : title ? { agentNickname: title } : {}),
+      ...(model ? { model } : {}),
+      ...(task ? { prompt: task } : {}),
+    },
+  ];
+}
+
+function piSubagentPromptText(args: unknown, details?: Record<string, unknown>): string | undefined {
+  const argsRecord = toolRecord(args);
+  return firstStringValue(argsRecord, ["task", "prompt", "message"]) ?? firstStringValue(details, ["task"]);
+}
+
+function isPiSubagentLaunchAcknowledgement(details: Record<string, unknown> | undefined): boolean {
+  const status = firstStringValue(details, ["status"]);
+  return (
+    status === "started" ||
+    status === "running" ||
+    status === "inProgress" ||
+    status === "in_progress"
+  );
+}
+
+function hasRenderablePiSubagentSessionEntry(entry: Record<string, unknown>): boolean {
+  if (entry.type !== "message") return false;
+  const message = toolRecord(entry.message);
+  const role = message?.role;
+  const content = Array.isArray(message?.content) ? message.content : [];
+  if (role === "assistant") {
+    return content.some((part) => {
+      const partRecord = toolRecord(part);
+      if (!partRecord) return false;
+      if (partRecord.type === "text") return typeof partRecord.text === "string" && partRecord.text.length > 0;
+      if (partRecord.type === "thinking") {
+        return typeof partRecord.thinking === "string" && partRecord.thinking.length > 0;
+      }
+      return partRecord.type === "toolCall" && firstStringValue(partRecord, ["id"]) !== undefined;
+    });
+  }
+  return role === "toolResult" && firstStringValue(message, ["toolCallId"]) !== undefined;
+}
+
+function piSubagentLifecycleItem(input: {
+  readonly toolName: string;
+  readonly args: unknown;
+  readonly receiverAgents: ReadonlyArray<Record<string, unknown>>;
+}): Record<string, unknown> {
+  const argsRecord = toolRecord(input.args);
+  const agent = firstStringValue(argsRecord, ["agent"]);
+  const name = firstStringValue(argsRecord, ["name"]);
+  const title = firstStringValue(argsRecord, ["title"]);
+  const task = firstStringValue(argsRecord, ["task", "prompt", "message"]);
+  const model = firstStringValue(argsRecord, ["model", "modelName", "model_name"]);
+  const children = Array.isArray(argsRecord?.children) ? argsRecord.children : undefined;
+  const childItems = children?.flatMap((child) => {
+    const childRecord = toolRecord(child);
+    if (!childRecord) return [];
+    const childAgent = firstStringValue(childRecord, ["agent"]);
+    const childName = firstStringValue(childRecord, ["name"]);
+    const childTitle = firstStringValue(childRecord, ["title"]);
+    const childTask = firstStringValue(childRecord, ["task", "prompt", "message"]);
+    const childModel = firstStringValue(childRecord, ["model", "modelName", "model_name"]);
+    return [
+      {
+        ...(childAgent ? { agent: childAgent, agentId: childAgent, agentRole: childAgent } : {}),
+        ...(childName ? { name: childName, agentNickname: childName } : {}),
+        ...(childTitle ? { title: childTitle } : {}),
+        ...(childTask ? { task: childTask, prompt: childTask } : {}),
+        ...(childModel ? { model: childModel } : {}),
+      },
+    ];
+  });
+
+  return {
+    type: "collabAgentToolCall",
+    tool: input.toolName,
+    toolName: input.toolName,
+    ...(input.args !== undefined ? { input: input.args, args: input.args, rawInput: input.args } : {}),
+    ...(agent ? { agent, agentId: agent, agentRole: agent } : {}),
+    ...(name ? { name, agentNickname: name } : {}),
+    ...(title ? { title } : {}),
+    ...(task ? { task, prompt: task } : {}),
+    ...(model ? { model } : {}),
+    ...(childItems && childItems.length > 0 ? { children: childItems } : {}),
+    ...(input.receiverAgents.length > 0
+      ? {
+          receiverAgents: input.receiverAgents,
+          receiverThreadIds: input.receiverAgents.flatMap((agent) =>
+            typeof agent.threadId === "string" ? [agent.threadId] : [],
+          ),
+        }
+      : {}),
+  };
+}
+
 function toolItemType(toolName: string): PiTrackedToolCall["itemType"] {
+  if (isPiSubagentTool(toolName)) {
+    return "collab_agent_tool_call";
+  }
   switch (toolName) {
     case "bash":
       return "command_execution";
@@ -552,6 +819,9 @@ function toolItemType(toolName: string): PiTrackedToolCall["itemType"] {
 }
 
 function toolTitle(toolName: string, args: unknown): string {
+  if (isPiSubagentTool(toolName)) {
+    return toolName === "subagent_resume" ? "Resume subagent" : "Subagent task";
+  }
   const command = toolName === "bash" ? toolCommand(args) : undefined;
   if (command) return command;
   const filePath = toolPath(args);
@@ -602,6 +872,25 @@ function toolLifecycleData(input: {
   };
 
   switch (toolName) {
+    case "subagent":
+    case "subagent_resume": {
+      const receiverAgents = piSubagentReceiverAgents({ args, details: outputDetails });
+      const item = piSubagentLifecycleItem({ toolName, args, receiverAgents });
+      return {
+        ...base,
+        kind: "subagent",
+        itemType: "collab_agent_tool_call",
+        item,
+        ...(receiverAgents.length > 0
+          ? {
+              receiverAgents,
+              receiverThreadIds: receiverAgents.flatMap((agent) =>
+                typeof agent.threadId === "string" ? [agent.threadId] : [],
+              ),
+            }
+          : {}),
+      };
+    }
     case "bash":
       return {
         ...base,
@@ -933,6 +1222,380 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           payload: input.cause ?? { message: input.message },
         },
       } satisfies ProviderRuntimeEvent);
+    };
+
+    const customMessageText = (content: unknown): string => {
+      if (typeof content === "string") return content;
+      if (!Array.isArray(content)) return "";
+      return textFromContent(content as (TextContent | ImageContent)[]);
+    };
+
+    const emitPiSubagentChildTranscript = (input: {
+      readonly context: PiSessionContext;
+      readonly providerThreadId: string;
+      readonly name?: string | undefined;
+      readonly promptText?: string | undefined;
+      readonly messageText: string;
+      readonly failed: boolean;
+      readonly raw: ProviderRuntimeEvent["raw"];
+    }): void => {
+      const childTurnId = TurnId.makeUnsafe(`pi-subagent-turn-${crypto.randomUUID()}`);
+      const assistantItemId = RuntimeItemId.makeUnsafe(
+        `pi-subagent-assistant-${crypto.randomUUID()}`,
+      );
+      const providerRefs = {
+        providerThreadId: input.providerThreadId,
+        providerParentThreadId: input.context.session.threadId,
+      };
+
+      if (input.promptText) {
+        offerRuntimeEvent({
+          ...makeEventBase(input.context, { includeTurnId: false }),
+          itemId: makePiSubagentPromptItemId(input.providerThreadId),
+          providerRefs,
+          type: "item.completed",
+          payload: {
+            itemType: "user_message",
+            status: "completed",
+            title: "Subagent prompt",
+            detail: input.promptText,
+          },
+          raw: input.raw,
+        } satisfies ProviderRuntimeEvent);
+      }
+
+      offerRuntimeEvent({
+        ...makeEventBase(input.context, { includeTurnId: false }),
+        turnId: childTurnId,
+        providerRefs,
+        type: "turn.started",
+        payload: {},
+        raw: input.raw,
+      } satisfies ProviderRuntimeEvent);
+      offerRuntimeEvent({
+        ...makeEventBase(input.context, { includeTurnId: false }),
+        turnId: childTurnId,
+        itemId: assistantItemId,
+        providerRefs,
+        type: "content.delta",
+        payload: { streamKind: "assistant_text", delta: input.messageText },
+        raw: input.raw,
+      } satisfies ProviderRuntimeEvent);
+      offerRuntimeEvent({
+        ...makeEventBase(input.context, { includeTurnId: false }),
+        turnId: childTurnId,
+        itemId: assistantItemId,
+        providerRefs,
+        type: "item.completed",
+        payload: {
+          itemType: "assistant_message",
+          status: input.failed ? "failed" : "completed",
+          title: input.name ? `Subagent ${input.name}` : "Subagent",
+          detail: input.messageText,
+        },
+        raw: input.raw,
+      } satisfies ProviderRuntimeEvent);
+      offerRuntimeEvent({
+        ...makeEventBase(input.context, { includeTurnId: false }),
+        turnId: childTurnId,
+        providerRefs,
+        type: "turn.completed",
+        payload: {
+          state: input.failed ? "failed" : "completed",
+          stopReason: null,
+          ...(input.failed ? { errorMessage: "Subagent failed" } : {}),
+        },
+        raw: input.raw,
+      } satisfies ProviderRuntimeEvent);
+    };
+
+    const emitPiSubagentSessionTranscript = (input: {
+      readonly context: PiSessionContext;
+      readonly providerThreadId: string;
+      readonly sessionFile: string;
+      readonly promptText?: string | undefined;
+      readonly raw: ProviderRuntimeEvent["raw"];
+    }): boolean => {
+      const sessionContent = readBoundedPiSubagentSessionFile(input.sessionFile);
+      if (sessionContent === undefined) {
+        return false;
+      }
+
+      const transcriptKey = `${input.providerThreadId}\u0000${input.sessionFile}`;
+      if (input.context.emittedSubagentSessionTranscripts.has(transcriptKey)) {
+        return true;
+      }
+
+      const childTurnId = TurnId.makeUnsafe(`pi-subagent-turn-${crypto.randomUUID()}`);
+      const providerRefs = {
+        providerThreadId: input.providerThreadId,
+        providerParentThreadId: input.context.session.threadId,
+      };
+      const sessionLines = sessionContent.split(/\r?\n/);
+      const sessionEntries = sessionLines.flatMap((line) => {
+        const entry = parseJsonLineRecord(line);
+        return entry ? [entry] : [];
+      });
+      if (!sessionEntries.some(hasRenderablePiSubagentSessionEntry)) {
+        return false;
+      }
+      input.context.emittedSubagentSessionTranscripts.add(transcriptKey);
+
+      const sessionStartedAt = sessionLines
+        .map((line) => timestampFromUnknown(parseJsonLineRecord(line)?.timestamp))
+        .find((timestamp) => timestamp !== undefined);
+      const pendingTools = new Map<
+        string,
+        { toolName: string; args: unknown; itemId: RuntimeItemId }
+      >();
+      let emittedRenderableEvent = false;
+
+      const transcriptRaw = {
+        ...(input.raw && typeof input.raw === "object" ? input.raw : {}),
+        sessionFile: input.sessionFile,
+      } as ProviderRuntimeEvent["raw"];
+
+      const childBase = (createdAt?: string) => ({
+        ...makeEventBase(input.context, { includeTurnId: false }),
+        ...(createdAt ? { createdAt } : {}),
+        turnId: childTurnId,
+        providerRefs,
+      });
+
+      if (input.promptText) {
+        offerRuntimeEvent({
+          ...makeEventBase(input.context, { includeTurnId: false }),
+          ...(sessionStartedAt ? { createdAt: sessionStartedAt } : {}),
+          itemId: makePiSubagentPromptItemId(input.providerThreadId),
+          providerRefs,
+          type: "item.completed",
+          payload: {
+            itemType: "user_message",
+            status: "completed",
+            title: "Subagent prompt",
+            detail: input.promptText,
+          },
+          raw: transcriptRaw,
+        } satisfies ProviderRuntimeEvent);
+      }
+
+      offerRuntimeEvent({
+        ...childBase(sessionStartedAt),
+        type: "turn.started",
+        payload: {},
+        raw: transcriptRaw,
+      } satisfies ProviderRuntimeEvent);
+
+      for (const entry of sessionEntries) {
+        if (entry?.type !== "message") continue;
+        const message = toolRecord(entry.message);
+        const role = message?.role;
+        const content = Array.isArray(message?.content) ? message.content : [];
+        const createdAt = timestampFromUnknown(entry.timestamp) ?? timestampFromUnknown(message?.timestamp);
+
+        if (role === "assistant") {
+          for (const [index, part] of content.entries()) {
+            const partRecord = toolRecord(part);
+            if (!partRecord) continue;
+            if (partRecord.type === "text" && typeof partRecord.text === "string") {
+              const text = partRecord.text;
+              if (text.length === 0) continue;
+              const itemId = RuntimeItemId.makeUnsafe(
+                `pi-subagent-session-assistant-${entry.id ?? crypto.randomUUID()}-${index}`,
+              );
+              emittedRenderableEvent = true;
+              offerRuntimeEvent({
+                ...childBase(createdAt),
+                itemId,
+                type: "content.delta",
+                payload: { streamKind: "assistant_text", delta: text },
+                raw: transcriptRaw,
+              } satisfies ProviderRuntimeEvent);
+              offerRuntimeEvent({
+                ...childBase(createdAt),
+                itemId,
+                type: "item.completed",
+                payload: {
+                  itemType: "assistant_message",
+                  status: "completed",
+                  title: "Assistant message",
+                  detail: text,
+                },
+                raw: transcriptRaw,
+              } satisfies ProviderRuntimeEvent);
+              continue;
+            }
+            if (partRecord.type === "thinking" && typeof partRecord.thinking === "string") {
+              const thinking = partRecord.thinking;
+              if (thinking.length === 0) continue;
+              const itemId = RuntimeItemId.makeUnsafe(
+                `pi-subagent-session-thinking-${entry.id ?? crypto.randomUUID()}-${index}`,
+              );
+              emittedRenderableEvent = true;
+              offerRuntimeEvent({
+                ...childBase(createdAt),
+                itemId,
+                type: "content.delta",
+                payload: { streamKind: "reasoning_text", delta: thinking },
+                raw: transcriptRaw,
+              } satisfies ProviderRuntimeEvent);
+              offerRuntimeEvent({
+                ...childBase(createdAt),
+                itemId,
+                type: "item.completed",
+                payload: {
+                  itemType: "reasoning",
+                  status: "completed",
+                  title: "Reasoning",
+                  detail: thinking,
+                },
+                raw: transcriptRaw,
+              } satisfies ProviderRuntimeEvent);
+              continue;
+            }
+            if (partRecord.type === "toolCall") {
+              const toolCallId = firstStringValue(partRecord, ["id"]);
+              const toolName = firstStringValue(partRecord, ["name"]) ?? "tool";
+              if (!toolCallId) continue;
+              const args = partRecord.arguments;
+              const itemId = RuntimeItemId.makeUnsafe(`pi-subagent-session-tool-${toolCallId}`);
+              pendingTools.set(toolCallId, { toolName, args, itemId });
+              emittedRenderableEvent = true;
+              offerRuntimeEvent({
+                ...childBase(createdAt),
+                itemId,
+                providerRefs: {
+                  ...providerRefs,
+                  providerItemId: ProviderItemId.makeUnsafe(toolCallId),
+                },
+                type: "item.started",
+                payload: {
+                  itemType: toolItemType(toolName),
+                  status: "inProgress",
+                  title: toolTitle(toolName, args),
+                  data: toolLifecycleData({ toolCallId, toolName, args }),
+                },
+                raw: transcriptRaw,
+              } satisfies ProviderRuntimeEvent);
+            }
+          }
+          continue;
+        }
+
+        if (role === "toolResult") {
+          const toolCallId = firstStringValue(message, ["toolCallId"]);
+          if (!toolCallId) continue;
+          const pending = pendingTools.get(toolCallId);
+          const toolName = pending?.toolName ?? firstStringValue(message, ["toolName"]) ?? "tool";
+          const args = pending?.args;
+          const isError = message?.isError === true;
+          const result = { content };
+          const detail = textFromToolResult(result);
+          const itemId =
+            pending?.itemId ?? RuntimeItemId.makeUnsafe(`pi-subagent-session-tool-${toolCallId}`);
+          pendingTools.delete(toolCallId);
+          emittedRenderableEvent = true;
+          offerRuntimeEvent({
+            ...childBase(createdAt),
+            itemId,
+            providerRefs: {
+              ...providerRefs,
+              providerItemId: ProviderItemId.makeUnsafe(toolCallId),
+            },
+            type: "item.completed",
+            payload: {
+              itemType: toolItemType(toolName),
+              status: isError ? "failed" : "completed",
+              title: toolTitle(toolName, args),
+              ...(detail ? { detail } : {}),
+              data: toolLifecycleData({
+                toolCallId,
+                toolName,
+                args,
+                result,
+                isError,
+              }),
+            },
+            raw: transcriptRaw,
+          } satisfies ProviderRuntimeEvent);
+        }
+      }
+
+      offerRuntimeEvent({
+        ...childBase(),
+        type: "turn.completed",
+        payload: { state: "completed", stopReason: null },
+        raw: transcriptRaw,
+      } satisfies ProviderRuntimeEvent);
+
+      return emittedRenderableEvent;
+    };
+
+    const emitPiSubagentCustomMessage = (context: PiSessionContext, message: unknown): boolean => {
+      const record = toolRecord(message);
+      const customType = firstStringValue(record, ["customType"]);
+      if (customType !== "subagent_result" && customType !== "subagent_ping") return false;
+
+      const details = toolRecord(record?.details);
+      const providerThreadId =
+        firstStringValue(details, ["id", "paseoAgentId", "name"]) ??
+        `subagent-message-${crypto.randomUUID()}`;
+      const agent = firstStringValue(details, ["agent"]);
+      const name = firstStringValue(details, ["name"]);
+      const task = firstStringValue(details, ["task"]);
+      const status = firstStringValue(details, ["status"]);
+      const sessionFile = firstStringValue(details, ["sessionFile", "sessionPath", "session_file"]);
+      const promptText = task;
+      const failed = status === "failed" || status === "cancelled";
+      const messageText = customMessageText(record?.content);
+      const receiverAgent = {
+        threadId: providerThreadId,
+        ...(agent ? { agentId: agent, agentRole: agent } : {}),
+        ...(name ? { agentNickname: name } : {}),
+        ...(task ? { prompt: task } : {}),
+      };
+      const raw = {
+        source: "pi.sdk.event",
+        messageType: "message_end",
+        payload: { message },
+      } as const;
+
+      offerRuntimeEvent({
+        ...makeEventBase(context, { includeTurnId: false }),
+        itemId: RuntimeItemId.makeUnsafe(`pi-subagent-message-${crypto.randomUUID()}`),
+        type: "item.completed",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: failed ? "failed" : "completed",
+          title: customType === "subagent_ping" ? "Subagent needs help" : "Subagent result",
+          ...(messageText ? { detail: messageText } : {}),
+          data: {
+            receiverThreadIds: [providerThreadId],
+            receiverAgents: [receiverAgent],
+            item: { receiverThreadIds: [providerThreadId], receiverAgents: [receiverAgent] },
+          },
+        },
+        raw,
+      } satisfies ProviderRuntimeEvent);
+
+      if (!messageText) return true;
+
+      const emittedSessionTranscript = sessionFile
+        ? emitPiSubagentSessionTranscript({ context, providerThreadId, sessionFile, promptText, raw })
+        : false;
+      if (!emittedSessionTranscript) {
+        emitPiSubagentChildTranscript({
+          context,
+          providerThreadId,
+          ...(name ? { name } : {}),
+          ...(promptText ? { promptText } : {}),
+          messageText,
+          failed,
+          raw,
+        });
+      }
+
+      return true;
     };
 
     const resolvePiExtensionUserInput = (
@@ -1328,6 +1991,12 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           } satisfies ProviderRuntimeEvent);
           return;
         case "turn_start":
+          if (!context.activeTurnId) {
+            const turnId = TurnId.makeUnsafe(crypto.randomUUID());
+            context.activeTurnId = turnId;
+            context.turns.push({ id: turnId, items: [] });
+            context.session = makeSessionSnapshot(context);
+          }
           offerRuntimeEvent({
             ...makeEventBase(context),
             type: "turn.started",
@@ -1341,6 +2010,9 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             },
             raw: { source: "pi.sdk.event", messageType: event.type, payload: event },
           } satisfies ProviderRuntimeEvent);
+          return;
+        case "message_end":
+          if (emitPiSubagentCustomMessage(context, event.message)) return;
           return;
         case "message_update":
           handleMessageUpdate(context, event);
@@ -1422,6 +2094,14 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           };
           context.activeToolItems.delete(event.toolCallId);
           const detail = textFromToolResult(event.result);
+          const lifecycleData = toolLifecycleData({
+            toolCallId: event.toolCallId,
+            toolName: event.toolName,
+            args: tracked.args,
+            result: event.result,
+            isError: event.isError,
+          });
+          const raw = { source: "pi.sdk.event", messageType: event.type, payload: event } as const;
           recordItem(context, {
             type: "tool_call",
             status: event.isError ? "failed" : "completed",
@@ -1439,16 +2119,62 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
               status: event.isError ? "failed" : "completed",
               title: toolTitle(event.toolName, tracked.args),
               ...(detail ? { detail } : {}),
-              data: toolLifecycleData({
-                toolCallId: event.toolCallId,
-                toolName: event.toolName,
-                args: tracked.args,
-                result: event.result,
-                isError: event.isError,
-              }),
+              data: lifecycleData,
             },
-            raw: { source: "pi.sdk.event", messageType: event.type, payload: event },
+            raw,
           } satisfies ProviderRuntimeEvent);
+          if (isPiSubagentTool(event.toolName) && detail) {
+            const outputDetails = toolRecord(toolRawOutput(event.result)?.details);
+            if (isPiSubagentLaunchAcknowledgement(outputDetails)) {
+              return;
+            }
+            const receiverAgents = piSubagentReceiverAgents({
+              args: tracked.args,
+              details: outputDetails,
+            });
+            const fallbackThreadId = firstStringValue(outputDetails, ["id", "threadId"]);
+            const sessionFile = firstStringValue(outputDetails, [
+              "sessionFile",
+              "sessionPath",
+              "session_file",
+            ]);
+            const promptText = piSubagentPromptText(tracked.args, outputDetails);
+            const transcriptTargets =
+              receiverAgents.length > 0
+                ? receiverAgents
+                : fallbackThreadId
+                  ? [{ threadId: fallbackThreadId }]
+                  : [];
+            for (const receiverAgent of transcriptTargets) {
+              const providerThreadId = firstStringValue(receiverAgent, ["threadId"]);
+              if (!providerThreadId) continue;
+              const emittedSessionTranscript = sessionFile
+                ? emitPiSubagentSessionTranscript({
+                    context,
+                    providerThreadId,
+                    sessionFile,
+                    promptText,
+                    raw,
+                  })
+                : false;
+              if (!emittedSessionTranscript) {
+                const childName = firstStringValue(receiverAgent, [
+                  "agentNickname",
+                  "name",
+                  "threadId",
+                ]);
+                emitPiSubagentChildTranscript({
+                  context,
+                  providerThreadId,
+                  ...(childName ? { name: childName } : {}),
+                  ...(promptText ? { promptText } : {}),
+                  messageText: detail,
+                  failed: event.isError,
+                  raw,
+                });
+              }
+            }
+          }
           return;
         }
         case "compaction_start": {
@@ -1613,6 +2339,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       Effect.gen(function* () {
         const cwd = trimToUndefined(input.cwd) ?? serverConfig.cwd;
         const piSdk = yield* loadPiSdk("session/start");
+        ensurePiSubagentChildLauncherEnv();
         const agentDir = makeAgentDir(input.providerOptions?.pi?.agentDir, piSdk);
         const sessionFile = extractResumeSessionFile(input.resumeCursor);
         const sessionManager = sessionFile
@@ -1676,12 +2403,14 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           runtime,
           modelRegistry,
           session,
+          agentDir,
           turns: [],
           activeTurnId: undefined,
           activeAssistantItemId: undefined,
           activeReasoningItemId: undefined,
           activeToolItems: new Map(),
           pendingUserInputs: new Map(),
+          emittedSubagentSessionTranscripts: new Set(),
           stopped: false,
           lastKnownTokenUsage: undefined,
           unsubscribe: undefined,
@@ -1758,10 +2487,13 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         return session;
       });
 
-    const buildPromptPayload = (input: {
-      readonly input?: string | undefined;
-      readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;
-    }) =>
+    const buildPromptPayload = (
+      context: PiSessionContext,
+      input: {
+        readonly input?: string | undefined;
+        readonly attachments?: ReadonlyArray<ChatAttachment> | undefined;
+      },
+    ) =>
       Effect.gen(function* () {
         const text =
           appendFileAttachmentsPromptBlock({
@@ -1770,6 +2502,10 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             attachmentsDir: serverConfig.attachmentsDir,
             include: "all-files",
           }) ?? "";
+        const piSubagentAgents = listPiSubagentDefinitions({
+          agentDir: context.agentDir,
+          cwd: context.session.cwd ?? serverConfig.cwd,
+        });
         const images = yield* Effect.forEach(
           input.attachments ?? [],
           (attachment) =>
@@ -1806,7 +2542,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           { concurrency: 1 },
         );
         return {
-          text,
+          text: buildPiSubagentPrompt(text, piSubagentAgents),
           images: images.filter((image): image is ImageContent => image !== undefined),
         };
       });
@@ -1847,7 +2583,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             context.runtime.session.setThinkingLevel(thinkingLevel);
           }
         }
-        const payload = yield* buildPromptPayload(input);
+        const payload = yield* buildPromptPayload(context, input);
         const turnId = TurnId.makeUnsafe(crypto.randomUUID());
         context.activeTurnId = turnId;
         context.turns.push({ id: turnId, items: [] });
@@ -1925,7 +2661,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
     const steerTurn: NonNullable<PiAdapterShape["steerTurn"]> = (input) =>
       Effect.gen(function* () {
         const context = yield* requireSession(input.threadId);
-        const payload = yield* buildPromptPayload(input);
+        const payload = yield* buildPromptPayload(context, input);
         const turnId = context.activeTurnId ?? TurnId.makeUnsafe(crypto.randomUUID());
         if (!context.activeTurnId) {
           context.activeTurnId = turnId;
@@ -2159,6 +2895,27 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           }),
       });
 
+    const listAgents: NonNullable<PiAdapterShape["listAgents"]> = (input) =>
+      Effect.tryPromise({
+        try: async () => {
+          const piSdk = await loadPiCodingAgentModule();
+          const agentDir = makeAgentDir(input.agentDir, piSdk);
+          const cwd = trimToUndefined(input.cwd) ?? serverConfig.cwd;
+          return {
+            agents: listPiSubagentDefinitions({ agentDir, cwd }),
+            source: "pi.agents",
+            cached: false,
+          } satisfies ProviderListAgentsResult;
+        },
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "agent/list",
+            detail: toMessage(cause, "Failed to list Pi agents."),
+            cause,
+          }),
+      });
+
     const listSkills: NonNullable<PiAdapterShape["listSkills"]> = (input) =>
       Effect.tryPromise({
         try: async () => {
@@ -2329,6 +3086,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       compactThread,
       stopAll,
       listModels,
+      listAgents,
       listSkills,
       listCommands,
       getComposerCapabilities,

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -94,7 +94,7 @@ interface PiSessionContext {
   activeReasoningItemId: RuntimeItemId | undefined;
   activeToolItems: Map<string, PiTrackedToolCall>;
   pendingUserInputs: Map<ApprovalRequestId, PiPendingUserInput>;
-  emittedSubagentSessionTranscripts: Set<string>;
+  emittedSubagentSessionTranscripts: Map<string, string>;
   stopped: boolean;
   lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
   unsubscribe: (() => void) | undefined;
@@ -147,9 +147,14 @@ function trimToUndefined(value: string | null | undefined): string | undefined {
 
 export function ensurePiSubagentChildLauncherEnv(
   env: Pick<NodeJS.ProcessEnv, "PI_SUBAGENT_PI_COMMAND"> = process.env,
+  binaryPath?: string | null | undefined,
 ): void {
-  if (trimToUndefined(env.PI_SUBAGENT_PI_COMMAND)) return;
-  env.PI_SUBAGENT_PI_COMMAND = DEFAULT_PI_SUBAGENT_PI_COMMAND;
+  const configuredCommand = trimToUndefined(binaryPath);
+  const existingCommand = trimToUndefined(env.PI_SUBAGENT_PI_COMMAND);
+  if (existingCommand && (!configuredCommand || existingCommand !== DEFAULT_PI_SUBAGENT_PI_COMMAND)) {
+    return;
+  }
+  env.PI_SUBAGENT_PI_COMMAND = configuredCommand ?? DEFAULT_PI_SUBAGENT_PI_COMMAND;
 }
 
 function isPiThinkingLevel(value: string | null | undefined): value is ThinkingLevel {
@@ -461,6 +466,28 @@ function stablePiSubagentHash(parts: ReadonlyArray<unknown>): string {
   return crypto.createHash("sha256").update(JSON.stringify(parts)).digest("hex").slice(0, 24);
 }
 
+function makePiSubagentSessionTranscriptKey(input: {
+  readonly providerThreadId: string;
+  readonly sessionFile: string;
+}): string {
+  return `${input.providerThreadId}\u0000${input.sessionFile}`;
+}
+
+export function recordPiSubagentSessionTranscriptEmission(input: {
+  readonly emittedTranscripts: Map<string, string>;
+  readonly providerThreadId: string;
+  readonly sessionFile: string;
+  readonly sessionContent: string;
+}): boolean {
+  const transcriptKey = makePiSubagentSessionTranscriptKey(input);
+  const contentSignature = stablePiSubagentHash([input.sessionContent]);
+  if (input.emittedTranscripts.get(transcriptKey) === contentSignature) {
+    return false;
+  }
+  input.emittedTranscripts.set(transcriptKey, contentSignature);
+  return true;
+}
+
 export function makePiSubagentSourceKey(input: {
   readonly kind: string;
   readonly parentThreadId: string;
@@ -551,23 +578,34 @@ function readBalancedInlineTask(
   return null;
 }
 
-function buildPiSubagentPrompt(
+function piSubagentPromptScopeClause(agent: ProviderAgentDescriptor): string {
+  if (agent.scope === "project") {
+    return ' from the project agent scope (pass scope/source "project" if the subagent tool accepts it)';
+  }
+  if (agent.scope === "global") {
+    return ' from the global agent scope (pass scope/source "global" if the subagent tool accepts it)';
+  }
+  return "";
+}
+
+export function buildPiSubagentPrompt(
   text: string,
   agents: ReadonlyArray<ProviderAgentDescriptor>,
 ): string {
   if (agents.length === 0 || !text.includes("@")) return text;
-  const agentNames = new Set(agents.map((agent) => agent.name));
-  const directives: Array<{ alias: string; task: string }> = [];
+  const agentsByName = new Map(agents.map((agent) => [agent.name, agent]));
+  const directives: Array<{ agent: ProviderAgentDescriptor; task: string }> = [];
 
   for (let index = 0; index < text.length; index += 1) {
     if (text[index] !== "@" || !isInlineAgentMentionBoundary(text[index - 1])) continue;
     let aliasEnd = index + 1;
     while (isInlineAgentAliasChar(text[aliasEnd])) aliasEnd += 1;
     const alias = text.slice(index + 1, aliasEnd);
-    if (!agentNames.has(alias) || text[aliasEnd] !== "(") continue;
+    const agent = agentsByName.get(alias);
+    if (!agent || text[aliasEnd] !== "(") continue;
     const taskMatch = readBalancedInlineTask(text, aliasEnd);
     if (!taskMatch) continue;
-    directives.push({ alias, task: taskMatch.task });
+    directives.push({ agent, task: taskMatch.task });
     index = taskMatch.end - 1;
   }
 
@@ -576,7 +614,7 @@ function buildPiSubagentPrompt(
   const directiveLines = directives
     .map(
       (directive, index) =>
-        `${index + 1}. Launch the "${directive.alias}" subagent for this task:\n${directive.task}`,
+        `${index + 1}. Launch the "${directive.agent.name}" subagent${piSubagentPromptScopeClause(directive.agent)} for this task:\n${directive.task}`,
     )
     .join("\n\n");
 
@@ -1385,11 +1423,6 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         return false;
       }
 
-      const transcriptKey = `${input.providerThreadId}\u0000${input.sessionFile}`;
-      if (input.context.emittedSubagentSessionTranscripts.has(transcriptKey)) {
-        return true;
-      }
-
       const childTurnId = makePiSubagentTurnId(input.sourceKey);
       const providerRefs = {
         providerThreadId: input.providerThreadId,
@@ -1403,7 +1436,16 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       if (!sessionEntries.some(hasRenderablePiSubagentSessionEntry)) {
         return false;
       }
-      input.context.emittedSubagentSessionTranscripts.add(transcriptKey);
+      if (
+        !recordPiSubagentSessionTranscriptEmission({
+          emittedTranscripts: input.context.emittedSubagentSessionTranscripts,
+          providerThreadId: input.providerThreadId,
+          sessionFile: input.sessionFile,
+          sessionContent,
+        })
+      ) {
+        return true;
+      }
 
       const sessionStartedAt = sessionLines
         .map((line) => timestampFromUnknown(parseJsonLineRecord(line)?.timestamp))
@@ -1663,6 +1705,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         ...(name ? { agentNickname: name } : {}),
         ...(task ? { prompt: task } : {}),
       };
+      const parentTurnId = context.activeTurnId;
       const raw = {
         source: "pi.sdk.event",
         messageType: "message_end",
@@ -1680,9 +1723,14 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           title: customType === "subagent_ping" ? "Subagent needs help" : "Subagent result",
           ...(messageText ? { detail: messageText } : {}),
           data: {
+            ...(parentTurnId ? { parentTurnId } : {}),
             receiverThreadIds: [providerThreadId],
             receiverAgents: [receiverAgent],
-            item: { receiverThreadIds: [providerThreadId], receiverAgents: [receiverAgent] },
+            item: {
+              ...(parentTurnId ? { parentTurnId } : {}),
+              receiverThreadIds: [providerThreadId],
+              receiverAgents: [receiverAgent],
+            },
           },
         },
         raw,
@@ -2468,7 +2516,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       Effect.gen(function* () {
         const cwd = trimToUndefined(input.cwd) ?? serverConfig.cwd;
         const piSdk = yield* loadPiSdk("session/start");
-        ensurePiSubagentChildLauncherEnv();
+        ensurePiSubagentChildLauncherEnv(process.env, input.providerOptions?.pi?.binaryPath);
         const agentDir = makeAgentDir(input.providerOptions?.pi?.agentDir, piSdk);
         const sessionFile = extractResumeSessionFile(input.resumeCursor);
         const sessionManager = sessionFile
@@ -2539,7 +2587,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           activeReasoningItemId: undefined,
           activeToolItems: new Map(),
           pendingUserInputs: new Map(),
-          emittedSubagentSessionTranscripts: new Set(),
+          emittedSubagentSessionTranscripts: new Map(),
           stopped: false,
           lastKnownTokenUsage: undefined,
           unsubscribe: undefined,

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -493,14 +493,23 @@ export function recordPiSubagentSessionTranscriptEmission(input: {
   readonly providerThreadId: string;
   readonly sessionFile: string;
   readonly sessionContent: string;
-}): boolean {
+}): "recorded" | "replayed" {
   const transcriptKey = makePiSubagentSessionTranscriptKey(input);
   const contentSignature = stablePiSubagentHash([input.sessionContent]);
   if (input.emittedTranscripts.get(transcriptKey) === contentSignature) {
-    return false;
+    return "replayed";
   }
   input.emittedTranscripts.set(transcriptKey, contentSignature);
-  return true;
+  return "recorded";
+}
+
+type PiSubagentSessionTranscriptImportResult = "emitted" | "replayed" | "unavailable";
+
+export function shouldEmitPiSubagentFallbackTranscript(input: {
+  readonly transcriptResult: PiSubagentSessionTranscriptImportResult;
+  readonly messageText?: string | undefined;
+}): boolean {
+  return input.transcriptResult === "unavailable" && (input.messageText?.length ?? 0) > 0;
 }
 
 export function makePiSubagentSourceKey(input: {
@@ -1488,10 +1497,10 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
       readonly promptText?: string | undefined;
       readonly failed: boolean;
       readonly raw: ProviderRuntimeEvent["raw"];
-    }): boolean => {
+    }): PiSubagentSessionTranscriptImportResult => {
       const sessionContent = readBoundedPiSubagentSessionFile(input.sessionFile);
       if (sessionContent === undefined) {
-        return false;
+        return "unavailable";
       }
 
       const childTurnId = makePiSubagentTurnId(input.sourceKey);
@@ -1505,7 +1514,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         return entry ? [entry] : [];
       });
       if (!sessionEntries.some(hasRenderablePiSubagentSessionEntry)) {
-        return false;
+        return "unavailable";
       }
       const hasTranscriptUserMessage = sessionEntries.some((entry) => {
         if (entry?.type !== "message") return false;
@@ -1516,15 +1525,14 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
           textFromContent(content as (TextContent | ImageContent)[]).trim().length > 0
         );
       });
-      if (
-        !recordPiSubagentSessionTranscriptEmission({
-          emittedTranscripts: input.context.emittedSubagentSessionTranscripts,
-          providerThreadId: input.providerThreadId,
-          sessionFile: input.sessionFile,
-          sessionContent,
-        })
-      ) {
-        return false;
+      const transcriptEmission = recordPiSubagentSessionTranscriptEmission({
+        emittedTranscripts: input.context.emittedSubagentSessionTranscripts,
+        providerThreadId: input.providerThreadId,
+        sessionFile: input.sessionFile,
+        sessionContent,
+      });
+      if (transcriptEmission === "replayed") {
+        return "replayed";
       }
 
       const sessionStartedAt = sessionLines
@@ -1772,7 +1780,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
         raw: transcriptRaw,
       } satisfies ProviderRuntimeEvent);
 
-      return emittedRenderableEvent;
+      return emittedRenderableEvent ? "emitted" : "unavailable";
     };
 
     const emitPiSubagentCustomMessage = (context: PiSessionContext, message: unknown): boolean => {
@@ -1842,7 +1850,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
 
       if (!messageText) return true;
 
-      const emittedSessionTranscript = sessionFile
+      const sessionTranscriptResult = sessionFile
         ? emitPiSubagentSessionTranscript({
             context,
             providerThreadId,
@@ -1852,8 +1860,13 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
             failed,
             raw,
           })
-        : false;
-      if (!emittedSessionTranscript) {
+        : "unavailable";
+      if (
+        shouldEmitPiSubagentFallbackTranscript({
+          transcriptResult: sessionTranscriptResult,
+          messageText,
+        })
+      ) {
         emitPiSubagentChildTranscript({
           context,
           providerThreadId,
@@ -2442,7 +2455,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
                 ...(childPromptText ? { promptText: childPromptText } : {}),
                 ...(detail ? { messageText: detail } : {}),
               });
-              const emittedSessionTranscript = childSessionFile
+              const sessionTranscriptResult = childSessionFile
                 ? emitPiSubagentSessionTranscript({
                     context,
                     providerThreadId,
@@ -2452,8 +2465,13 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
                     failed: event.isError,
                     raw,
                   })
-                : false;
-              if (!emittedSessionTranscript && detail) {
+                : "unavailable";
+              if (
+                shouldEmitPiSubagentFallbackTranscript({
+                  transcriptResult: sessionTranscriptResult,
+                  messageText: detail,
+                })
+              ) {
                 const childName = firstStringValue(receiverAgent, [
                   "agentNickname",
                   "name",

--- a/apps/server/src/provider/Layers/PiAdapter.ts
+++ b/apps/server/src/provider/Layers/PiAdapter.ts
@@ -1538,7 +1538,7 @@ const makePiAdapter = (options?: PiAdapterLiveOptions) =>
 
       const details = toolRecord(record?.details);
       const providerThreadId =
-        firstStringValue(details, ["id", "paseoAgentId", "name"]) ??
+        firstStringValue(details, ["id", "name"]) ??
         `subagent-message-${crypto.randomUUID()}`;
       const agent = firstStringValue(details, ["agent"]);
       const name = firstStringValue(details, ["name"]);

--- a/apps/server/src/provider/piSubagentDefinitions.test.ts
+++ b/apps/server/src/provider/piSubagentDefinitions.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -43,6 +43,7 @@ describe("listPiSubagentDefinitions", () => {
         name: "scout",
         displayName: "Scout",
         description: "Project scout",
+        scope: "project",
       },
     ]);
   });
@@ -64,6 +65,26 @@ describe("listPiSubagentDefinitions", () => {
         name: "scout",
         displayName: "Scout",
         description: "Ancestor project scout",
+        scope: "project",
+      },
+    ]);
+  });
+
+  it("skips unreadable Pi agent definition files", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "synara-pi-agents-"));
+    const agentDir = path.join(root, "agent");
+    const agentsDir = path.join(agentDir, "agents");
+    const cwd = path.join(root, "repo");
+    mkdirSync(agentsDir, { recursive: true });
+    symlinkSync(path.join(root, "missing.md"), path.join(agentsDir, "broken.md"));
+    writeAgent(agentsDir, "scout.md", ["name: scout", "description: Valid scout"].join("\n"));
+
+    expect(listPiSubagentDefinitions({ agentDir, cwd })).toEqual([
+      {
+        name: "scout",
+        displayName: "Scout",
+        description: "Valid scout",
+        scope: "global",
       },
     ]);
   });

--- a/apps/server/src/provider/piSubagentDefinitions.test.ts
+++ b/apps/server/src/provider/piSubagentDefinitions.test.ts
@@ -1,0 +1,70 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { listPiSubagentDefinitions } from "./piSubagentDefinitions.ts";
+
+function writeAgent(dir: string, fileName: string, frontmatter: string): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, fileName), `---\n${frontmatter}\n---\n\nBody\n`);
+}
+
+describe("listPiSubagentDefinitions", () => {
+  it("reads global and project Pi subagent definitions with project overrides", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "synara-pi-agents-"));
+    const agentDir = path.join(root, "agent");
+    const cwd = path.join(root, "repo");
+
+    writeAgent(
+      path.join(agentDir, "agents"),
+      "scout.md",
+      [
+        "name: scout",
+        "description: Global scout",
+        "model: openai/gpt-5.5",
+        "thinking: low",
+      ].join("\n"),
+    );
+    writeAgent(
+      path.join(cwd, ".pi", "agents"),
+      "scout.md",
+      ["name: scout", "description: Project scout", "enabled: true"].join("\n"),
+    );
+    writeAgent(
+      path.join(cwd, ".pi", "agents"),
+      "disabled.md",
+      ["name: disabled", "description: Hidden", "enabled: false"].join("\n"),
+    );
+
+    expect(listPiSubagentDefinitions({ agentDir, cwd })).toEqual([
+      {
+        name: "scout",
+        displayName: "Scout",
+        description: "Project scout",
+      },
+    ]);
+  });
+
+  it("discovers project agents from the nearest ancestor .pi directory", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "synara-pi-agents-"));
+    const agentDir = path.join(root, "agent");
+    const cwd = path.join(root, "repo", "packages", "app");
+
+    writeAgent(
+      path.join(root, "repo", ".pi", "agents"),
+      "scout.md",
+      ["name: scout", "description: Ancestor project scout"].join("\n"),
+    );
+    mkdirSync(cwd, { recursive: true });
+
+    expect(listPiSubagentDefinitions({ agentDir, cwd })).toEqual([
+      {
+        name: "scout",
+        displayName: "Scout",
+        description: "Ancestor project scout",
+      },
+    ]);
+  });
+});

--- a/apps/server/src/provider/piSubagentDefinitions.test.ts
+++ b/apps/server/src/provider/piSubagentDefinitions.test.ts
@@ -88,4 +88,25 @@ describe("listPiSubagentDefinitions", () => {
       },
     ]);
   });
+
+  it("accepts CRLF-delimited frontmatter", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "synara-pi-agents-"));
+    const agentDir = path.join(root, "agent");
+    const agentsDir = path.join(agentDir, "agents");
+    const cwd = path.join(root, "repo");
+    mkdirSync(agentsDir, { recursive: true });
+    writeFileSync(
+      path.join(agentsDir, "windows.md"),
+      ["---", "name: windows", "description: CRLF agent", "---", "", "Body"].join("\r\n"),
+    );
+
+    expect(listPiSubagentDefinitions({ agentDir, cwd })).toEqual([
+      {
+        name: "windows",
+        displayName: "Windows",
+        description: "CRLF agent",
+        scope: "global",
+      },
+    ]);
+  });
 });

--- a/apps/server/src/provider/piSubagentDefinitions.test.ts
+++ b/apps/server/src/provider/piSubagentDefinitions.test.ts
@@ -20,12 +20,9 @@ describe("listPiSubagentDefinitions", () => {
     writeAgent(
       path.join(agentDir, "agents"),
       "scout.md",
-      [
-        "name: scout",
-        "description: Global scout",
-        "model: openai/gpt-5.5",
-        "thinking: low",
-      ].join("\n"),
+      ["name: scout", "description: Global scout", "model: openai/gpt-5.5", "thinking: low"].join(
+        "\n",
+      ),
     );
     writeAgent(
       path.join(cwd, ".pi", "agents"),

--- a/apps/server/src/provider/piSubagentDefinitions.ts
+++ b/apps/server/src/provider/piSubagentDefinitions.ts
@@ -1,0 +1,126 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type { ProviderAgentDescriptor } from "@t3tools/contracts";
+
+interface PiSubagentDefinition {
+  readonly name: string;
+  readonly description?: string;
+  readonly model?: string;
+  readonly thinking?: string;
+  readonly source: "global" | "project";
+}
+
+function expandHome(input: string): string {
+  return input === "~" || input.startsWith("~/") ? path.join(homedir(), input.slice(2)) : input;
+}
+
+function frontmatterValue(frontmatter: string, key: string): string | undefined {
+  const match = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+  const value = match?.[1]?.trim();
+  return value && value.length > 0 ? value : undefined;
+}
+
+function parseDefinitionFile(
+  filePath: string,
+  source: PiSubagentDefinition["source"],
+): PiSubagentDefinition | null {
+  const content = readFileSync(filePath, "utf8");
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return null;
+
+  const frontmatter = match[1] ?? "";
+  if (frontmatterValue(frontmatter, "enabled") === "false") return null;
+
+  const fallbackName = path.basename(filePath, ".md");
+  const name = frontmatterValue(frontmatter, "name") ?? fallbackName;
+  const description = frontmatterValue(frontmatter, "description");
+  const model = frontmatterValue(frontmatter, "model");
+  const thinking = frontmatterValue(frontmatter, "thinking");
+
+  return {
+    name,
+    source,
+    ...(description ? { description } : {}),
+    ...(model ? { model } : {}),
+    ...(thinking ? { thinking } : {}),
+  };
+}
+
+function readAgentDirectory(
+  dir: string,
+  source: PiSubagentDefinition["source"],
+): PiSubagentDefinition[] {
+  const resolvedDir = expandHome(dir);
+  if (!existsSync(resolvedDir)) return [];
+
+  return readdirSync(resolvedDir, { withFileTypes: true })
+    .filter((entry) => entry.name.endsWith(".md") && (entry.isFile() || entry.isSymbolicLink()))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .flatMap((entry) => {
+      const definition = parseDefinitionFile(path.join(resolvedDir, entry.name), source);
+      return definition ? [definition] : [];
+    });
+}
+
+function isDirectory(dir: string): boolean {
+  try {
+    return statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function findNearestProjectAgentsDir(cwd: string): string | undefined {
+  let currentDir = path.resolve(expandHome(cwd));
+  while (true) {
+    const candidate = path.join(currentDir, ".pi", "agents");
+    if (isDirectory(candidate)) return candidate;
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) return undefined;
+    currentDir = parentDir;
+  }
+}
+
+function displayNameFromAgentName(name: string): string {
+  return name
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ") || name;
+}
+
+function modelWithThinking(definition: PiSubagentDefinition): string | undefined {
+  if (!definition.model) return undefined;
+  if (!definition.thinking || definition.model.includes(":")) return definition.model;
+  return `${definition.model}:${definition.thinking}`;
+}
+
+export function listPiSubagentDefinitions(input: {
+  readonly agentDir: string;
+  readonly cwd: string;
+}): ProviderAgentDescriptor[] {
+  const agents = new Map<string, PiSubagentDefinition>();
+  for (const definition of readAgentDirectory(path.join(input.agentDir, "agents"), "global")) {
+    agents.set(definition.name, definition);
+  }
+  const projectAgentsDir = findNearestProjectAgentsDir(input.cwd);
+  if (projectAgentsDir) {
+    for (const definition of readAgentDirectory(projectAgentsDir, "project")) {
+      agents.set(definition.name, definition);
+    }
+  }
+
+  return [...agents.values()]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((definition) => {
+      const model = modelWithThinking(definition);
+      return {
+        name: definition.name,
+        displayName: displayNameFromAgentName(definition.name),
+        ...(definition.description ? { description: definition.description } : {}),
+        ...(model ? { model } : {}),
+      };
+    });
+}

--- a/apps/server/src/provider/piSubagentDefinitions.ts
+++ b/apps/server/src/provider/piSubagentDefinitions.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync, type Dirent } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 
@@ -26,7 +26,12 @@ function parseDefinitionFile(
   filePath: string,
   source: PiSubagentDefinition["source"],
 ): PiSubagentDefinition | null {
-  const content = readFileSync(filePath, "utf8");
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) return null;
 
@@ -55,7 +60,14 @@ function readAgentDirectory(
   const resolvedDir = expandHome(dir);
   if (!existsSync(resolvedDir)) return [];
 
-  return readdirSync(resolvedDir, { withFileTypes: true })
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(resolvedDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  return entries
     .filter((entry) => entry.name.endsWith(".md") && (entry.isFile() || entry.isSymbolicLink()))
     .sort((a, b) => a.name.localeCompare(b.name))
     .flatMap((entry) => {
@@ -119,6 +131,7 @@ export function listPiSubagentDefinitions(input: {
       return {
         name: definition.name,
         displayName: displayNameFromAgentName(definition.name),
+        scope: definition.source,
         ...(definition.description ? { description: definition.description } : {}),
         ...(model ? { model } : {}),
       };

--- a/apps/server/src/provider/piSubagentDefinitions.ts
+++ b/apps/server/src/provider/piSubagentDefinitions.ts
@@ -96,11 +96,13 @@ function findNearestProjectAgentsDir(cwd: string): string | undefined {
 }
 
 function displayNameFromAgentName(name: string): string {
-  return name
-    .split(/[-_]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ") || name;
+  return (
+    name
+      .split(/[-_]+/)
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ") || name
+  );
 }
 
 function modelWithThinking(definition: PiSubagentDefinition): string | undefined {

--- a/apps/server/src/provider/piSubagentDefinitions.ts
+++ b/apps/server/src/provider/piSubagentDefinitions.ts
@@ -32,7 +32,7 @@ function parseDefinitionFile(
   } catch {
     return null;
   }
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
   if (!match) return null;
 
   const frontmatter = match[1] ?? "";

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1871,6 +1871,14 @@ export default function ChatView({
       enabled: kiloModelDiscoveryEnabled,
     }),
   );
+  const piDynamicAgentsQuery = useQuery(
+    providerAgentsQueryOptions({
+      provider: "pi",
+      agentDir: settings.piAgentDir || null,
+      cwd: providerModelDiscoveryCwd,
+      enabled: piModelDiscoveryEnabled,
+    }),
+  );
   const cursorRuntimeModels = useMemo(
     () =>
       showExpandedCursorModelVariants
@@ -3098,7 +3106,9 @@ export default function ChatView({
         ? (kiloDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS)
         : selectedProvider === "opencode"
           ? (openCodeDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS)
-          : (codexDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS);
+          : selectedProvider === "pi"
+            ? (piDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS)
+            : (codexDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS);
   const dynamicAgents = useMemo(
     () =>
       selectedDynamicAgents.map((agent) =>

--- a/apps/web/src/components/chat/AgentActivityDetailView.test.tsx
+++ b/apps/web/src/components/chat/AgentActivityDetailView.test.tsx
@@ -6,6 +6,7 @@ describe("AgentActivityDetailView", () => {
   it("renders a full agent activity detail surface", () => {
     const markup = renderToStaticMarkup(
       <AgentActivityDetailView
+        parentThreadId="parent-thread"
         detail={{
           id: "agent-task-1",
           title: "Find changelog implementation",

--- a/apps/web/src/components/chat/AgentActivityDetailView.tsx
+++ b/apps/web/src/components/chat/AgentActivityDetailView.tsx
@@ -35,6 +35,7 @@ const MIN_DETAIL_BOTTOM_INSET_PX = 64;
 
 interface AgentActivityDetailViewProps {
   detail: AgentActivityDetail;
+  parentThreadId: string;
   bottomContentInsetPx?: number | undefined;
   chatFontSizePx: number;
   contentInsetRightPx?: number | undefined;
@@ -47,6 +48,7 @@ interface AgentActivityDetailViewProps {
 
 export const AgentActivityDetailView = memo(function AgentActivityDetailView({
   detail,
+  parentThreadId,
   bottomContentInsetPx,
   chatFontSizePx,
   contentInsetRightPx,
@@ -152,6 +154,7 @@ export const AgentActivityDetailView = memo(function AgentActivityDetailView({
                 <SubagentDetailRow
                   key={subagent.threadId}
                   subagent={subagent}
+                  parentThreadId={parentThreadId}
                   textStyle={chatTypographyStyle}
                   {...(onOpenThread ? { onOpenThread } : {})}
                 />
@@ -228,6 +231,7 @@ function AgentActivityEventRow(props: {
 
 function SubagentDetailRow(props: {
   subagent: WorkLogSubagent;
+  parentThreadId: string;
   textStyle: CSSProperties;
   onOpenThread?: (threadId: ThreadId) => void;
 }) {
@@ -240,6 +244,9 @@ function SubagentDetailRow(props: {
   const modelLabel = formatSubagentModelLabel(props.subagent.model);
   const statusLabel = humanizeSubagentStatus(props.subagent.rawStatus, props.subagent.isActive);
   const canOpenThread = Boolean(props.onOpenThread);
+  const targetThreadId =
+    props.subagent.resolvedThreadId ??
+    `subagent:${props.parentThreadId}:${props.subagent.providerThreadId ?? props.subagent.threadId}`;
 
   return (
     <div className="flex items-start gap-2.5 rounded-md border border-border/40 bg-background/45 px-3 py-2">
@@ -276,11 +283,7 @@ function SubagentDetailRow(props: {
             : "cursor-default opacity-50",
         )}
         disabled={!canOpenThread}
-        onClick={() =>
-          props.onOpenThread?.(
-            ThreadId.makeUnsafe(props.subagent.resolvedThreadId ?? props.subagent.threadId),
-          )
-        }
+        onClick={() => props.onOpenThread?.(ThreadId.makeUnsafe(targetThreadId))}
       >
         Open
       </button>

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -182,6 +182,7 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
         {agentActivityDetail && onCloseAgentActivityDetail ? (
           <AgentActivityDetailView
             detail={agentActivityDetail}
+            parentThreadId={activeThreadId}
             bottomContentInsetPx={bottomContentInsetPx}
             chatFontSizePx={chatFontSizePx}
             contentInsetRightPx={contentInsetRightPx}
@@ -194,6 +195,7 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
         ) : (
           <MessagesTimeline
             key={activeThreadId}
+            activeThreadId={activeThreadId}
             hasMessages={hasMessages}
             isWorking={isWorking}
             worktreeSetup={worktreeSetup}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -368,6 +368,7 @@ function WorktreeSetupCard({ steps }: { steps: ReadonlyArray<WorktreeSetupStep> 
 }
 
 interface MessagesTimelineProps {
+  activeThreadId: string;
   hasMessages: boolean;
   isWorking: boolean;
   activeTurnInProgress: boolean;
@@ -433,6 +434,7 @@ interface MessagesTimelineProps {
 }
 
 export const MessagesTimeline = memo(function MessagesTimeline({
+  activeThreadId,
   hasMessages,
   isWorking,
   activeTurnInProgress,
@@ -973,9 +975,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             <div>
               <div className="space-y-0.5">
                 {visibleEntries.map((workEntry) => (
-                  <SimpleWorkEntryRow
-                    key={`work-row:${workEntry.id}`}
-                    workEntry={workEntry}
+                    <SimpleWorkEntryRow
+                      key={`work-row:${workEntry.id}`}
+                      parentThreadId={activeThreadId}
+                      workEntry={workEntry}
                     chatMetaFontSizePx={appTypographyScale.chatMetaPx}
                     textFontSizePx={normalizedChatFontSizePx}
                     density={prefersCompactWorkEntryRow(workEntry) ? "compact" : "default"}
@@ -1351,6 +1354,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     {display.visibleRenderableToolEntries.map((workEntry) => (
                       <SimpleWorkEntryRow
                         key={`${placement}-tool-row:${row.message.id}:${workEntry.id}`}
+                        parentThreadId={activeThreadId}
                         workEntry={workEntry}
                         chatMetaFontSizePx={appTypographyScale.chatMetaPx}
                         textFontSizePx={normalizedChatFontSizePx}
@@ -1389,6 +1393,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   {display.statusEntries.map((workEntry) => (
                     <SimpleWorkEntryRow
                       key={`${placement}-status-row:${row.message.id}:${workEntry.id}`}
+                      parentThreadId={activeThreadId}
                       workEntry={workEntry}
                       chatMetaFontSizePx={appTypographyScale.chatMetaPx}
                       textFontSizePx={normalizedChatFontSizePx}
@@ -1409,6 +1414,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             item.kind === "work" ? (
               <SimpleWorkEntryRow
                 key={`${keyPrefix}:work:${row.message.id}:${item.id}`}
+                parentThreadId={activeThreadId}
                 workEntry={item.entry}
                 chatMetaFontSizePx={appTypographyScale.chatMetaPx}
                 textFontSizePx={normalizedChatFontSizePx}
@@ -2929,6 +2935,7 @@ function ToolRowTooltip(props: { content: ReactNode; children: ReactElement }) {
 }
 
 const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
+  parentThreadId: string;
   workEntry: TimelineWorkEntry;
   chatMetaFontSizePx: number;
   textFontSizePx?: number;
@@ -2944,6 +2951,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   onOpenAutomation?: (automationId: string) => void;
 }) {
   const {
+    parentThreadId,
     workEntry,
     chatMetaFontSizePx,
     textFontSizePx = chatMetaFontSizePx,
@@ -3173,6 +3181,9 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
                   subagent.statusLabel ??
                   humanizeSubagentStatus(subagent.rawStatus, subagent.isActive);
                 const canOpenThread = Boolean(onOpenThread);
+                const targetThreadId =
+                  subagent.resolvedThreadId ??
+                  `subagent:${parentThreadId}:${subagent.providerThreadId ?? subagent.threadId}`;
                 return (
                   <div
                     key={`${workEntry.id}:${subagent.threadId}`}
@@ -3243,11 +3254,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
                             : "cursor-default opacity-50",
                         )}
                         disabled={!canOpenThread}
-                        onClick={() =>
-                          onOpenThread?.(
-                            ThreadId.makeUnsafe(subagent.resolvedThreadId ?? subagent.threadId),
-                          )
-                        }
+                        onClick={() => onOpenThread?.(ThreadId.makeUnsafe(targetThreadId))}
                       >
                         Open thread
                       </button>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -975,10 +975,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             <div>
               <div className="space-y-0.5">
                 {visibleEntries.map((workEntry) => (
-                    <SimpleWorkEntryRow
-                      key={`work-row:${workEntry.id}`}
-                      parentThreadId={activeThreadId}
-                      workEntry={workEntry}
+                  <SimpleWorkEntryRow
+                    key={`work-row:${workEntry.id}`}
+                    parentThreadId={activeThreadId}
+                    workEntry={workEntry}
                     chatMetaFontSizePx={appTypographyScale.chatMetaPx}
                     textFontSizePx={normalizedChatFontSizePx}
                     density={prefersCompactWorkEntryRow(workEntry) ? "compact" : "default"}

--- a/apps/web/src/components/chat/agentActivity.logic.test.ts
+++ b/apps/web/src/components/chat/agentActivity.logic.test.ts
@@ -109,4 +109,250 @@ describe("deriveAgentActivityTimelineState", () => {
       detail: "Full changelog report\nwith many file references and implementation notes.",
     });
   });
+
+  it("groups delayed subagent result rows with the launch activity", () => {
+    const state = deriveAgentActivityTimelineState([
+      workEntry({
+        id: "agent-task-start",
+        label: "Subagent smoke test",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Subagent smoke test",
+        subagentAction: {
+          tool: "subagent",
+          status: "inProgress",
+          summaryText: "Agent activity",
+          prompt: "Run a harmless subagent smoke test.",
+        },
+        subagents: [
+          {
+            threadId: "child-provider-1",
+            providerThreadId: "child-provider-1",
+            nickname: "smoke-test",
+            prompt: "Run a harmless subagent smoke test.",
+          },
+        ],
+      }),
+      workEntry({
+        id: "agent-task-result",
+        label: "Subagent result",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Subagent result",
+        detail: "Subagent launched successfully from /home/ethan/synara and changed no files.",
+        subagents: [
+          {
+            threadId: "child-provider-1",
+            providerThreadId: "child-provider-1",
+            nickname: "smoke-test",
+            prompt: "Run a harmless subagent smoke test.",
+          },
+        ],
+      }),
+    ]);
+
+    expect(state.timelineWorkEntries.map((entry) => entry.id)).toEqual(["agent-task-start"]);
+    expect(state.timelineWorkEntries[0]).toMatchObject({
+      id: "agent-task-start",
+      toolTitle: "Subagent smoke test",
+      detail: "Subagent launched successfully from /home/ethan/synara and changed no files.",
+      subagents: [{ threadId: "child-provider-1", nickname: "smoke-test" }],
+    });
+    expect(state.detailById.get("agent-task-start")?.entries.map((entry) => entry.id)).toEqual([
+      "agent-task-start",
+      "agent-task-result",
+    ]);
+  });
+
+  it("groups single subagent launch and result rows by child identity", () => {
+    const state = deriveAgentActivityTimelineState([
+      workEntry({
+        id: "agent-task-start",
+        label: "Agent activity",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Agent activity",
+        subagentAction: {
+          tool: "subagent",
+          status: "inProgress",
+          summaryText: "Agent activity",
+          prompt: "Run a smoke test and report back briefly.",
+        },
+        subagents: [
+          {
+            threadId: "child-provider-1",
+            providerThreadId: "child-provider-1",
+            nickname: "subagent-smoke-test",
+          },
+        ],
+      }),
+      workEntry({
+        id: "agent-task-result",
+        label: "Spawning 1 agent",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Spawning 1 agent",
+        detail: "Subagent smoke test succeeded. No files were modified.",
+        subagentAction: {
+          tool: "spawnAgent",
+          status: "completed",
+          summaryText: "Spawning 1 agent",
+        },
+        subagents: [
+          {
+            threadId: "child-provider-1",
+            providerThreadId: "child-provider-1",
+            nickname: "subagent-smoke-test",
+          },
+        ],
+      }),
+    ]);
+
+    expect(state.timelineWorkEntries.map((entry) => entry.id)).toEqual(["agent-task-start"]);
+    expect(state.timelineWorkEntries[0]).toMatchObject({
+      detail: "Subagent smoke test succeeded. No files were modified.",
+      subagents: [{ threadId: "child-provider-1", nickname: "subagent-smoke-test" }],
+    });
+    expect(state.detailById.get("agent-task-start")?.entries.map((entry) => entry.id)).toEqual([
+      "agent-task-start",
+      "agent-task-result",
+    ]);
+  });
+
+  it("omits redundant single-agent launch rows when a parallel dispatch summary exists", () => {
+    const state = deriveAgentActivityTimelineState([
+      workEntry({
+        id: "parallel-summary",
+        label: "Agent activity",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Agent activity",
+        subagentAction: {
+          tool: "spawnAgent",
+          status: "completed",
+          summaryText: "Agent activity",
+        },
+        subagents: [
+          { threadId: "child-one", providerThreadId: "child-one", nickname: "one" },
+          { threadId: "child-two", providerThreadId: "child-two", nickname: "two" },
+          { threadId: "child-three", providerThreadId: "child-three", nickname: "three" },
+        ],
+      }),
+      workEntry({
+        id: "launch-one",
+        label: "Spawning 1 agent",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Spawning 1 agent",
+        detail: "parallel-test-one(explore)",
+        preview: "parallel-test-one [explore]",
+        subagentAction: {
+          tool: "spawnAgent",
+          status: "inProgress",
+          summaryText: "Spawning 1 agent",
+        },
+        subagents: [{ threadId: "child-one", providerThreadId: "child-one", nickname: "one" }],
+      }),
+      workEntry({
+        id: "launch-two",
+        label: "Spawning 1 agent",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Spawning 1 agent",
+        subagentAction: {
+          tool: "spawnAgent",
+          status: "inProgress",
+          summaryText: "Spawning 1 agent",
+        },
+        subagents: [{ threadId: "child-two", providerThreadId: "child-two", nickname: "two" }],
+      }),
+      workEntry({
+        id: "launch-three",
+        label: "Spawning 1 agent",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Spawning 1 agent",
+        subagentAction: {
+          tool: "spawnAgent",
+          status: "inProgress",
+          summaryText: "Spawning 1 agent",
+        },
+        subagents: [
+          { threadId: "child-three", providerThreadId: "child-three", nickname: "three" },
+        ],
+      }),
+    ]);
+
+    expect(state.timelineWorkEntries.map((entry) => entry.id)).toEqual(["parallel-summary"]);
+    expect(state.timelineWorkEntries[0]?.subagents?.map((subagent) => subagent.threadId)).toEqual([
+      "child-one",
+      "child-two",
+      "child-three",
+    ]);
+  });
+
+  it("keeps matching single-agent result details in the grouped activity", () => {
+    const state = deriveAgentActivityTimelineState([
+      workEntry({
+        id: "parallel-summary",
+        label: "Agent activity",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Agent activity",
+        subagents: [
+          { threadId: "child-one", providerThreadId: "child-one", nickname: "one" },
+          { threadId: "child-two", providerThreadId: "child-two", nickname: "two" },
+        ],
+      }),
+      workEntry({
+        id: "result-one",
+        label: "Agent activity",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Agent result",
+        detail: "Child one found the relevant files.",
+        subagentAction: {
+          tool: "spawnAgent",
+          status: "completed",
+          summaryText: "Agent activity",
+        },
+        subagents: [{ threadId: "child-one", providerThreadId: "child-one", nickname: "one" }],
+      }),
+    ]);
+
+    expect(state.timelineWorkEntries.map((entry) => entry.id)).toEqual(["parallel-summary"]);
+    expect(state.timelineWorkEntries[0]).toMatchObject({
+      detail: "Child one found the relevant files.",
+    });
+    expect(state.detailById.get("parallel-summary")?.entries.map((entry) => entry.id)).toEqual([
+      "parallel-summary",
+      "result-one",
+    ]);
+  });
+
+  it("does not group independent launches by prompt or nickname alone", () => {
+    const state = deriveAgentActivityTimelineState([
+      workEntry({
+        id: "agent-task-one",
+        label: "Agent activity",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Agent activity",
+        subagentAction: {
+          tool: "subagent",
+          status: "completed",
+          summaryText: "Agent activity",
+          prompt: "Run the shared smoke check.",
+        },
+        subagents: [{ threadId: "first-child", nickname: "smoke-test" }],
+      }),
+      workEntry({
+        id: "agent-task-two",
+        label: "Agent activity",
+        itemType: "collab_agent_tool_call",
+        toolTitle: "Agent activity",
+        subagentAction: {
+          tool: "subagent",
+          status: "completed",
+          summaryText: "Agent activity",
+          prompt: "Run the shared smoke check.",
+        },
+        subagents: [{ threadId: "second-child", nickname: "smoke-test" }],
+      }),
+    ]);
+
+    expect(state.timelineWorkEntries.map((entry) => entry.id)).toEqual([
+      "agent-task-one",
+      "agent-task-two",
+    ]);
+  });
 });

--- a/apps/web/src/components/chat/agentActivity.logic.ts
+++ b/apps/web/src/components/chat/agentActivity.logic.ts
@@ -199,11 +199,12 @@ function buildGroupedAgentActivityEntry(
     ...(prompt || primaryEntry.subagentAction || latest.subagentAction
       ? {
           subagentAction: {
-            ...(primaryEntry.subagentAction ?? latest.subagentAction ?? {
-              tool: "spawnAgent",
-              status: latest.subagentAction?.status ?? "completed",
-              summaryText: "Agent activity",
-            }),
+            ...(primaryEntry.subagentAction ??
+              latest.subagentAction ?? {
+                tool: "spawnAgent",
+                status: latest.subagentAction?.status ?? "completed",
+                summaryText: "Agent activity",
+              }),
             ...(prompt ? { prompt } : {}),
           },
         }
@@ -316,14 +317,12 @@ function isRedundantSingleSubagentLaunch(
 function subagentThreadIdentityKeys(
   subagent: NonNullable<WorkLogEntry["subagents"]>[number],
 ): string[] {
-  return [
-    subagent.resolvedThreadId,
-    subagent.providerThreadId,
-    subagent.threadId,
-  ].flatMap((value) => {
-    const normalized = normalizeGroupKey(value);
-    return normalized ? [normalized] : [];
-  });
+  return [subagent.resolvedThreadId, subagent.providerThreadId, subagent.threadId].flatMap(
+    (value) => {
+      const normalized = normalizeGroupKey(value);
+      return normalized ? [normalized] : [];
+    },
+  );
 }
 
 function normalizeGroupKey(value: string | null | undefined): string | null {

--- a/apps/web/src/components/chat/agentActivity.logic.ts
+++ b/apps/web/src/components/chat/agentActivity.logic.ts
@@ -79,6 +79,11 @@ export function deriveAgentActivityTimelineState(
 ): AgentActivityTimelineState {
   const timelineWorkEntries: WorkLogEntry[] = [];
   const detailById = new Map<string, AgentActivityDetail>();
+  const collabGroupByKey = new Map<
+    string,
+    { id: string; timelineIndex: number; primaryEntry: WorkLogEntry; entries: WorkLogEntry[] }
+  >();
+  const multiSubagentIdentities = collectMultiSubagentIdentities(entries);
   let pendingReasoningEntries: WorkLogEntry[] = [];
 
   const flushReasoningEntries = () => {
@@ -119,6 +124,52 @@ export function deriveAgentActivityTimelineState(
     }
 
     flushReasoningEntries();
+
+    if (entry.itemType === "collab_agent_tool_call") {
+      if (isRedundantSingleSubagentLaunch(entry, multiSubagentIdentities)) {
+        continue;
+      }
+
+      const groupKeys = collabAgentActivityGroupKeys(entry);
+      const existingGroup = groupKeys.map((key) => collabGroupByKey.get(key)).find(Boolean);
+      if (existingGroup) {
+        existingGroup.entries.push(entry);
+        timelineWorkEntries[existingGroup.timelineIndex] = buildGroupedAgentActivityEntry(
+          existingGroup.id,
+          existingGroup.primaryEntry,
+          existingGroup.entries,
+        );
+        for (const key of groupKeys) {
+          collabGroupByKey.set(key, existingGroup);
+        }
+        detailById.set(
+          existingGroup.id,
+          buildAgentActivityDetail(
+            existingGroup.id,
+            existingGroup.primaryEntry,
+            existingGroup.entries,
+          ),
+        );
+        continue;
+      }
+
+      const timelineIndex = timelineWorkEntries.length;
+      timelineWorkEntries.push(entry);
+      detailById.set(entry.id, buildAgentActivityDetail(entry.id, entry, [entry]));
+      if (groupKeys.length > 0) {
+        const group = {
+          id: entry.id,
+          timelineIndex,
+          primaryEntry: entry,
+          entries: [entry],
+        };
+        for (const key of groupKeys) {
+          collabGroupByKey.set(key, group);
+        }
+      }
+      continue;
+    }
+
     timelineWorkEntries.push(entry);
     if (isAgentActivityWorkEntry(entry)) {
       detailById.set(entry.id, buildAgentActivityDetail(entry.id, entry, [entry]));
@@ -127,6 +178,157 @@ export function deriveAgentActivityTimelineState(
 
   flushReasoningEntries();
   return { timelineWorkEntries, detailById };
+}
+
+function buildGroupedAgentActivityEntry(
+  id: string,
+  primaryEntry: WorkLogEntry,
+  entries: ReadonlyArray<WorkLogEntry>,
+): WorkLogEntry {
+  const latest = entries[entries.length - 1] ?? primaryEntry;
+  const prompt = findFirstCollabPrompt(entries);
+  const result = findLatestCollabResult(entries);
+  const subagents = mergeCollabSubagents(entries);
+  return {
+    ...primaryEntry,
+    ...latest,
+    id,
+    createdAt: latest.createdAt,
+    label: primaryEntry.label,
+    ...(primaryEntry.toolTitle ? { toolTitle: primaryEntry.toolTitle } : {}),
+    ...(prompt || primaryEntry.subagentAction || latest.subagentAction
+      ? {
+          subagentAction: {
+            ...(primaryEntry.subagentAction ?? latest.subagentAction ?? {
+              tool: "spawnAgent",
+              status: latest.subagentAction?.status ?? "completed",
+              summaryText: "Agent activity",
+            }),
+            ...(prompt ? { prompt } : {}),
+          },
+        }
+      : {}),
+    ...(result ? { detail: result } : {}),
+    ...(subagents.length > 0 ? { subagents } : {}),
+  };
+}
+
+function collabAgentActivityGroupKeys(entry: WorkLogEntry): string[] {
+  const keys = new Set<string>();
+  const toolCallId = normalizeGroupKey(entry.toolCallId);
+  if (toolCallId) {
+    keys.add(`tool:${toolCallId}`);
+  }
+  for (const subagent of entry.subagents ?? []) {
+    for (const identity of subagentThreadIdentityKeys(subagent)) {
+      keys.add(`agent:${identity}`);
+    }
+  }
+  return [...keys];
+}
+
+function findCollabPrompt(entry: WorkLogEntry): string | null {
+  return (
+    normalizeOptionalText(entry.subagentAction?.prompt) ??
+    normalizeOptionalText(entry.subagents?.find((agent) => agent.prompt)?.prompt)
+  );
+}
+
+function findFirstCollabPrompt(entries: ReadonlyArray<WorkLogEntry>): string | null {
+  for (const entry of entries) {
+    const prompt = findCollabPrompt(entry);
+    if (prompt) {
+      return prompt;
+    }
+  }
+  return null;
+}
+
+function findLatestCollabResult(entries: ReadonlyArray<WorkLogEntry>): string | null {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index]!;
+    if (entry.itemType === "collab_agent_tool_call") {
+      const result = normalizeOptionalText(entry.detail);
+      if (result && result !== findCollabPrompt(entry)) {
+        return result;
+      }
+    }
+  }
+  return null;
+}
+
+function mergeCollabSubagents(entries: ReadonlyArray<WorkLogEntry>): WorkLogEntry["subagents"] {
+  const byThreadId = new Map<string, NonNullable<WorkLogEntry["subagents"]>[number]>();
+  for (const entry of entries) {
+    for (const subagent of entry.subagents ?? []) {
+      byThreadId.set(subagent.threadId, { ...byThreadId.get(subagent.threadId), ...subagent });
+    }
+  }
+  return [...byThreadId.values()];
+}
+
+function collectMultiSubagentIdentities(entries: ReadonlyArray<WorkLogEntry>): Set<string> {
+  const identities = new Set<string>();
+  for (const entry of entries) {
+    if (entry.itemType !== "collab_agent_tool_call" || (entry.subagents?.length ?? 0) <= 1) {
+      continue;
+    }
+    for (const subagent of entry.subagents ?? []) {
+      for (const identity of subagentThreadIdentityKeys(subagent)) {
+        identities.add(identity);
+      }
+    }
+  }
+  return identities;
+}
+
+function isRedundantSingleSubagentLaunch(
+  entry: WorkLogEntry,
+  multiSubagentIdentities: ReadonlySet<string>,
+): boolean {
+  const subagents = entry.subagents ?? [];
+  if (subagents.length !== 1 || multiSubagentIdentities.size === 0) {
+    return false;
+  }
+  if (
+    !subagentThreadIdentityKeys(subagents[0]!).some((identity) =>
+      multiSubagentIdentities.has(identity),
+    )
+  ) {
+    return false;
+  }
+
+  const tool = normalizeGroupKey(entry.subagentAction?.tool);
+  const summary = normalizeGroupKey(entry.subagentAction?.summaryText);
+  const label = normalizeGroupKey(entry.label);
+  const title = normalizeGroupKey(entry.toolTitle);
+  const isSpawnLaunch =
+    summary === "spawning 1 agent" ||
+    label === "spawning 1 agent" ||
+    title === "spawning 1 agent" ||
+    (tool === "spawnagent" && (entry.subagentAction?.status === "inProgress" || !entry.detail));
+  if (!isSpawnLaunch) {
+    return false;
+  }
+  return true;
+}
+
+function subagentThreadIdentityKeys(
+  subagent: NonNullable<WorkLogEntry["subagents"]>[number],
+): string[] {
+  return [
+    subagent.resolvedThreadId,
+    subagent.providerThreadId,
+    subagent.threadId,
+  ].flatMap((value) => {
+    const normalized = normalizeGroupKey(value);
+    return normalized ? [normalized] : [];
+  });
+}
+
+function normalizeGroupKey(value: string | null | undefined): string | null {
+  const normalized = normalizeOptionalText(value)?.toLowerCase();
+  return normalized && normalized.length > 0 ? normalized : null;
 }
 
 function buildAgentActivityDetail(

--- a/apps/web/src/hooks/useProviderModelCatalog.ts
+++ b/apps/web/src/hooks/useProviderModelCatalog.ts
@@ -142,6 +142,14 @@ export function useProviderModelCatalog(input: {
       enabled: selectedProvider === "kilo" || discoveryEnabled,
     }),
   );
+  const piDynamicAgentsQuery = useQuery(
+    providerAgentsQueryOptions({
+      provider: "pi",
+      agentDir: settings.piAgentDir || null,
+      cwd: discoveryCwd,
+      enabled: selectedProvider === "pi" || discoveryEnabled,
+    }),
+  );
 
   const cursorRuntimeModels = useMemo(
     () =>
@@ -325,7 +333,9 @@ export function useProviderModelCatalog(input: {
         ? (kiloDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS)
         : selectedProvider === "opencode"
           ? (openCodeDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS)
-          : (codexDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS);
+          : selectedProvider === "pi"
+            ? (piDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS)
+            : (codexDynamicAgentsQuery.data?.agents ?? EMPTY_PROVIDER_AGENTS);
   const selectedRuntimeAgents = useMemo<ReadonlyArray<ProviderAgentDescriptor>>(
     () =>
       selectedDynamicAgents.map((agent) =>

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -73,8 +73,13 @@ export const providerDiscoveryQueryKeys = {
   ) => ["provider-discovery", "models", provider, binaryPath, apiEndpoint, agentDir, cwd] as const,
   agentsForProvider: (provider: ProviderKind) =>
     ["provider-discovery", "agents", provider] as const,
-  agents: (provider: ProviderKind, binaryPath: string | null, cwd: string | null) =>
-    [...providerDiscoveryQueryKeys.agentsForProvider(provider), binaryPath, cwd] as const,
+  agents: (
+    provider: ProviderKind,
+    binaryPath: string | null,
+    agentDir: string | null,
+    cwd: string | null,
+  ) =>
+    [...providerDiscoveryQueryKeys.agentsForProvider(provider), binaryPath, agentDir, cwd] as const,
 };
 
 export function providerComposerCapabilitiesQueryOptions(provider: ProviderKind) {
@@ -217,6 +222,7 @@ export function providerModelsQueryOptions(input: {
 export function providerAgentsQueryOptions(input: {
   provider: ProviderKind;
   binaryPath?: string | null;
+  agentDir?: string | null;
   cwd?: string | null;
   enabled?: boolean;
 }) {
@@ -224,6 +230,7 @@ export function providerAgentsQueryOptions(input: {
     queryKey: providerDiscoveryQueryKeys.agents(
       input.provider,
       input.binaryPath ?? null,
+      input.agentDir ?? null,
       input.cwd ?? null,
     ),
     queryFn: async () => {
@@ -231,6 +238,7 @@ export function providerAgentsQueryOptions(input: {
       return api.provider.listAgents({
         provider: input.provider,
         ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
+        ...(input.agentDir ? { agentDir: input.agentDir } : {}),
         ...(input.cwd ? { cwd: input.cwd } : {}),
       });
     },

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -962,7 +962,9 @@ describe("deriveWorkLogEntries", () => {
           title: "Subagent result",
           detail: "Subagent launched successfully and changed no files.",
           data: {
+            parentTurnId: "turn-1",
             item: {
+              parentTurnId: "turn-1",
               receiverThreadIds: ["child-provider-1"],
               receiverAgents: [
                 {
@@ -986,6 +988,53 @@ describe("deriveWorkLogEntries", () => {
       detail: "Subagent launched successfully and changed no files.",
       subagents: [{ threadId: "child-provider-1", nickname: "smoke-test" }],
     });
+  });
+
+  it("hides thread-scoped Pi subagent result messages that have no launch turn", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "visible-subagent-launch",
+        turnId: "turn-2",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        summary: "Subagent task",
+        kind: "tool.started",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "inProgress",
+          title: "Subagent task",
+          data: {
+            item: {
+              receiverThreadIds: ["child-provider-1"],
+              receiverAgents: [{ threadId: "child-provider-1", agentNickname: "current" }],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "thread-scoped-subagent-result-without-parent",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        summary: "Subagent result",
+        kind: "tool.completed",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "completed",
+          title: "Subagent result",
+          detail: "Unscoped subagent output should stay hidden while turn 2 is visible.",
+          data: {
+            item: {
+              receiverThreadIds: ["child-provider-1"],
+              receiverAgents: [{ threadId: "child-provider-1", agentNickname: "unknown" }],
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, TurnId.makeUnsafe("turn-2"), {
+      visibleTurnIds: new Set([TurnId.makeUnsafe("turn-2")]),
+    });
+
+    expect(entries.map((entry) => entry.id)).toEqual([]);
   });
 
   it("does not leak old thread-scoped collab completions into the visible work log", () => {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -802,6 +802,198 @@ describe("deriveWorkLogEntries", () => {
     expect(entries.map((entry) => entry.id)).toEqual(["tool-start"]);
   });
 
+  it("surfaces Pi subagent titles and prompts from tool input data", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "pi-subagent-start",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        summary: "Subagent task",
+        kind: "tool.started",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "inProgress",
+          title: "Subagent task",
+          data: {
+            toolCallId: "call-1",
+            toolName: "subagent",
+            input: {
+              agent: "explore",
+              name: "dispatch-smoke-test",
+              title: "Subagent dispatch smoke test",
+              task: "Inspect the repository and report whether dispatch worked.",
+              model: "windsurf/swe-1.6",
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "pi-subagent-start",
+      itemType: "collab_agent_tool_call",
+      toolTitle: "Subagent dispatch smoke test",
+      subagentAction: {
+        tool: "subagent",
+        status: "inProgress",
+        model: "windsurf/swe-1.6",
+        prompt: "Inspect the repository and report whether dispatch worked.",
+      },
+    });
+  });
+
+  it("keeps routed Pi subagent tool completions so details include result and child metadata", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "pi-subagent-start",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        summary: "Subagent task started",
+        kind: "tool.started",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "inProgress",
+          title: "Subagent task",
+          data: {
+            toolCallId: "call-1",
+            toolName: "subagent",
+            item: {
+              type: "collabAgentToolCall",
+              toolName: "subagent",
+              input: {
+                title: "Repository smoke check",
+                task: "Inspect the repository root and report the main packages/apps.",
+              },
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "pi-subagent-complete",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        summary: "Subagent task",
+        kind: "tool.completed",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "completed",
+          title: "Subagent task",
+          detail: "Inspected apps/server, apps/web, packages/contracts, and packages/shared.",
+          data: {
+            toolCallId: "call-1",
+            toolName: "subagent",
+            item: {
+              type: "collabAgentToolCall",
+              toolName: "subagent",
+              receiverThreadIds: ["child-provider-1"],
+              receiverAgents: [
+                {
+                  threadId: "child-provider-1",
+                  agentId: "explore",
+                  agentNickname: "repo-smoke",
+                  prompt: "Inspect the repository root and report the main packages/apps.",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "pi-subagent-complete",
+      itemType: "collab_agent_tool_call",
+      toolTitle: "Repository smoke check",
+      detail: "Inspected apps/server, apps/web, packages/contracts, and packages/shared.",
+      subagents: [
+        {
+          threadId: "child-provider-1",
+          agentId: "explore",
+          nickname: "repo-smoke",
+          prompt: "Inspect the repository root and report the main packages/apps.",
+        },
+      ],
+    });
+  });
+
+  it("keeps thread-scoped Pi subagent result messages with visible turn filtering", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "visible-tool",
+        turnId: "turn-1",
+        summary: "Visible tool",
+        kind: "tool.started",
+      }),
+      makeActivity({
+        id: "pi-subagent-result",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        summary: "Subagent result",
+        kind: "tool.completed",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "completed",
+          title: "Subagent result",
+          detail: "Subagent launched successfully and changed no files.",
+          data: {
+            item: {
+              receiverThreadIds: ["child-provider-1"],
+              receiverAgents: [
+                {
+                  threadId: "child-provider-1",
+                  agentNickname: "smoke-test",
+                  prompt: "Run a harmless subagent smoke test.",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, TurnId.makeUnsafe("turn-1"), {
+      visibleTurnIds: new Set([TurnId.makeUnsafe("turn-1")]),
+    });
+
+    expect(entries.map((entry) => entry.id)).toEqual(["visible-tool", "pi-subagent-result"]);
+    expect(entries[1]).toMatchObject({
+      detail: "Subagent launched successfully and changed no files.",
+      subagents: [{ threadId: "child-provider-1", nickname: "smoke-test" }],
+    });
+  });
+
+  it("does not leak old turn-stamped collab completions into the visible work log", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "visible-tool",
+        turnId: "turn-2",
+        summary: "Visible tool",
+        kind: "tool.started",
+      }),
+      makeActivity({
+        id: "old-opencode-task-result",
+        turnId: "turn-1",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        summary: "Task",
+        kind: "tool.completed",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "completed",
+          title: "Task",
+          detail: "Old task result should stay hidden while turn 2 is visible.",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, TurnId.makeUnsafe("turn-2"), {
+      visibleTurnIds: new Set([TurnId.makeUnsafe("turn-2")]),
+    });
+
+    expect(entries.map((entry) => entry.id)).toEqual(["visible-tool"]);
+  });
+
   it("omits task start and completion lifecycle entries", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -928,6 +928,30 @@ describe("deriveWorkLogEntries", () => {
         kind: "tool.started",
       }),
       makeActivity({
+        id: "visible-subagent-launch",
+        turnId: "turn-1",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        summary: "Subagent task",
+        kind: "tool.started",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "inProgress",
+          title: "Subagent task",
+          data: {
+            item: {
+              receiverThreadIds: ["child-provider-1"],
+              receiverAgents: [
+                {
+                  threadId: "child-provider-1",
+                  agentNickname: "smoke-test",
+                  prompt: "Run a harmless subagent smoke test.",
+                },
+              ],
+            },
+          },
+        },
+      }),
+      makeActivity({
         id: "pi-subagent-result",
         createdAt: "2026-02-23T00:00:03.000Z",
         summary: "Subagent result",
@@ -962,6 +986,61 @@ describe("deriveWorkLogEntries", () => {
       detail: "Subagent launched successfully and changed no files.",
       subagents: [{ threadId: "child-provider-1", nickname: "smoke-test" }],
     });
+  });
+
+  it("does not leak old thread-scoped collab completions into the visible work log", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "visible-tool",
+        turnId: "turn-2",
+        summary: "Visible tool",
+        kind: "tool.started",
+      }),
+      makeActivity({
+        id: "visible-subagent-launch",
+        turnId: "turn-2",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        summary: "Subagent task",
+        kind: "tool.started",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "inProgress",
+          title: "Subagent task",
+          data: {
+            item: {
+              receiverThreadIds: ["child-provider-1"],
+              receiverAgents: [{ threadId: "child-provider-1", agentNickname: "current" }],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "old-thread-scoped-subagent-result",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        summary: "Subagent result",
+        kind: "tool.completed",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "completed",
+          title: "Subagent result",
+          detail: "Old subagent output should stay hidden while turn 2 is visible.",
+          data: {
+            parentTurnId: "turn-1",
+            item: {
+              parentTurnId: "turn-1",
+              receiverThreadIds: ["child-provider-1"],
+              receiverAgents: [{ threadId: "child-provider-1", agentNickname: "old" }],
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, TurnId.makeUnsafe("turn-2"), {
+      visibleTurnIds: new Set([TurnId.makeUnsafe("turn-2")]),
+    });
+
+    expect(entries.map((entry) => entry.id)).toEqual(["visible-tool"]);
   });
 
   it("does not leak old turn-stamped collab completions into the visible work log", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -827,8 +827,16 @@ export function deriveWorkLogEntries(
 ): WorkLogEntry[] {
   const visibleTurnIds = options.visibleTurnIds;
   const ordered = orderedActivities(activities);
+  const visibleSubagentThreadIds = collectVisibleTurnSubagentThreadIds(ordered, visibleTurnIds);
   const entries = ordered
-    .filter((activity) => shouldKeepActivityForWorkLog(activity, latestTurnId, visibleTurnIds))
+    .filter((activity) =>
+      shouldKeepActivityForWorkLog(
+        activity,
+        latestTurnId,
+        visibleTurnIds,
+        visibleSubagentThreadIds,
+      ),
+    )
     .filter((activity) => !shouldOmitRoutedCollabAgentToolActivity(activity))
     .filter((activity) => activity.kind !== "task.started" && activity.kind !== "task.completed")
     .filter((activity) => !isQuietTurnLifecycleActivity(activity))
@@ -859,10 +867,54 @@ export function deriveWorkLogEntries(
   );
 }
 
+function collectVisibleTurnSubagentThreadIds(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  visibleTurnIds: ReadonlySet<TurnId | string> | undefined,
+): ReadonlySet<string> | undefined {
+  if (!visibleTurnIds || visibleTurnIds.size === 0) {
+    return undefined;
+  }
+  const threadIds = new Set<string>();
+  for (const activity of activities) {
+    if (activity.turnId === null || !visibleTurnIds.has(activity.turnId)) {
+      continue;
+    }
+    const payload = asRecord(activity.payload);
+    for (const subagent of extractCollabSubagents(payload)) {
+      threadIds.add(subagent.threadId);
+      if (subagent.providerThreadId) {
+        threadIds.add(subagent.providerThreadId);
+      }
+    }
+  }
+  return threadIds;
+}
+
+function threadScopedSubagentResultMatchesVisibleTurn(
+  payload: Record<string, unknown> | null,
+  visibleTurnIds: ReadonlySet<TurnId | string>,
+  visibleSubagentThreadIds: ReadonlySet<string> | undefined,
+): boolean {
+  const parentTurnId = extractCollabParentTurnId(payload);
+  if (parentTurnId) {
+    return visibleTurnIds.has(parentTurnId);
+  }
+  if (!visibleSubagentThreadIds || visibleSubagentThreadIds.size === 0) {
+    return false;
+  }
+  return extractCollabSubagents(payload).some(
+    (subagent) =>
+      visibleSubagentThreadIds.has(subagent.threadId) ||
+      (subagent.providerThreadId !== undefined &&
+        visibleSubagentThreadIds.has(subagent.providerThreadId)),
+  );
+}
+
 function shouldKeepActivityForWorkLog(
   activity: OrchestrationThreadActivity,
   latestTurnId: TurnId | undefined,
   visibleTurnIds: ReadonlySet<TurnId | string> | undefined,
+  visibleSubagentThreadIds: ReadonlySet<string> | undefined,
 ): boolean {
   // Thread-level compaction progress has no provider turn id but should stay visible.
   if (activity.kind === "context-compaction" && activity.turnId === null) {
@@ -885,6 +937,13 @@ function shouldKeepActivityForWorkLog(
       asTrimmedString(payload?.itemType) === "collab_agent_tool_call" &&
       asTrimmedString(payload?.detail)
     ) {
+      if (visibleTurnIds && visibleTurnIds.size > 0) {
+        return threadScopedSubagentResultMatchesVisibleTurn(
+          payload,
+          visibleTurnIds,
+          visibleSubagentThreadIds,
+        );
+      }
       return true;
     }
   }
@@ -1110,6 +1169,15 @@ function extractCollabTaskOutputDetail(payload: Record<string, unknown> | null):
     }
   }
   return null;
+}
+
+function extractCollabParentTurnId(payload: Record<string, unknown> | null): string | null {
+  if (extractWorkLogItemType(payload) !== "collab_agent_tool_call") {
+    return null;
+  }
+  const data = asRecord(payload?.data);
+  const item = collabPayloadItem(payload);
+  return asTrimmedString(data?.parentTurnId ?? item?.parentTurnId);
 }
 
 function extractCollabActionTitle(payload: Record<string, unknown> | null): string | null {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -724,9 +724,24 @@ function shouldOmitRoutedCollabAgentToolActivity(activity: OrchestrationThreadAc
   if (asTrimmedString(payload?.itemType) !== "collab_agent_tool_call") {
     return false;
   }
-  // Routed subagent activity is rendered through child-thread/subagent surfaces;
-  // generic OpenCode task calls have no receiver metadata and need a chat row.
-  return extractCollabSubagents(payload).length > 0;
+  // Routed subagent message echoes without a provider tool-call id are rendered through
+  // child-thread/subagent surfaces. Real tool lifecycle updates must stay in the parent
+  // work log so the openable activity detail can merge the start prompt with the final
+  // result and child-agent metadata.
+  if (extractCollabSubagents(payload).length === 0) {
+    return false;
+  }
+  const data = asRecord(payload?.data);
+  const item = collabPayloadItem(payload);
+  const toolCallId = asTrimmedString(
+    data?.toolCallId ?? data?.callId ?? item?.toolCallId ?? item?.callId,
+  );
+  if (toolCallId) {
+    return false;
+  }
+  // Keep completed result text in the parent work log; the agent activity detail
+  // groups it with the launch row so users can see the actual subagent report.
+  return activity.kind !== "tool.completed" || !asTrimmedString(payload.detail);
 }
 
 export function findLatestProposedPlan(
@@ -858,6 +873,20 @@ function shouldKeepActivityForWorkLog(
   // keep them so the transcript card survives once the thread has turn-stamped messages.
   if (activity.kind === "automation.created") {
     return true;
+  }
+
+  // Pi subagent reports can arrive after the parent turn via a thread-scoped
+  // custom message. Keep only those thread-scoped result activities when the
+  // visible transcript turn filter is active; turn-stamped provider tool rows
+  // should still obey the normal visible-turn filter.
+  if (activity.kind === "tool.completed" && activity.turnId === null) {
+    const payload = asRecord(activity.payload);
+    if (
+      asTrimmedString(payload?.itemType) === "collab_agent_tool_call" &&
+      asTrimmedString(payload?.detail)
+    ) {
+      return true;
+    }
   }
 
   // An empty set means the transcript has no turn-stamped assistant messages
@@ -1088,14 +1117,18 @@ function extractCollabActionTitle(payload: Record<string, unknown> | null): stri
     return null;
   }
   const item = collabPayloadItem(payload);
-  const input = asRecord(item?.input);
+  const input = collabPayloadInput(item);
   const state = asRecord(item?.state);
   const candidates = [
     state?.title,
     item?.title,
     payload?.title,
+    input?.title,
     input?.description,
     item?.description,
+    input?.name,
+    item?.task,
+    input?.task,
   ];
   for (const candidate of candidates) {
     const title = asTrimmedString(candidate);
@@ -1461,8 +1494,12 @@ function collabPayloadItem(
   return asRecord(data?.item) ?? data;
 }
 
+function collabPayloadInput(item: Record<string, unknown> | null): Record<string, unknown> | null {
+  return asRecord(item?.input) ?? asRecord(item?.args) ?? asRecord(item?.rawInput);
+}
+
 function inferSubagentActionTool(item: Record<string, unknown> | null): string | null {
-  const directTool = asTrimmedString(item?.tool ?? item?.name);
+  const directTool = asTrimmedString(item?.tool ?? item?.toolName ?? item?.name);
   if (directTool) {
     return directTool;
   }
@@ -1510,7 +1547,7 @@ function extractCollabAction(
   }
 
   const item = collabPayloadItem(payload);
-  const itemInput = asRecord(item?.input);
+  const itemInput = collabPayloadInput(item);
   const tool = inferSubagentActionTool(item);
   const status = asTrimmedString(item?.status ?? payload?.status) ?? "in_progress";
   const model = asTrimmedString(
@@ -1518,10 +1555,21 @@ function extractCollabAction(
       item?.modelName ??
       item?.model_name ??
       item?.requestedModel ??
-      item?.requested_model,
+      item?.requested_model ??
+      itemInput?.model ??
+      itemInput?.modelName ??
+      itemInput?.model_name ??
+      itemInput?.requestedModel ??
+      itemInput?.requested_model,
   );
   const prompt = asTrimmedString(
-    item?.prompt ?? item?.task ?? item?.message ?? itemInput?.prompt ?? itemInput?.description,
+    item?.prompt ??
+      item?.task ??
+      item?.message ??
+      itemInput?.prompt ??
+      itemInput?.task ??
+      itemInput?.message ??
+      itemInput?.description,
   );
   const agentStates = decodeSubagentAgentStates(item);
   const receiverThreadIds = decodeSubagentReceiverThreadIds(item);

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -827,15 +827,9 @@ export function deriveWorkLogEntries(
 ): WorkLogEntry[] {
   const visibleTurnIds = options.visibleTurnIds;
   const ordered = orderedActivities(activities);
-  const visibleSubagentThreadIds = collectVisibleTurnSubagentThreadIds(ordered, visibleTurnIds);
   const entries = ordered
     .filter((activity) =>
-      shouldKeepActivityForWorkLog(
-        activity,
-        latestTurnId,
-        visibleTurnIds,
-        visibleSubagentThreadIds,
-      ),
+      shouldKeepActivityForWorkLog(activity, latestTurnId, visibleTurnIds),
     )
     .filter((activity) => !shouldOmitRoutedCollabAgentToolActivity(activity))
     .filter((activity) => activity.kind !== "task.started" && activity.kind !== "task.completed")
@@ -867,54 +861,18 @@ export function deriveWorkLogEntries(
   );
 }
 
-function collectVisibleTurnSubagentThreadIds(
-  activities: ReadonlyArray<OrchestrationThreadActivity>,
-  visibleTurnIds: ReadonlySet<TurnId | string> | undefined,
-): ReadonlySet<string> | undefined {
-  if (!visibleTurnIds || visibleTurnIds.size === 0) {
-    return undefined;
-  }
-  const threadIds = new Set<string>();
-  for (const activity of activities) {
-    if (activity.turnId === null || !visibleTurnIds.has(activity.turnId)) {
-      continue;
-    }
-    const payload = asRecord(activity.payload);
-    for (const subagent of extractCollabSubagents(payload)) {
-      threadIds.add(subagent.threadId);
-      if (subagent.providerThreadId) {
-        threadIds.add(subagent.providerThreadId);
-      }
-    }
-  }
-  return threadIds;
-}
-
 function threadScopedSubagentResultMatchesVisibleTurn(
   payload: Record<string, unknown> | null,
   visibleTurnIds: ReadonlySet<TurnId | string>,
-  visibleSubagentThreadIds: ReadonlySet<string> | undefined,
 ): boolean {
   const parentTurnId = extractCollabParentTurnId(payload);
-  if (parentTurnId) {
-    return visibleTurnIds.has(parentTurnId);
-  }
-  if (!visibleSubagentThreadIds || visibleSubagentThreadIds.size === 0) {
-    return false;
-  }
-  return extractCollabSubagents(payload).some(
-    (subagent) =>
-      visibleSubagentThreadIds.has(subagent.threadId) ||
-      (subagent.providerThreadId !== undefined &&
-        visibleSubagentThreadIds.has(subagent.providerThreadId)),
-  );
+  return parentTurnId ? visibleTurnIds.has(parentTurnId) : false;
 }
 
 function shouldKeepActivityForWorkLog(
   activity: OrchestrationThreadActivity,
   latestTurnId: TurnId | undefined,
   visibleTurnIds: ReadonlySet<TurnId | string> | undefined,
-  visibleSubagentThreadIds: ReadonlySet<string> | undefined,
 ): boolean {
   // Thread-level compaction progress has no provider turn id but should stay visible.
   if (activity.kind === "context-compaction" && activity.turnId === null) {
@@ -938,11 +896,7 @@ function shouldKeepActivityForWorkLog(
       asTrimmedString(payload?.detail)
     ) {
       if (visibleTurnIds && visibleTurnIds.size > 0) {
-        return threadScopedSubagentResultMatchesVisibleTurn(
-          payload,
-          visibleTurnIds,
-          visibleSubagentThreadIds,
-        );
+        return threadScopedSubagentResultMatchesVisibleTurn(payload, visibleTurnIds);
       }
       return true;
     }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -828,9 +828,7 @@ export function deriveWorkLogEntries(
   const visibleTurnIds = options.visibleTurnIds;
   const ordered = orderedActivities(activities);
   const entries = ordered
-    .filter((activity) =>
-      shouldKeepActivityForWorkLog(activity, latestTurnId, visibleTurnIds),
-    )
+    .filter((activity) => shouldKeepActivityForWorkLog(activity, latestTurnId, visibleTurnIds))
     .filter((activity) => !shouldOmitRoutedCollabAgentToolActivity(activity))
     .filter((activity) => activity.kind !== "task.started" && activity.kind !== "task.completed")
     .filter((activity) => !isQuietTurnLifecycleActivity(activity))

--- a/bun.lock
+++ b/bun.lock
@@ -50,9 +50,9 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.154",
         "@anthropic-ai/sdk": "^0.100.0",
-        "@earendil-works/pi-agent-core": "^0.74.0",
-        "@earendil-works/pi-ai": "^0.74.0",
-        "@earendil-works/pi-coding-agent": "^0.74.0",
+        "@earendil-works/pi-agent-core": "^0.79.0",
+        "@earendil-works/pi-ai": "^0.79.0",
+        "@earendil-works/pi-coding-agent": "^0.79.0",
         "@effect/platform-node": "catalog:",
         "@effect/sql-sqlite-bun": "catalog:",
         "@opencode-ai/sdk": "^1.15.13",
@@ -265,8 +265,6 @@
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.3", "", { "dependencies": { "yaml": "^2.8.2" } }, "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg=="],
 
-    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
-
     "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
 
     "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
@@ -275,67 +273,45 @@
 
     "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
-    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1045.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.8", "@aws-sdk/credential-provider-node": "^3.972.39", "@aws-sdk/eventstream-handler-node": "^3.972.14", "@aws-sdk/middleware-eventstream": "^3.972.10", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/middleware-websocket": "^3.972.16", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/token-providers": "3.1045.0", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.24", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/eventstream-serde-browser": "^4.2.14", "@smithy/eventstream-serde-config-resolver": "^4.3.14", "@smithy/eventstream-serde-node": "^4.2.14", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-aPC6gAz9uKRiwfnKB7peTs6yD0FpSzmVnSkx0f2QtJfosFM6J6KtBvR1lMKby050K4C4PAyEScwA5YTsGfTcGA=="],
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
 
-    "@aws-sdk/core": ["@aws-sdk/core@3.974.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/xml-builder": "^3.972.22", "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw=="],
+    "@aws-sdk/core": ["@aws-sdk/core@3.974.27", "", { "dependencies": { "@aws-sdk/types": "^3.973.15", "@aws-sdk/xml-builder": "^3.972.33", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.0", "@smithy/signature-v4": "^5.6.1", "@smithy/types": "^4.15.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA=="],
 
-    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.34", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ=="],
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.53", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w=="],
 
-    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/node-http-handler": "^4.6.1", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-stream": "^4.5.25", "tslib": "^2.6.2" } }, "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg=="],
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.55", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g=="],
 
-    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/credential-provider-env": "^3.972.34", "@aws-sdk/credential-provider-http": "^3.972.36", "@aws-sdk/credential-provider-login": "^3.972.38", "@aws-sdk/credential-provider-process": "^3.972.34", "@aws-sdk/credential-provider-sso": "^3.972.38", "@aws-sdk/credential-provider-web-identity": "^3.972.38", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ=="],
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.972.60", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/credential-provider-env": "^3.972.53", "@aws-sdk/credential-provider-http": "^3.972.55", "@aws-sdk/credential-provider-login": "^3.972.59", "@aws-sdk/credential-provider-process": "^3.972.53", "@aws-sdk/credential-provider-sso": "^3.972.59", "@aws-sdk/credential-provider-web-identity": "^3.972.59", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/credential-provider-imds": "^4.4.5", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ=="],
 
-    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/protocol-http": "^5.3.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww=="],
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw=="],
 
-    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.39", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.34", "@aws-sdk/credential-provider-http": "^3.972.36", "@aws-sdk/credential-provider-ini": "^3.972.38", "@aws-sdk/credential-provider-process": "^3.972.34", "@aws-sdk/credential-provider-sso": "^3.972.38", "@aws-sdk/credential-provider-web-identity": "^3.972.38", "@aws-sdk/types": "^3.973.8", "@smithy/credential-provider-imds": "^4.2.14", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg=="],
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.62", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.53", "@aws-sdk/credential-provider-http": "^3.972.55", "@aws-sdk/credential-provider-ini": "^3.972.60", "@aws-sdk/credential-provider-process": "^3.972.53", "@aws-sdk/credential-provider-sso": "^3.972.59", "@aws-sdk/credential-provider-web-identity": "^3.972.59", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/credential-provider-imds": "^4.4.5", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw=="],
 
-    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.34", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q=="],
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.53", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw=="],
 
-    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/token-providers": "3.1041.0", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA=="],
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/token-providers": "3.1079.0", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA=="],
 
-    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw=="],
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.59", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w=="],
 
-    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.14", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/eventstream-codec": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg=="],
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.25", "", { "dependencies": { "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-df7HN1ozwMrB9+59re9PM7tSLxLAcheMWc5u/KyfCPCAWtN/vP7y7RTUZOy48uT1K9MESisVeOPPzF3O1AW01A=="],
 
-    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ=="],
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.21", "", { "dependencies": { "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-HvLgDnxBLaHi9E5K++6Vuk+1+qqn7Pmn8zrlzd+NXH3jBzwujnuzZtAR9WHPkbUGPO92FkoQWj/M1IsdxTlBmQ=="],
 
-    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg=="],
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.35", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/signature-v4": "^5.6.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-7/ZAlq5o5A9FnRsQEftZvcct9LVZf1YaYmWR3eOzyJAdKU66YpOKy5ahUVvyBvCTLyO4Ej4yWIk8dllWNXPBsw=="],
 
-    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ=="],
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.27", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/signature-v4-multi-region": "^3.996.38", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ=="],
 
-    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ=="],
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.38", "", { "dependencies": { "@aws-sdk/types": "^3.973.15", "@smithy/signature-v4": "^5.6.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g=="],
 
-    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.37", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/core": "^3.23.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-stream": "^4.5.25", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA=="],
-
-    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@smithy/core": "^3.23.17", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-retry": "^4.3.6", "tslib": "^2.6.2" } }, "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A=="],
-
-    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.16", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-format-url": "^3.972.10", "@smithy/eventstream-codec": "^4.2.14", "@smithy/eventstream-serde-browser": "^4.2.14", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-base64": "^4.3.2", "@smithy/util-hex-encoding": "^4.2.2", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg=="],
-
-    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.6", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.8", "@aws-sdk/middleware-host-header": "^3.972.10", "@aws-sdk/middleware-logger": "^3.972.10", "@aws-sdk/middleware-recursion-detection": "^3.972.11", "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/region-config-resolver": "^3.972.13", "@aws-sdk/signature-v4-multi-region": "^3.996.25", "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-endpoints": "^3.996.8", "@aws-sdk/util-user-agent-browser": "^3.972.10", "@aws-sdk/util-user-agent-node": "^3.973.24", "@smithy/config-resolver": "^4.4.17", "@smithy/core": "^3.23.17", "@smithy/fetch-http-handler": "^5.3.17", "@smithy/hash-node": "^4.2.14", "@smithy/invalid-dependency": "^4.2.14", "@smithy/middleware-content-length": "^4.2.14", "@smithy/middleware-endpoint": "^4.4.32", "@smithy/middleware-retry": "^4.5.7", "@smithy/middleware-serde": "^4.2.20", "@smithy/middleware-stack": "^4.2.14", "@smithy/node-config-provider": "^4.3.14", "@smithy/node-http-handler": "^4.6.1", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-base64": "^4.3.2", "@smithy/util-body-length-browser": "^4.2.2", "@smithy/util-body-length-node": "^4.2.3", "@smithy/util-defaults-mode-browser": "^4.3.49", "@smithy/util-defaults-mode-node": "^4.2.54", "@smithy/util-endpoints": "^3.4.2", "@smithy/util-middleware": "^4.2.14", "@smithy/util-retry": "^4.3.6", "@smithy/util-utf8": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w=="],
-
-    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.13", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/config-resolver": "^4.4.17", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A=="],
-
-    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.25", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.37", "@aws-sdk/types": "^3.973.8", "@smithy/protocol-http": "^5.3.14", "@smithy/signature-v4": "^5.3.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw=="],
-
-    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1045.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q=="],
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
 
     "@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
 
-    "@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.972.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA=="],
-
-    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "@smithy/url-parser": "^4.2.14", "@smithy/util-endpoints": "^3.4.2", "tslib": "^2.6.2" } }, "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g=="],
-
-    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/querystring-builder": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ=="],
-
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
 
-    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/types": "^4.14.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g=="],
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.33", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A=="],
 
-    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.973.24", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "^3.972.38", "@aws-sdk/types": "^3.973.8", "@smithy/node-config-provider": "^4.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw=="],
-
-    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.22", "", { "dependencies": { "@nodable/entities": "2.1.0", "@smithy/types": "^4.14.1", "fast-xml-parser": "5.7.2", "tslib": "^2.6.2" } }, "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA=="],
-
-    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -401,8 +377,6 @@
 
     "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
-    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
-
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 
     "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
@@ -421,19 +395,19 @@
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.71.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "enquirer": "^2.4.1", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.4", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-KEUw/mGu+EDRhYWRTNGHIimVCs9NvMFaIXOGrHSXoCteKLE5EsJnmPjOPpYorjXVg/0xG0fbdVw720azw1z4ag=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.74.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.74.0", "typebox": "^1.1.24" } }, "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.10", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.10", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-XKxgdjhcPuyjrthCOFSgfzT3xZ1uBrJ1IMVDxci1to6hIN6BIg9J5iY8q0pGXK1DLgATLP23da+1UyZLwA360Q=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.74.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.91.1", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "typebox": "^1.1.24", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.79.10", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.74.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.74.0", "@earendil-works/pi-ai": "^0.74.0", "@earendil-works/pi-tui": "^0.74.0", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "jiti": "^2.7.0", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "typebox": "^1.1.24", "undici": "^7.19.1", "uuid": "^14.0.0", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.5" }, "bin": { "pi": "dist/cli.js" } }, "sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.79.10", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.79.10", "@earendil-works/pi-ai": "^0.79.10", "@earendil-works/pi-tui": "^0.79.10", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-YxaRhmgyDTvLDdGVbe7YzTHV80oL5mX5odg6EhGHz3w5Wu1Ix8DCw7bhtiOBLGQNFRcknia0zPmVWIj30XP1EA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.74.0", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.79.10", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-FUVOjDn1DVwM1uHD5MNYboXQrXjIDbSt+BQ3py7nQWCY62tKfxgiM1OBMxTcwRWLfSdZHUPpV0hm1loIdUJnPw=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.6", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g=="],
 
     "@effect/language-service": ["@effect/language-service@0.75.1", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-g9xD2tAQgRFpYC2YgpZq02VeSL5fBbFJ0B/g1o+14NuNmwtaYJc7SjiLWAA9eyhJHosNrn6h1Ye+Kx6j5mN0AA=="],
 
-    "@effect/openapi-generator": ["@effect/openapi-generator@https://pkg.pr.new/Effect-TS/effect-smol/@effect/openapi-generator@8881a9b", { "peerDependencies": { "@effect/platform-node": "^4.0.0-beta.25", "effect": "^4.0.0-beta.25" }, "bin": { "openapigen": "./dist/bin.js" } }, "sha512-omxybvCIbJpO9MMp679OZNGfWlMpOBOaoTPxv4NXGZ/Tszc33M0Yd5Esg/FODn4Tpx4aQZk73M7uoJTrgAjS6A=="],
+    "@effect/openapi-generator": ["@effect/openapi-generator@https://pkg.pr.new/Effect-TS/effect-smol/@effect/openapi-generator@8881a9b", { "peerDependencies": { "@effect/platform-node": "^4.0.0-beta.25", "effect": "^4.0.0-beta.25" }, "bin": { "openapigen": "./dist/bin.js" } }],
 
     "@effect/platform-node": ["@effect/platform-node@https://pkg.pr.new/Effect-TS/effect-smol/@effect/platform-node@8881a9b", { "dependencies": { "@effect/platform-node-shared": "https://pkg.pr.new/Effect-TS/effect-smol/@effect/platform-node-shared@8881a9b606d84a6f5eb6615279138322984f5368", "mime": "^4.1.0", "undici": "^7.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.25", "ioredis": "^5.7.0" } }],
 
@@ -667,29 +641,29 @@
 
     "@lexical/yjs": ["@lexical/yjs@0.41.0", "", { "dependencies": { "@lexical/offset": "0.41.0", "@lexical/selection": "0.41.0", "lexical": "0.41.0" }, "peerDependencies": { "yjs": ">=13.5.22" } }, "sha512-PaKTxSbVC4fpqUjQ7vUL9RkNF1PjL8TFl5jRe03PqoPYpE33buf3VXX6+cOUEfv9+uknSqLCPHoBS/4jN3a97w=="],
 
-    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.5", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.2", "@mariozechner/clipboard-darwin-universal": "0.3.2", "@mariozechner/clipboard-darwin-x64": "0.3.2", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2", "@mariozechner/clipboard-linux-arm64-musl": "0.3.2", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-musl": "0.3.2", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2", "@mariozechner/clipboard-win32-x64-msvc": "0.3.2" } }, "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA=="],
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
 
-    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw=="],
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
 
-    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.2", "", { "os": "darwin" }, "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg=="],
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.9", "", { "os": "darwin" }, "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ=="],
 
-    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg=="],
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg=="],
 
-    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ=="],
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw=="],
 
-    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw=="],
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ=="],
 
-    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA=="],
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.9", "", { "os": "linux", "cpu": "none" }, "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw=="],
 
-    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A=="],
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw=="],
 
-    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw=="],
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ=="],
 
-    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg=="],
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
 
-    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA=="],
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -739,8 +713,6 @@
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
-    "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
-
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -754,6 +726,10 @@
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.15.13", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
@@ -963,83 +939,23 @@
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
-    "@smithy/config-resolver": ["@smithy/config-resolver@4.5.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-abXk3LhODsvRHsk0ZS9ztrg/fZatTa9Z/z4pgx65YSLR+rY6kvUG/1IgcDKEUciR8MfdnkT5oPeHJTy/HhzDIQ=="],
+    "@smithy/core": ["@smithy/core@3.29.1", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A=="],
 
-    "@smithy/core": ["@smithy/core@3.24.1", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g=="],
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.6", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ=="],
 
-    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-0S/acwHnqX4WrjXzhdiDRxsG2s9SC0cpPIK9nZ1R6UOHd+j7uL28+4bHu22urbLk2TVw3fkp6na/+fkUt/pLNQ=="],
-
-    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-yS8AiJM3Kf7LR+lZyUilUyjdJGksAqxfSC3C9k3d1OCrAvWjpMlsJ+rW9cIslZJM4AtWh2UAqgZUWTtMeMdtDQ=="],
-
-    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-X7MyI1fu8M84IPKk49kO4kb27Mqp6un9/0o/MsA1ngZ5OxxWKGUxPS3S/AJ9q1cPVTSGmRcbaGNfGUSsflTJkg=="],
-
-    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-JZGbSXaBk7JY8VPzsh66ksJ0nTWXbApduFDkA/pEl3aTm2EoAiUZE1Iltp6c+X1bB8kxPQW0mHDfVdYCpWTOzg=="],
-
-    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-6Cn4xTNVxn9PWTHSbvf8zmcDhQW8lrLE1Xq5CJgmX6wEvdjS2S0KuE79Aiznv/jx51jpFJ98OuWyE+Bt+oG1MQ=="],
-
-    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-r7bN6spQ+caZC8AnyvSxkRUb57zt2jhhRw3Z+2Ez8hjq6coIikDBFUUI/+CQ1xx9K6eX1Gx6wUKo4ylU66TIqw=="],
-
-    "@smithy/hash-node": ["@smithy/hash-node@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-u0/zo11mg7yNneoYgTkH4sXwSmcBpbl49o4UNCtQ7hYsXxynsN25KYHmXzqi7TPk5HQL5klGnpU5koOY0O+9hw=="],
-
-    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-cLmwtDoulyZvRepAfyV+3rx5oMvuh51dbE+6En3vGC09j3uVSRt1U4oguNu32ub3soGX0oYtBs8E7S2Q4SxTqg=="],
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.3", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ=="],
 
     "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
-    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-l4BUIP+wljW/Ar+0/QcGdmElI9lalrywfzNijXMBG34Z510FRzPyrDLx/blNTZOAm0C4Mvx5t/bf760CZo1ajg=="],
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
 
-    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.5.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-qtqu5TS+8Y18ZDkJoiXN5AMW1G4JAg1+xytzpsUvIR5a4EUsgd5HQg12lekEHWpm2TDUmOgg+hBaHK7dvyWdkA=="],
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.2", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g=="],
 
-    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.6.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-eTaQhxs0rfUuAkL2MSKrH8DTO7YCeAgrdN0B2/RAeuHmXQ+x52dk5qUBsi/jtcqe5LxItgq5AG5tI6Cp8c0sow=="],
-
-    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-t7YtUe076zWVypVmy1rX91oKi2TFJCkpfFpfMhJFpEIRPP0iL9JxjeSyFQ+1bF45JUfDzOzslUJa150WcSrBug=="],
-
-    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-1jKwiKZxCMQNqmp4uVPYA6r+MLGjEtH07gnOUdPgbnjuOIrl/0JY/ICdpQtFgeBsQ/Up01gnSv8GYEL0fb8yvg=="],
-
-    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-q7tDJEJXcaSG/8TVpu2f2l9bzxTzDM9geWmltbzsY6Hfh3yiuXXTpLIO8+zwYASPPVFaTJpdKwjSSjdoDoccgw=="],
-
-    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-BdEYko85f/ldp68uH8XEyIvo810xFk6eyPH81SRggTOApYHWA+Xu7B2EzLuHbe37WVLaUA7F1fWR3/zBeme2WA=="],
-
-    "@smithy/property-provider": ["@smithy/property-provider@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-3NHoqVBhzpY2b4YBx9AqyKC4C8nnEjl5FyKuxrCjvnjinG0ODj+yg1xX360nNahT6wghYjSw1SooCt3kIdnqIA=="],
-
-    "@smithy/protocol-http": ["@smithy/protocol-http@5.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-8irPNCQgYxcSFp1aGcnDNFkTwSA+xPUaFq9V/v1+JXWu8sKr5b3cFmg2kBTkjkvypDmGeNffuNu0x5iqw1NoAw=="],
-
-    "@smithy/querystring-builder": ["@smithy/querystring-builder@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-toyi8sXPWDNoVH6yK7sXJ9dm5uxw2tWLCHzPy/t16Fvl62Es4vXQXzlilyNaw+DqFwxSlrFClh0rGLPUF2p9Lg=="],
-
-    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.5.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-FKoKxVzdFPhyynFI+SPTWrgOP60fZ4l1UwukWYj4eyhpSmEI7MJ6p58hawIIt9bwp+aek9NEm8Zika7E+GEoeg=="],
-
-    "@smithy/signature-v4": ["@smithy/signature-v4@5.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-728lZZEWYWubBESrfntNslZQYDKRlJDY4dcDnYbL50+gu35pGPLblu4S0/RH/RDLF6me1M87ECHsHELGL7dA/Q=="],
-
-    "@smithy/smithy-client": ["@smithy/smithy-client@4.13.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-IcznNM8Qd9u1X3oflp12tkzyOB4HbT+sfYWlWiyEysgNzSHoWcHUUsTT4y1jjDjtVuuVVQbYks+g1kVd7u1eGQ=="],
-
-    "@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
-
-    "@smithy/url-parser": ["@smithy/url-parser@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-tuelFlF2PZR/wogFC58NIrPOv+Zna4N1+3kA161/33D1Gbwvl6Nh4WsAsW05ZyPp0O6CMGsdbb0S2b/qVjRMCw=="],
-
-    "@smithy/util-base64": ["@smithy/util-base64@4.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-fTHiwW2xbiRiWzfSk4IGAr3gNZCH4fuRYqt8+IuarsP/YON35576iVdePraZ6yJlFxlCL0eMec3/F7xYqoKzlg=="],
-
-    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-1scg5t4nV3hV7CZs996/XHb80aDZ5YotH4NcvkW/w/rHj+cSz0aCIzwz8aUNKB4nCDPSHRCbrKoj+TvycYefmw=="],
-
-    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-VRC8MKVPKrgUYThTA7ughcKMfjW6/X92H0wXGJoda0Apw4O5xbXL0GMLz40DTWlsb5hh2iItk6+XL72uJdxYcw=="],
+    "@smithy/types": ["@smithy/types@4.15.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q=="],
 
     "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
-    "@smithy/util-config-provider": ["@smithy/util-config-provider@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-lw6L5GF5+W19vO6o3fZwRT2cXEG+8b2LH0b9ppjDT6nIxjUgmljEQGninx5XorylwKZZ4XLVABeroJ8oaF9RmQ=="],
-
-    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-1rA7w+LjK1WJClsffC81Z/ZtjFt22QsKhBjUYEnZsGVS2nOTfOENKBzdg4SxhdwFvBCjcbpjscUfXOPwE3UHWQ=="],
-
-    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-1fk1wfQHBenQD5NitVKOFgW0wsISYAFPIXGyStJWAeCtMyRhgHYvtJxBk2rwGWA0L5QX6oM6yeHSLKPFMk59ww=="],
-
-    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.5.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-yORYzJD5zoGbSDkAACr0dIjDiSEA3X8h8lggDENl1dkKpCG0TQIoItPBqtvuJHzFFjRXumcoH+/09xIuixGyCw=="],
-
-    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-j6dAIaXfj2nsvv/sN9+fi7e/AJxBHgBoIdNjmQjp9jlii72rEniUGQkipnkHMP2XUKHx5q0B1iv0xQEG1AsLBA=="],
-
-    "@smithy/util-middleware": ["@smithy/util-middleware@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-SRRMDcIgVXVhVbxviBaSZbuWuVW3jD08wv4ESV0V2oiw0Mki8TPVQ5IxwD3MvSTPg52QYsRP+JoMw5WdUdeWAg=="],
-
-    "@smithy/util-retry": ["@smithy/util-retry@4.4.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-qkgWgwn1xw0GoY9Ea/B6FrYSPfHA0zyOtJkokwxZuvucRf2+2lfTut6adi4e4Y7LEAaxsFG7r6i05mtDCxbHKA=="],
-
-    "@smithy/util-stream": ["@smithy/util-stream@4.6.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-GjZfEft0M0V3n2YM/LGkr5LeLd8gxHUIzW0rUz6VtTtlAq245GxHlJghvoPEjJHKTj255iHFAiA4IsIdK40Ueg=="],
-
-    "@smithy/util-utf8": ["@smithy/util-utf8@4.3.1", "", { "dependencies": { "@smithy/core": "^3.24.1", "tslib": "^2.6.2" } }, "sha512-FtRrSnriXtOs4+J8/y9SbQ1xmN71hrOsN/YJr5PQQj5nR1l7YNkGS/TEk4gr0WN7gyrUqw8/RFaYVjI18732ZA=="],
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
@@ -1125,12 +1041,6 @@
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.6", "", {}, "sha512-EGWs9yvJA821pUkwkiZLQW89CzUumHyJy8NKq229BubyoWXfDw1oWnTJYSS/hhbLiwP9+KpopjeF5wWwnCCyeQ=="],
 
-    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
-
-    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
-
-    "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
-
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
@@ -1168,8 +1078,6 @@
     "@types/keyv": ["@types/keyv@3.1.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
-
-    "@types/mime-types": ["@types/mime-types@2.1.4", "", {}, "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
@@ -1271,8 +1179,6 @@
 
     "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
 
-    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
-
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
@@ -1308,8 +1214,6 @@
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.8", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ=="],
-
-    "basic-ftp": ["basic-ftp@5.3.1", "", {}, "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
@@ -1378,8 +1282,6 @@
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
-
-    "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
 
     "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
 
@@ -1466,8 +1368,6 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
-
-    "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -1565,17 +1465,11 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
-
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
-
-    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
-    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
@@ -1607,10 +1501,6 @@
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
-    "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
-
-    "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
-
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
@@ -1620,8 +1510,6 @@
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
-
-    "file-type": ["file-type@21.3.4", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -1681,8 +1569,6 @@
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
-    "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
-
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
@@ -1706,8 +1592,6 @@
     "graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 
     "h3": ["h3@1.15.6", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-oi15ESLW5LRthZ+qPCi5GNasY/gvynSKUQxgiovrY63bPAtG59wtM+LSrlcwvOHAXzGrXVLnI97brbkdPF9WoQ=="],
-
-    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
@@ -1774,8 +1658,6 @@
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
-    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -1891,8 +1773,6 @@
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
-    "koffi": ["koffi@2.16.2", "", {}, "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA=="],
-
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "lazy-val": ["lazy-val@1.0.5", "", {}, "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="],
@@ -1955,7 +1835,7 @@
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
-    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+    "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
     "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
@@ -2067,9 +1947,9 @@
 
     "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -2099,15 +1979,11 @@
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
-    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
-
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
-
-    "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
 
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
 
@@ -2183,10 +2059,6 @@
 
     "p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
-    "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
-
-    "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
-
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
@@ -2199,17 +2071,13 @@
 
     "parse-ms": ["parse-ms@4.0.0", "", {}, "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="],
 
-    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
-
-    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
-
-    "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -2262,8 +2130,6 @@
     "protobufjs": ["protobufjs@7.5.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "proxy-agent": ["proxy-agent@6.5.0", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "http-proxy-agent": "^7.0.1", "https-proxy-agent": "^7.0.6", "lru-cache": "^7.14.1", "pac-proxy-agent": "^7.1.0", "proxy-from-env": "^1.1.0", "socks-proxy-agent": "^8.0.5" } }, "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
@@ -2435,13 +2301,7 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
-    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
-
     "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
-
-    "socks": ["socks@2.8.9", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw=="],
-
-    "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
@@ -2477,17 +2337,11 @@
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
-    "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
-
-    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
-
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "sumchecker": ["sumchecker@3.0.1", "", { "dependencies": { "debug": "^4.1.0" } }, "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg=="],
-
-    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
 
@@ -2502,10 +2356,6 @@
     "tailwindcss": ["tailwindcss@4.2.1", "", {}, "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
-
-    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
-
-    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
@@ -2534,8 +2384,6 @@
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
-    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
 
@@ -2592,8 +2440,6 @@
     "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
-
-    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
 
@@ -2727,8 +2573,6 @@
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
-    "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
-
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
@@ -2767,11 +2611,41 @@
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
-    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+    "@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
 
-    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+    "@aws-sdk/credential-provider-env/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
 
-    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1041.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw=="],
+    "@aws-sdk/credential-provider-http/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.3", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg=="],
+
+    "@aws-sdk/credential-provider-ini/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/credential-provider-login/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/credential-provider-node/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/credential-provider-process/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1079.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.27", "@aws-sdk/nested-clients": "^3.997.27", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/credential-provider-web-identity/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/eventstream-handler-node/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/middleware-eventstream/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/middleware-websocket/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/nested-clients/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.3", "", { "dependencies": { "@smithy/core": "^3.29.1", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg=="],
+
+    "@aws-sdk/signature-v4-multi-region/@aws-sdk/types": ["@aws-sdk/types@3.973.15", "", { "dependencies": { "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ=="],
+
+    "@aws-sdk/types/@smithy/types": ["@smithy/types@4.14.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg=="],
 
     "@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
@@ -2837,13 +2711,19 @@
 
     "@dotenvx/dotenvx/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "@earendil-works/pi-agent-core/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
     "@earendil-works/pi-ai/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
+    "@earendil-works/pi-coding-agent/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "@earendil-works/pi-coding-agent/jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "@earendil-works/pi-coding-agent/uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
+    "@earendil-works/pi-coding-agent/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
-    "@earendil-works/pi-coding-agent/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+    "@earendil-works/pi-coding-agent/undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+
+    "@earendil-works/pi-coding-agent/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "@effect/openapi-generator/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.57", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.57", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.57", "ioredis": "^5.7.0" } }, "sha512-la0xxPSAYOsY0d+uVxEBxok3jYB31iPQmIaZZRUj2SNWqcGGHJc6KorKtI8guqSLuv9FGZ255kBWXRbG6hMeeg=="],
 
@@ -2915,13 +2795,11 @@
 
     "@vitest/browser/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "ast-kit/@babel/parser": ["@babel/parser@8.0.0-rc.2", "", { "dependencies": { "@babel/types": "^8.0.0-rc.2" }, "bin": "./bin/babel-parser.js" }, "sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ=="],
-
-    "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -2931,29 +2809,19 @@
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
-    "degenerator/ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
-
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "enquirer/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "execa/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "font-ligatures/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
-    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
-    "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
-
     "h3/cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
-
-    "hast-util-from-html/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
-
-    "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
@@ -2969,13 +2837,9 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
-
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -2989,6 +2853,8 @@
 
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "shadcn/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
@@ -2999,8 +2865,6 @@
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "socks/ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
-
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
@@ -3008,6 +2872,8 @@
     "t3/@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.154", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.154", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.154", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.154", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.154", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.154", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.154", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.154", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.154" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-iEn25urI2QrMPFIhId3h7v/7EG5gsmF7ooe+6EvsAosePeLmpVVerp5nXtHnlmBkMinLecurcPA+OddKw76jYw=="],
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "unrun/rolldown": ["rolldown@1.0.0-rc.9", "", { "dependencies": { "@oxc-project/types": "=0.115.0", "@rolldown/pluginutils": "1.0.0-rc.9" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-x64": "1.0.0-rc.9", "@rolldown/binding-freebsd-x64": "1.0.0-rc.9", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q=="],
 
@@ -3189,11 +3055,9 @@
 
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.2", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.2", "@babel/helper-validator-identifier": "^8.0.0-rc.2" } }, "sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw=="],
-
-    "cli-highlight/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
-
-    "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -3203,15 +3067,19 @@
 
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "rolldown-plugin-dts/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.2", "", {}, "sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ=="],
 
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "shadcn/open/wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "unrun/rolldown/@oxc-project/types": ["@oxc-project/types@0.115.0", "", {}, "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="],
 
@@ -3317,12 +3185,8 @@
 
     "ast-kit/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.2", "", {}, "sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ=="],
 
-    "cli-highlight/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "@babel/plugin-transform-modules-commonjs/@babel/helper-module-transforms/@babel/helper-module-imports/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
     "@babel/plugin-transform-modules-commonjs/@babel/helper-module-transforms/@babel/traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
-
-    "cli-highlight/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/packages/contracts/src/providerDiscovery.ts
+++ b/packages/contracts/src/providerDiscovery.ts
@@ -299,6 +299,7 @@ export const ProviderAgentDescriptor = Schema.Struct({
   displayName: TrimmedNonEmptyString,
   description: Schema.optional(TrimmedNonEmptyString),
   model: Schema.optional(TrimmedNonEmptyString),
+  scope: Schema.optional(Schema.Literals(["global", "project"])),
 });
 export type ProviderAgentDescriptor = typeof ProviderAgentDescriptor.Type;
 

--- a/packages/contracts/src/providerDiscovery.ts
+++ b/packages/contracts/src/providerDiscovery.ts
@@ -289,6 +289,7 @@ export type ProviderListModelsResult = typeof ProviderListModelsResult.Type;
 export const ProviderListAgentsInput = Schema.Struct({
   provider: ProviderDiscoveryKind,
   binaryPath: Schema.optional(TrimmedNonEmptyString),
+  agentDir: Schema.optional(TrimmedNonEmptyString),
   cwd: Schema.optional(TrimmedNonEmptyString),
 });
 export type ProviderListAgentsInput = typeof ProviderListAgentsInput.Type;


### PR DESCRIPTION
## Summary
- add Pi subagent agent discovery and inline @agent(task) prompt expansion
- surface Pi subagent launch/results as collab agent activity with child-thread transcript import
- group/open subagent activity in the web UI and avoid duplicate async launch/prompt rows

## Compatibility
- targets the non-merged/local-process pi-subagents contract (`subagent_result`, `subagent_ping`, `details.id`, `details.sessionFile`)
- does not reference or require Paseo metadata

## Tests
- `bun run test --filter=t3 -- ProviderRuntimeIngestion.test.ts PiAdapter.test.ts piSubagentDefinitions.test.ts`
- `cd apps/web && bun run test -- agentActivity.logic.test.ts session-logic.test.ts AgentActivityDetailView.test.tsx`
- `cd apps/web && bun run test -- session-logic.test.ts agentActivity.logic.test.ts`
- `cd apps/server && bun run test OpenCodeAdapter.test.ts ClaudeAdapter.test.ts -- --runInBand`
- `cd apps/server && bun run test PiAdapter.test.ts`
- `git diff --check`

Full fmt/lint/typecheck not run per repo instruction unless explicitly requested.