### PR TITLE
Fix desktop EPIPE loop when stderr closes

### DIFF
--- a/apps/desktop/src/desktopProcessErrors.test.ts
+++ b/apps/desktop/src/desktopProcessErrors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { isBrokenPipeError } from "./desktopProcessErrors";
+
+describe("isBrokenPipeError", () => {
+  it("recognizes stderr broken pipe errors", () => {
+    const error = new Error("write EPIPE") as NodeJS.ErrnoException;
+    error.code = "EPIPE";
+
+    expect(isBrokenPipeError(error)).toBe(true);
+  });
+
+  it("ignores other process errors", () => {
+    const error = new Error("connection reset") as NodeJS.ErrnoException;
+    error.code = "ECONNRESET";
+
+    expect(isBrokenPipeError(error)).toBe(false);
+  });
+
+  it("ignores non-error values", () => {
+    expect(isBrokenPipeError("EPIPE")).toBe(false);
+    expect(isBrokenPipeError(null)).toBe(false);
+  });
+});

--- a/apps/desktop/src/desktopProcessErrors.ts
+++ b/apps/desktop/src/desktopProcessErrors.ts
@@ -1,0 +1,11 @@
+// FILE: desktopProcessErrors.ts
+// Purpose: Classifies process-level errors that need desktop shutdown handling.
+// Layer: Desktop main process helpers
+
+export function isBrokenPipeError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  return (error as NodeJS.ErrnoException).code === "EPIPE";
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -123,6 +123,7 @@ import {
   resolveLegacyDesktopUserDataPaths,
   seedDesktopUserDataProfileFromLegacy,
 } from "./desktopUserDataProfile";
+import { isBrokenPipeError } from "./desktopProcessErrors";
 
 syncShellEnvironment();
 
@@ -313,6 +314,16 @@ function writeBackendSessionBoundary(phase: "START" | "END", details: string): v
   backendLogSink.write(
     `[${logTimestamp()}] ---- APP SESSION ${phase} run=${APP_RUN_ID} ${normalizedDetails} ----\n`,
   );
+}
+
+function safeConsoleError(...args: Parameters<typeof console.error>): void {
+  try {
+    console.error(...args);
+  } catch (error: unknown) {
+    if (!isBrokenPipeError(error)) {
+      throw error;
+    }
+  }
 }
 
 function formatErrorMessage(error: unknown): string {
@@ -1960,7 +1971,7 @@ function scheduleBackendRestart(reason: string): void {
 
   const delayMs = Math.min(500 * 2 ** restartAttempt, 10_000);
   restartAttempt += 1;
-  console.error(`[desktop] backend exited unexpectedly (${reason}); restarting in ${delayMs}ms`);
+  safeConsoleError(`[desktop] backend exited unexpectedly (${reason}); restarting in ${delayMs}ms`);
 
   restartTimer = setTimeout(() => {
     restartTimer = null;
@@ -2834,6 +2845,15 @@ app.on("window-all-closed", () => {
 });
 
 if (process.platform !== "win32") {
+  process.on("uncaughtException", (error: unknown) => {
+    if (!isBrokenPipeError(error)) {
+      throw error;
+    }
+    if (desktopShutdownPromise) return;
+    writeDesktopLogHeader("EPIPE received");
+    requestGracefulAppQuit("EPIPE");
+  });
+
   process.on("SIGINT", () => {
     if (desktopShutdownPromise) return;
     writeDesktopLogHeader("SIGINT received");


### PR DESCRIPTION
Fixes #287.

This makes the backend restart log tolerate a broken inherited stderr pipe, then handles EPIPE-only uncaught exceptions by shutting the desktop app down cleanly. Other uncaught errors still rethrow.

Checked:
- bunx vitest run apps/desktop/src/desktopProcessErrors.test.ts --config vitest.config.ts
- bun run test in apps/desktop
- bun run typecheck in apps/desktop
- bunx oxlint apps/desktop/src/main.ts apps/desktop/src/desktopProcessErrors.ts apps/desktop/src/desktopProcessErrors.test.ts
- bun run fmt:check on the touched desktop files
- bun run build in apps/desktop