### PR TITLE
Add prompt enhancer

### DIFF
--- a/apps/server/src/automation/Layers/AutomationService.test.ts
+++ b/apps/server/src/automation/Layers/AutomationService.test.ts
@@ -441,6 +441,7 @@ const textGeneration = {
         })
       : Effect.succeed(completionEvaluation);
   },
+  generatePromptEnhancement: () => Effect.die("unused"),
 } as unknown as TextGenerationShape;
 
 const gitCore = {

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -20,6 +20,7 @@ import {
   type CommitMessageGenerationResult,
   type DiffSummaryGenerationResult,
   type PrContentGenerationResult,
+  type PromptEnhancementGenerationResult,
   type ThreadTitleGenerationResult,
   type ThreadRecapGenerationResult,
   type TextGenerationOperation,
@@ -33,10 +34,12 @@ import {
   buildCommitMessagePrompt,
   buildDiffSummaryPrompt,
   buildPrContentPrompt,
+  buildPromptEnhancementPrompt,
   buildThreadRecapPrompt,
   buildThreadTitlePrompt,
   sanitizeCommitSubject,
   sanitizeDiffSummary,
+  sanitizeEnhancedPrompt,
   sanitizeThreadRecap,
   sanitizePrTitle,
   toJsonSchemaObject,
@@ -631,6 +634,31 @@ const makeCodexTextGeneration = Effect.gen(function* () {
     });
   };
 
+  const generatePromptEnhancement: TextGenerationShape["generatePromptEnhancement"] = (input) => {
+    const { prompt, outputSchemaJson } = buildPromptEnhancementPrompt({
+      systemPrompt: input.systemPrompt,
+      prompt: input.prompt,
+    });
+
+    return runCodexJson({
+      operation: "generatePromptEnhancement",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson,
+      ...(input.codexHomePath ? { codexHomePath: input.codexHomePath } : {}),
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.modelSelection ? { modelSelection: input.modelSelection } : {}),
+      ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
+    }).pipe(
+      Effect.map(
+        (generated) =>
+          ({
+            enhancedPrompt: sanitizeEnhancedPrompt(generated.enhancedPrompt, input.prompt),
+          }) satisfies PromptEnhancementGenerationResult,
+      ),
+    );
+  };
+
   return {
     generateCommitMessage,
     generatePrContent,
@@ -640,6 +668,7 @@ const makeCodexTextGeneration = Effect.gen(function* () {
     generateThreadRecap,
     generateAutomationIntent,
     evaluateAutomationCompletion,
+    generatePromptEnhancement,
   } satisfies TextGenerationShape;
 });
 

--- a/apps/server/src/git/Layers/CursorTextGeneration.ts
+++ b/apps/server/src/git/Layers/CursorTextGeneration.ts
@@ -24,12 +24,14 @@ import {
   buildCommitMessagePrompt,
   buildDiffSummaryPrompt,
   buildPrContentPrompt,
+  buildPromptEnhancementPrompt,
   buildThreadRecapPrompt,
   buildThreadTitlePrompt,
   decodeStructuredTextGenerationOutput,
   type RawTextFallback,
   sanitizeCommitSubject,
   sanitizeDiffSummary,
+  sanitizeEnhancedPrompt,
   sanitizeThreadRecap,
   sanitizePrTitle,
 } from "../textGenerationShared.ts";
@@ -429,6 +431,36 @@ const makeCursorTextGeneration = Effect.gen(function* () {
       });
     });
 
+  const generatePromptEnhancement: TextGenerationShape["generatePromptEnhancement"] = Effect.fn(
+    "CursorTextGeneration.generatePromptEnhancement",
+  )(function* (input) {
+    const modelSelection = resolveCursorModelSelection(input);
+    if (!modelSelection) {
+      return yield* new TextGenerationError({
+        operation: "generatePromptEnhancement",
+        detail: "Invalid Cursor model selection.",
+      });
+    }
+
+    const { prompt, outputSchemaJson, rawTextFallback } = buildPromptEnhancementPrompt({
+      systemPrompt: input.systemPrompt,
+      prompt: input.prompt,
+    });
+    const generated = yield* runCursorJson({
+      operation: "generatePromptEnhancement",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson,
+      rawTextFallback,
+      modelSelection,
+      ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
+    });
+
+    return {
+      enhancedPrompt: sanitizeEnhancedPrompt(generated.enhancedPrompt, input.prompt),
+    };
+  });
+
   return {
     generateCommitMessage,
     generatePrContent,
@@ -438,6 +470,7 @@ const makeCursorTextGeneration = Effect.gen(function* () {
     generateThreadRecap,
     generateAutomationIntent,
     evaluateAutomationCompletion,
+    generatePromptEnhancement,
   } satisfies TextGenerationShape;
 });
 

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -89,6 +89,14 @@ interface FakeGitTextGeneration {
   evaluateAutomationCompletion: (
     input: AutomationCompletionEvaluationInput,
   ) => Effect.Effect<AutomationCompletionEvaluationResult, TextGenerationError>;
+  generatePromptEnhancement: (input: {
+    cwd: string;
+    prompt: string;
+    systemPrompt: string;
+    providerOptions?: ProviderStartOptions;
+    model?: string;
+    modelSelection?: ModelSelection;
+  }) => Effect.Effect<{ enhancedPrompt: string }, TextGenerationError>;
 }
 
 function makeTempDir(
@@ -199,6 +207,10 @@ function createTextGeneration(overrides: Partial<FakeGitTextGeneration> = {}): T
         confidence: 0.2,
         reason: "Stop condition was not met.",
       }),
+    generatePromptEnhancement: () =>
+      Effect.succeed({
+        enhancedPrompt: "Enhanced prompt",
+      }),
     ...overrides,
   };
 
@@ -286,6 +298,17 @@ function createTextGeneration(overrides: Partial<FakeGitTextGeneration> = {}): T
           (cause) =>
             new TextGenerationError({
               operation: "evaluateAutomationCompletion",
+              detail: "fake text generation failed",
+              ...(cause !== undefined ? { cause } : {}),
+            }),
+        ),
+      ),
+    generatePromptEnhancement: (input) =>
+      implementation.generatePromptEnhancement(input).pipe(
+        Effect.mapError(
+          (cause) =>
+            new TextGenerationError({
+              operation: "generatePromptEnhancement",
               detail: "fake text generation failed",
               ...(cause !== undefined ? { cause } : {}),
             }),

--- a/apps/server/src/git/Layers/OpenCodeTextGeneration.ts
+++ b/apps/server/src/git/Layers/OpenCodeTextGeneration.ts
@@ -45,12 +45,14 @@ import {
   buildCommitMessagePrompt,
   buildDiffSummaryPrompt,
   buildPrContentPrompt,
+  buildPromptEnhancementPrompt,
   buildThreadRecapPrompt,
   buildThreadTitlePrompt,
   decodeStructuredTextGenerationOutput,
   type RawTextFallback,
   sanitizeCommitSubject,
   sanitizeDiffSummary,
+  sanitizeEnhancedPrompt,
   sanitizeThreadRecap,
   sanitizePrTitle,
 } from "../textGenerationShared.ts";
@@ -702,6 +704,36 @@ const makeOpenCodeCompatibleTextGeneration = (config: OpenCodeCompatibleTextGene
         });
       });
 
+    const generatePromptEnhancement: TextGenerationShape["generatePromptEnhancement"] = Effect.fn(
+      `${config.serviceName}.generatePromptEnhancement`,
+    )(function* (input) {
+      const modelSelection = resolveOpenCodeCompatibleModelSelection(config, input);
+      if (!modelSelection) {
+        return yield* new TextGenerationError({
+          operation: "generatePromptEnhancement",
+          detail: `Invalid ${config.displayName} model selection.`,
+        });
+      }
+
+      const { prompt, outputSchemaJson, rawTextFallback } = buildPromptEnhancementPrompt({
+        systemPrompt: input.systemPrompt,
+        prompt: input.prompt,
+      });
+      const generated = yield* runOpenCodeJson({
+        operation: "generatePromptEnhancement",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson,
+        rawTextFallback,
+        modelSelection,
+        ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
+      });
+
+      return {
+        enhancedPrompt: sanitizeEnhancedPrompt(generated.enhancedPrompt, input.prompt),
+      };
+    });
+
     return {
       generateCommitMessage,
       generatePrContent,
@@ -711,6 +743,7 @@ const makeOpenCodeCompatibleTextGeneration = (config: OpenCodeCompatibleTextGene
       generateThreadRecap,
       generateAutomationIntent,
       evaluateAutomationCompletion,
+      generatePromptEnhancement,
     } satisfies TextGenerationShape;
   });
 

--- a/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.test.ts
@@ -67,6 +67,11 @@ function createTextGenerationDouble(label: string) {
         reason: `${label} completion`,
       }),
   );
+  const generatePromptEnhancement = vi.fn<TextGenerationShape["generatePromptEnhancement"]>(() =>
+    Effect.succeed({
+      enhancedPrompt: `${label} enhanced prompt`,
+    }),
+  );
 
   return {
     service: {
@@ -78,6 +83,7 @@ function createTextGenerationDouble(label: string) {
       generateThreadRecap,
       generateAutomationIntent,
       evaluateAutomationCompletion,
+      generatePromptEnhancement,
     } satisfies TextGenerationShape,
     generateCommitMessage,
     generatePrContent,
@@ -87,6 +93,7 @@ function createTextGenerationDouble(label: string) {
     generateThreadRecap,
     generateAutomationIntent,
     evaluateAutomationCompletion,
+    generatePromptEnhancement,
   };
 }
 

--- a/apps/server/src/git/Layers/ProviderTextGeneration.ts
+++ b/apps/server/src/git/Layers/ProviderTextGeneration.ts
@@ -45,6 +45,8 @@ const makeProviderTextGeneration = Effect.gen(function* () {
       resolveImplementation(input).generateAutomationIntent(input),
     evaluateAutomationCompletion: (input) =>
       resolveImplementation(input).evaluateAutomationCompletion(input),
+    generatePromptEnhancement: (input) =>
+      resolveImplementation(input).generatePromptEnhancement(input),
   } satisfies TextGenerationShape;
 });
 

--- a/apps/server/src/git/Services/TextGeneration.ts
+++ b/apps/server/src/git/Services/TextGeneration.ts
@@ -167,6 +167,23 @@ export interface AutomationCompletionEvaluationResult {
   reason: string;
 }
 
+export interface PromptEnhancementGenerationInput {
+  cwd: string;
+  prompt: string;
+  systemPrompt: string;
+  codexHomePath?: string;
+  /** Model to use for generation. Defaults to gpt-5.4-mini if not specified. */
+  model?: string;
+  /** Optional provider-aware selection for providers that need more than a raw model slug. */
+  modelSelection?: ModelSelection;
+  /** Optional provider startup overrides, such as custom binary paths or server URLs. */
+  providerOptions?: ProviderStartOptions;
+}
+
+export interface PromptEnhancementGenerationResult {
+  enhancedPrompt: string;
+}
+
 export type TextGenerationOperation =
   | "generateCommitMessage"
   | "generatePrContent"
@@ -175,7 +192,8 @@ export type TextGenerationOperation =
   | "generateThreadTitle"
   | "generateThreadRecap"
   | "generateAutomationIntent"
-  | "evaluateAutomationCompletion";
+  | "evaluateAutomationCompletion"
+  | "generatePromptEnhancement";
 
 export interface TextGenerationService {
   generateCommitMessage(
@@ -192,6 +210,9 @@ export interface TextGenerationService {
   evaluateAutomationCompletion(
     input: AutomationCompletionEvaluationInput,
   ): Promise<AutomationCompletionEvaluationResult>;
+  generatePromptEnhancement(
+    input: PromptEnhancementGenerationInput,
+  ): Promise<PromptEnhancementGenerationResult>;
 }
 
 /**
@@ -253,6 +274,13 @@ export interface TextGenerationShape {
   readonly evaluateAutomationCompletion: (
     input: AutomationCompletionEvaluationInput,
   ) => Effect.Effect<AutomationCompletionEvaluationResult, TextGenerationError>;
+
+  /**
+   * Rewrite a composer draft prompt using the configured enhancer system prompt.
+   */
+  readonly generatePromptEnhancement: (
+    input: PromptEnhancementGenerationInput,
+  ) => Effect.Effect<PromptEnhancementGenerationResult, TextGenerationError>;
 }
 
 /**

--- a/apps/server/src/git/textGenerationShared.test.ts
+++ b/apps/server/src/git/textGenerationShared.test.ts
@@ -9,7 +9,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildAutomationCompletionEvaluationPrompt,
   buildAutomationIntentPrompt,
+  buildPromptEnhancementPrompt,
   decodeStructuredTextGenerationOutput,
+  sanitizeEnhancedPrompt,
 } from "./textGenerationShared.ts";
 
 describe("textGenerationShared", () => {
@@ -40,6 +42,22 @@ describe("textGenerationShared", () => {
       confidence: 1.2,
       reason: "The run says the PR is ready.",
     });
+  });
+
+  it("builds a prompt enhancement request that includes the system prompt and draft", () => {
+    const { prompt } = buildPromptEnhancementPrompt({
+      systemPrompt: "Rewrite for coding agents.",
+      prompt: "fix login",
+    });
+
+    expect(prompt).toContain("Rewrite for coding agents.");
+    expect(prompt).toContain("enhancedPrompt");
+    expect(prompt).toContain("fix login");
+  });
+
+  it("sanitizes enhanced prompts and falls back to the original draft", () => {
+    expect(sanitizeEnhancedPrompt("```\nImproved prompt\n```", "original")).toBe("Improved prompt");
+    expect(sanitizeEnhancedPrompt("   ", "original draft")).toBe("original draft");
   });
 
   it("asks automation intent generation for detailed prompts without invented context", () => {

--- a/apps/server/src/git/textGenerationShared.ts
+++ b/apps/server/src/git/textGenerationShared.ts
@@ -220,6 +220,19 @@ export function sanitizeThreadRecap(raw: string, previousRecap?: string): string
   return `${clipped}...`;
 }
 
+export function sanitizeEnhancedPrompt(raw: string, fallbackPrompt: string): string {
+  const candidate = raw
+    .trim()
+    .replace(/^```(?:\w+)?\s*/u, "")
+    .replace(/\s*```$/u, "")
+    .trim();
+  if (candidate.length > 0) {
+    return candidate.slice(0, 64_000);
+  }
+  const fallback = fallbackPrompt.trim();
+  return fallback.length > 0 ? fallback.slice(0, 64_000) : "Improve this prompt.";
+}
+
 function attachmentMetadataLines(attachments: ReadonlyArray<ChatAttachment> | undefined): string[] {
   return (attachments ?? [])
     .filter((attachment) => attachment.type === "image")
@@ -573,5 +586,30 @@ export function buildThreadTitlePrompt(input: {
       key: "title",
       maxWords: MAX_CHAT_THREAD_TITLE_WORDS + 4,
     } satisfies RawTextFallback,
+  };
+}
+
+export function buildPromptEnhancementPrompt(input: {
+  readonly systemPrompt: string;
+  readonly prompt: string;
+}) {
+  return {
+    prompt: [
+      input.systemPrompt.trim(),
+      "",
+      "Return a JSON object with key: enhancedPrompt.",
+      "Respond with only the JSON object, no prose and no code fences.",
+      "Rules:",
+      "- enhancedPrompt must contain only the rewritten user prompt",
+      "- preserve the user's language",
+      "- do not wrap the result in quotes or markdown fences",
+      "",
+      "User prompt:",
+      limitSection(input.prompt, 32_000),
+    ].join("\n"),
+    outputSchemaJson: Schema.Struct({
+      enhancedPrompt: Schema.String,
+    }),
+    rawTextFallback: { key: "enhancedPrompt" } satisfies RawTextFallback,
   };
 }

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -1120,6 +1120,26 @@ export const makeWsRpcLayer = () =>
             }),
             "Failed to generate automation intent",
           ),
+        [WS_METHODS.serverEnhancePrompt]: (input) =>
+          rpcEffect(
+            Effect.gen(function* () {
+              const settings = yield* serverSettings.getSettings;
+              const modelSelection =
+                input.textGenerationModelSelection ?? settings.textGenerationModelSelection;
+              const systemPrompt =
+                input.systemPrompt?.trim() || settings.promptEnhancerSystemPrompt;
+              return yield* textGeneration.generatePromptEnhancement({
+                cwd: input.cwd,
+                prompt: input.prompt,
+                systemPrompt,
+                ...(input.codexHomePath ? { codexHomePath: input.codexHomePath } : {}),
+                model: input.textGenerationModel ?? modelSelection.model,
+                modelSelection,
+                ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
+              });
+            }),
+            "Failed to enhance prompt",
+          ),
         [WS_METHODS.serverUpsertKeybinding]: (input) =>
           rpcEffect(
             keybindings

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -9,6 +9,7 @@ import { Option, Schema } from "effect";
 import {
   type AssistantDeliveryMode,
   DEFAULT_GIT_TEXT_GENERATION_MODEL,
+  DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT,
   DEFAULT_SERVER_SETTINGS,
   TrimmedNonEmptyString,
   ProviderKind,
@@ -203,6 +204,9 @@ export const AppSettingsSchema = Schema.Struct({
   customPiModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   textGenerationProvider: ProviderKind.pipe(withDefaults(() => "codex" as const)),
   textGenerationModel: Schema.optional(TrimmedNonEmptyString),
+  promptEnhancerSystemPrompt: Schema.String.check(Schema.isMaxLength(16_000)).pipe(
+    withDefaults(() => DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT),
+  ),
   uiFontFamily: Schema.String.check(Schema.isMaxLength(256)).pipe(withDefaults(() => "")),
   defaultProvider: ProviderKind.pipe(withDefaults(() => "codex" as const)),
   // Local-only UI preference: providers explicitly hidden from the composer picker.
@@ -467,6 +471,7 @@ function serverSettingsToAppSettings(settings: ServerSettings): Partial<AppSetti
     customPiModels: settings.providers.pi.customModels,
     textGenerationProvider: settings.textGenerationModelSelection.provider,
     textGenerationModel: settings.textGenerationModelSelection.model,
+    promptEnhancerSystemPrompt: settings.promptEnhancerSystemPrompt,
   };
 }
 
@@ -522,6 +527,10 @@ function appSettingsPatchToServerSettingsPatch(patch: Partial<AppSettings>): Ser
       }),
       model,
     };
+  }
+  if (hasOwn(patch, "promptEnhancerSystemPrompt")) {
+    serverPatch.promptEnhancerSystemPrompt =
+      patch.promptEnhancerSystemPrompt ?? DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT;
   }
 
   if (
@@ -659,6 +668,7 @@ function buildInitialServerSettingsMigrationPatch(settings: AppSettings): Server
     "piBinaryPath",
     "textGenerationModel",
     "textGenerationProvider",
+    "promptEnhancerSystemPrompt",
   ] as const) {
     if (normalizedSettings[key] !== defaults[key]) {
       patch[key] = normalizedSettings[key] as never;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3861,10 +3861,7 @@ export default function ChatView({
       return;
     }
 
-    const cwd =
-      activeProject?.cwd?.trim() ||
-      serverConfigQuery.data?.cwd?.trim() ||
-      null;
+    const cwd = activeProject?.cwd?.trim() || serverConfigQuery.data?.cwd?.trim() || null;
     if (!cwd) {
       toastManager.add({
         type: "error",
@@ -10646,9 +10643,7 @@ export default function ChatView({
                                 isEnhancingPrompt ||
                                 !prompt.trim()
                               }
-                              aria-label={
-                                isEnhancingPrompt ? "Enhancing prompt" : "Enhance prompt"
-                              }
+                              aria-label={isEnhancingPrompt ? "Enhancing prompt" : "Enhance prompt"}
                               onClick={() => void enhanceComposerDraftPrompt()}
                             >
                               {isEnhancingPrompt ? (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2,6 +2,7 @@ import {
   type AutomationDefinition,
   type AutomationSchedule,
   type ApprovalRequestId,
+  DEFAULT_GIT_TEXT_GENERATION_MODEL,
   DEFAULT_MODEL_BY_PROVIDER,
   EventId,
   MessageId,
@@ -143,6 +144,7 @@ import {
   buildComposerAutomationDraft,
   resolveComposerAutomationRequest,
 } from "../lib/composerAutomation";
+import { enhanceComposerPrompt } from "../lib/composerPromptEnhance";
 import {
   acknowledgedRiskIdsForDraft,
   buildAutomationDraftWarnings,
@@ -267,6 +269,7 @@ import {
   ChevronRightIcon,
   ComposerSendArrowIcon,
   LayoutSidebarIcon,
+  SparklesIcon,
   RefreshCwIcon,
   TemporaryThreadIcon,
   XIcon,
@@ -1065,6 +1068,7 @@ export default function ChatView({
     cancelRecording: cancelVoiceRecording,
   } = useVoiceRecorder();
   const [isVoiceTranscribing, setIsVoiceTranscribing] = useState(false);
+  const [isEnhancingPrompt, setIsEnhancingPrompt] = useState(false);
   const composerSendState = useMemo(
     () =>
       deriveComposerSendState({
@@ -3849,6 +3853,73 @@ export default function ChatView({
     },
     [scheduleComposerFocus, setPrompt],
   );
+  const enhanceComposerDraftPrompt = useCallback(async () => {
+    const api = readNativeApi();
+    const livePrompt =
+      composerEditorRef.current?.readSnapshot().value.trim() || promptRef.current.trim();
+    if (!api || !livePrompt || isEnhancingPrompt) {
+      return;
+    }
+
+    const cwd =
+      activeProject?.cwd?.trim() ||
+      serverConfigQuery.data?.cwd?.trim() ||
+      null;
+    if (!cwd) {
+      toastManager.add({
+        type: "error",
+        title: "Open a project before enhancing the prompt.",
+      });
+      return;
+    }
+
+    setIsEnhancingPrompt(true);
+    try {
+      const fallbackModelSelection: ModelSelection = {
+        provider: settings.textGenerationProvider ?? "codex",
+        model: settings.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL,
+      };
+      const enhancedPrompt = await enhanceComposerPrompt({
+        cwd,
+        prompt: livePrompt,
+        enhancePrompt: api.server.enhancePrompt,
+        composerModelSelection: selectedModelSelection,
+        fallbackModelSelection,
+        providerOptions: providerOptionsForDispatch,
+      });
+      if (!enhancedPrompt) {
+        toastManager.add({
+          type: "error",
+          title: "Prompt enhancer returned an empty result.",
+        });
+        return;
+      }
+
+      promptRef.current = enhancedPrompt;
+      setPrompt(enhancedPrompt);
+      setComposerCursor(collapseExpandedComposerCursor(enhancedPrompt, enhancedPrompt.length));
+      setComposerTrigger(detectComposerTrigger(enhancedPrompt, enhancedPrompt.length));
+      scheduleComposerFocus();
+    } catch (error) {
+      toastManager.add({
+        type: "error",
+        title: "Failed to enhance prompt.",
+        description: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setIsEnhancingPrompt(false);
+    }
+  }, [
+    activeProject?.cwd,
+    isEnhancingPrompt,
+    providerOptionsForDispatch,
+    scheduleComposerFocus,
+    selectedModelSelection,
+    serverConfigQuery.data?.cwd,
+    setPrompt,
+    settings.textGenerationModel,
+    settings.textGenerationProvider,
+  ]);
   const addTerminalContextToDraft = useCallback(
     (selection: TerminalContextSelection) => {
       if (!activeThread) {
@@ -10562,9 +10633,55 @@ export default function ChatView({
                           )
                         ) : (
                           <>
+                            <Button
+                              type="button"
+                              size="icon-xs"
+                              variant="chrome"
+                              className="size-7 shrink-0 rounded-full sm:size-7"
+                              disabled={
+                                isComposerApprovalState ||
+                                isConnecting ||
+                                isSendBusy ||
+                                isVoiceTranscribing ||
+                                isEnhancingPrompt ||
+                                !prompt.trim()
+                              }
+                              aria-label={
+                                isEnhancingPrompt ? "Enhancing prompt" : "Enhance prompt"
+                              }
+                              onClick={() => void enhanceComposerDraftPrompt()}
+                            >
+                              {isEnhancingPrompt ? (
+                                <svg
+                                  width="12"
+                                  height="12"
+                                  viewBox="0 0 14 14"
+                                  fill="none"
+                                  className="animate-spin"
+                                  aria-hidden="true"
+                                >
+                                  <circle
+                                    cx="7"
+                                    cy="7"
+                                    r="5.5"
+                                    stroke="currentColor"
+                                    strokeWidth="1.5"
+                                    strokeLinecap="round"
+                                    strokeDasharray="20 12"
+                                  />
+                                </svg>
+                              ) : (
+                                <SparklesIcon aria-hidden="true" className="size-3.5 shrink-0" />
+                              )}
+                            </Button>
                             {showVoiceNotesControl ? (
                               <ComposerVoiceButton
-                                disabled={isComposerApprovalState || isConnecting || isSendBusy}
+                                disabled={
+                                  isComposerApprovalState ||
+                                  isConnecting ||
+                                  isSendBusy ||
+                                  isEnhancingPrompt
+                                }
                                 isRecording={isVoiceRecording}
                                 isTranscribing={isVoiceTranscribing}
                                 durationLabel={voiceRecordingDurationLabel}
@@ -10580,6 +10697,7 @@ export default function ChatView({
                                 isSendBusy ||
                                 isConnecting ||
                                 isVoiceTranscribing ||
+                                isEnhancingPrompt ||
                                 !composerSendState.hasSendableContent
                               }
                               aria-label={

--- a/apps/web/src/components/settings/DebouncedSettingTextarea.tsx
+++ b/apps/web/src/components/settings/DebouncedSettingTextarea.tsx
@@ -1,0 +1,93 @@
+// FILE: DebouncedSettingTextarea.tsx
+// Purpose: Multiline settings field that commits on debounce/blur like DebouncedSettingTextInput.
+// Layer: Settings UI components
+
+import { type ComponentProps, useCallback, useEffect, useRef, useState } from "react";
+
+import { Textarea } from "~/components/ui/textarea";
+
+type DebouncedSettingTextareaProps = Omit<
+  ComponentProps<typeof Textarea>,
+  "value" | "onChange" | "defaultValue"
+> & {
+  value: string;
+  onCommit: (value: string) => void;
+  debounceMs?: number;
+};
+
+export function DebouncedSettingTextarea({
+  value,
+  onCommit,
+  debounceMs = 300,
+  onBlur,
+  onFocus,
+  ...textareaProps
+}: DebouncedSettingTextareaProps) {
+  const [draft, setDraft] = useState(value);
+  const focusedRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestDraftRef = useRef(value);
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const onCommitRef = useRef(onCommit);
+  onCommitRef.current = onCommit;
+
+  useEffect(() => {
+    if (!focusedRef.current) {
+      setDraft(value);
+      latestDraftRef.current = value;
+    }
+  }, [value]);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const flush = useCallback(() => {
+    clearTimer();
+    if (latestDraftRef.current !== valueRef.current) {
+      onCommitRef.current(latestDraftRef.current);
+    }
+  }, [clearTimer]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        if (latestDraftRef.current !== valueRef.current) {
+          onCommitRef.current(latestDraftRef.current);
+        }
+      }
+    },
+    [],
+  );
+
+  return (
+    <Textarea
+      {...textareaProps}
+      value={draft}
+      onChange={(event) => {
+        const next = event.target.value;
+        setDraft(next);
+        latestDraftRef.current = next;
+        clearTimer();
+        timerRef.current = setTimeout(() => {
+          timerRef.current = null;
+          onCommitRef.current(next);
+        }, debounceMs);
+      }}
+      onFocus={(event) => {
+        focusedRef.current = true;
+        onFocus?.(event);
+      }}
+      onBlur={(event) => {
+        focusedRef.current = false;
+        flush();
+        onBlur?.(event);
+      }}
+    />
+  );
+}

--- a/apps/web/src/lib/composerPromptEnhance.test.ts
+++ b/apps/web/src/lib/composerPromptEnhance.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  enhanceComposerPrompt,
-  resolvePromptEnhanceModelSelection,
-} from "./composerPromptEnhance";
+import { enhanceComposerPrompt, resolvePromptEnhanceModelSelection } from "./composerPromptEnhance";
 
 describe("composerPromptEnhance", () => {
   it("prefers the composer model when the provider supports text generation", () => {

--- a/apps/web/src/lib/composerPromptEnhance.test.ts
+++ b/apps/web/src/lib/composerPromptEnhance.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  enhanceComposerPrompt,
+  resolvePromptEnhanceModelSelection,
+} from "./composerPromptEnhance";
+
+describe("composerPromptEnhance", () => {
+  it("prefers the composer model when the provider supports text generation", () => {
+    expect(
+      resolvePromptEnhanceModelSelection({
+        composerModelSelection: { provider: "codex", model: "gpt-5.4" },
+        fallbackModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+      }),
+    ).toEqual({ provider: "codex", model: "gpt-5.4" });
+  });
+
+  it("falls back when the composer provider cannot do text generation", () => {
+    expect(
+      resolvePromptEnhanceModelSelection({
+        composerModelSelection: { provider: "claudeAgent", model: "claude-opus-4-6" },
+        fallbackModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+      }),
+    ).toEqual({ provider: "codex", model: "gpt-5.4-mini" });
+  });
+
+  it("calls enhancePrompt with the resolved model selection", async () => {
+    const enhancePrompt = async (input: {
+      cwd: string;
+      prompt: string;
+      textGenerationModelSelection?: { provider: string; model: string };
+    }) => {
+      expect(input.cwd).toBe("/tmp/project");
+      expect(input.prompt).toBe("fix the bug");
+      expect(input.textGenerationModelSelection).toEqual({
+        provider: "cursor",
+        model: "gpt-5.4",
+      });
+      return { enhancedPrompt: "Investigate and fix the reported bug." };
+    };
+
+    await expect(
+      enhanceComposerPrompt({
+        cwd: "/tmp/project",
+        prompt: "fix the bug",
+        enhancePrompt,
+        composerModelSelection: { provider: "cursor", model: "gpt-5.4" },
+        fallbackModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+      }),
+    ).resolves.toBe("Investigate and fix the reported bug.");
+  });
+});

--- a/apps/web/src/lib/composerPromptEnhance.ts
+++ b/apps/web/src/lib/composerPromptEnhance.ts
@@ -1,0 +1,49 @@
+// FILE: composerPromptEnhance.ts
+// Purpose: Resolve model + call server.enhancePrompt for composer draft rewriting.
+// Layer: Web composer orchestration helper
+
+import type {
+  ModelSelection,
+  ProviderStartOptions,
+  ServerEnhancePromptInput,
+  ServerEnhancePromptResult,
+} from "@t3tools/contracts";
+
+type EnhancePrompt = (input: ServerEnhancePromptInput) => Promise<ServerEnhancePromptResult>;
+
+const TEXT_GENERATION_PROVIDERS = new Set(["codex", "cursor", "kilo", "opencode"]);
+
+export function resolvePromptEnhanceModelSelection(input: {
+  readonly composerModelSelection: ModelSelection;
+  readonly fallbackModelSelection: ModelSelection;
+}): ModelSelection {
+  if (TEXT_GENERATION_PROVIDERS.has(input.composerModelSelection.provider)) {
+    return input.composerModelSelection;
+  }
+  return input.fallbackModelSelection;
+}
+
+export async function enhanceComposerPrompt(input: {
+  readonly cwd: string;
+  readonly prompt: string;
+  readonly enhancePrompt: EnhancePrompt;
+  readonly composerModelSelection: ModelSelection;
+  readonly fallbackModelSelection: ModelSelection;
+  readonly providerOptions?: ProviderStartOptions;
+  readonly systemPrompt?: string;
+}): Promise<string> {
+  const textGenerationModelSelection = resolvePromptEnhanceModelSelection({
+    composerModelSelection: input.composerModelSelection,
+    fallbackModelSelection: input.fallbackModelSelection,
+  });
+
+  const result = await input.enhancePrompt({
+    cwd: input.cwd,
+    prompt: input.prompt,
+    textGenerationModelSelection,
+    ...(input.systemPrompt ? { systemPrompt: input.systemPrompt } : {}),
+    ...(input.providerOptions ? { providerOptions: input.providerOptions } : {}),
+  });
+
+  return result.enhancedPrompt.trim();
+}

--- a/apps/web/src/providerUpdates.test.ts
+++ b/apps/web/src/providerUpdates.test.ts
@@ -3,7 +3,12 @@
 // Layer: Web utility tests
 // Exports: Vitest suites for providerUpdates.ts
 
-import type { ProviderKind, ServerProviderStatus, ServerSettings } from "@t3tools/contracts";
+import {
+  DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT,
+  type ProviderKind,
+  type ServerProviderStatus,
+  type ServerSettings,
+} from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -50,6 +55,7 @@ function serverSettings(overrides: Partial<ServerSettings["providers"]> = {}): S
     defaultThreadEnvMode: "local",
     addProjectBaseDirectory: "",
     textGenerationModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+    promptEnhancerSystemPrompt: DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT,
     providers: {
       codex: { ...provider, binaryPath: "codex", homePath: "" },
       claudeAgent: { ...provider, binaryPath: "claude", launchArgs: "" },

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -9,6 +9,7 @@ import {
   type ServerProviderStatus,
   type ThreadId,
   DEFAULT_GIT_TEXT_GENERATION_MODEL,
+  DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT,
 } from "@t3tools/contracts";
 import { createFileRoute, useSearch } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -83,6 +84,7 @@ import { Switch } from "../components/ui/switch";
 import { toastManager } from "../components/ui/toast";
 import { ThemePackEditor } from "../components/ThemePackEditor";
 import { DebouncedSettingTextInput } from "../components/settings/DebouncedSettingTextInput";
+import { DebouncedSettingTextarea } from "../components/settings/DebouncedSettingTextarea";
 import {
   SettingsCard,
   SettingsListRow,
@@ -3302,6 +3304,50 @@ function SettingsRouteView() {
     </div>
   );
 
+  const renderPromptEnhancerPanel = () => {
+    const currentPrompt =
+      settings.promptEnhancerSystemPrompt?.trim() || DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT;
+    const defaultPrompt =
+      defaults.promptEnhancerSystemPrompt?.trim() || DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT;
+    const isDirty = currentPrompt !== defaultPrompt;
+
+    return (
+      <div className="space-y-6">
+        <SettingsSection title="Composer rewrite">
+          <SettingsRow
+            title="Enhancer system prompt"
+            description="Instructions used when rewriting the composer draft. The enhancer prefers the current composer model when that provider supports one-off text generation."
+            resetAction={
+              isDirty ? (
+                <SettingResetButton
+                  label="enhancer system prompt"
+                  onClick={() =>
+                    updateSettings({
+                      promptEnhancerSystemPrompt: DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT,
+                    })
+                  }
+                />
+              ) : null
+            }
+          >
+            <div className={cn("mt-4 pt-4", SETTINGS_CARD_ROW_DIVIDER_CLASS_NAME)}>
+              <DebouncedSettingTextarea
+                value={currentPrompt}
+                onCommit={(value) => {
+                  const next = value.trim() || DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT;
+                  updateSettings({ promptEnhancerSystemPrompt: next });
+                }}
+                aria-label="Prompt enhancer system prompt"
+                className="min-h-40 w-full font-mono text-[12px]"
+                rows={10}
+              />
+            </div>
+          </SettingsRow>
+        </SettingsSection>
+      </div>
+    );
+  };
+
   const renderActivePanel = () => {
     switch (activeSection) {
       case "general":
@@ -3320,6 +3366,8 @@ function SettingsRouteView() {
         return renderArchivedPanel();
       case "models":
         return renderModelsPanel();
+      case "prompt-enhancer":
+        return renderPromptEnhancerPanel();
       case "providers":
         return renderProvidersPanel();
       case "profile":

--- a/apps/web/src/settingsNavigation.ts
+++ b/apps/web/src/settingsNavigation.ts
@@ -13,6 +13,7 @@ export const SETTINGS_SECTION_IDS = [
   "worktrees",
   "archived",
   "models",
+  "prompt-enhancer",
   "providers",
   "skills",
   "usage",
@@ -126,6 +127,14 @@ export const SETTINGS_NAV_ITEMS: readonly SettingsNavItem[] = [
     description: "Git writing defaults and custom model slugs.",
     icon: "brain",
     eyebrow: "AI configuration",
+  },
+  {
+    id: "prompt-enhancer",
+    group: "synara",
+    label: "Prompt enhancer",
+    description: "System prompt used when rewriting composer drafts.",
+    icon: "sparkles-two",
+    eyebrow: "Composer rewrite",
   },
   {
     id: "providers",

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -269,6 +269,15 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
     keywords: "Add custom model slugs for supported providers. custom model",
   },
 
+  // ── Prompt enhancer ───────────────────────────────────────────────────────────
+  {
+    id: "prompt-enhancer:system-prompt",
+    section: "prompt-enhancer",
+    title: "Enhancer system prompt",
+    keywords:
+      "Rewrite composer drafts enhance prompt system instructions coding agent clarity constraints",
+  },
+
   // ── Providers ─────────────────────────────────────────────────────────────────
   {
     id: "providers:automatic-cli-update-checks",

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -291,6 +291,8 @@ describe("wsNativeApi", () => {
         defaultThreadEnvMode: "local",
         addProjectBaseDirectory: "",
         textGenerationModelSelection: { provider: "codex", model: "gpt-5.4-mini" },
+        promptEnhancerSystemPrompt:
+          "You rewrite user prompts for coding agents. Improve clarity, structure, and actionability while preserving the user's intent, language, and technical meaning. Make the goal explicit, call out constraints and acceptance criteria when useful, and remove fluff. Do not invent requirements the user did not imply. Return only the enhanced prompt text.",
         providers: {
           codex: { enabled: true, binaryPath: "codex", homePath: "", customModels: [] },
           claudeAgent: { enabled: true, binaryPath: "claude", launchArgs: "", customModels: [] },

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -640,6 +640,10 @@ export function createWsNativeApi(): NativeApi {
         transport.request(WS_METHODS.serverGenerateAutomationIntent, input, {
           timeoutMs: null,
         }),
+      enhancePrompt: (input) =>
+        transport.request(WS_METHODS.serverEnhancePrompt, input, {
+          timeoutMs: null,
+        }),
       transcribeVoice: (input) => {
         if (window.desktopBridge?.server?.transcribeVoice) {
           return window.desktopBridge.server.transcribeVoice(input);

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -96,6 +96,8 @@ import type { StudioListThreadOutputsInput, StudioListThreadOutputsResult } from
 import type {
   ServerConfig,
   ServerDiagnosticsResult,
+  ServerEnhancePromptInput,
+  ServerEnhancePromptResult,
   ServerGenerateAutomationIntentInput,
   ServerGenerateAutomationIntentResult,
   ServerGenerateThreadRecapInput,
@@ -540,6 +542,7 @@ export interface NativeApi {
     generateAutomationIntent: (
       input: ServerGenerateAutomationIntentInput,
     ) => Promise<ServerGenerateAutomationIntentResult>;
+    enhancePrompt: (input: ServerEnhancePromptInput) => Promise<ServerEnhancePromptResult>;
     transcribeVoice: (
       input: ServerVoiceTranscriptionInput,
     ) => Promise<ServerVoiceTranscriptionResult>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -118,6 +118,8 @@ import {
   ServerConfig,
   ServerConfigStreamEvent,
   ServerDiagnosticsResult,
+  ServerEnhancePromptInput,
+  ServerEnhancePromptResult,
   ServerGenerateAutomationIntentInput,
   ServerGenerateAutomationIntentResult,
   ServerGenerateThreadRecapInput,
@@ -656,6 +658,12 @@ export const WsServerGenerateAutomationIntentRpc = Rpc.make(
   },
 );
 
+export const WsServerEnhancePromptRpc = Rpc.make(WS_METHODS.serverEnhancePrompt, {
+  payload: ServerEnhancePromptInput,
+  success: ServerEnhancePromptResult,
+  error: WsRpcError,
+});
+
 export const WsServerUpsertKeybindingRpc = Rpc.make(WS_METHODS.serverUpsertKeybinding, {
   payload: KeybindingRule,
   success: ServerUpsertKeybindingResult,
@@ -881,6 +889,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerTranscribeVoiceRpc,
   WsServerGenerateThreadRecapRpc,
   WsServerGenerateAutomationIntentRpc,
+  WsServerEnhancePromptRpc,
   WsServerUpsertKeybindingRpc,
   WsSubscribeServerLifecycleRpc,
   WsSubscribeServerConfigRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -330,6 +330,22 @@ export const ServerGenerateAutomationIntentResult = Schema.Struct({
 });
 export type ServerGenerateAutomationIntentResult = typeof ServerGenerateAutomationIntentResult.Type;
 
+export const ServerEnhancePromptInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  prompt: TrimmedNonEmptyString.check(Schema.isMaxLength(64_000)),
+  systemPrompt: Schema.optional(TrimmedNonEmptyString.check(Schema.isMaxLength(16_000))),
+  codexHomePath: Schema.optional(TrimmedNonEmptyString),
+  providerOptions: Schema.optional(ProviderStartOptions),
+  textGenerationModel: Schema.optional(TrimmedNonEmptyString),
+  textGenerationModelSelection: Schema.optional(ModelSelection),
+});
+export type ServerEnhancePromptInput = typeof ServerEnhancePromptInput.Type;
+
+export const ServerEnhancePromptResult = Schema.Struct({
+  enhancedPrompt: TrimmedNonEmptyString.check(Schema.isMaxLength(64_000)),
+});
+export type ServerEnhancePromptResult = typeof ServerEnhancePromptResult.Type;
+
 export const ServerUpsertKeybindingInput = KeybindingRule;
 export type ServerUpsertKeybindingInput = typeof ServerUpsertKeybindingInput.Type;
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -4,9 +4,19 @@ import { DEFAULT_GIT_TEXT_GENERATION_MODEL } from "./model";
 import { ModelSelection, ProviderKind, ThreadEnvironmentMode } from "./orchestration";
 
 const StringSetting = TrimmedString.check(Schema.isMaxLength(4096));
+const PromptEnhancerSystemPromptSetting = TrimmedString.check(Schema.isMaxLength(16_000));
 const CustomModels = Schema.Array(Schema.String.check(Schema.isMaxLength(256))).pipe(
   Schema.withDecodingDefault(() => []),
 );
+
+/** Default instructions for the composer prompt enhancer. */
+export const DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT = [
+  "You rewrite user prompts for coding agents.",
+  "Improve clarity, structure, and actionability while preserving the user's intent, language, and technical meaning.",
+  "Make the goal explicit, call out constraints and acceptance criteria when useful, and remove fluff.",
+  "Do not invent requirements the user did not imply.",
+  "Return only the enhanced prompt text.",
+].join(" ");
 
 const ProviderSettingsBase = {
   enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
@@ -95,6 +105,9 @@ export const ServerSettings = Schema.Struct({
       model: DEFAULT_GIT_TEXT_GENERATION_MODEL,
     })),
   ),
+  promptEnhancerSystemPrompt: PromptEnhancerSystemPromptSetting.pipe(
+    Schema.withDecodingDefault(() => DEFAULT_PROMPT_ENHANCER_SYSTEM_PROMPT),
+  ),
   providers: Schema.Struct({
     codex: CodexServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
     claudeAgent: ClaudeServerProviderSettings.pipe(Schema.withDecodingDefault(() => ({}))),
@@ -129,6 +142,7 @@ export const ServerSettingsPatch = Schema.Struct({
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvironmentMode),
   addProjectBaseDirectory: Schema.optionalKey(StringSetting),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
+  promptEnhancerSystemPrompt: Schema.optionalKey(PromptEnhancerSystemPromptSetting),
   providers: Schema.optionalKey(
     Schema.Struct({
       codex: Schema.optionalKey(

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -85,6 +85,7 @@ import { FilesystemBrowseInput } from "./filesystem";
 import { OpenInEditorInput } from "./editor";
 import {
   ServerConfigUpdatedPayload,
+  ServerEnhancePromptInput,
   ServerGenerateAutomationIntentInput,
   ServerGenerateThreadRecapInput,
   ServerLifecycleStreamEvent,
@@ -190,6 +191,7 @@ export const WS_METHODS = {
   serverTranscribeVoice: "server.transcribeVoice",
   serverGenerateThreadRecap: "server.generateThreadRecap",
   serverGenerateAutomationIntent: "server.generateAutomationIntent",
+  serverEnhancePrompt: "server.enhancePrompt",
   serverUpsertKeybinding: "server.upsertKeybinding",
   subscribeServerLifecycle: "server.subscribeLifecycle",
   subscribeServerConfig: "server.subscribeConfig",
@@ -345,6 +347,7 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.serverTranscribeVoice, ServerVoiceTranscriptionInput),
   tagRequestBody(WS_METHODS.serverGenerateThreadRecap, ServerGenerateThreadRecapInput),
   tagRequestBody(WS_METHODS.serverGenerateAutomationIntent, ServerGenerateAutomationIntentInput),
+  tagRequestBody(WS_METHODS.serverEnhancePrompt, ServerEnhancePromptInput),
   tagRequestBody(WS_METHODS.serverUpsertKeybinding, KeybindingRule),
 
   // Provider discovery


### PR DESCRIPTION
## Summary
- Adds `server.enhancePrompt` (WS/RPC) and text-generation support for Codex/Cursor/OpenCode/Kilo
- Settings → Prompt enhancer with an editable system prompt
- Composer sparkle action that replaces the draft with the enhanced prompt

## Test plan
- [ ] Settings → Prompt enhancer: edit and reset the system prompt
- [ ] Composer: enhance a draft with a Codex/Cursor/OpenCode/Kilo model
- [ ] Confirm fallback when the composer model cannot generate text
- [ ] Run focused tests for the touched server/web helpers


Made with [Cursor](https://cursor.com)