### PR TITLE
Fix Codex overlay auth when symlinks fail

### DIFF
--- a/apps/desktop/src/desktopProcessErrors.test.ts
+++ b/apps/desktop/src/desktopProcessErrors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { isBrokenPipeError } from "./desktopProcessErrors";
+
+describe("isBrokenPipeError", () => {
+  it("recognizes stderr broken pipe errors", () => {
+    const error = new Error("write EPIPE") as NodeJS.ErrnoException;
+    error.code = "EPIPE";
+
+    expect(isBrokenPipeError(error)).toBe(true);
+  });
+
+  it("ignores other process errors", () => {
+    const error = new Error("connection reset") as NodeJS.ErrnoException;
+    error.code = "ECONNRESET";
+
+    expect(isBrokenPipeError(error)).toBe(false);
+  });
+
+  it("ignores non-error values", () => {
+    expect(isBrokenPipeError("EPIPE")).toBe(false);
+    expect(isBrokenPipeError(null)).toBe(false);
+  });
+});

--- a/apps/desktop/src/desktopProcessErrors.ts
+++ b/apps/desktop/src/desktopProcessErrors.ts
@@ -1,0 +1,11 @@
+// FILE: desktopProcessErrors.ts
+// Purpose: Classifies process-level errors that need desktop shutdown handling.
+// Layer: Desktop main process helpers
+
+export function isBrokenPipeError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  return (error as NodeJS.ErrnoException).code === "EPIPE";
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -123,6 +123,7 @@ import {
   resolveLegacyDesktopUserDataPaths,
   seedDesktopUserDataProfileFromLegacy,
 } from "./desktopUserDataProfile";
+import { isBrokenPipeError } from "./desktopProcessErrors";
 
 syncShellEnvironment();
 
@@ -313,6 +314,16 @@ function writeBackendSessionBoundary(phase: "START" | "END", details: string): v
   backendLogSink.write(
     `[${logTimestamp()}] ---- APP SESSION ${phase} run=${APP_RUN_ID} ${normalizedDetails} ----\n`,
   );
+}
+
+function safeConsoleError(...args: Parameters<typeof console.error>): void {
+  try {
+    console.error(...args);
+  } catch (error: unknown) {
+    if (!isBrokenPipeError(error)) {
+      throw error;
+    }
+  }
 }
 
 function formatErrorMessage(error: unknown): string {
@@ -1960,7 +1971,7 @@ function scheduleBackendRestart(reason: string): void {
 
   const delayMs = Math.min(500 * 2 ** restartAttempt, 10_000);
   restartAttempt += 1;
-  console.error(`[desktop] backend exited unexpectedly (${reason}); restarting in ${delayMs}ms`);
+  safeConsoleError(`[desktop] backend exited unexpectedly (${reason}); restarting in ${delayMs}ms`);
 
   restartTimer = setTimeout(() => {
     restartTimer = null;
@@ -2834,6 +2845,15 @@ app.on("window-all-closed", () => {
 });
 
 if (process.platform !== "win32") {
+  process.on("uncaughtException", (error: unknown) => {
+    if (!isBrokenPipeError(error)) {
+      throw error;
+    }
+    if (desktopShutdownPromise) return;
+    writeDesktopLogHeader("EPIPE received");
+    requestGracefulAppQuit("EPIPE");
+  });
+
   process.on("SIGINT", () => {
     if (desktopShutdownPromise) return;
     writeDesktopLogHeader("SIGINT received");

--- a/apps/server/src/codexProcessEnv.test.ts
+++ b/apps/server/src/codexProcessEnv.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { linkOrCopyCodexOverlayEntry } from "./codexProcessEnv";
+import { linkOrCopyCodexOverlayEntry, prioritizeCodexOverlayEntries } from "./codexProcessEnv";
 
 describe("linkOrCopyCodexOverlayEntry", () => {
   it("copies auth.json when symlink creation is unavailable", () => {
@@ -46,5 +46,15 @@ describe("linkOrCopyCodexOverlayEntry", () => {
         { symlink, copyFile: vi.fn() },
       ),
     ).toThrow("symlinks unavailable");
+  });
+});
+
+describe("prioritizeCodexOverlayEntries", () => {
+  it("prepares auth.json before entries whose symlinks may fail first", () => {
+    expect(prioritizeCodexOverlayEntries(["sessions", "auth.json", "config.toml"])).toEqual([
+      "auth.json",
+      "sessions",
+      "config.toml",
+    ]);
   });
 });

--- a/apps/server/src/codexProcessEnv.test.ts
+++ b/apps/server/src/codexProcessEnv.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { linkOrCopyCodexOverlayEntry } from "./codexProcessEnv";
+
+describe("linkOrCopyCodexOverlayEntry", () => {
+  it("copies auth.json when symlink creation is unavailable", () => {
+    const symlink = vi.fn(() => {
+      throw new Error("symlinks unavailable");
+    });
+    const copyFile = vi.fn();
+
+    linkOrCopyCodexOverlayEntry(
+      {
+        entryName: "auth.json",
+        sourcePath: "C:\\Users\\test\\.codex\\auth.json",
+        targetPath: "C:\\Users\\test\\.synara\\codex-home-overlay\\auth.json",
+        type: "file",
+      },
+      { symlink, copyFile },
+    );
+
+    expect(symlink).toHaveBeenCalledWith(
+      "C:\\Users\\test\\.codex\\auth.json",
+      "C:\\Users\\test\\.synara\\codex-home-overlay\\auth.json",
+      "file",
+    );
+    expect(copyFile).toHaveBeenCalledWith(
+      "C:\\Users\\test\\.codex\\auth.json",
+      "C:\\Users\\test\\.synara\\codex-home-overlay\\auth.json",
+    );
+  });
+
+  it("keeps symlink failures visible for other overlay entries", () => {
+    const symlink = vi.fn(() => {
+      throw new Error("symlinks unavailable");
+    });
+
+    expect(() =>
+      linkOrCopyCodexOverlayEntry(
+        {
+          entryName: "sessions",
+          sourcePath: "C:\\Users\\test\\.codex\\sessions",
+          targetPath: "C:\\Users\\test\\.synara\\codex-home-overlay\\sessions",
+          type: "dir",
+        },
+        { symlink, copyFile: vi.fn() },
+      ),
+    ).toThrow("symlinks unavailable");
+  });
+});

--- a/apps/server/src/codexProcessEnv.ts
+++ b/apps/server/src/codexProcessEnv.ts
@@ -5,6 +5,7 @@
 // Depends on: Codex home path helpers, shared Codex config parsing, login-shell env reader.
 
 import {
+  copyFileSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -34,6 +35,11 @@ const CODEX_PROCESS_SHELL_ENV_NAMES = ["PATH", "SSH_AUTH_SOCK"] as const;
 const NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS = "NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS";
 const DPCODE_BROWSER_PLUGIN_CONFIG_HEADER = '[plugins."dpcode-browser@local"]';
 const CODEX_OVERLAY_SHARED_STATE_FILES = new Set(["auth.json"]);
+
+interface CodexOverlayEntryLinker {
+  readonly symlink: typeof symlinkSync;
+  readonly copyFile: typeof copyFileSync;
+}
 
 export function resolveCodexBrowserUsePipePath(
   input: {
@@ -99,6 +105,29 @@ export function disableDpCodeBrowserPluginInCodexConfig(config: string): string 
   return output.join("\n");
 }
 
+export function linkOrCopyCodexOverlayEntry(
+  input: {
+    readonly entryName: string;
+    readonly sourcePath: string;
+    readonly targetPath: string;
+    readonly type: "dir" | "file";
+  },
+  linker: CodexOverlayEntryLinker = {
+    symlink: symlinkSync,
+    copyFile: copyFileSync,
+  },
+): void {
+  try {
+    linker.symlink(input.sourcePath, input.targetPath, input.type);
+  } catch (error: unknown) {
+    if (input.type === "file" && CODEX_OVERLAY_SHARED_STATE_FILES.has(input.entryName)) {
+      linker.copyFile(input.sourcePath, input.targetPath);
+      return;
+    }
+    throw error;
+  }
+}
+
 function ensureCodexOverlaySymlink(input: {
   readonly entryName: string;
   readonly sourcePath: string;
@@ -130,7 +159,7 @@ function ensureCodexOverlaySymlink(input: {
     }
   }
 
-  symlinkSync(input.sourcePath, input.targetPath, input.type);
+  linkOrCopyCodexOverlayEntry(input);
 }
 
 function prepareDpCodeCodexHomeOverlay(input: {

--- a/apps/server/src/codexProcessEnv.ts
+++ b/apps/server/src/codexProcessEnv.ts
@@ -128,6 +128,21 @@ export function linkOrCopyCodexOverlayEntry(
   }
 }
 
+export function prioritizeCodexOverlayEntries(entries: readonly string[]): string[] {
+  const sharedStateEntries: string[] = [];
+  const otherEntries: string[] = [];
+
+  for (const entry of entries) {
+    if (CODEX_OVERLAY_SHARED_STATE_FILES.has(entry)) {
+      sharedStateEntries.push(entry);
+    } else {
+      otherEntries.push(entry);
+    }
+  }
+
+  return [...sharedStateEntries, ...otherEntries];
+}
+
 function ensureCodexOverlaySymlink(input: {
   readonly entryName: string;
   readonly sourcePath: string;
@@ -175,7 +190,9 @@ function prepareDpCodeCodexHomeOverlay(input: {
   mkdirSync(overlayHomePath, { recursive: true });
 
   try {
-    for (const entry of readdirSync(sourceHomePath)) {
+    // Auth must get a best-effort link/copy before optional entries whose
+    // symlinks may fail on restricted Windows installs.
+    for (const entry of prioritizeCodexOverlayEntries(readdirSync(sourceHomePath))) {
       if (entry === "config.toml") {
         continue;
       }


### PR DESCRIPTION
Fixes #303.

When Synara builds the Codex home overlay, it links shared state like `auth.json` from the real Codex home. On Windows, creating that symlink can fail depending on local permissions, which leaves the overlay unauthenticated.

This keeps the existing symlink path, but falls back to copying `auth.json` when linking is unavailable.

Checked:
- bunx vitest run apps/server/src/codexProcessEnv.test.ts apps/server/src/codexAppServerManager.test.ts -t "Codex process env|linkOrCopyCodexOverlayEntry|repairs stale auth|disables the local dpcode-browser plugin|repairs stale real files"
- bun run --filter t3 typecheck
- bunx oxlint apps/server/src/codexProcessEnv.ts apps/server/src/codexProcessEnv.test.ts
- bunx oxfmt --check apps/server/src/codexProcessEnv.ts apps/server/src/codexProcessEnv.test.ts