### PR TITLE
Fix git status timeout outside repositories

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1507,6 +1507,30 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("does not resolve upstream before rejecting non-repository directories", () =>
+      Effect.gen(function* () {
+        const operations: string[] = [];
+        const core = yield* makeIsolatedGitCore((input) =>
+          Effect.sync(() => {
+            operations.push(input.operation);
+            if (input.operation === "GitCore.statusDetails.isInsideWorkTree") {
+              return {
+                code: 128,
+                stdout: "",
+                stderr: "fatal: not a git repository",
+              };
+            }
+            throw new Error(`Unexpected git command: ${input.operation}`);
+          }),
+        );
+
+        const details = yield* core.statusDetails("C:\\Users\\Windows");
+
+        expect(details.isRepo).toBe(false);
+        expect(operations).toEqual(["GitCore.statusDetails.isInsideWorkTree"]);
+      }),
+    );
+
     it.effect("reports the tracked branch name without the remote prefix", () =>
       Effect.gen(function* () {
         const remote = yield* makeTmpDir();

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1554,6 +1554,48 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("rejects unrelated nonzero repository precheck results", () =>
+      Effect.gen(function* () {
+        const core = yield* makeIsolatedGitCore(() =>
+          Effect.succeed({
+            code: 128,
+            stdout: "",
+            stderr: "fatal: detected dubious ownership in repository at 'C:\\repo'",
+          }),
+        );
+
+        const result = yield* Effect.result(core.statusDetails("C:\\repo"));
+
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+          expect(result.failure).toMatchObject({
+            _tag: "GitCommandError",
+            operation: "GitCore.statusDetails.isInsideWorkTree",
+            detail: "fatal: detected dubious ownership in repository at 'C:\\repo'",
+          });
+        }
+      }),
+    );
+
+    it.effect("keeps missing repository directories on the non-repository fallback", () =>
+      Effect.gen(function* () {
+        const core = yield* makeIsolatedGitCore(() =>
+          Effect.fail(
+            new GitCommandError({
+              operation: "GitCore.statusDetails.isInsideWorkTree",
+              command: "git rev-parse --is-inside-work-tree",
+              cwd: "C:\\missing",
+              detail: "ENOENT: no such file or directory",
+            }),
+          ),
+        );
+
+        const details = yield* core.statusDetails("C:\\missing");
+
+        expect(details.isRepo).toBe(false);
+      }),
+    );
+
     it.effect("reports the tracked branch name without the remote prefix", () =>
       Effect.gen(function* () {
         const remote = yield* makeTmpDir();

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1531,6 +1531,29 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("preserves failures from the repository precheck", () =>
+      Effect.gen(function* () {
+        const precheckError = new GitCommandError({
+          operation: "GitCore.statusDetails.isInsideWorkTree",
+          command: "git rev-parse --is-inside-work-tree",
+          cwd: "C:\\repo",
+          detail: "git rev-parse --is-inside-work-tree timed out.",
+        });
+        const core = yield* makeIsolatedGitCore(() => Effect.fail(precheckError));
+
+        const result = yield* Effect.result(core.statusDetails("C:\\repo"));
+
+        expect(result._tag).toBe("Failure");
+        if (result._tag === "Failure") {
+          expect(result.failure).toMatchObject({
+            _tag: "GitCommandError",
+            operation: precheckError.operation,
+            detail: precheckError.detail,
+          });
+        }
+      }),
+    );
+
     it.effect("reports the tracked branch name without the remote prefix", () =>
       Effect.gen(function* () {
         const remote = yield* makeTmpDir();

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1300,6 +1300,22 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
 
     const statusDetails: GitCoreShape["statusDetails"] = (cwd) =>
       Effect.gen(function* () {
+        const isInsideWorkTree = yield* executeGit(
+          "GitCore.statusDetails.isInsideWorkTree",
+          cwd,
+          ["rev-parse", "--is-inside-work-tree"],
+          {
+            allowNonZeroExit: true,
+            timeoutMs: 5_000,
+          },
+        ).pipe(
+          Effect.map((result) => result.code === 0 && result.stdout.trim() === "true"),
+          Effect.catch(() => Effect.succeed(false)),
+        );
+        if (!isInsideWorkTree) {
+          return NON_REPOSITORY_STATUS_DETAILS;
+        }
+
         yield* refreshStatusUpstreamIfStale(cwd).pipe(
           Effect.catchIf(isMissingGitCwdError, () => Effect.void),
           Effect.ignoreCause({ log: true }),

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1310,7 +1310,7 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
           },
         ).pipe(
           Effect.map((result) => result.code === 0 && result.stdout.trim() === "true"),
-          Effect.catch(() => Effect.succeed(false)),
+          Effect.catchIf(isMissingGitCwdError, () => Effect.succeed(false)),
         );
         if (!isInsideWorkTree) {
           return NON_REPOSITORY_STATUS_DETAILS;

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1300,16 +1300,31 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
 
     const statusDetails: GitCoreShape["statusDetails"] = (cwd) =>
       Effect.gen(function* () {
-        const isInsideWorkTree = yield* executeGit(
-          "GitCore.statusDetails.isInsideWorkTree",
-          cwd,
-          ["rev-parse", "--is-inside-work-tree"],
-          {
-            allowNonZeroExit: true,
-            timeoutMs: 5_000,
-          },
-        ).pipe(
-          Effect.map((result) => result.code === 0 && result.stdout.trim() === "true"),
+        const operation = "GitCore.statusDetails.isInsideWorkTree";
+        const args = ["rev-parse", "--is-inside-work-tree"] as const;
+        const isInsideWorkTree = yield* executeGit(operation, cwd, args, {
+          allowNonZeroExit: true,
+          timeoutMs: 5_000,
+        }).pipe(
+          Effect.flatMap((result) => {
+            if (result.code === 0) {
+              return Effect.succeed(result.stdout.trim() === "true");
+            }
+            if (
+              result.code === 128 &&
+              result.stderr.toLowerCase().includes("not a git repository")
+            ) {
+              return Effect.succeed(false);
+            }
+            return Effect.fail(
+              createGitCommandError(
+                operation,
+                cwd,
+                args,
+                result.stderr.trim() || `${commandLabel(args)} failed: code=${result.code}`,
+              ),
+            );
+          }),
           Effect.catchIf(isMissingGitCwdError, () => Effect.succeed(false)),
         );
         if (!isInsideWorkTree) {


### PR DESCRIPTION
## Summary
- Add a fast `git rev-parse --is-inside-work-tree` precheck before `statusDetails()` refreshes upstream state.
- Return the existing non-repository status immediately for non-repo cwd values, such as the Windows desktop default `C:\Users\Windows`.
- Treat only Git's expected exit-128 "not a git repository" result as a non-repository directory.
- Preserve missing-directory fallback behavior while propagating timeouts, dubious ownership, permission errors, and other unexpected Git failures as `GitCommandError`.
- Cover command ordering and error classification with regression tests.

## Why
On Windows desktop startup, Synara can ask for git status from a cwd that is not a repository. `statusDetails()` previously tried to resolve or refresh upstream state before determining that the cwd was not a repo, which could leave the UI stuck waiting on git status work that should have been skipped.

The precheck must remain narrow: unexpected Git failures inside real repositories must not be misreported as "not a repository."

## Validation
- Focused repository-precheck regressions: 4 passed.
- Full `apps/server/src/git/Layers/GitCore.test.ts`: 82 passed.
- `bun run --cwd apps/server typecheck`: passed.
- Affected-file `oxfmt`: passed.
- `git diff --check`: passed.
- Final diff against the PR base: 2 files (`GitCore.ts` and `GitCore.test.ts`).