### PR TITLE
Add project actions menu and worktree setup step

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -3805,6 +3805,119 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("runs the setup action from the newly-created worktree before starting the turn", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: withProjectScripts(
+        createSnapshotForTargetUser({
+          targetMessageId: "msg-user-new-worktree-setup-action-test" as MessageId,
+          targetText: "new worktree setup action test",
+        }),
+        [
+          {
+            id: "setup",
+            name: "Setup",
+            command: "printf setup",
+            icon: "configure",
+            runOnWorktreeCreate: true,
+          },
+        ],
+      ),
+    });
+
+    try {
+      const newThreadButton = page.getByTestId("new-thread-button");
+      await expect.element(newThreadButton).toBeInTheDocument();
+      await newThreadButton.click();
+
+      const newThreadPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should have changed to a new draft thread UUID.",
+      );
+      const newThreadId = newThreadPath.slice(1) as ThreadId;
+
+      const envPickerTrigger = await waitForEnvironmentModeButton("Local");
+      envPickerTrigger.click();
+
+      const newWorktreeOption = page.getByText("New worktree");
+      await expect.element(newWorktreeOption).toBeInTheDocument();
+      await newWorktreeOption.click();
+
+      useComposerDraftStore.getState().setPrompt(newThreadId, "Ship it with setup");
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditor.textContent ?? "").toContain("Ship it with setup");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      await sendButton.click();
+
+      await vi.waitFor(
+        () => {
+          const createWorktreeIndex = wsRequests.findIndex((request) => {
+            return (
+              request._tag === WS_METHODS.gitCreateWorktree &&
+              request.cwd === "/repo/project" &&
+              request.branch === "main" &&
+              typeof request.newBranch === "string"
+            );
+          });
+          expect(createWorktreeIndex).toBeGreaterThanOrEqual(0);
+          const createWorktreeRequest = wsRequests[createWorktreeIndex];
+          if (
+            !createWorktreeRequest ||
+            createWorktreeRequest._tag !== WS_METHODS.gitCreateWorktree
+          ) {
+            throw new Error("Expected create worktree request.");
+          }
+          const worktreePath = `/repo/.codex/worktrees/project/${String(
+            createWorktreeRequest.newBranch,
+          ).replaceAll("/", "-")}`;
+
+          const terminalOpenIndex = wsRequests.findIndex((request) => {
+            return (
+              request._tag === WS_METHODS.terminalOpen &&
+              request.threadId === newThreadId &&
+              request.cwd === worktreePath
+            );
+          });
+          expect(terminalOpenIndex).toBeGreaterThan(createWorktreeIndex);
+          expect(wsRequests[terminalOpenIndex]).toMatchObject({
+            _tag: WS_METHODS.terminalOpen,
+            cwd: worktreePath,
+            env: {
+              T3CODE_PROJECT_ROOT: "/repo/project",
+              T3CODE_WORKTREE_PATH: worktreePath,
+            },
+          });
+
+          const terminalWriteIndex = wsRequests.findIndex((request) => {
+            return (
+              request._tag === WS_METHODS.terminalWrite &&
+              request.threadId === newThreadId &&
+              request.data === "printf setup\r"
+            );
+          });
+          expect(terminalWriteIndex).toBeGreaterThan(terminalOpenIndex);
+
+          const turnStartIndex = wsRequests.findIndex((request) => {
+            const command = readDispatchedCommand(request);
+            return command?.type === "thread.turn.start" && command.threadId === newThreadId;
+          });
+          expect(turnStartIndex).toBeGreaterThan(terminalWriteIndex);
+        },
+        { timeout: 10_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("hydrates the provider alongside a sticky claude model", async () => {
     useComposerDraftStore.setState({
       stickyModelSelectionByProvider: {

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   appendVoiceTranscriptToPrompt,
   buildComposerMenuSelectionKey,
+  createLocalDispatchSnapshot,
   createWorktreeSetupSnapshot,
   derivePromptHistoryFromMessages,
   failWorktreeSetupSnapshot,
@@ -1269,6 +1270,45 @@ describe("worktree setup snapshots", () => {
       "done",
       "done",
       "active",
+    ]);
+  });
+
+  it("inserts the setup action step when a worktree setup script is present", () => {
+    expect(
+      createWorktreeSetupSnapshot("run-setup-action", { setupScriptName: "Setup" }).steps,
+    ).toEqual([
+      { id: "create-worktree", label: "Creating branch and worktree", status: "done" },
+      { id: "prepare-thread", label: "Linking thread workspace", status: "done" },
+      { id: "run-setup-action", label: "Running setup action: Setup", status: "active" },
+      { id: "start-session", label: "Starting session", status: "pending" },
+    ]);
+  });
+
+  it("keeps the setup action step done when the session starts afterward", () => {
+    expect(
+      createWorktreeSetupSnapshot("start-session", { setupScriptName: "Setup" }).steps.map(
+        (step) => step.status,
+      ),
+    ).toEqual(["done", "done", "done", "active"]);
+  });
+
+  it("preserves setup action metadata while advancing local worktree setup", () => {
+    const current = createLocalDispatchSnapshot(undefined, {
+      worktreeSetupStepId: "create-worktree",
+      setupScriptName: "Setup",
+    });
+
+    const next = resolveNextLocalDispatchSnapshot({
+      current,
+      activeThread: undefined,
+      options: { worktreeSetupStepId: "run-setup-action", setupScriptName: "Setup" },
+    });
+
+    expect(next.worktreeSetup?.steps).toEqual([
+      { id: "create-worktree", label: "Creating branch and worktree", status: "done" },
+      { id: "prepare-thread", label: "Linking thread workspace", status: "done" },
+      { id: "run-setup-action", label: "Running setup action: Setup", status: "active" },
+      { id: "start-session", label: "Starting session", status: "pending" },
     ]);
   });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -656,16 +656,46 @@ export const WORKTREE_SETUP_STEP_DEFINITIONS: ReadonlyArray<{
   { id: "start-session", label: "Starting session" },
 ];
 
+export interface WorktreeSetupSnapshotOptions {
+  setupScriptName?: string | null;
+}
+
+export interface WorktreeSetupDispatchOptions extends WorktreeSetupSnapshotOptions {
+  worktreeSetupStepId?: WorktreeSetupStepId;
+}
+
+function worktreeSetupStepDefinitions(
+  activeStepId: WorktreeSetupStepId,
+  options?: WorktreeSetupSnapshotOptions,
+): ReadonlyArray<{ id: WorktreeSetupStepId; label: string }> {
+  const setupScriptName = options?.setupScriptName?.trim();
+  const includeSetupStep = activeStepId === "run-setup-action" || Boolean(setupScriptName);
+  if (!includeSetupStep) {
+    return WORKTREE_SETUP_STEP_DEFINITIONS;
+  }
+  return [
+    { id: "create-worktree", label: "Creating branch and worktree" },
+    { id: "prepare-thread", label: "Linking thread workspace" },
+    {
+      id: "run-setup-action",
+      label: setupScriptName ? `Running setup action: ${setupScriptName}` : "Running setup action",
+    },
+    { id: "start-session", label: "Starting session" },
+  ];
+}
+
 // How long a failed setup step stays visible before the row is dismissed, so
 // the error state can paint instead of being batched away with the reset.
 export const WORKTREE_SETUP_ERROR_HOLD_MS = 1200;
 
 export function createWorktreeSetupSnapshot(
   activeStepId: WorktreeSetupStepId,
+  options?: WorktreeSetupSnapshotOptions,
 ): WorktreeSetupSnapshot {
-  const activeIndex = WORKTREE_SETUP_STEP_DEFINITIONS.findIndex((step) => step.id === activeStepId);
+  const stepDefinitions = worktreeSetupStepDefinitions(activeStepId, options);
+  const activeIndex = stepDefinitions.findIndex((step) => step.id === activeStepId);
   return {
-    steps: WORKTREE_SETUP_STEP_DEFINITIONS.map((step, index) => ({
+    steps: stepDefinitions.map((step, index) => ({
       ...step,
       status: index < activeIndex ? "done" : index === activeIndex ? "active" : "pending",
     })),
@@ -708,14 +738,14 @@ export interface LocalDispatchSnapshot {
 
 export function createLocalDispatchSnapshot(
   activeThread: Thread | undefined,
-  options?: { worktreeSetupStepId?: WorktreeSetupStepId },
+  options?: WorktreeSetupDispatchOptions,
 ): LocalDispatchSnapshot {
   const latestTurn = activeThread?.latestTurn ?? null;
   const session = activeThread?.session ?? null;
   return {
     startedAt: new Date().toISOString(),
     worktreeSetup: options?.worktreeSetupStepId
-      ? createWorktreeSetupSnapshot(options.worktreeSetupStepId)
+      ? createWorktreeSetupSnapshot(options.worktreeSetupStepId, options)
       : null,
     latestTurnTurnId: latestTurn?.turnId ?? null,
     latestTurnRequestedAt: latestTurn?.requestedAt ?? null,
@@ -731,7 +761,7 @@ export function createLocalDispatchSnapshot(
 export function resolveNextLocalDispatchSnapshot(input: {
   current: LocalDispatchSnapshot | null;
   activeThread: Thread | undefined;
-  options?: { worktreeSetupStepId?: WorktreeSetupStepId };
+  options?: WorktreeSetupDispatchOptions;
 }): LocalDispatchSnapshot {
   const worktreeSetupStepId = input.options?.worktreeSetupStepId;
   if (!input.current || worktreeSetupHasError(input.current.worktreeSetup)) {
@@ -747,7 +777,10 @@ export function resolveNextLocalDispatchSnapshot(input: {
   );
   return alreadyActive
     ? input.current
-    : { ...input.current, worktreeSetup: createWorktreeSetupSnapshot(worktreeSetupStepId) };
+    : {
+        ...input.current,
+        worktreeSetup: createWorktreeSetupSnapshot(worktreeSetupStepId, input.options),
+      };
 }
 
 export function hasServerAcknowledgedLocalDispatch(input: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4414,7 +4414,9 @@ export default function ChatView({
           error instanceof Error ? error.message : `Failed to run script "${script.name}".`,
         );
         if (options?.throwOnError) {
-          throw error instanceof Error ? error : new Error(`Failed to run script "${script.name}".`);
+          throw error instanceof Error
+            ? error
+            : new Error(`Failed to run script "${script.name}".`);
         }
         return null;
       }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -286,6 +286,8 @@ import {
   projectScriptRuntimeEnv,
   projectScriptIdFromCommand,
   setupProjectScript,
+  type ProjectScriptRunOptions,
+  type ProjectScriptRunResult,
 } from "~/projectScripts";
 import { runProjectCommandInTerminal } from "~/projectTerminalRunner";
 import { newCommandId, newMessageId, newProjectId, newThreadId } from "~/lib/utils";
@@ -4349,15 +4351,8 @@ export default function ChatView({
   const runProjectScript = useCallback(
     async (
       script: ProjectScript,
-      options?: {
-        cwd?: string;
-        env?: Record<string, string>;
-        worktreePath?: string | null;
-        preferNewTerminal?: boolean;
-        rememberAsLastInvoked?: boolean;
-        throwOnError?: boolean;
-      },
-    ) => {
+      options?: ProjectScriptRunOptions,
+    ): Promise<ProjectScriptRunResult | null> => {
       const api = readNativeApi();
       if (!api || !activeThreadId || !activeProject || !activeThread) return null;
       if (options?.rememberAsLastInvoked !== false) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -243,7 +243,6 @@ import {
   MAX_TERMINALS_PER_GROUP,
   type ChatMessage,
   type Thread,
-  type WorktreeSetupStepId,
 } from "../types";
 import { useTheme } from "../hooks/useTheme";
 import { useThreadWorkspaceHandoff } from "../hooks/useThreadWorkspaceHandoff";
@@ -506,6 +505,7 @@ import {
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
   LastInvokedScriptByProjectSchema,
   type LocalDispatchSnapshot,
+  type WorktreeSetupDispatchOptions,
   PullRequestDialogState,
   type QueuedSteerGate,
   resolveQueuedSteerGateTransition,
@@ -557,6 +557,87 @@ const LOCAL_PROJECT_DRAFT_CONTEXT = {
 } as const;
 const DRAFT_PROJECT_SYNC_MAX_ATTEMPTS = 6;
 const DRAFT_PROJECT_SYNC_DELAY_MS = 50;
+const SETUP_SCRIPT_TERMINAL_ACTIVITY_START_TIMEOUT_MS = 1_000;
+const SETUP_SCRIPT_TERMINAL_MAX_RUNTIME_MS = 10 * 60 * 1000;
+
+function terminalHasRunningSubprocess(threadId: ThreadId, terminalId: string): boolean {
+  const terminalState = selectThreadTerminalState(
+    useTerminalStateStore.getState().terminalStateByThreadId,
+    threadId,
+  );
+  return terminalState.runningTerminalIds.includes(terminalId);
+}
+
+function waitForSetupScriptTerminalActivity(input: {
+  threadId: ThreadId;
+  terminalId: string;
+  observeStartTimeoutMs?: number;
+  maxRuntimeMs?: number;
+}): Promise<void> {
+  if (typeof window === "undefined") {
+    return Promise.resolve();
+  }
+
+  const observeStartTimeoutMs =
+    input.observeStartTimeoutMs ?? SETUP_SCRIPT_TERMINAL_ACTIVITY_START_TIMEOUT_MS;
+  const maxRuntimeMs = input.maxRuntimeMs ?? SETUP_SCRIPT_TERMINAL_MAX_RUNTIME_MS;
+
+  return new Promise((resolve) => {
+    let resolved = false;
+    let observedRunning = terminalHasRunningSubprocess(input.threadId, input.terminalId);
+    let observeStartTimer: number | null = null;
+    let maxRuntimeTimer: number | null = null;
+
+    const unsubscribe = useTerminalStateStore.subscribe(() => {
+      checkRunningState();
+    });
+
+    const clearTimers = () => {
+      if (observeStartTimer !== null) {
+        window.clearTimeout(observeStartTimer);
+        observeStartTimer = null;
+      }
+      if (maxRuntimeTimer !== null) {
+        window.clearTimeout(maxRuntimeTimer);
+        maxRuntimeTimer = null;
+      }
+    };
+
+    const finish = () => {
+      if (resolved) return;
+      resolved = true;
+      clearTimers();
+      unsubscribe();
+      resolve();
+    };
+
+    const ensureMaxRuntimeTimer = () => {
+      if (maxRuntimeTimer !== null) return;
+      maxRuntimeTimer = window.setTimeout(finish, maxRuntimeMs);
+    };
+
+    function checkRunningState() {
+      const running = terminalHasRunningSubprocess(input.threadId, input.terminalId);
+      if (running) {
+        observedRunning = true;
+        if (observeStartTimer !== null) {
+          window.clearTimeout(observeStartTimer);
+          observeStartTimer = null;
+        }
+        ensureMaxRuntimeTimer();
+        return;
+      }
+      if (observedRunning) {
+        finish();
+      }
+    }
+
+    checkRunningState();
+    if (!observedRunning) {
+      observeStartTimer = window.setTimeout(finish, observeStartTimeoutMs);
+    }
+  });
+}
 
 function waitForDraftProjectSyncDelay(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -4274,10 +4355,11 @@ export default function ChatView({
         worktreePath?: string | null;
         preferNewTerminal?: boolean;
         rememberAsLastInvoked?: boolean;
+        throwOnError?: boolean;
       },
     ) => {
       const api = readNativeApi();
-      if (!api || !activeThreadId || !activeProject || !activeThread) return;
+      if (!api || !activeThreadId || !activeProject || !activeThread) return null;
       if (options?.rememberAsLastInvoked !== false) {
         setLastInvokedScriptByProjectId((current) => {
           if (current[activeProject.id] === script.id) return current;
@@ -4325,11 +4407,16 @@ export default function ChatView({
             label: metadata.label,
           });
         }
+        return { terminalId: targetTerminalId };
       } catch (error) {
         setThreadError(
           activeThreadId,
           error instanceof Error ? error.message : `Failed to run script "${script.name}".`,
         );
+        if (options?.throwOnError) {
+          throw error instanceof Error ? error : new Error(`Failed to run script "${script.name}".`);
+        }
+        return null;
       }
     },
     [
@@ -5466,7 +5553,7 @@ export default function ChatView({
   });
 
   const beginLocalDispatch = useCallback(
-    (options?: { worktreeSetupStepId?: WorktreeSetupStepId }) => {
+    (options?: WorktreeSetupDispatchOptions) => {
       setLocalDispatch((current) => {
         const next = resolveNextLocalDispatchSnapshot(
           options ? { current, activeThread, options } : { current, activeThread },
@@ -7309,9 +7396,16 @@ export default function ChatView({
       return false;
     }
 
+    const setupScriptForWorktree = baseBranchForWorktree
+      ? setupProjectScript(targetProjectScriptsForSend)
+      : null;
+    const worktreeSetupScriptName = setupScriptForWorktree?.name ?? null;
+
     sendInFlightRef.current = true;
     beginLocalDispatch(
-      baseBranchForWorktree ? { worktreeSetupStepId: "create-worktree" } : undefined,
+      baseBranchForWorktree
+        ? { worktreeSetupStepId: "create-worktree", setupScriptName: worktreeSetupScriptName }
+        : undefined,
     );
 
     const composerImagesSnapshot = [...composerImagesForSend];
@@ -7446,7 +7540,10 @@ export default function ChatView({
           branch: baseBranchForWorktree,
           newBranch: buildTemporaryWorktreeBranchName(),
         });
-        beginLocalDispatch({ worktreeSetupStepId: "prepare-thread" });
+        beginLocalDispatch({
+          worktreeSetupStepId: "prepare-thread",
+          setupScriptName: worktreeSetupScriptName,
+        });
         nextThreadBranch = result.worktree.branch;
         nextThreadWorktreePath = result.worktree.path;
         const nextAssociatedWorktree = deriveAssociatedWorktreeMetadata({
@@ -7533,10 +7630,7 @@ export default function ChatView({
         createdServerThreadForLocalDraft = true;
       }
 
-      let setupScript: ProjectScript | null = null;
-      if (baseBranchForWorktree) {
-        setupScript = setupProjectScript(targetProjectScriptsForSend);
-      }
+      const setupScript = setupScriptForWorktree;
       if (setupScript) {
         let shouldRunSetupScript = false;
         if (isServerThread) {
@@ -7547,14 +7641,25 @@ export default function ChatView({
           }
         }
         if (shouldRunSetupScript) {
+          beginLocalDispatch({
+            worktreeSetupStepId: "run-setup-action",
+            setupScriptName: setupScript.name,
+          });
           const setupScriptOptions: Parameters<typeof runProjectScript>[1] = {
             worktreePath: nextThreadWorktreePath,
             rememberAsLastInvoked: false,
+            throwOnError: true,
           };
           if (nextThreadWorktreePath) {
             setupScriptOptions.cwd = nextThreadWorktreePath;
           }
-          await runProjectScript(setupScript, setupScriptOptions);
+          const setupTerminal = await runProjectScript(setupScript, setupScriptOptions);
+          if (setupTerminal) {
+            await waitForSetupScriptTerminalActivity({
+              threadId: threadIdForSend,
+              terminalId: setupTerminal.terminalId,
+            });
+          }
         }
       }
 
@@ -7569,7 +7674,9 @@ export default function ChatView({
       }
 
       beginLocalDispatch(
-        baseBranchForWorktree ? { worktreeSetupStepId: "start-session" } : undefined,
+        baseBranchForWorktree
+          ? { worktreeSetupStepId: "start-session", setupScriptName: worktreeSetupScriptName }
+          : undefined,
       );
       const turnAttachments = await turnAttachmentsPromise;
       rememberCustomBinaryPathForDispatch({

--- a/apps/web/src/components/ProjectScriptsControl.browser.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.browser.tsx
@@ -87,4 +87,32 @@ describe("ProjectScriptsControl", () => {
     await expect.poll(() => document.body.textContent).toContain("Setup (setup)");
     await expect.poll(() => document.body.textContent).toContain("Add action");
   });
+
+  it("keeps the edit dialog delete action legible", async () => {
+    const setupScript: ProjectScript = {
+      id: "setup",
+      name: "Setup",
+      command: "bun install",
+      icon: "configure",
+      runOnWorktreeCreate: true,
+    };
+    await using _ = await mountProjectScriptsControl({
+      scripts: [setupScript],
+      preferredScriptId: "setup",
+    });
+
+    await page.getByLabelText("Script actions").click();
+    await expect
+      .poll(() => document.querySelector<HTMLButtonElement>('button[aria-label="Edit Setup"]'))
+      .not.toBeNull();
+    document.querySelector<HTMLButtonElement>('button[aria-label="Edit Setup"]')?.click();
+
+    await expect.poll(() => document.body.textContent).toContain("Edit Action");
+    const deleteButton = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+      (button) => button.textContent?.trim() === "Delete",
+    );
+
+    expect(deleteButton?.className).toContain("text-destructive");
+    expect(deleteButton?.className).not.toContain("text-destructive-foreground");
+  });
 });

--- a/apps/web/src/components/ProjectScriptsControl.browser.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.browser.tsx
@@ -27,7 +27,7 @@ async function mountProjectScriptsControl(props?: {
     <ProjectScriptsControl
       scripts={props?.scripts ?? []}
       keybindings={EMPTY_KEYBINDINGS}
-      preferredScriptId={props?.preferredScriptId}
+      preferredScriptId={props?.preferredScriptId ?? null}
       onRunScript={onRunScript}
       onAddScript={onAddScript}
       onUpdateScript={onUpdateScript}

--- a/apps/web/src/components/ProjectScriptsControl.browser.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.browser.tsx
@@ -1,0 +1,90 @@
+// FILE: ProjectScriptsControl.browser.tsx
+// Purpose: Browser regressions for the chat-header project action control.
+// Layer: Browser UI test
+
+import "../index.css";
+
+import { type ProjectScript, type ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import ProjectScriptsControl, { type NewProjectScriptInput } from "./ProjectScriptsControl";
+
+const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
+
+async function mountProjectScriptsControl(props?: {
+  scripts?: ProjectScript[];
+  preferredScriptId?: string | null;
+}) {
+  const onRunScript = vi.fn();
+  const onAddScript = vi.fn<(input: NewProjectScriptInput) => void>();
+  const onUpdateScript = vi.fn<(scriptId: string, input: NewProjectScriptInput) => void>();
+  const onDeleteScript = vi.fn<(scriptId: string) => void>();
+  const host = document.createElement("div");
+  document.body.append(host);
+  const screen = await render(
+    <ProjectScriptsControl
+      scripts={props?.scripts ?? []}
+      keybindings={EMPTY_KEYBINDINGS}
+      preferredScriptId={props?.preferredScriptId}
+      onRunScript={onRunScript}
+      onAddScript={onAddScript}
+      onUpdateScript={onUpdateScript}
+      onDeleteScript={onDeleteScript}
+    />,
+    { container: host },
+  );
+
+  const cleanup = async () => {
+    await screen.unmount();
+    host.remove();
+  };
+
+  return {
+    [Symbol.asyncDispose]: cleanup,
+    cleanup,
+    onRunScript,
+    onAddScript,
+    onUpdateScript,
+    onDeleteScript,
+  };
+}
+
+describe("ProjectScriptsControl", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("opens the add-action dialog from the header when no script exists yet", async () => {
+    await using _ = await mountProjectScriptsControl();
+
+    await page.getByRole("button", { name: "Add action" }).click();
+
+    await expect.poll(() => document.body.textContent).toContain("Add Action");
+    expect(document.body.textContent).toContain(
+      "Actions are project-scoped commands you can run from the top bar or keybindings.",
+    );
+  });
+
+  it("runs the primary action and exposes setup actions in the dropdown", async () => {
+    const setupScript: ProjectScript = {
+      id: "setup",
+      name: "Setup",
+      command: "bun install",
+      icon: "configure",
+      runOnWorktreeCreate: true,
+    };
+    await using control = await mountProjectScriptsControl({
+      scripts: [setupScript],
+      preferredScriptId: "setup",
+    });
+
+    await page.getByRole("button", { name: "Run Setup" }).click();
+    expect(control.onRunScript).toHaveBeenCalledWith(setupScript);
+
+    await page.getByLabelText("Script actions").click();
+    await expect.poll(() => document.body.textContent).toContain("Setup (setup)");
+    await expect.poll(() => document.body.textContent).toContain("Add action");
+  });
+});

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -11,16 +11,13 @@ import {
   ListChecksIcon,
   PlayIcon,
   PlusIcon,
-  SearchIcon,
   SettingsIcon,
 } from "~/lib/icons";
 import React, {
   type FormEvent,
   type KeyboardEvent,
   useCallback,
-  useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 
@@ -44,11 +41,14 @@ import {
   AlertDialogPopup,
   AlertDialogTitle,
 } from "./ui/alert-dialog";
-import { Button, headerButtonDarkBorderClassName } from "./ui/button";
+import { Button } from "./ui/button";
 import {
-  CHAT_HEADER_CONTROL_CLASS_NAME,
-  CHAT_HEADER_ICON_CONTROL_CLASS_NAME,
-  CHAT_HEADER_ICON_STRENGTH_CLASS_NAME,
+  CHAT_HEADER_SPLIT_LEADING_CLASS_NAME,
+  CHAT_HEADER_SPLIT_TRAILING_CLASS_NAME,
+  ChatHeaderButton,
+  ChatHeaderIconButton,
+  ChatHeaderSplitDivider,
+  ChatHeaderSplitGroup,
 } from "./chat/chatHeaderControls";
 import {
   Dialog,
@@ -59,7 +59,6 @@ import {
   DialogPopup,
   DialogTitle,
 } from "./ui/dialog";
-import { Group, GroupSeparator } from "./ui/group";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Menu, MenuItem, MenuPopup, MenuShortcut, MenuTrigger } from "./ui/menu";
@@ -85,7 +84,7 @@ function ScriptIcon({
 }) {
   if (icon === "test") return <FlaskConicalIcon className={className} />;
   if (icon === "lint") return <ListChecksIcon className={className} />;
-  if (icon === "configure") return <SearchIcon className={className} />;
+  if (icon === "configure") return <SettingsIcon className={className} />;
   if (icon === "build") return <HammerIcon className={className} />;
   if (icon === "debug") return <BugIcon className={className} />;
   return <PlayIcon className={className} />;
@@ -104,7 +103,7 @@ interface ProjectScriptsControlProps {
   keybindings: ResolvedKeybindingsConfig;
   preferredScriptId?: string | null;
   showInlineControls?: boolean;
-  openAddActionNonce?: number;
+  hideInlineLabel?: boolean;
   onRunScript: (script: ProjectScript) => void;
   onAddScript: (input: NewProjectScriptInput) => Promise<void> | void;
   onUpdateScript: (scriptId: string, input: NewProjectScriptInput) => Promise<void> | void;
@@ -167,7 +166,7 @@ export default function ProjectScriptsControl({
   keybindings,
   preferredScriptId = null,
   showInlineControls = true,
-  openAddActionNonce,
+  hideInlineLabel = false,
   onRunScript,
   onAddScript,
   onUpdateScript,
@@ -184,7 +183,6 @@ export default function ProjectScriptsControl({
   const [keybinding, setKeybinding] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-  const lastOpenAddActionNonceRef = useRef<number | undefined>(openAddActionNonce);
 
   const primaryScript = useMemo(() => {
     if (preferredScriptId) {
@@ -194,8 +192,8 @@ export default function ProjectScriptsControl({
     return primaryProjectScript(scripts);
   }, [preferredScriptId, scripts]);
   const isEditing = editingScriptId !== null;
-  const dropdownItemClassName =
-    "data-highlighted:bg-transparent data-highlighted:text-foreground hover:bg-[var(--sidebar-accent)] hover:text-foreground focus-visible:bg-[var(--sidebar-accent)] focus-visible:text-foreground data-highlighted:hover:bg-[var(--sidebar-accent)] data-highlighted:hover:text-foreground data-highlighted:focus-visible:bg-[var(--sidebar-accent)] data-highlighted:focus-visible:text-foreground";
+  const actionMenuItemClassName =
+    "group grid min-h-9 grid-cols-[1rem_minmax(0,1fr)_1.5rem] items-center gap-2 rounded-xl px-2.5 py-1.5 text-[13px] leading-none data-highlighted:bg-transparent data-highlighted:text-foreground hover:bg-[var(--color-background-button-secondary-hover)] hover:text-foreground focus-visible:bg-[var(--color-background-button-secondary-hover)] focus-visible:text-foreground data-highlighted:hover:bg-[var(--color-background-button-secondary-hover)] data-highlighted:hover:text-foreground data-highlighted:focus-visible:bg-[var(--color-background-button-secondary-hover)] data-highlighted:focus-visible:text-foreground [&>svg]:mx-0 [&>svg]:size-4";
 
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Tab") return;
@@ -277,19 +275,6 @@ export default function ProjectScriptsControl({
     setDialogOpen(true);
   };
 
-  // Allow parent surfaces like the compact header menu to open the shared
-  // "Add action" dialog without duplicating script form logic.
-  useEffect(() => {
-    if (openAddActionNonce === undefined) return;
-    if (lastOpenAddActionNonceRef.current === undefined) {
-      lastOpenAddActionNonceRef.current = openAddActionNonce;
-      return;
-    }
-    if (openAddActionNonce === lastOpenAddActionNonceRef.current) return;
-    lastOpenAddActionNonceRef.current = openAddActionNonce;
-    openAddDialog();
-  }, [openAddActionNonce]);
-
   const confirmDeleteScript = useCallback(() => {
     if (!editingScriptId) return;
     setDeleteConfirmOpen(false);
@@ -300,42 +285,41 @@ export default function ProjectScriptsControl({
   return (
     <>
       {showInlineControls && primaryScript ? (
-        <Group aria-label="Project scripts">
-          <Button
-            size="xs"
-            variant="outline"
+        <ChatHeaderSplitGroup label="Project actions">
+          <ChatHeaderButton
             className={cn(
-              headerButtonDarkBorderClassName,
-              CHAT_HEADER_CONTROL_CLASS_NAME,
-              CHAT_HEADER_ICON_STRENGTH_CLASS_NAME,
+              CHAT_HEADER_SPLIT_LEADING_CLASS_NAME,
+              "min-w-0 gap-1.5 px-2.5",
+              hideInlineLabel ? "px-2" : "max-w-44",
             )}
             onClick={() => onRunScript(primaryScript)}
+            aria-label={`Run ${primaryScript.name}`}
             title={`Run ${primaryScript.name}`}
           >
-            <ScriptIcon icon={primaryScript.icon} />
-            <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
+            <ScriptIcon icon={primaryScript.icon} className="size-3.5 shrink-0" />
+            <span
+              className={cn(
+                "max-w-32 truncate font-normal",
+                hideInlineLabel ? "sr-only" : "hidden sm:inline",
+              )}
+            >
               {primaryScript.name}
             </span>
-          </Button>
-          <GroupSeparator className="hidden @sm/header-actions:block" />
+          </ChatHeaderButton>
+          <ChatHeaderSplitDivider />
           <Menu highlightItemOnHover={false}>
             <MenuTrigger
               render={
-                <Button
-                  size="icon-xs"
-                  variant="outline"
-                  className={cn(
-                    headerButtonDarkBorderClassName,
-                    CHAT_HEADER_ICON_CONTROL_CLASS_NAME,
-                    CHAT_HEADER_ICON_STRENGTH_CLASS_NAME,
-                  )}
-                  aria-label="Script actions"
+                <ChatHeaderIconButton
+                  label="Script actions"
+                  tone="outline"
+                  className={CHAT_HEADER_SPLIT_TRAILING_CLASS_NAME}
                 />
               }
             >
-              <ChevronDownIcon className="size-4" />
+              <ChevronDownIcon className="size-3.5" />
             </MenuTrigger>
-            <MenuPopup align="end">
+            <MenuPopup align="end" className="min-w-64" sideOffset={8}>
               {scripts.map((script) => {
                 const shortcutLabel = shortcutLabelForCommand(
                   keybindings,
@@ -344,14 +328,14 @@ export default function ProjectScriptsControl({
                 return (
                   <MenuItem
                     key={script.id}
-                    className={`group ${dropdownItemClassName}`}
+                    className={actionMenuItemClassName}
                     onClick={() => onRunScript(script)}
                   >
-                    <ScriptIcon icon={script.icon} className="size-4" />
-                    <span className="truncate">
+                    <ScriptIcon icon={script.icon} className="size-4 text-muted-foreground" />
+                    <span className="min-w-0 truncate">
                       {script.runOnWorktreeCreate ? `${script.name} (setup)` : script.name}
                     </span>
-                    <span className="relative ms-auto flex h-6 min-w-6 items-center justify-end">
+                    <span className="flex min-w-0 items-center justify-end">
                       {shortcutLabel && (
                         <MenuShortcut className="ms-0 transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0">
                           {shortcutLabel}
@@ -361,7 +345,7 @@ export default function ProjectScriptsControl({
                         type="button"
                         variant="ghost"
                         size="icon-xs"
-                        className="absolute right-0 top-1/2 size-6 -translate-y-1/2 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-visible:opacity-100 group-focus-visible:pointer-events-auto"
+                        className="size-6 rounded-lg opacity-50 transition-opacity sm:pointer-events-none sm:opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-visible:pointer-events-auto sm:group-focus-visible:opacity-100"
                         aria-label={`Edit ${script.name}`}
                         onPointerDown={(event) => {
                           event.preventDefault();
@@ -379,13 +363,30 @@ export default function ProjectScriptsControl({
                   </MenuItem>
                 );
               })}
-              <MenuItem className={dropdownItemClassName} onClick={openAddDialog}>
-                <PlusIcon className="size-4" />
-                Add action
+              <MenuItem className={actionMenuItemClassName} onClick={openAddDialog}>
+                <PlusIcon className="size-4 text-muted-foreground" />
+                <span className="col-span-2 min-w-0 truncate">Add action</span>
               </MenuItem>
             </MenuPopup>
           </Menu>
-        </Group>
+        </ChatHeaderSplitGroup>
+      ) : showInlineControls ? (
+        <ChatHeaderButton
+          className={cn(
+            "gap-1.5 px-2.5",
+            hideInlineLabel && "px-2",
+          )}
+          onClick={openAddDialog}
+          aria-label="Add action"
+          title="Add action"
+        >
+          <PlusIcon className="size-3.5" />
+          <span
+            className={cn("font-normal", hideInlineLabel ? "sr-only" : "hidden sm:inline")}
+          >
+            Add action
+          </span>
+        </ChatHeaderButton>
       ) : null}
 
       <Dialog

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -13,13 +13,7 @@ import {
   PlusIcon,
   SettingsIcon,
 } from "~/lib/icons";
-import React, {
-  type FormEvent,
-  type KeyboardEvent,
-  useCallback,
-  useMemo,
-  useState,
-} from "react";
+import React, { type FormEvent, type KeyboardEvent, useCallback, useMemo, useState } from "react";
 
 import {
   keybindingValueForCommand,
@@ -372,18 +366,13 @@ export default function ProjectScriptsControl({
         </ChatHeaderSplitGroup>
       ) : showInlineControls ? (
         <ChatHeaderButton
-          className={cn(
-            "gap-1.5 px-2.5",
-            hideInlineLabel && "px-2",
-          )}
+          className={cn("gap-1.5 px-2.5", hideInlineLabel && "px-2")}
           onClick={openAddDialog}
           aria-label="Add action"
           title="Add action"
         >
           <PlusIcon className="size-3.5" />
-          <span
-            className={cn("font-normal", hideInlineLabel ? "sr-only" : "hidden sm:inline")}
-          >
+          <span className={cn("font-normal", hideInlineLabel ? "sr-only" : "hidden sm:inline")}>
             Add action
           </span>
         </ChatHeaderButton>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -523,7 +523,6 @@ export const ChatHeader = memo(function ChatHeader({
   const { isMobile, state } = useSidebar();
   const headerRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
-  const [openAddActionNonce, setOpenAddActionNonce] = useState(0);
   const {
     additions: diffAdditions,
     deletions: diffDeletions,
@@ -779,16 +778,12 @@ export const ChatHeader = memo(function ChatHeader({
             </ComposerPickerMenuPopup>
           </Menu>
         ) : null}
-        {/* Keep the shared project-action dialog mounted for the Open-in picker's
-            "Add action" entry, but hide the inline quick-run button (play + chevron)
-            from the header. */}
         {activeProjectScripts ? (
           <ProjectScriptsControl
             scripts={activeProjectScripts}
             keybindings={keybindings}
             preferredScriptId={preferredScriptId}
-            openAddActionNonce={openAddActionNonce}
-            showInlineControls={false}
+            hideInlineLabel={compact}
             onRunScript={onRunProjectScript}
             onAddScript={onAddProjectScript}
             onUpdateScript={onUpdateProjectScript}
@@ -843,15 +838,12 @@ export const ChatHeader = memo(function ChatHeader({
         ) : (
           <>
             {/* Open in editor: dedicated split-button with an editor switcher; the project
-                "Add action" entry lives at the bottom of that same menu. */}
+                action control now lives beside Hand off as its own project command surface. */}
             {activeProjectName ? (
               <OpenInPicker
                 keybindings={keybindings}
                 availableEditors={availableEditors}
                 openInTarget={openInTarget}
-                {...(activeProjectScripts
-                  ? { onAddAction: () => setOpenAddActionNonce((current) => current + 1) }
-                  : {})}
               />
             ) : null}
 

--- a/apps/web/src/components/chat/MessagesTimeline.worktreeSetup.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.worktreeSetup.browser.tsx
@@ -39,6 +39,17 @@ function setupSnapshot(statuses: [WorktreeSetupStepStatus, WorktreeSetupStepStat
   } satisfies WorktreeSetupSnapshot;
 }
 
+function setupActionSnapshot() {
+  return {
+    steps: [
+      { id: "create-worktree", label: "Creating branch and worktree", status: "done" },
+      { id: "prepare-thread", label: "Linking thread workspace", status: "done" },
+      { id: "run-setup-action", label: "Running setup action: Setup", status: "active" },
+      { id: "start-session", label: "Starting session", status: "pending" },
+    ],
+  } satisfies WorktreeSetupSnapshot;
+}
+
 function WorktreeSetupTimeline() {
   const [worktreeSetup, setWorktreeSetup] = useState<WorktreeSetupSnapshot | null>(() =>
     setupSnapshot(["active", "pending"]),
@@ -79,6 +90,34 @@ function WorktreeSetupTimeline() {
           workspaceRoot={undefined}
         />
       </div>
+    </div>
+  );
+}
+
+function SetupActionTimeline() {
+  return (
+    <div style={{ height: 420 }}>
+      <MessagesTimeline
+        hasMessages
+        isWorking
+        activeTurnInProgress={false}
+        activeTurnStartedAt={null}
+        worktreeSetup={setupActionSnapshot()}
+        timelineEntries={[userEntry("user-message", "Start in a worktree.")]}
+        turnDiffSummaryByAssistantMessageId={new Map()}
+        nowIso="2026-03-17T19:12:30.000Z"
+        expandedWorkGroups={{}}
+        onToggleWorkGroup={() => {}}
+        onOpenTurnDiff={() => {}}
+        revertTurnCountByUserMessageId={new Map()}
+        onRevertUserMessage={() => {}}
+        isRevertingCheckpoint={false}
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        resolvedTheme="dark"
+        timestampFormat="locale"
+        workspaceRoot={undefined}
+      />
     </div>
   );
 }
@@ -153,6 +192,18 @@ describe("MessagesTimeline worktree setup card", () => {
       await expect.poll(() => setupRow()?.textContent).toContain("Creating branch and worktree");
       expect(setupRow()?.textContent).toContain("failed");
       expect(document.body.textContent).not.toContain("Send a message to start the conversation.");
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("renders the project setup action as its own active worktree step", async () => {
+    const screen = await render(<SetupActionTimeline />);
+
+    try {
+      await expect.poll(() => setupRow()?.textContent).toContain("Running setup action: Setup");
+      expect(setupRow()?.textContent).toContain("Starting session");
+      expect(workingRow()).toBeNull();
     } finally {
       await screen.unmount();
     }

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -7,17 +7,16 @@ import { type EditorId, type ResolvedKeybindingsConfig } from "@t3tools/contract
 import { useQuery } from "@tanstack/react-query";
 import { memo } from "react";
 import { useEditorLaunchers } from "~/hooks/useEditorLaunchers";
-import { ChevronDownIcon, PlusIcon } from "~/lib/icons";
+import { ChevronDownIcon } from "~/lib/icons";
 import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
 import { cn } from "~/lib/utils";
 import {
   Menu,
-  MenuItem,
   MenuRadioGroup,
   MenuRadioItem,
-  MenuSeparator,
   MenuShortcut,
   MenuTrigger,
+  MenuItem,
 } from "../ui/menu";
 import { ComposerPickerMenuPopup } from "./ComposerPickerMenuPopup";
 import {
@@ -36,7 +35,6 @@ export const OpenInPicker = memo(function OpenInPicker({
   keybindings: keybindingsProp,
   availableEditors: availableEditorsProp,
   openInTarget,
-  onAddAction,
   labelMode = "responsive",
   defaultEditor,
 }: {
@@ -47,8 +45,6 @@ export const OpenInPicker = memo(function OpenInPicker({
   keybindings?: ResolvedKeybindingsConfig;
   availableEditors?: ReadonlyArray<EditorId>;
   openInTarget: string | null;
-  // Optional project "Add action" entry rendered at the bottom of the editor menu.
-  onAddAction?: () => void;
   // "responsive" (default) hides the "Open" label until the `header-actions`
   // inline-size container (declared on an ancestor — the chat header and the
   // file-preview header both do) is wide enough; "always" keeps it visible
@@ -135,17 +131,6 @@ export const OpenInPicker = memo(function OpenInPicker({
               </MenuRadioItem>
             ))}
           </MenuRadioGroup>
-          {onAddAction ? (
-            <>
-              <MenuSeparator className="mx-1" />
-              <MenuItem onClick={onAddAction}>
-                <span className="shrink-0">
-                  <PlusIcon aria-hidden="true" className="size-3.5 text-muted-foreground" />
-                </span>
-                Add action
-              </MenuItem>
-            </>
-          ) : null}
         </ComposerPickerMenuPopup>
       </Menu>
     </ChatHeaderSplitGroup>

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -79,7 +79,7 @@ const buttonVariants = cva(
         destructive:
           "border-destructive bg-destructive text-white [:hover,[data-pressed]]:bg-destructive/90",
         "destructive-outline":
-          "border-[color:var(--color-border)] bg-[var(--color-background-elevated-primary-opaque)] text-destructive-foreground [:hover,[data-pressed]]:border-destructive/32 [:hover,[data-pressed]]:bg-destructive/4",
+          "border-[color:var(--color-border)] bg-[var(--color-background-elevated-primary-opaque)] text-destructive [:hover,[data-pressed]]:border-destructive/32 [:hover,[data-pressed]]:bg-destructive/4 [:hover,[data-pressed]]:text-destructive",
         ghost:
           "border-transparent bg-transparent text-[var(--color-text-foreground-secondary)] focus-visible:ring-[color:var(--color-border-focus)]/60 focus-visible:ring-offset-0 [:hover,[data-pressed]]:bg-[var(--color-background-button-secondary-hover)] [:hover,[data-pressed]]:text-[var(--color-text-foreground)] data-pressed:bg-[var(--color-background-button-secondary)] data-pressed:text-[var(--color-text-foreground)]",
         link: "border-transparent underline-offset-4 [:hover,[data-pressed]]:underline",

--- a/apps/web/src/hooks/useThreadWorkspaceHandoff.ts
+++ b/apps/web/src/hooks/useThreadWorkspaceHandoff.ts
@@ -7,7 +7,11 @@ import { buildSuggestedWorktreeName } from "../components/ChatView.logic";
 import { toastManager } from "../components/ui/toast";
 import { newCommandId } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
-import { setupProjectScript } from "../projectScripts";
+import {
+  setupProjectScript,
+  type ProjectScriptRunOptions,
+  type ProjectScriptRunResult,
+} from "../projectScripts";
 import type { Project, ProjectScript, Thread, ThreadWorkspacePatch } from "../types";
 
 export function useThreadWorkspaceHandoff(input: {
@@ -23,13 +27,8 @@ export function useThreadWorkspaceHandoff(input: {
   stopActiveThreadSession: () => Promise<void>;
   runProjectScript: (
     script: ProjectScript,
-    options?: {
-      cwd?: string;
-      worktreePath?: string | null;
-      rememberAsLastInvoked?: boolean;
-      env?: Record<string, string>;
-    },
-  ) => Promise<void>;
+    options?: ProjectScriptRunOptions,
+  ) => Promise<ProjectScriptRunResult | null>;
   setStoreThreadWorkspace: (threadId: ThreadId, patch: ThreadWorkspacePatch) => void;
   syncServerShellSnapshot: (snapshot: OrchestrationShellSnapshot) => void;
 }) {

--- a/apps/web/src/projectScripts.ts
+++ b/apps/web/src/projectScripts.ts
@@ -63,6 +63,19 @@ interface ProjectScriptRuntimeEnvInput {
   extraEnv?: Record<string, string>;
 }
 
+export interface ProjectScriptRunOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+  worktreePath?: string | null;
+  preferNewTerminal?: boolean;
+  rememberAsLastInvoked?: boolean;
+  throwOnError?: boolean;
+}
+
+export interface ProjectScriptRunResult {
+  terminalId: string;
+}
+
 export function projectScriptCwd(input: {
   project: {
     cwd: string;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -144,7 +144,11 @@ export interface TurnDiffSummary {
 // Ephemeral client-side progress of the "New worktree" first-send setup
 // sequence (create worktree → link thread → start session). Rendered as a
 // transient transcript row; never persisted.
-export type WorktreeSetupStepId = "create-worktree" | "prepare-thread" | "start-session";
+export type WorktreeSetupStepId =
+  | "create-worktree"
+  | "prepare-thread"
+  | "run-setup-action"
+  | "start-session";
 export type WorktreeSetupStepStatus = "pending" | "active" | "done" | "error";
 
 export interface WorktreeSetupStep {


### PR DESCRIPTION
## Summary
- Adds a project Actions split-button to the chat header, with quick-run, dropdown run/edit controls, and first-class Add action handling.
- Moves Add action out of the Open in editor menu so project commands have a single canonical header surface.
- Shows setup actions as an intermediate New worktree progress step and runs them from the newly-created worktree before starting the provider turn.

## Changes
- Reuses the shared chat-header split-button primitives for the Actions control and tightens menu spacing/alignment for action rows and edit affordances.
- Extends worktree setup snapshots with an optional `run-setup-action` step labeled with the setup action name.
- Waits on the setup terminal activity when available, while keeping bounded fallbacks so long-running or unobserved setup commands cannot block forever.
- Adds browser coverage for the Actions control, the setup progress row, and the worktree setup command cwd/env/order.

## Testing
- `bun run test -- src/components/ChatView.logic.test.ts` - Passed, 94 tests.
- `bun run test:browser -- src/components/ProjectScriptsControl.browser.tsx` - Passed, 2 tests.
- `bun run test:browser -- src/components/ChatView.browser.tsx -t "setup action from the newly-created worktree"` - Passed, 1 focused test.
- `bun run test:browser -- src/components/ChatView.browser.tsx -t "runs project scripts"` - Passed, 2 focused tests.
- `bun run test:browser -- src/components/chat/MessagesTimeline.worktreeSetup.browser.tsx` - Passed, 3 tests.
- `git diff --check origin/main...HEAD` - Passed.
- Not run: `bun fmt`, `bun lint`, and `bun typecheck` because repo instructions say not to run them unless explicitly requested in the current conversation.

## Risks and Rollback
- Risk: Medium - touches first-send worktree sequencing and chat-header command UI, but the setup command is bounded and covered by focused browser tests.
- Rollback: Revert this commit to restore the previous hidden project-action dialog and three-step worktree setup progress.

## Review Setup
- App deploy: Required for reviewers to exercise the new web header control and worktree setup progress UI.
- Supabase Edge Functions: None.
- SQL migrations: None.
- Reviewer steps: Deploy the app, create a project action with "Run automatically on worktree creation" enabled, then start a New worktree thread and confirm the setup action runs from the created worktree before the turn starts.
