### PR TITLE
Fix Windows provider CLI resolution for npm global shims

### DIFF
--- a/packages/shared/src/windowsProcess.test.ts
+++ b/packages/shared/src/windowsProcess.test.ts
@@ -46,10 +46,50 @@ describe("windowsProcess", () => {
     );
   });
 
+  it("prefers .cmd over extensionless npm shims from where.exe", () => {
+    const spawnSync = vi.fn(() => ({
+      stdout: [
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+      ].join("\r\n"),
+      status: 0,
+    }));
+
+    expect(
+      resolveWindowsCommandPath("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toBe("C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd");
+  });
+
   it("skips current-directory command hits from where.exe", () => {
     const spawnSync = vi.fn(() => ({
       stdout: [
         "C:\\projects\\synara\\codex.cmd",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+      ].join("\r\n"),
+      status: 0,
+    }));
+
+    expect(
+      resolveWindowsCommandPath("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toBe("C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd");
+  });
+
+  it("keeps current-directory filtering before preferring spawn-safe candidates", () => {
+    const spawnSync = vi.fn(() => ({
+      stdout: [
+        "C:\\projects\\synara\\codex",
+        "C:\\projects\\synara\\codex.cmd",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
         "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
       ].join("\r\n"),
       status: 0,
@@ -91,7 +131,10 @@ describe("windowsProcess", () => {
 
   it("resolves extensionless path-like Windows shims before spawning", () => {
     const spawnSync = vi.fn(() => ({
-      stdout: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd\r\n",
+      stdout: [
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+      ].join("\r\n"),
       status: 0,
     }));
 
@@ -152,7 +195,9 @@ describe("windowsProcess", () => {
         "/s",
         "/v:off",
         "/c",
-        '"C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
+        "call",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+        "app-server",
       ],
       shell: false,
       windowsHide: true,
@@ -161,7 +206,10 @@ describe("windowsProcess", () => {
 
   it("wraps resolved extensionless path-like shims through cmd.exe", () => {
     const spawnSync = vi.fn(() => ({
-      stdout: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd\r\n",
+      stdout: [
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+      ].join("\r\n"),
       status: 0,
     }));
 
@@ -179,14 +227,16 @@ describe("windowsProcess", () => {
         "/s",
         "/v:off",
         "/c",
-        '"C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
+        "call",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+        "app-server",
       ],
       shell: false,
       windowsHide: true,
     });
   });
 
-  it("quotes batch commands and arguments in a single cmd.exe command line", () => {
+  it("wraps batch commands through cmd.exe call arguments", () => {
     expect(
       buildWindowsBatchCommandArgs("C:\\Users\\Test User\\npm\\tool.cmd", [
         "path with spaces",
@@ -197,24 +247,33 @@ describe("windowsProcess", () => {
       "/s",
       "/v:off",
       "/c",
-      '"C:\\Users\\Test User\\npm\\tool.cmd" "path with spaces" "flag=value"',
+      "call",
+      "C:\\Users\\Test User\\npm\\tool.cmd",
+      "path with spaces",
+      "flag=value",
     ]);
   });
 
-  it("escapes batch arguments that cmd.exe can expand or reinterpret", () => {
+  it("rejects batch tokens with cmd.exe control characters", () => {
+    expect(() => buildWindowsBatchCommandArgs("C:\\tools\\bad%path\\codex.cmd", [])).toThrow(
+      /Cannot safely execute Windows batch command/,
+    );
+    expect(() => buildWindowsBatchCommandArgs("C:\\tools\\codex.cmd", ["one&two"])).toThrow(
+      /Cannot safely execute Windows batch argument/,
+    );
+  });
+
+  it("allows batch paths with spaces and parentheses", () => {
     expect(
-      buildWindowsBatchCommandArgs("C:\\tools\\bad%path\\codex.cmd", [
-        "%PATH%",
-        'approval_policy="never"',
-        "one&two",
-        "bang!value",
-      ]),
+      buildWindowsBatchCommandArgs("C:\\Program Files (x86)\\Tool\\tool.cmd", ["--version"]),
     ).toEqual([
       "/d",
       "/s",
       "/v:off",
       "/c",
-      '"C:\\tools\\bad%%path\\codex.cmd" "%%PATH%%" "approval_policy=^"never^"" "one^&two" "bang^!value"',
+      "call",
+      "C:\\Program Files (x86)\\Tool\\tool.cmd",
+      "--version",
     ]);
   });
 

--- a/packages/shared/src/windowsProcess.ts
+++ b/packages/shared/src/windowsProcess.ts
@@ -35,9 +35,9 @@ export interface WindowsSafeProcessCommand {
 }
 
 const WINDOWS_BATCH_EXTENSION_PATTERN = /\.(?:cmd|bat)$/i;
+const WINDOWS_SPAWN_SAFE_EXTENSION_PATTERN = /\.(?:exe|com|cmd|bat)$/i;
 const WINDOWS_PATH_SEPARATOR_PATTERN = /[\\/]/;
-const WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN = /[\r\n]/;
-const WINDOWS_BATCH_CARET_ESCAPE_PATTERN = /[&|<>()^"!]/g;
+const WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN = /[\r\n&|<>^%]/;
 const WHERE_TIMEOUT_MS = 2_000;
 
 function trimNonEmpty(value: string | null | undefined): string | null {
@@ -67,23 +67,26 @@ export function isWindowsBatchCommand(command: string): boolean {
 
 function quoteWindowsBatchToken(token: string, label: string): string {
   if (WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN.test(token)) {
-    throw new Error(`Cannot safely execute Windows batch ${label} containing line breaks.`);
+    throw new Error(
+      `Cannot safely execute Windows batch ${label} containing cmd.exe control characters.`,
+    );
   }
-  const escaped = token
-    .replace(/%/g, "%%")
-    .replace(WINDOWS_BATCH_CARET_ESCAPE_PATTERN, (match) => `^${match}`);
-  return `"${escaped}"`;
+  return token;
 }
 
 export function buildWindowsBatchCommandArgs(
   command: string,
   args: ReadonlyArray<string>,
 ): string[] {
-  const commandLine = [
+  return [
+    "/d",
+    "/s",
+    "/v:off",
+    "/c",
+    "call",
     quoteWindowsBatchToken(command, "command"),
     ...args.map((arg) => quoteWindowsBatchToken(arg, "argument")),
-  ].join(" ");
-  return ["/d", "/s", "/v:off", "/c", commandLine];
+  ];
 }
 
 function isPathLikeCommand(command: string): boolean {
@@ -103,9 +106,28 @@ function isFromCurrentDirectory(candidate: string, cwd: string | undefined): boo
   return candidateDir === currentDir;
 }
 
+function isWindowsSpawnSafeResolvedCommand(command: string): boolean {
+  return WINDOWS_SPAWN_SAFE_EXTENSION_PATTERN.test(command);
+}
+
+function selectWindowsCommandCandidate(
+  candidates: ReadonlyArray<string>,
+  cwd: string | undefined,
+  pathLikeCommand: boolean,
+): string | undefined {
+  const allowedCandidates = pathLikeCommand
+    ? candidates
+    : candidates.filter((candidate) => !isFromCurrentDirectory(candidate, cwd));
+  return (
+    allowedCandidates.find(isWindowsSpawnSafeResolvedCommand) ??
+    allowedCandidates[0]
+  );
+}
+
 // Resolve PATH/PATHEXT commands through where.exe so `.cmd` shims can be wrapped
-// explicitly. We skip current-directory hits to avoid restoring shell-style CWD
-// command hijacking.
+// explicitly. Prefer candidates that native spawn can execute or that we can
+// wrap, and skip current-directory hits for PATH commands to avoid restoring
+// shell-style CWD command hijacking.
 export function resolveWindowsCommandPath(
   command: string,
   input: WindowsSafeProcessInput = {},
@@ -135,10 +157,7 @@ export function resolveWindowsCommandPath(
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
-  if (pathLikeCommand) {
-    return candidates[0] ?? command;
-  }
-  return candidates.find((candidate) => !isFromCurrentDirectory(candidate, cwd)) ?? command;
+  return selectWindowsCommandCandidate(candidates, cwd, pathLikeCommand) ?? command;
 }
 
 export function prepareWindowsSafeProcess(


### PR DESCRIPTION
## Summary
- prefer Windows `where.exe` candidates that native spawn can execute or Synara can wrap (`.exe`, `.com`, `.cmd`, `.bat`)
- keep current-directory hit filtering for PATH commands to avoid CWD command hijacking
- resolve extensionless path-like npm shims to their `.cmd` wrapper
- run Windows batch shims through explicit `cmd.exe /c call` arguments so npm `.cmd` CLIs can be spawned without `shell: true`

## Testing
- `bun run --cwd packages/shared test src/windowsProcess.test.ts`
- built and installed a Windows desktop artifact from this branch
- refreshed installed provider health on Windows; npm global `codex`, `claude`, `gemini`, `opencode`, and `pi` resolve without extensionless-shim spawn failures

Related to #288.