### PR TITLE
Fix runaway Claude usage: per-thread 1M window, compaction, fallback pinning, fewer restarts

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2337,6 +2337,12 @@ describe("ProviderCommandReactor", () => {
 
     await waitFor(() => harness.startSession.mock.calls.length === 1);
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      modelSelection: {
+        provider: "claudeAgent",
+        model: "claude-opus-4-7",
+      },
+    });
     harness.startSession.mockClear();
 
     // Context-window changes switch in-session via setModel on the next turn.
@@ -2381,6 +2387,173 @@ describe("ProviderCommandReactor", () => {
         options: {
           effort: "max",
         },
+      },
+    });
+  });
+
+  it("restarts a directly started Claude session when spawn-fixed options change", async () => {
+    const initialSelection: ModelSelection = {
+      provider: "claudeAgent",
+      model: "claude-opus-4-7",
+    };
+    const harness = await createHarness({ threadModelSelection: initialSelection });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const now = new Date().toISOString();
+
+    // Mirrors native import: ProviderService owns the runtime start directly,
+    // while the reactor learns the original selection from thread.created.
+    await harness.drain();
+    const importedSession = await Effect.runPromise(
+      harness.startSession(threadId, {
+        threadId,
+        provider: "claudeAgent",
+        runtimeMode: "approval-required",
+        modelSelection: initialSelection,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-direct-claude-session-set"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "claudeAgent",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: importedSession.updatedAt,
+        },
+        createdAt: importedSession.updatedAt,
+      }),
+    );
+    harness.startSession.mockClear();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-direct-claude-effort-update"),
+        threadId,
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-7",
+          options: { effort: "max" },
+        },
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+      modelSelection: {
+        provider: "claudeAgent",
+        model: "claude-opus-4-7",
+        options: { effort: "max" },
+      },
+    });
+  });
+
+  it("keeps the applied Claude spawn profile while metadata changes mid-turn", async () => {
+    const harness = await createHarness({
+      threadModelSelection: { provider: "claudeAgent", model: "claude-opus-4-7" },
+    });
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const turnId = asTurnId("turn-active-selection-change");
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-active-selection-bootstrap"),
+        threadId,
+        message: {
+          messageId: asMessageId("user-message-active-selection-bootstrap"),
+          role: "user",
+          text: "bootstrap",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    harness.startSession.mockClear();
+
+    harness.setRuntimeSessionTurnState({ threadId, status: "running", activeTurnId: turnId });
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-active-selection-session-running"),
+        threadId,
+        session: {
+          threadId,
+          status: "running",
+          providerName: "claudeAgent",
+          runtimeMode: "approval-required",
+          activeTurnId: turnId,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-active-selection-effort"),
+        threadId,
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-7",
+          options: { effort: "max" },
+        },
+      }),
+    );
+    await harness.drain();
+    expect(harness.startSession).not.toHaveBeenCalled();
+
+    harness.setRuntimeSessionTurnState({ threadId, status: "ready" });
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-active-selection-session-ready"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "claudeAgent",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    // The context-only edit is compared with the profile that is actually live,
+    // so the pending effort change still forces exactly one replacement.
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-active-selection-context"),
+        threadId,
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-7",
+          options: { effort: "max", contextWindow: "1m" },
+        },
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+      modelSelection: {
+        provider: "claudeAgent",
+        model: "claude-opus-4-7",
+        options: { effort: "max", contextWindow: "1m" },
       },
     });
   });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -2312,7 +2312,7 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
-  it("restarts an idle Claude session immediately when thread model selection changes", async () => {
+  it("restarts an idle Claude session only for spawn-fixed model selection changes", async () => {
     const harness = await createHarness({
       threadModelSelection: { provider: "claudeAgent", model: "claude-opus-4-7" },
     });
@@ -2339,6 +2339,9 @@ describe("ProviderCommandReactor", () => {
     await waitFor(() => harness.sendTurn.mock.calls.length === 1);
     harness.startSession.mockClear();
 
+    // Context-window changes switch in-session via setModel on the next turn.
+    // Restarting would resume via --resume and replay the whole conversation
+    // as uncached input tokens.
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.meta.update",
@@ -2354,13 +2357,29 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
+    // Effort is fixed at subprocess spawn, so an effort change still restarts.
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-thread-meta-update-claude-effort"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-7",
+          options: {
+            effort: "max",
+          },
+        },
+      }),
+    );
+
     await waitFor(() => harness.startSession.mock.calls.length === 1);
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
       modelSelection: {
         provider: "claudeAgent",
         model: "claude-opus-4-7",
         options: {
-          contextWindow: "1m",
+          effort: "max",
         },
       },
     });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -757,10 +757,16 @@ const make = Effect.gen(function* () {
       // Claude restarts resume via `--resume`, which replays the whole conversation
       // as uncached input tokens. Only spawn-fixed options (effort/settings) may
       // force that; model and context-window changes switch in-session via setModel.
+      // When the dispatch cache has no entry (the session was started by a turn
+      // without a selection), compare against the projected thread selection the
+      // session was actually spawned from so spawn-fixed changes still restart.
       const shouldRestartForModelSelectionChange =
         requestedModelSelection !== undefined &&
         (currentProvider === "claudeAgent"
-          ? claudeSelectionRequiresRestart(previousModelSelection, requestedModelSelection)
+          ? claudeSelectionRequiresRestart(
+              previousModelSelection ?? thread.modelSelection,
+              requestedModelSelection,
+            )
           : currentProvider === "grok" &&
             !Equal.equals(previousModelSelection, requestedModelSelection));
 
@@ -794,6 +800,7 @@ const make = Effect.gen(function* () {
       const restartedSession = yield* startProviderSession(
         resumeCursor !== undefined ? { resumeCursor } : undefined,
       );
+      threadModelSelections.set(threadId, desiredModelSelection);
       yield* Effect.logInfo("provider command reactor restarted provider session", {
         threadId,
         previousSessionId: existingSessionThreadId,
@@ -817,6 +824,7 @@ const make = Effect.gen(function* () {
         runtimeMode: desiredRuntimeMode,
       });
       if (forked) {
+        threadModelSelections.set(threadId, desiredModelSelection);
         const forkedSession =
           (yield* resolveActiveSession(threadId)) ??
           ({
@@ -840,6 +848,10 @@ const make = Effect.gen(function* () {
     }
 
     const startedSession = yield* startProviderSession(undefined);
+    // Record the exact selection the session was spawned with so later
+    // restart-necessity checks compare against the live spawn state even when
+    // the spawning dispatch carried no explicit model selection.
+    threadModelSelections.set(threadId, desiredModelSelection);
     yield* bindSessionToThread(startedSession);
     return startedSession.threadId;
   });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -71,6 +71,7 @@ type ProviderIntentEvent = Extract<
   OrchestrationEvent,
   {
     type:
+      | "thread.created"
       | "thread.meta-updated"
       | "thread.runtime-mode-set"
       | "thread.turn-queued"
@@ -269,7 +270,24 @@ const make = Effect.gen(function* () {
     );
 
   const threadProviderOptions = new Map<string, ProviderStartOptions>();
-  const threadModelSelections = new Map<string, ModelSelection>();
+  // The selection last applied to each live session. Keep this separate from
+  // projected thread metadata so an option changed mid-turn is still compared
+  // against the old subprocess configuration before the next turn starts.
+  const threadSessionModelSelections = new Map<string, ModelSelection>();
+  const seedThreadModelSelections = projectionSnapshotQuery.getCommandReadModel().pipe(
+    Effect.tap((snapshot) =>
+      Effect.sync(() => {
+        for (const thread of snapshot.threads) {
+          threadSessionModelSelections.set(thread.id, thread.modelSelection);
+        }
+      }),
+    ),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("provider command reactor failed to seed model selections", {
+        cause: Cause.pretty(cause),
+      }),
+    ),
+  );
 
   const resolveThreadWorkspaceProject = Effect.fnUntraced(function* (
     thread: Pick<OrchestrationThread, "projectId">,
@@ -314,7 +332,9 @@ const make = Effect.gen(function* () {
   }) {
     const thread = yield* resolveThread(input.threadId);
     const modelSelection =
-      input.modelSelection ?? threadModelSelections.get(input.threadId) ?? thread?.modelSelection;
+      input.modelSelection ??
+      thread?.modelSelection ??
+      threadSessionModelSelections.get(input.threadId);
     const providerOptions = input.providerOptions ?? threadProviderOptions.get(input.threadId);
     const threadTextGenerationInput = resolveTextGenerationInputForSelection(
       modelSelection,
@@ -753,7 +773,7 @@ const make = Effect.gen(function* () {
         requestedModelSelection !== undefined &&
         requestedModelSelection.model !== activeSession?.model;
       const shouldRestartForModelChange = modelChanged && sessionModelSwitch === "restart-session";
-      const previousModelSelection = threadModelSelections.get(threadId);
+      const previousModelSelection = threadSessionModelSelections.get(threadId);
       // Claude restarts resume via `--resume`, which replays the whole conversation
       // as uncached input tokens. Only spawn-fixed options (effort/settings) may
       // force that; model and context-window changes switch in-session via setModel.
@@ -800,7 +820,7 @@ const make = Effect.gen(function* () {
       const restartedSession = yield* startProviderSession(
         resumeCursor !== undefined ? { resumeCursor } : undefined,
       );
-      threadModelSelections.set(threadId, desiredModelSelection);
+      threadSessionModelSelections.set(threadId, desiredModelSelection);
       yield* Effect.logInfo("provider command reactor restarted provider session", {
         threadId,
         previousSessionId: existingSessionThreadId,
@@ -824,7 +844,7 @@ const make = Effect.gen(function* () {
         runtimeMode: desiredRuntimeMode,
       });
       if (forked) {
-        threadModelSelections.set(threadId, desiredModelSelection);
+        threadSessionModelSelections.set(threadId, desiredModelSelection);
         const forkedSession =
           (yield* resolveActiveSession(threadId)) ??
           ({
@@ -851,7 +871,7 @@ const make = Effect.gen(function* () {
     // Record the exact selection the session was spawned with so later
     // restart-necessity checks compare against the live spawn state even when
     // the spawning dispatch carried no explicit model selection.
-    threadModelSelections.set(threadId, desiredModelSelection);
+    threadSessionModelSelections.set(threadId, desiredModelSelection);
     yield* bindSessionToThread(startedSession);
     return startedSession.threadId;
   });
@@ -889,7 +909,7 @@ const make = Effect.gen(function* () {
       threadProviderOptions.set(input.threadId, input.providerOptions);
     }
     if (input.modelSelection !== undefined) {
-      threadModelSelections.set(input.threadId, input.modelSelection);
+      threadSessionModelSelections.set(input.threadId, input.modelSelection);
     }
     const shouldBootstrapHandoff =
       thread.handoff?.bootstrapStatus === "pending" &&
@@ -914,7 +934,7 @@ const make = Effect.gen(function* () {
         : null;
     const selectedProvider =
       input.modelSelection?.provider ??
-      threadModelSelections.get(input.threadId)?.provider ??
+      threadSessionModelSelections.get(input.threadId)?.provider ??
       thread.session?.providerName ??
       thread.modelSelection.provider;
     const shouldBootstrapPriorTranscriptContext =
@@ -979,7 +999,7 @@ const make = Effect.gen(function* () {
         ? "in-session"
         : (yield* providerService.getCapabilities(activeSession.provider)).sessionModelSwitch;
     const requestedModelSelection =
-      input.modelSelection ?? threadModelSelections.get(input.threadId) ?? thread.modelSelection;
+      input.modelSelection ?? thread.modelSelection;
     const modelForTurn =
       sessionModelSwitch === "unsupported"
         ? activeSession?.model !== undefined
@@ -988,7 +1008,7 @@ const make = Effect.gen(function* () {
               model: activeSession.model,
             }
           : requestedModelSelection
-        : input.modelSelection;
+        : requestedModelSelection;
     const sendQueuedProviderTurn = (messageText: string | undefined) =>
       providerService.sendTurn({
         threadId: input.threadId,
@@ -2056,18 +2076,24 @@ const make = Effect.gen(function* () {
   const processDomainEvent = (event: ProviderIntentEvent) =>
     Effect.gen(function* () {
       switch (event.type) {
+        case "thread.created":
+          threadSessionModelSelections.set(event.payload.threadId, event.payload.modelSelection);
+          return;
         case "thread.meta-updated": {
           const thread = yield* resolveThread(event.payload.threadId);
           if (event.payload.modelSelection === undefined) {
             return;
           }
 
-          if (
-            !thread?.session ||
-            thread.session.status === "stopped" ||
-            thread.session.activeTurnId !== null
-          ) {
-            threadModelSelections.set(event.payload.threadId, event.payload.modelSelection);
+          if (!thread?.session || thread.session.status === "stopped") {
+            threadSessionModelSelections.set(event.payload.threadId, event.payload.modelSelection);
+            return;
+          }
+
+          if (thread.session.activeTurnId !== null) {
+            // The current runtime still owns the previous spawn profile. The
+            // projected thread now carries the desired selection; compare them
+            // when the next turn ensures the session.
             return;
           }
 
@@ -2078,7 +2104,7 @@ const make = Effect.gen(function* () {
               ? { providerOptions: cachedProviderOptions }
               : {}),
           });
-          threadModelSelections.set(event.payload.threadId, event.payload.modelSelection);
+          threadSessionModelSelections.set(event.payload.threadId, event.payload.modelSelection);
           return;
         }
         case "thread.runtime-mode-set": {
@@ -2087,12 +2113,11 @@ const make = Effect.gen(function* () {
             return;
           }
           const cachedProviderOptions = threadProviderOptions.get(event.payload.threadId);
-          const cachedModelSelection = threadModelSelections.get(event.payload.threadId);
           yield* ensureSessionForThread(event.payload.threadId, event.occurredAt, {
             ...(cachedProviderOptions !== undefined
               ? { providerOptions: cachedProviderOptions }
               : {}),
-            ...(cachedModelSelection !== undefined ? { modelSelection: cachedModelSelection } : {}),
+            modelSelection: thread.modelSelection,
             runtimeMode: event.payload.runtimeMode,
           });
           return;
@@ -2162,32 +2187,37 @@ const make = Effect.gen(function* () {
 
   const worker = yield* makeDrainableWorker(processDomainEventSafely);
 
-  const start: ProviderCommandReactorShape["start"] = Effect.all([
-    Stream.runForEach(orchestrationEngine.streamDomainEvents, (event) => {
-      if (
-        event.type !== "thread.meta-updated" &&
-        event.type !== "thread.runtime-mode-set" &&
-        event.type !== "thread.turn-queued" &&
-        event.type !== "thread.turn-start-requested" &&
-        event.type !== "thread.turn-interrupt-requested" &&
-        event.type !== "thread.approval-response-requested" &&
-        event.type !== "thread.user-input-response-requested" &&
-        event.type !== "thread.conversation-rollback-requested" &&
-        event.type !== "thread.message-edit-resend-requested" &&
-        event.type !== "thread.session-stop-requested"
-      ) {
-        return Effect.void;
-      }
+  const start: ProviderCommandReactorShape["start"] = seedThreadModelSelections.pipe(
+    Effect.andThen(
+      Effect.all([
+        Stream.runForEach(orchestrationEngine.streamDomainEvents, (event) => {
+          if (
+            event.type !== "thread.created" &&
+            event.type !== "thread.meta-updated" &&
+            event.type !== "thread.runtime-mode-set" &&
+            event.type !== "thread.turn-queued" &&
+            event.type !== "thread.turn-start-requested" &&
+            event.type !== "thread.turn-interrupt-requested" &&
+            event.type !== "thread.approval-response-requested" &&
+            event.type !== "thread.user-input-response-requested" &&
+            event.type !== "thread.conversation-rollback-requested" &&
+            event.type !== "thread.message-edit-resend-requested" &&
+            event.type !== "thread.session-stop-requested"
+          ) {
+            return Effect.void;
+          }
 
-      return worker.enqueue(event);
-    }).pipe(Effect.forkScoped),
-    Stream.runForEach(providerService.streamEvents, (event) => {
-      if (event.type !== "turn.completed" && event.type !== "turn.aborted") {
-        return Effect.void;
-      }
-      return processQueueDrainEventSafely(event);
-    }).pipe(Effect.forkScoped),
-  ]).pipe(Effect.asVoid);
+          return worker.enqueue(event);
+        }).pipe(Effect.forkScoped),
+        Stream.runForEach(providerService.streamEvents, (event) => {
+          if (event.type !== "turn.completed" && event.type !== "turn.aborted") {
+            return Effect.void;
+          }
+          return processQueueDrainEventSafely(event);
+        }).pipe(Effect.forkScoped),
+      ]).pipe(Effect.asVoid),
+    ),
+  );
 
   return {
     start,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -998,8 +998,7 @@ const make = Effect.gen(function* () {
       activeSession === undefined
         ? "in-session"
         : (yield* providerService.getCapabilities(activeSession.provider)).sessionModelSwitch;
-    const requestedModelSelection =
-      input.modelSelection ?? thread.modelSelection;
+    const requestedModelSelection = input.modelSelection ?? thread.modelSelection;
     const modelForTurn =
       sessionModelSwitch === "unsupported"
         ? activeSession?.model !== undefined

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -31,6 +31,7 @@ import {
   resolveTailUserMessageEditTarget,
 } from "@t3tools/shared/conversationEdit";
 import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import { claudeSelectionRequiresRestart } from "@t3tools/shared/model";
 import { buildStalePendingRequestFailureDetail } from "@t3tools/shared/threadSummary";
 import { resolveThreadWorkspaceState } from "@t3tools/shared/threadEnvironment";
 
@@ -753,10 +754,15 @@ const make = Effect.gen(function* () {
         requestedModelSelection.model !== activeSession?.model;
       const shouldRestartForModelChange = modelChanged && sessionModelSwitch === "restart-session";
       const previousModelSelection = threadModelSelections.get(threadId);
+      // Claude restarts resume via `--resume`, which replays the whole conversation
+      // as uncached input tokens. Only spawn-fixed options (effort/settings) may
+      // force that; model and context-window changes switch in-session via setModel.
       const shouldRestartForModelSelectionChange =
-        (currentProvider === "claudeAgent" || currentProvider === "grok") &&
         requestedModelSelection !== undefined &&
-        !Equal.equals(previousModelSelection, requestedModelSelection);
+        (currentProvider === "claudeAgent"
+          ? claudeSelectionRequiresRestart(previousModelSelection, requestedModelSelection)
+          : currentProvider === "grok" &&
+            !Equal.equals(previousModelSelection, requestedModelSelection));
 
       if (
         !runtimeModeChanged &&

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1008,6 +1008,25 @@ function runtimeEventToActivities(
       ];
     }
 
+    case "model.rerouted": {
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "model.rerouted",
+          summary: `Model switched: ${event.payload.fromModel} -> ${event.payload.toModel}`,
+          payload: toActivityPayload({
+            fromModel: event.payload.fromModel,
+            toModel: event.payload.toModel,
+            detail: truncateDetail(event.payload.reason, 500),
+          }),
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
     case "turn.tasks.updated": {
       return [
         {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -17,7 +17,7 @@ import {
   ThreadId,
 } from "@t3tools/contracts";
 import { assert, describe, it } from "@effect/vitest";
-import { Effect, Fiber, Layer, Random, Stream } from "effect";
+import { Effect, Exit, Fiber, Layer, Random, Stream } from "effect";
 
 import { attachmentRelativePath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
@@ -187,6 +187,30 @@ function makeHarness(config?: {
     query,
     getLastCreateQueryInput: () => createInput,
   };
+}
+
+function makeMultiQueryHarness(config?: { readonly failCreateAt?: number }) {
+  const queries: Array<FakeClaudeQuery> = [];
+  const createInputs: Array<{
+    readonly prompt: AsyncIterable<SDKUserMessage>;
+    readonly options: ClaudeQueryOptions;
+  }> = [];
+  const layer = makeClaudeAdapterLive({
+    createQuery: (input) => {
+      if (queries.length === config?.failCreateAt) {
+        throw new Error("simulated Claude spawn failure");
+      }
+      const query = new FakeClaudeQuery();
+      queries.push(query);
+      createInputs.push(input);
+      return query;
+    },
+  }).pipe(
+    Layer.provideMerge(ServerConfig.layerTest("/tmp/claude-adapter-test", "/tmp")),
+    Layer.provideMerge(NodeServices.layer),
+  );
+
+  return { layer, queries, createInputs };
 }
 
 function makeDeterministicRandomService(seed = 0x1234_5678): {
@@ -3597,6 +3621,38 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("warns immediately when a thread starts with the 1M context window", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const warningFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) =>
+          event.type === "runtime.warning" && event.payload.message.includes("1M context window"),
+      ).pipe(Stream.runHead, Effect.forkChild);
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-8",
+          options: { contextWindow: "1m" },
+        },
+      });
+
+      const warning = yield* Fiber.join(warningFiber);
+      assert.equal(warning._tag, "Some");
+      if (warning._tag === "Some" && warning.value.type === "runtime.warning") {
+        assert.ok(warning.value.payload.message.includes("Switch this thread to 200k"));
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("pins the fallback model after a safeguard reroute", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -3605,7 +3661,7 @@ describe("ClaudeAdapterLive", () => {
       const reroutedFiber = yield* Stream.filter(
         adapter.streamEvents,
         (event) => event.type === "model.rerouted",
-      ).pipe(Stream.runHead, Effect.forkChild);
+      ).pipe(Stream.take(2), Stream.runCollect, Effect.forkChild);
 
       const session = yield* adapter.startSession({
         threadId: THREAD_ID,
@@ -3621,21 +3677,37 @@ describe("ClaudeAdapterLive", () => {
         type: "system",
         subtype: "model_refusal_fallback",
         content: "Fable 5's safeguards flagged this message. Switched to Opus 4.8.",
-        originalModel: "claude-fable-5",
-        fallbackModel: "claude-opus-4-8",
+        original_model: "claude-fable-5",
+        fallback_model: "claude-opus-4-8",
+        request_id: "fallback-request-1",
         session_id: "sdk-session-fallback",
         uuid: "fallback-1",
       } as unknown as SDKMessage);
+      harness.query.emit({
+        type: "system",
+        subtype: "model_refusal_fallback",
+        content: "The safeguard repeated its Opus 4.8 fallback.",
+        original_model: "claude-fable-5",
+        fallback_model: "claude-opus-4-8",
+        request_id: "fallback-request-2",
+        session_id: "sdk-session-fallback",
+        uuid: "fallback-2",
+      } as unknown as SDKMessage);
 
-      const rerouted = yield* Fiber.join(reroutedFiber);
-      assert.equal(rerouted._tag, "Some");
-      if (rerouted._tag === "Some" && rerouted.value.type === "model.rerouted") {
-        assert.equal(rerouted.value.payload.fromModel, "claude-fable-5");
-        assert.equal(rerouted.value.payload.toModel, "claude-opus-4-8");
+      const rerouted = Array.from(yield* Fiber.join(reroutedFiber));
+      assert.equal(rerouted.length, 2);
+      const firstReroute = rerouted[0];
+      if (firstReroute?.type === "model.rerouted") {
+        assert.equal(firstReroute.payload.fromModel, "claude-fable-5");
+        assert.equal(firstReroute.payload.toModel, "claude-opus-4-8");
       }
 
       // A turn still requesting the refused model must not flip back: each bounce
       // re-ingests the entire context as uncached tokens.
+      const turnStartedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.started",
+      ).pipe(Stream.runHead, Effect.forkChild);
       yield* adapter.sendTurn({
         threadId: session.threadId,
         input: "continue",
@@ -3646,6 +3718,25 @@ describe("ClaudeAdapterLive", () => {
         attachments: [],
       });
       assert.deepEqual(harness.query.setModelCalls, []);
+      const turnStarted = yield* Fiber.join(turnStartedFiber);
+      assert.equal(turnStarted._tag, "Some");
+      if (turnStarted._tag === "Some" && turnStarted.value.type === "turn.started") {
+        assert.equal(turnStarted.value.payload.model, "claude-opus-4-8");
+      }
+
+      // Context changes apply to the effective fallback without switching back
+      // to the refused model.
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "continue with the larger window",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-fable-5",
+          options: { contextWindow: "1m" },
+        },
+        attachments: [],
+      });
+      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-8[1m]"]);
 
       // Picking a genuinely different model clears the pin and applies it.
       yield* adapter.sendTurn({
@@ -3657,7 +3748,10 @@ describe("ClaudeAdapterLive", () => {
         },
         attachments: [],
       });
-      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6"]);
+      assert.deepEqual(harness.query.setModelCalls, [
+        "claude-opus-4-8[1m]",
+        "claude-opus-4-6",
+      ]);
 
       // And the original model can be re-applied after the explicit switch.
       yield* adapter.sendTurn({
@@ -3669,7 +3763,120 @@ describe("ClaudeAdapterLive", () => {
         },
         attachments: [],
       });
-      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6", "claude-fable-5"]);
+      assert.deepEqual(harness.query.setModelCalls, [
+        "claude-opus-4-8[1m]",
+        "claude-opus-4-6",
+        "claude-fable-5",
+      ]);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("preserves fallback routing while replacing and resuming a session", () => {
+    const harness = makeMultiQueryHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const reroutedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "model.rerouted",
+      ).pipe(Stream.runHead, Effect.forkChild);
+
+      const firstSession = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-fable-5",
+          options: { contextWindow: "1m" },
+        },
+      });
+      const firstQuery = harness.queries[0];
+      assert.ok(firstQuery);
+
+      firstQuery.emit({
+        type: "system",
+        subtype: "model_refusal_fallback",
+        original_model: "claude-fable-5",
+        fallback_model: "claude-opus-4-8",
+        request_id: "fallback-request-resume",
+        session_id: "sdk-session-fallback-resume",
+        uuid: "fallback-resume-1",
+      } as unknown as SDKMessage);
+      yield* Fiber.join(reroutedFiber);
+
+      const activeAfterFallback = (yield* adapter.listSessions()).find(
+        (session) => session.threadId === firstSession.threadId,
+      );
+      assert.ok(activeAfterFallback?.resumeCursor);
+
+      const resumedSession = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-fable-5",
+          options: { contextWindow: "1m" },
+        },
+        resumeCursor: activeAfterFallback?.resumeCursor,
+      });
+      const secondQuery = harness.queries[1];
+      assert.ok(secondQuery);
+      assert.equal(firstQuery.closeCalls, 1);
+      assert.equal(harness.createInputs[1]?.options.model, "claude-opus-4-8[1m]");
+      assert.equal(yield* adapter.hasSession(THREAD_ID), true);
+      assert.equal((yield* adapter.listSessions()).length, 1);
+
+      yield* adapter.sendTurn({
+        threadId: resumedSession.threadId,
+        input: "continue after resume",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-fable-5",
+          options: { contextWindow: "1m" },
+        },
+        attachments: [],
+      });
+      assert.deepEqual(secondQuery.setModelCalls, []);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps the current Claude session when replacement spawn fails", () => {
+    const harness = makeMultiQueryHarness({ failCreateAt: 1 });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+        modelSelection: { provider: "claudeAgent", model: "claude-opus-4-8" },
+      });
+      const firstQuery = harness.queries[0];
+      assert.ok(firstQuery);
+
+      const replacement = yield* Effect.exit(
+        adapter.startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "full-access",
+          modelSelection: {
+            provider: "claudeAgent",
+            model: "claude-opus-4-8",
+            options: { effort: "max" },
+          },
+        }),
+      );
+
+      assert.ok(Exit.isFailure(replacement));
+      assert.equal(firstQuery.closeCalls, 0);
+      assert.equal(yield* adapter.hasSession(THREAD_ID), true);
+      assert.equal((yield* adapter.listSessions()).length, 1);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -3743,14 +3950,15 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("warns about the long-context premium past 200k on a 1M session", () => {
+  it.effect("warns about large prompts past 200k on a 1M session", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
 
       const warningsFiber = yield* Stream.filter(
         adapter.streamEvents,
-        (event) => event.type === "runtime.warning",
+        (event) =>
+          event.type === "runtime.warning" && event.payload.message.includes("processing"),
       ).pipe(Stream.take(1), Stream.runCollect, Effect.forkChild);
 
       const session = yield* adapter.startSession({
@@ -3790,8 +3998,9 @@ describe("ClaudeAdapterLive", () => {
       const warning = warnings[0];
       assert.equal(warning?.type, "runtime.warning");
       if (warning?.type === "runtime.warning") {
-        assert.ok(warning.payload.message.includes("1M window"));
-        assert.ok(warning.payload.message.includes("premium"));
+        assert.ok(warning.payload.message.includes("prompt tokens per request"));
+        assert.ok(warning.payload.message.includes("usage limits"));
+        assert.ok(!warning.payload.message.includes("premium"));
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
@@ -3804,10 +4013,10 @@ describe("ClaudeAdapterLive", () => {
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
 
-      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 6).pipe(
-        Stream.runCollect,
-        Effect.forkChild,
-      );
+      const runtimeEventsFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "thread.token-usage.updated",
+      ).pipe(Stream.take(1), Stream.runCollect, Effect.forkChild);
 
       const session = yield* adapter.startSession({
         threadId: THREAD_ID,
@@ -3864,10 +4073,10 @@ describe("ClaudeAdapterLive", () => {
       return Effect.gen(function* () {
         const adapter = yield* ClaudeAdapter;
 
-        const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 8).pipe(
-          Stream.runCollect,
-          Effect.forkChild,
-        );
+        const runtimeEventsFiber = yield* Stream.filter(
+          adapter.streamEvents,
+          (event) => event.type === "thread.token-usage.updated",
+        ).pipe(Stream.take(2), Stream.runCollect, Effect.forkChild);
 
         const session = yield* adapter.startSession({
           threadId: THREAD_ID,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3880,6 +3880,36 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("closes an uninstalled Claude query when post-spawn setup fails", () => {
+    const query = new FakeClaudeQuery();
+    (query as { supportedModels: () => Promise<[]> }).supportedModels = () => {
+      throw new Error("simulated post-spawn setup failure");
+    };
+    const layer = makeClaudeAdapterLive({ createQuery: () => query }).pipe(
+      Layer.provideMerge(ServerConfig.layerTest("/tmp/claude-adapter-test", "/tmp")),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      const result = yield* Effect.exit(
+        adapter.startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "full-access",
+        }),
+      );
+
+      assert.ok(Exit.isFailure(result));
+      assert.equal(query.closeCalls, 1);
+      assert.equal(yield* adapter.hasSession(THREAD_ID), false);
+      assert.equal((yield* adapter.listSessions()).length, 0);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
   it.effect("warns once when the per-request prompt nears the context window", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3748,10 +3748,7 @@ describe("ClaudeAdapterLive", () => {
         },
         attachments: [],
       });
-      assert.deepEqual(harness.query.setModelCalls, [
-        "claude-opus-4-8[1m]",
-        "claude-opus-4-6",
-      ]);
+      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-8[1m]", "claude-opus-4-6"]);
 
       // And the original model can be re-applied after the explicit switch.
       yield* adapter.sendTurn({
@@ -3957,8 +3954,7 @@ describe("ClaudeAdapterLive", () => {
 
       const warningsFiber = yield* Stream.filter(
         adapter.streamEvents,
-        (event) =>
-          event.type === "runtime.warning" && event.payload.message.includes("processing"),
+        (event) => event.type === "runtime.warning" && event.payload.message.includes("processing"),
       ).pipe(Stream.take(1), Stream.runCollect, Effect.forkChild);
 
       const session = yield* adapter.startSession({

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -498,6 +498,7 @@ describe("ClaudeAdapterLive", () => {
       assert.equal(createInput?.options.model, "claude-sonnet-5");
       assert.equal(createInput?.options.effort, "xhigh");
       assert.deepEqual(createInput?.options.settings, {
+        autoCompactEnabled: true,
         ultracode: true,
       });
     }).pipe(
@@ -575,6 +576,7 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.deepEqual(createInput?.options.settings, {
+        autoCompactEnabled: true,
         alwaysThinkingEnabled: false,
       });
     }).pipe(
@@ -601,7 +603,7 @@ describe("ClaudeAdapterLive", () => {
       });
 
       const createInput = harness.getLastCreateQueryInput();
-      assert.equal(createInput?.options.settings, undefined);
+      assert.deepEqual(createInput?.options.settings, { autoCompactEnabled: true });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -627,6 +629,7 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.deepEqual(createInput?.options.settings, {
+        autoCompactEnabled: true,
         fastMode: true,
       });
     }).pipe(
@@ -653,7 +656,7 @@ describe("ClaudeAdapterLive", () => {
       });
 
       const createInput = harness.getLastCreateQueryInput();
-      assert.equal(createInput?.options.settings, undefined);
+      assert.deepEqual(createInput?.options.settings, { autoCompactEnabled: true });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -3542,6 +3545,259 @@ describe("ClaudeAdapterLive", () => {
       );
     },
   );
+
+  it.effect("skips redundant setModel when the turn model matches the session", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-8",
+        },
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-8",
+        },
+        attachments: [],
+      });
+
+      assert.deepEqual(harness.query.setModelCalls, []);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("always enables auto-compaction in the query settings", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+
+      const settings = harness.getLastCreateQueryInput()?.options.settings;
+      assert.ok(settings && typeof settings === "object");
+      assert.equal((settings as { autoCompactEnabled?: boolean }).autoCompactEnabled, true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("pins the fallback model after a safeguard reroute", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const reroutedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "model.rerouted",
+      ).pipe(Stream.runHead, Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-fable-5",
+        },
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "model_refusal_fallback",
+        content: "Fable 5's safeguards flagged this message. Switched to Opus 4.8.",
+        originalModel: "claude-fable-5",
+        fallbackModel: "claude-opus-4-8",
+        session_id: "sdk-session-fallback",
+        uuid: "fallback-1",
+      } as unknown as SDKMessage);
+
+      const rerouted = yield* Fiber.join(reroutedFiber);
+      assert.equal(rerouted._tag, "Some");
+      if (rerouted._tag === "Some" && rerouted.value.type === "model.rerouted") {
+        assert.equal(rerouted.value.payload.fromModel, "claude-fable-5");
+        assert.equal(rerouted.value.payload.toModel, "claude-opus-4-8");
+      }
+
+      // A turn still requesting the refused model must not flip back: each bounce
+      // re-ingests the entire context as uncached tokens.
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "continue",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-fable-5",
+        },
+        attachments: [],
+      });
+      assert.deepEqual(harness.query.setModelCalls, []);
+
+      // Picking a genuinely different model clears the pin and applies it.
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "switch",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-6",
+        },
+        attachments: [],
+      });
+      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6"]);
+
+      // And the original model can be re-applied after the explicit switch.
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "back to fable",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-fable-5",
+        },
+        attachments: [],
+      });
+      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6", "claude-fable-5"]);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("warns once when the per-request prompt nears the context window", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const warningsFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "runtime.warning",
+      ).pipe(Stream.take(1), Stream.runCollect, Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      const bigUsageAssistant = (uuid: string) =>
+        ({
+          type: "assistant",
+          session_id: "sdk-session-context",
+          uuid,
+          parent_tool_use_id: null,
+          message: {
+            id: `assistant-${uuid}`,
+            content: [{ type: "text", text: "working" }],
+            usage: {
+              input_tokens: 2,
+              cache_read_input_tokens: 170_000,
+              output_tokens: 5,
+            },
+          },
+        }) as unknown as SDKMessage;
+
+      harness.query.emit(bigUsageAssistant("ctx-1"));
+      harness.query.emit(bigUsageAssistant("ctx-2"));
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-context",
+        uuid: "result-ctx",
+      } as unknown as SDKMessage);
+
+      const warnings = Array.from(yield* Fiber.join(warningsFiber));
+      assert.equal(warnings.length, 1);
+      const warning = warnings[0];
+      assert.equal(warning?.type, "runtime.warning");
+      if (warning?.type === "runtime.warning") {
+        assert.ok(warning.payload.message.includes("80%"));
+      }
+
+      // The second oversized request must not emit another warning; the turn
+      // completed without a second runtime.warning in the stream.
+      const thread = yield* adapter.readThread(session.threadId);
+      assert.ok(thread.turns.length >= 1);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("warns about the long-context premium past 200k on a 1M session", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const warningsFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "runtime.warning",
+      ).pipe(Stream.take(1), Stream.runCollect, Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-6",
+          options: { contextWindow: "1m" },
+        },
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-1m",
+        uuid: "assistant-1m",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-message-1m",
+          content: [{ type: "text", text: "working" }],
+          usage: {
+            input_tokens: 2,
+            cache_read_input_tokens: 320_000,
+            output_tokens: 5,
+          },
+        },
+      } as unknown as SDKMessage);
+
+      const warnings = Array.from(yield* Fiber.join(warningsFiber));
+      assert.equal(warnings.length, 1);
+      const warning = warnings[0];
+      assert.equal(warning?.type, "runtime.warning");
+      if (warning?.type === "runtime.warning") {
+        assert.ok(warning.payload.message.includes("1M window"));
+        assert.ok(warning.payload.message.includes("premium"));
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
 
   it.effect("uses the requested Claude context window for in-flight usage snapshots", () => {
     const harness = makeHarness();

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -76,6 +76,7 @@ import {
   Queue,
   Random,
   Ref,
+  Semaphore,
   Stream,
 } from "effect";
 
@@ -117,6 +118,8 @@ interface ClaudeResumeState {
   readonly resume?: string;
   readonly resumeSessionAt?: string;
   readonly turnCount?: number;
+  readonly rerouteOriginalApiModelId?: string;
+  readonly rerouteFallbackApiModelId?: string;
 }
 
 interface ClaudeTurnState {
@@ -437,6 +440,10 @@ interface ClaudeModelRefusalFallback {
   readonly content?: string;
 }
 
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
 function readClaudeModelRefusalFallback(message: unknown): ClaudeModelRefusalFallback | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
@@ -444,6 +451,8 @@ function readClaudeModelRefusalFallback(message: unknown): ClaudeModelRefusalFal
   const record = message as {
     type?: unknown;
     subtype?: unknown;
+    original_model?: unknown;
+    fallback_model?: unknown;
     originalModel?: unknown;
     fallbackModel?: unknown;
     content?: unknown;
@@ -451,14 +460,12 @@ function readClaudeModelRefusalFallback(message: unknown): ClaudeModelRefusalFal
   if (record.type !== "system" || record.subtype !== "model_refusal_fallback") {
     return undefined;
   }
+  // Claude Agent SDK 0.3.x emits snake_case fields. Accept camelCase too so a
+  // future typed SDK projection cannot silently disable reroute protection.
   const originalModel =
-    typeof record.originalModel === "string" && record.originalModel.trim().length > 0
-      ? record.originalModel
-      : undefined;
+    readNonEmptyString(record.original_model) ?? readNonEmptyString(record.originalModel);
   const fallbackModel =
-    typeof record.fallbackModel === "string" && record.fallbackModel.trim().length > 0
-      ? record.fallbackModel
-      : undefined;
+    readNonEmptyString(record.fallback_model) ?? readNonEmptyString(record.fallbackModel);
   if (!originalModel || !fallbackModel) {
     return undefined;
   }
@@ -562,6 +569,29 @@ const CLAUDE_CONTEXT_WINDOW_MAX_TOKENS = {
   "1m": 1_000_000,
 } as const;
 
+function resolveClaudeApiModelIdForContextWindow(
+  apiModelId: string,
+  selectedContextWindow: string | null | undefined,
+): string {
+  const baseApiModelId = stripClaudeContextWindowSuffix(apiModelId);
+  const caps = getModelCapabilities("claudeAgent", baseApiModelId);
+  return selectedContextWindow === "1m" && hasContextWindowOption(caps, "1m")
+    ? `${baseApiModelId}[1m]`
+    : baseApiModelId;
+}
+
+function resolveClaudeApiModelIdContextWindowMaxTokens(
+  apiModelId: string | undefined,
+): number | undefined {
+  if (!apiModelId) {
+    return undefined;
+  }
+  return resolveSelectedClaudeContextWindowMaxTokens(
+    stripClaudeContextWindowSuffix(apiModelId),
+    apiModelId.endsWith("[1m]") ? "1m" : undefined,
+  );
+}
+
 function resolveSelectedClaudeContextWindowMaxTokens(
   model: string | null | undefined,
   selectedContextWindow: string | null | undefined,
@@ -631,6 +661,8 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     sessionId?: unknown;
     resumeSessionAt?: unknown;
     turnCount?: unknown;
+    rerouteOriginalApiModelId?: unknown;
+    rerouteFallbackApiModelId?: unknown;
   };
 
   const threadIdCandidate = typeof cursor.threadId === "string" ? cursor.threadId : undefined;
@@ -648,6 +680,10 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
   const resumeSessionAt =
     typeof cursor.resumeSessionAt === "string" ? cursor.resumeSessionAt : undefined;
   const turnCountValue = typeof cursor.turnCount === "number" ? cursor.turnCount : undefined;
+  const rerouteOriginalApiModelId = readNonEmptyString(cursor.rerouteOriginalApiModelId);
+  const rerouteFallbackApiModelId = readNonEmptyString(cursor.rerouteFallbackApiModelId);
+  const hasCompleteReroute =
+    rerouteOriginalApiModelId !== undefined && rerouteFallbackApiModelId !== undefined;
 
   return {
     ...(threadId ? { threadId } : {}),
@@ -655,6 +691,9 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     ...(resumeSessionAt ? { resumeSessionAt } : {}),
     ...(turnCountValue !== undefined && Number.isInteger(turnCountValue) && turnCountValue >= 0
       ? { turnCount: turnCountValue }
+      : {}),
+    ...(hasCompleteReroute
+      ? { rerouteOriginalApiModelId, rerouteFallbackApiModelId }
       : {}),
   };
 }
@@ -1369,6 +1408,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
       }) => query({ prompt: input.prompt, options: input.options }) as ClaudeQueryRuntime);
 
     const sessions = new Map<ThreadId, ClaudeSessionContext>();
+    const sessionLifecycleLocks = new Map<ThreadId, Semaphore.Semaphore>();
     let cachedModels: ProviderListModelsResult | null = null;
     let cachedAgents: ProviderListAgentsResult | null = null;
     const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
@@ -1376,6 +1416,17 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
     const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
     const nextEventId = Effect.map(Random.nextUUIDv4, (id) => EventId.makeUnsafe(id));
     const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+    const withSessionLifecycleLock = <A, E, R>(
+      threadId: ThreadId,
+      effect: Effect.Effect<A, E, R>,
+    ): Effect.Effect<A, E, R> => {
+      let lock = sessionLifecycleLocks.get(threadId);
+      if (lock === undefined) {
+        lock = Semaphore.makeUnsafe(1);
+        sessionLifecycleLocks.set(threadId, lock);
+      }
+      return lock.withPermits(1)(effect);
+    };
     const resolveClaudeSdkEnv = Effect.sync(() =>
       buildClaudeProcessEnv({ env: process.env, homeDir: serverConfig.homeDir }),
     );
@@ -1459,6 +1510,12 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           ...(context.resumeSessionId ? { resume: context.resumeSessionId } : {}),
           ...(context.lastAssistantUuid ? { resumeSessionAt: context.lastAssistantUuid } : {}),
           turnCount: context.turns.length,
+          ...(context.rerouteOriginalApiModelId && context.currentApiModelId
+            ? {
+                rerouteOriginalApiModelId: context.rerouteOriginalApiModelId,
+                rerouteFallbackApiModelId: context.currentApiModelId,
+              }
+            : {}),
         };
 
         context.session = {
@@ -1754,10 +1811,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         });
       });
 
-    // Warns once per session per threshold when the per-request prompt size makes
-    // token burn dangerous: every request re-sends the whole context, and after a
-    // 5-minute prompt-cache expiry it is re-ingested as uncached tokens. Above 200k
-    // (1M window) requests additionally bill at the long-context premium.
+    // Warn once per session per threshold when the per-request prompt size makes
+    // usage burn dangerous. Every request processes the full context again; cache
+    // behavior changes how those tokens are categorized, not how large the request is.
     const maybeEmitContextUsageWarning = (
       context: ClaudeSessionContext,
       rawUsage: Record<string, unknown>,
@@ -1768,18 +1824,20 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           return;
         }
         const approxThousands = Math.round(promptTokens / 1000);
-        const isLongContextSession = context.currentApiModelId?.endsWith("[1m]") === true;
-        if (isLongContextSession) {
-          if (
-            promptTokens > CLAUDE_DEFAULT_CONTEXT_WINDOW_TOKENS &&
-            !context.emittedContextUsageWarnings.has("long-context-premium")
-          ) {
-            context.emittedContextUsageWarnings.add("long-context-premium");
-            yield* emitRuntimeWarning(
-              context,
-              `Claude context passed 200k tokens in the 1M window (~${approxThousands}k tokens per request). Long-context requests bill at a premium and consume usage limits much faster - consider compacting or starting a fresh thread.`,
-            );
-          }
+        if (
+          promptTokens > CLAUDE_DEFAULT_CONTEXT_WINDOW_TOKENS &&
+          !context.emittedContextUsageWarnings.has("large-prompt")
+        ) {
+          context.emittedContextUsageWarnings.add("large-prompt");
+          const windowLabel =
+            context.lastKnownContextWindow === CLAUDE_CONTEXT_WINDOW_MAX_TOKENS["1m"] ||
+            context.currentApiModelId?.endsWith("[1m]") === true
+              ? " with the 1M window enabled"
+              : "";
+          yield* emitRuntimeWarning(
+            context,
+            `Claude is processing ~${approxThousands}k prompt tokens per request${windowLabel}. Large prompts consume usage limits much faster - consider starting a fresh thread.`,
+          );
           return;
         }
         const contextWindow =
@@ -2634,9 +2692,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         // costs two full-context cache misses per bounce.
         const refusalFallback = readClaudeModelRefusalFallback(message);
         if (refusalFallback) {
-          context.rerouteOriginalApiModelId =
-            context.currentApiModelId ?? refusalFallback.originalModel;
+          context.rerouteOriginalApiModelId ??= refusalFallback.originalModel;
           context.currentApiModelId = refusalFallback.fallbackModel;
+          yield* updateResumeCursor(context);
           yield* offerRuntimeEvent({
             ...base,
             type: "model.rerouted",
@@ -3064,7 +3122,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           });
         }
 
-        sessions.delete(context.session.threadId);
+        if (sessions.get(context.session.threadId) === context) {
+          sessions.delete(context.session.threadId);
+        }
       });
 
     const requireSession = (
@@ -3416,7 +3476,27 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         const requestedEffort = trimOrNull(modelSelection?.options?.effort ?? null);
         const requestedContextWindow = trimOrNull(modelSelection?.options?.contextWindow ?? null);
         const caps = getModelCapabilities("claudeAgent", modelSelection?.model);
-        const apiModelId = modelSelection ? resolveApiModelId(modelSelection) : undefined;
+        const requestedApiModelId = modelSelection ? resolveApiModelId(modelSelection) : undefined;
+        const resumeRerouteOriginalApiModelId = resumeState?.rerouteOriginalApiModelId;
+        const resumeRerouteFallbackApiModelId = resumeState?.rerouteFallbackApiModelId;
+        const resumedRerouteMatchesSelection =
+          resumeRerouteOriginalApiModelId !== undefined &&
+          resumeRerouteFallbackApiModelId !== undefined &&
+          (requestedApiModelId === undefined ||
+            stripClaudeContextWindowSuffix(requestedApiModelId) ===
+              stripClaudeContextWindowSuffix(resumeRerouteOriginalApiModelId));
+        const resumedRerouteOriginalApiModelId = resumedRerouteMatchesSelection
+          ? resumeRerouteOriginalApiModelId
+          : undefined;
+        const resumedRerouteFallbackApiModelId = resumedRerouteMatchesSelection
+          ? requestedApiModelId === undefined
+            ? resumeRerouteFallbackApiModelId
+            : resolveClaudeApiModelIdForContextWindow(
+                resumeRerouteFallbackApiModelId,
+                requestedContextWindow,
+              )
+          : undefined;
+        const apiModelId = resumedRerouteFallbackApiModelId ?? requestedApiModelId;
         const effort =
           requestedEffort && hasEffortLevel(caps, requestedEffort) ? requestedEffort : null;
         const fastMode = modelSelection?.options?.fastMode === true && caps.supportsFastMode;
@@ -3430,9 +3510,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           toPermissionMode(providerOptions?.permissionMode) ??
           (input.runtimeMode === "full-access" ? "bypassPermissions" : undefined);
         const settings = {
-          // Auto-compaction bounds context growth. Without it a long session replays
-          // its entire history as uncached tokens after every prompt-cache expiry,
-          // which is the dominant driver of runaway usage on long threads.
+          // Keep SDK auto-compaction explicit. Its threshold follows the effective
+          // context window, so 1M remains an intentional per-thread choice.
           autoCompactEnabled: true,
           ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
           ...(fastMode ? { fastMode: true } : {}),
@@ -3541,6 +3620,12 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               ? { resumeSessionAt: resumeState.resumeSessionAt }
               : {}),
             turnCount: resumeState?.turnCount ?? 0,
+            ...(resumedRerouteOriginalApiModelId && resumedRerouteFallbackApiModelId
+              ? {
+                  rerouteOriginalApiModelId: resumedRerouteOriginalApiModelId,
+                  rerouteFallbackApiModelId: resumedRerouteFallbackApiModelId,
+                }
+              : {}),
           },
           createdAt: startedAt,
           updatedAt: startedAt,
@@ -3562,78 +3647,100 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           inFlightTools,
           turnState: undefined,
           interruptRequestedTurnId: undefined,
-          lastKnownContextWindow: undefined,
+          lastKnownContextWindow: resolveClaudeApiModelIdContextWindowMaxTokens(apiModelId),
           lastKnownTokenUsage: undefined,
           lastAssistantUuid: resumeState?.resumeSessionAt,
           lastThreadStartedId: undefined,
-          rerouteOriginalApiModelId: undefined,
+          rerouteOriginalApiModelId: resumedRerouteOriginalApiModelId,
           emittedContextUsageWarnings: new Set(),
           stopped: false,
           warnedUnhandledSdkKinds: new Set(),
         };
-        yield* Ref.set(contextRef, context);
-        sessions.set(threadId, context);
-
-        const sessionStartedStamp = yield* makeEventStamp();
-        yield* offerRuntimeEvent({
-          type: "session.started",
-          eventId: sessionStartedStamp.eventId,
-          provider: PROVIDER,
-          createdAt: sessionStartedStamp.createdAt,
+        yield* withSessionLifecycleLock(
           threadId,
-          payload: input.resumeCursor !== undefined ? { resume: input.resumeCursor } : {},
-          providerRefs: {},
-        });
+          Effect.gen(function* () {
+            // Create the replacement first so a spawn failure leaves the current
+            // session usable, then atomically retire the old runtime before install.
+            const existing = sessions.get(threadId);
+            if (existing && existing !== context) {
+              yield* stopSessionInternal(existing, { emitExitEvent: false });
+            }
 
-        const configuredStamp = yield* makeEventStamp();
-        yield* offerRuntimeEvent({
-          type: "session.configured",
-          eventId: configuredStamp.eventId,
-          provider: PROVIDER,
-          createdAt: configuredStamp.createdAt,
-          threadId,
-          payload: {
-            config: {
-              ...(modelSelection?.model ? { model: modelSelection.model } : {}),
-              ...(apiModelId ? { apiModelId } : {}),
-              ...(requestedContextWindow ? { contextWindow: requestedContextWindow } : {}),
-              ...(input.cwd ? { cwd: input.cwd } : {}),
-              ...(effectiveEffort ? { effort: effectiveEffort } : {}),
-              ...(permissionMode ? { permissionMode } : {}),
-              ...(providerOptions?.maxThinkingTokens !== undefined
-                ? { maxThinkingTokens: providerOptions.maxThinkingTokens }
-                : {}),
-              ...(fastMode ? { fastMode: true } : {}),
-              ...(ultracode ? { ultracode: true } : {}),
-            },
-          },
-          providerRefs: {},
-        });
+            yield* Ref.set(contextRef, context);
+            sessions.set(threadId, context);
 
-        const readyStamp = yield* makeEventStamp();
-        yield* offerRuntimeEvent({
-          type: "session.state.changed",
-          eventId: readyStamp.eventId,
-          provider: PROVIDER,
-          createdAt: readyStamp.createdAt,
-          threadId,
-          payload: {
-            state: "ready",
-          },
-          providerRefs: {},
-        });
+            const sessionStartedStamp = yield* makeEventStamp();
+            yield* offerRuntimeEvent({
+              type: "session.started",
+              eventId: sessionStartedStamp.eventId,
+              provider: PROVIDER,
+              createdAt: sessionStartedStamp.createdAt,
+              threadId,
+              payload: input.resumeCursor !== undefined ? { resume: input.resumeCursor } : {},
+              providerRefs: {},
+            });
 
-        const streamFiber = Effect.runFork(runSdkStream(context));
-        context.streamFiber = streamFiber;
-        streamFiber.addObserver((exit) => {
-          if (context.stopped) {
-            return;
-          }
-          if (context.streamFiber === streamFiber) {
-            context.streamFiber = undefined;
-          }
-          Effect.runFork(handleStreamExit(context, exit));
-        });
+            const configuredStamp = yield* makeEventStamp();
+            yield* offerRuntimeEvent({
+              type: "session.configured",
+              eventId: configuredStamp.eventId,
+              provider: PROVIDER,
+              createdAt: configuredStamp.createdAt,
+              threadId,
+              payload: {
+                config: {
+                  ...(modelSelection?.model ? { model: modelSelection.model } : {}),
+                  ...(apiModelId ? { apiModelId } : {}),
+                  ...(requestedContextWindow ? { contextWindow: requestedContextWindow } : {}),
+                  ...(input.cwd ? { cwd: input.cwd } : {}),
+                  ...(effectiveEffort ? { effort: effectiveEffort } : {}),
+                  ...(permissionMode ? { permissionMode } : {}),
+                  ...(providerOptions?.maxThinkingTokens !== undefined
+                    ? { maxThinkingTokens: providerOptions.maxThinkingTokens }
+                    : {}),
+                  ...(fastMode ? { fastMode: true } : {}),
+                  ...(ultracode ? { ultracode: true } : {}),
+                },
+              },
+              providerRefs: {},
+            });
+
+            const readyStamp = yield* makeEventStamp();
+            yield* offerRuntimeEvent({
+              type: "session.state.changed",
+              eventId: readyStamp.eventId,
+              provider: PROVIDER,
+              createdAt: readyStamp.createdAt,
+              threadId,
+              payload: {
+                state: "ready",
+              },
+              providerRefs: {},
+            });
+
+            if (
+              context.lastKnownContextWindow === CLAUDE_CONTEXT_WINDOW_MAX_TOKENS["1m"]
+            ) {
+              context.emittedContextUsageWarnings.add("one-million-window");
+              yield* emitRuntimeWarning(
+                context,
+                "Claude's 1M context window is enabled for this thread. Auto-compaction follows that larger window, so long conversations can consume usage limits much faster. Switch this thread to 200k if 1M was inherited unintentionally.",
+              );
+            }
+
+            const streamFiber = Effect.runFork(runSdkStream(context));
+            context.streamFiber = streamFiber;
+            streamFiber.addObserver((exit) => {
+              if (context.stopped) {
+                return;
+              }
+              if (context.streamFiber === streamFiber) {
+                context.streamFiber = undefined;
+              }
+              Effect.runFork(handleStreamExit(context, exit));
+            });
+          }),
+        );
 
         return {
           ...session,
@@ -3667,7 +3774,25 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             // A safeguard reroute pinned this session to the fallback model. The
             // thread selection still names the refused model; switching back would
             // re-ingest the entire context uncached (and likely bounce again), so
-            // stay on the fallback until the user picks a different model.
+            // stay on the fallback until the user picks a different model. Context
+            // window changes still apply to the effective fallback model.
+            const fallbackApiModelId = context.currentApiModelId;
+            if (fallbackApiModelId !== undefined) {
+              const effectiveFallbackApiModelId = resolveClaudeApiModelIdForContextWindow(
+                fallbackApiModelId,
+                modelSelection.options?.contextWindow,
+              );
+              if (effectiveFallbackApiModelId !== fallbackApiModelId) {
+                yield* Effect.tryPromise({
+                  try: () => context.query.setModel(effectiveFallbackApiModelId),
+                  catch: (cause) => toRequestError(input.threadId, "turn/setModel", cause),
+                });
+              }
+              context.currentApiModelId = effectiveFallbackApiModelId;
+              context.lastKnownContextWindow =
+                resolveClaudeApiModelIdContextWindowMaxTokens(effectiveFallbackApiModelId);
+              yield* updateResumeCursor(context);
+            }
           } else {
             if (apiModelId !== context.currentApiModelId) {
               yield* Effect.tryPromise({
@@ -3680,6 +3805,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             if (requestedContextWindowMaxTokens !== undefined) {
               context.lastKnownContextWindow = requestedContextWindowMaxTokens;
             }
+            yield* updateResumeCursor(context);
           }
         }
 
@@ -3731,7 +3857,11 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           createdAt: turnStartedStamp.createdAt,
           threadId: context.session.threadId,
           turnId,
-          payload: modelSelection?.model ? { model: modelSelection.model } : {},
+          payload: context.currentApiModelId
+            ? { model: stripClaudeContextWindowSuffix(context.currentApiModelId) }
+            : modelSelection?.model
+              ? { model: modelSelection.model }
+              : {},
           providerRefs: {},
         });
 
@@ -3822,12 +3952,15 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
       });
 
     const stopSession: ClaudeAdapterShape["stopSession"] = (threadId) =>
-      Effect.gen(function* () {
-        const context = yield* requireSession(threadId);
-        yield* stopSessionInternal(context, {
-          emitExitEvent: true,
-        });
-      });
+      withSessionLifecycleLock(
+        threadId,
+        Effect.gen(function* () {
+          const context = yield* requireSession(threadId);
+          yield* stopSessionInternal(context, {
+            emitExitEvent: true,
+          });
+        }),
+      );
 
     const listSessions: ClaudeAdapterShape["listSessions"] = () =>
       Effect.sync(() => Array.from(sessions.values(), ({ session }) => ({ ...session })));

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3566,181 +3566,209 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             }),
         });
 
-        // Populate model cache in background from first session
-        if (!cachedModels) {
-          queryRuntime
-            .supportedModels()
-            .then((models) => {
-              cachedModels = {
-                models: models.map((m) => ({ slug: m.value, name: m.displayName })),
-                source: "sdk",
-                cached: false,
-              };
-            })
-            .catch(() => {
-              /* ignore discovery failures */
-            });
-        }
+        let installationContext: ClaudeSessionContext | undefined;
+        let installationComplete = false;
 
-        // Populate agent cache in background from first session
-        if (!cachedAgents) {
-          queryRuntime
-            .supportedAgents()
-            .then((agents) => {
-              cachedAgents = {
-                agents: agents.map((a) => ({
-                  name: a.name,
-                  displayName: a.name,
-                  ...(a.description ? { description: a.description } : {}),
-                  ...(a.model ? { model: a.model } : {}),
-                })),
-                source: "sdk",
-                cached: false,
-              };
-            })
-            .catch(() => {
-              /* ignore discovery failures */
-            });
-        }
+        return yield* Effect.gen(function* () {
+          // Populate model cache in background from first session
+          if (!cachedModels) {
+            queryRuntime
+              .supportedModels()
+              .then((models) => {
+                cachedModels = {
+                  models: models.map((m) => ({ slug: m.value, name: m.displayName })),
+                  source: "sdk",
+                  cached: false,
+                };
+              })
+              .catch(() => {
+                /* ignore discovery failures */
+              });
+          }
 
-        const session: ProviderSession = {
-          threadId,
-          provider: PROVIDER,
-          status: "ready",
-          runtimeMode: input.runtimeMode,
-          ...(input.cwd ? { cwd: input.cwd } : {}),
-          ...(modelSelection?.model ? { model: modelSelection.model } : {}),
-          ...(threadId ? { threadId } : {}),
-          resumeCursor: {
+          // Populate agent cache in background from first session
+          if (!cachedAgents) {
+            queryRuntime
+              .supportedAgents()
+              .then((agents) => {
+                cachedAgents = {
+                  agents: agents.map((a) => ({
+                    name: a.name,
+                    displayName: a.name,
+                    ...(a.description ? { description: a.description } : {}),
+                    ...(a.model ? { model: a.model } : {}),
+                  })),
+                  source: "sdk",
+                  cached: false,
+                };
+              })
+              .catch(() => {
+                /* ignore discovery failures */
+              });
+          }
+
+          const session: ProviderSession = {
+            threadId,
+            provider: PROVIDER,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            ...(input.cwd ? { cwd: input.cwd } : {}),
+            ...(modelSelection?.model ? { model: modelSelection.model } : {}),
             ...(threadId ? { threadId } : {}),
-            ...(sessionId ? { resume: sessionId } : {}),
-            ...(resumeState?.resumeSessionAt
-              ? { resumeSessionAt: resumeState.resumeSessionAt }
-              : {}),
-            turnCount: resumeState?.turnCount ?? 0,
-            ...(resumedRerouteOriginalApiModelId && resumedRerouteFallbackApiModelId
-              ? {
-                  rerouteOriginalApiModelId: resumedRerouteOriginalApiModelId,
-                  rerouteFallbackApiModelId: resumedRerouteFallbackApiModelId,
-                }
-              : {}),
-          },
-          createdAt: startedAt,
-          updatedAt: startedAt,
-        };
+            resumeCursor: {
+              ...(threadId ? { threadId } : {}),
+              ...(sessionId ? { resume: sessionId } : {}),
+              ...(resumeState?.resumeSessionAt
+                ? { resumeSessionAt: resumeState.resumeSessionAt }
+                : {}),
+              turnCount: resumeState?.turnCount ?? 0,
+              ...(resumedRerouteOriginalApiModelId && resumedRerouteFallbackApiModelId
+                ? {
+                    rerouteOriginalApiModelId: resumedRerouteOriginalApiModelId,
+                    rerouteFallbackApiModelId: resumedRerouteFallbackApiModelId,
+                  }
+                : {}),
+            },
+            createdAt: startedAt,
+            updatedAt: startedAt,
+          };
 
-        const context: ClaudeSessionContext = {
-          session,
-          promptQueue,
-          query: queryRuntime,
-          streamFiber: undefined,
-          startedAt,
-          basePermissionMode: permissionMode,
-          lastInteractionMode: undefined,
-          currentApiModelId: apiModelId,
-          resumeSessionId: sessionId,
-          pendingApprovals,
-          pendingUserInputs,
-          turns: [],
-          inFlightTools,
-          turnState: undefined,
-          interruptRequestedTurnId: undefined,
-          lastKnownContextWindow: resolveClaudeApiModelIdContextWindowMaxTokens(apiModelId),
-          lastKnownTokenUsage: undefined,
-          lastAssistantUuid: resumeState?.resumeSessionAt,
-          lastThreadStartedId: undefined,
-          rerouteOriginalApiModelId: resumedRerouteOriginalApiModelId,
-          emittedContextUsageWarnings: new Set(),
-          stopped: false,
-          warnedUnhandledSdkKinds: new Set(),
-        };
-        yield* withSessionLifecycleLock(
-          threadId,
-          Effect.gen(function* () {
-            // Create the replacement first so a spawn failure leaves the current
-            // session usable, then atomically retire the old runtime before install.
-            const existing = sessions.get(threadId);
-            if (existing && existing !== context) {
-              yield* stopSessionInternal(existing, { emitExitEvent: false });
-            }
+          const context: ClaudeSessionContext = {
+            session,
+            promptQueue,
+            query: queryRuntime,
+            streamFiber: undefined,
+            startedAt,
+            basePermissionMode: permissionMode,
+            lastInteractionMode: undefined,
+            currentApiModelId: apiModelId,
+            resumeSessionId: sessionId,
+            pendingApprovals,
+            pendingUserInputs,
+            turns: [],
+            inFlightTools,
+            turnState: undefined,
+            interruptRequestedTurnId: undefined,
+            lastKnownContextWindow: resolveClaudeApiModelIdContextWindowMaxTokens(apiModelId),
+            lastKnownTokenUsage: undefined,
+            lastAssistantUuid: resumeState?.resumeSessionAt,
+            lastThreadStartedId: undefined,
+            rerouteOriginalApiModelId: resumedRerouteOriginalApiModelId,
+            emittedContextUsageWarnings: new Set(),
+            stopped: false,
+            warnedUnhandledSdkKinds: new Set(),
+          };
+          installationContext = context;
+          yield* withSessionLifecycleLock(
+            threadId,
+            Effect.gen(function* () {
+              // Create the replacement first so a spawn failure leaves the current
+              // session usable, then atomically retire the old runtime before install.
+              const existing = sessions.get(threadId);
+              if (existing && existing !== context) {
+                yield* stopSessionInternal(existing, { emitExitEvent: false });
+              }
 
-            yield* Ref.set(contextRef, context);
-            sessions.set(threadId, context);
+              yield* Ref.set(contextRef, context);
+              sessions.set(threadId, context);
 
-            const sessionStartedStamp = yield* makeEventStamp();
-            yield* offerRuntimeEvent({
-              type: "session.started",
-              eventId: sessionStartedStamp.eventId,
-              provider: PROVIDER,
-              createdAt: sessionStartedStamp.createdAt,
-              threadId,
-              payload: input.resumeCursor !== undefined ? { resume: input.resumeCursor } : {},
-              providerRefs: {},
-            });
+              const sessionStartedStamp = yield* makeEventStamp();
+              yield* offerRuntimeEvent({
+                type: "session.started",
+                eventId: sessionStartedStamp.eventId,
+                provider: PROVIDER,
+                createdAt: sessionStartedStamp.createdAt,
+                threadId,
+                payload: input.resumeCursor !== undefined ? { resume: input.resumeCursor } : {},
+                providerRefs: {},
+              });
 
-            const configuredStamp = yield* makeEventStamp();
-            yield* offerRuntimeEvent({
-              type: "session.configured",
-              eventId: configuredStamp.eventId,
-              provider: PROVIDER,
-              createdAt: configuredStamp.createdAt,
-              threadId,
-              payload: {
-                config: {
-                  ...(modelSelection?.model ? { model: modelSelection.model } : {}),
-                  ...(apiModelId ? { apiModelId } : {}),
-                  ...(requestedContextWindow ? { contextWindow: requestedContextWindow } : {}),
-                  ...(input.cwd ? { cwd: input.cwd } : {}),
-                  ...(effectiveEffort ? { effort: effectiveEffort } : {}),
-                  ...(permissionMode ? { permissionMode } : {}),
-                  ...(providerOptions?.maxThinkingTokens !== undefined
-                    ? { maxThinkingTokens: providerOptions.maxThinkingTokens }
-                    : {}),
-                  ...(fastMode ? { fastMode: true } : {}),
-                  ...(ultracode ? { ultracode: true } : {}),
+              const configuredStamp = yield* makeEventStamp();
+              yield* offerRuntimeEvent({
+                type: "session.configured",
+                eventId: configuredStamp.eventId,
+                provider: PROVIDER,
+                createdAt: configuredStamp.createdAt,
+                threadId,
+                payload: {
+                  config: {
+                    ...(modelSelection?.model ? { model: modelSelection.model } : {}),
+                    ...(apiModelId ? { apiModelId } : {}),
+                    ...(requestedContextWindow ? { contextWindow: requestedContextWindow } : {}),
+                    ...(input.cwd ? { cwd: input.cwd } : {}),
+                    ...(effectiveEffort ? { effort: effectiveEffort } : {}),
+                    ...(permissionMode ? { permissionMode } : {}),
+                    ...(providerOptions?.maxThinkingTokens !== undefined
+                      ? { maxThinkingTokens: providerOptions.maxThinkingTokens }
+                      : {}),
+                    ...(fastMode ? { fastMode: true } : {}),
+                    ...(ultracode ? { ultracode: true } : {}),
+                  },
                 },
-              },
-              providerRefs: {},
-            });
+                providerRefs: {},
+              });
 
-            const readyStamp = yield* makeEventStamp();
-            yield* offerRuntimeEvent({
-              type: "session.state.changed",
-              eventId: readyStamp.eventId,
-              provider: PROVIDER,
-              createdAt: readyStamp.createdAt,
-              threadId,
-              payload: {
-                state: "ready",
-              },
-              providerRefs: {},
-            });
+              const readyStamp = yield* makeEventStamp();
+              yield* offerRuntimeEvent({
+                type: "session.state.changed",
+                eventId: readyStamp.eventId,
+                provider: PROVIDER,
+                createdAt: readyStamp.createdAt,
+                threadId,
+                payload: {
+                  state: "ready",
+                },
+                providerRefs: {},
+              });
 
-            if (context.lastKnownContextWindow === CLAUDE_CONTEXT_WINDOW_MAX_TOKENS["1m"]) {
-              context.emittedContextUsageWarnings.add("one-million-window");
-              yield* emitRuntimeWarning(
-                context,
-                "Claude's 1M context window is enabled for this thread. Auto-compaction follows that larger window, so long conversations can consume usage limits much faster. Switch this thread to 200k if 1M was inherited unintentionally.",
-              );
-            }
-
-            const streamFiber = Effect.runFork(runSdkStream(context));
-            context.streamFiber = streamFiber;
-            streamFiber.addObserver((exit) => {
-              if (context.stopped) {
-                return;
+              if (context.lastKnownContextWindow === CLAUDE_CONTEXT_WINDOW_MAX_TOKENS["1m"]) {
+                context.emittedContextUsageWarnings.add("one-million-window");
+                yield* emitRuntimeWarning(
+                  context,
+                  "Claude's 1M context window is enabled for this thread. Auto-compaction follows that larger window, so long conversations can consume usage limits much faster. Switch this thread to 200k if 1M was inherited unintentionally.",
+                );
               }
-              if (context.streamFiber === streamFiber) {
-                context.streamFiber = undefined;
+
+              const streamFiber = Effect.runFork(runSdkStream(context));
+              context.streamFiber = streamFiber;
+              streamFiber.addObserver((exit) => {
+                if (context.stopped) {
+                  return;
+                }
+                if (context.streamFiber === streamFiber) {
+                  context.streamFiber = undefined;
+                }
+                Effect.runFork(handleStreamExit(context, exit));
+              });
+            }),
+          );
+
+          installationComplete = true;
+          return {
+            ...session,
+          };
+        }).pipe(
+          Effect.ensuring(
+            Effect.suspend(() => {
+              if (installationComplete) {
+                return Effect.void;
               }
-              Effect.runFork(handleStreamExit(context, exit));
-            });
-          }),
+              if (installationContext !== undefined) {
+                return stopSessionInternal(installationContext, { emitExitEvent: false });
+              }
+              return Effect.gen(function* () {
+                yield* Queue.shutdown(promptQueue);
+                const closeExit = yield* Effect.exit(Effect.sync(() => queryRuntime.close()));
+                if (Exit.isFailure(closeExit)) {
+                  yield* Effect.logWarning("claude.session.failed_install_cleanup", {
+                    threadId,
+                    cause: Cause.pretty(closeExit.cause),
+                  });
+                }
+              });
+            }),
+          ),
         );
-
-        return {
-          ...session,
-        };
       });
 
     const sendTurn: ClaudeAdapterShape["sendTurn"] = (input) =>

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -692,9 +692,7 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
     ...(turnCountValue !== undefined && Number.isInteger(turnCountValue) && turnCountValue >= 0
       ? { turnCount: turnCountValue }
       : {}),
-    ...(hasCompleteReroute
-      ? { rerouteOriginalApiModelId, rerouteFallbackApiModelId }
-      : {}),
+    ...(hasCompleteReroute ? { rerouteOriginalApiModelId, rerouteFallbackApiModelId } : {}),
   };
 }
 
@@ -3718,9 +3716,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
               providerRefs: {},
             });
 
-            if (
-              context.lastKnownContextWindow === CLAUDE_CONTEXT_WINDOW_MAX_TOKENS["1m"]
-            ) {
+            if (context.lastKnownContextWindow === CLAUDE_CONTEXT_WINDOW_MAX_TOKENS["1m"]) {
               context.emittedContextUsageWarnings.add("one-million-window");
               yield* emitRuntimeWarning(
                 context,
@@ -3789,8 +3785,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 });
               }
               context.currentApiModelId = effectiveFallbackApiModelId;
-              context.lastKnownContextWindow =
-                resolveClaudeApiModelIdContextWindowMaxTokens(effectiveFallbackApiModelId);
+              context.lastKnownContextWindow = resolveClaudeApiModelIdContextWindowMaxTokens(
+                effectiveFallbackApiModelId,
+              );
               yield* updateResumeCursor(context);
             }
           } else {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -44,8 +44,6 @@ import {
   ThreadId,
   TurnId,
   type UserInputQuestion,
-  type ClaudeApiEffort,
-  type ClaudeCodeEffort,
   type ProviderComposerCapabilities,
   type ProviderListCommandsInput,
   type ProviderListCommandsResult,
@@ -57,6 +55,7 @@ import {
 } from "@t3tools/contracts";
 import {
   getDefaultContextWindow,
+  getEffectiveClaudeCodeEffort,
   hasEffortLevel,
   hasContextWindowOption,
   applyClaudePromptEffortPrefix,
@@ -219,6 +218,12 @@ interface ClaudeSessionContext {
   lastKnownTokenUsage: ThreadTokenUsageSnapshot | undefined;
   lastAssistantUuid: string | undefined;
   lastThreadStartedId: string | undefined;
+  // Original API model id the runtime rerouted away from (safeguard refusal
+  // fallback). While set, turns requesting that model stay on the fallback:
+  // every flip back re-ingests the entire context as uncached tokens.
+  rerouteOriginalApiModelId: string | undefined;
+  // Context-size warnings already emitted for this session (once per threshold).
+  readonly emittedContextUsageWarnings: Set<string>;
   stopped: boolean;
   // Unrecognized SDK message kinds already surfaced as a runtime warning. Newer
   // Claude SDKs stream high-frequency telemetry (e.g. `thinking_tokens`); de-duping
@@ -310,18 +315,6 @@ function normalizeClaudeStreamMessages(cause: Cause.Cause<Error>): ReadonlyArray
 
   const squashed = toMessage(Cause.squash(cause), "").trim();
   return squashed.length > 0 ? [squashed] : [];
-}
-
-function getEffectiveClaudeCodeEffort(
-  effort: ClaudeCodeEffort | null | undefined,
-): ClaudeApiEffort | null {
-  if (!effort) {
-    return null;
-  }
-  if (effort === "ultrathink") {
-    return null;
-  }
-  return effort === "ultracode" ? "xhigh" : effort;
 }
 
 function isClaudeInterruptedMessage(message: string): boolean {
@@ -418,6 +411,64 @@ function maxClaudeContextWindowFromModelUsage(
   }
 
   return maxContextWindow;
+}
+
+function finiteTokenCountOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function claudePromptTokensFromRawUsage(usage: Record<string, unknown>): number {
+  return (
+    finiteTokenCountOrZero(usage.input_tokens) +
+    finiteTokenCountOrZero(usage.cache_creation_input_tokens) +
+    finiteTokenCountOrZero(usage.cache_read_input_tokens)
+  );
+}
+
+function stripClaudeContextWindowSuffix(apiModelId: string): string {
+  return apiModelId.replace(/\[[^\]]+\]$/u, "");
+}
+
+// Safeguard reroutes (e.g. Fable 5 refusal -> Opus fallback) stream as an
+// untyped system message; match it structurally so SDK type drift stays inert.
+interface ClaudeModelRefusalFallback {
+  readonly originalModel: string;
+  readonly fallbackModel: string;
+  readonly content?: string;
+}
+
+function readClaudeModelRefusalFallback(message: unknown): ClaudeModelRefusalFallback | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const record = message as {
+    type?: unknown;
+    subtype?: unknown;
+    originalModel?: unknown;
+    fallbackModel?: unknown;
+    content?: unknown;
+  };
+  if (record.type !== "system" || record.subtype !== "model_refusal_fallback") {
+    return undefined;
+  }
+  const originalModel =
+    typeof record.originalModel === "string" && record.originalModel.trim().length > 0
+      ? record.originalModel
+      : undefined;
+  const fallbackModel =
+    typeof record.fallbackModel === "string" && record.fallbackModel.trim().length > 0
+      ? record.fallbackModel
+      : undefined;
+  if (!originalModel || !fallbackModel) {
+    return undefined;
+  }
+  return {
+    originalModel,
+    fallbackModel,
+    ...(typeof record.content === "string" && record.content.trim().length > 0
+      ? { content: record.content }
+      : {}),
+  };
 }
 
 function normalizeClaudeTokenUsage(
@@ -802,6 +853,8 @@ const CLAUDE_SETTING_SOURCES = [
   "project",
   "local",
 ] as const satisfies ReadonlyArray<SettingSource>;
+const CLAUDE_DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
+const CLAUDE_CONTEXT_WARNING_RATIO = 0.8;
 const EMBEDDED_CLAUDE_SYSTEM_PROMPT_APPEND = [
   "You are running inside Synara, a coding app that embeds the Claude Agent SDK.",
   "Do not present the host app as Claude Code unless the user is explicitly asking about Claude Code.",
@@ -1701,6 +1754,48 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         });
       });
 
+    // Warns once per session per threshold when the per-request prompt size makes
+    // token burn dangerous: every request re-sends the whole context, and after a
+    // 5-minute prompt-cache expiry it is re-ingested as uncached tokens. Above 200k
+    // (1M window) requests additionally bill at the long-context premium.
+    const maybeEmitContextUsageWarning = (
+      context: ClaudeSessionContext,
+      rawUsage: Record<string, unknown>,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const promptTokens = claudePromptTokensFromRawUsage(rawUsage);
+        if (promptTokens <= 0) {
+          return;
+        }
+        const approxThousands = Math.round(promptTokens / 1000);
+        const isLongContextSession = context.currentApiModelId?.endsWith("[1m]") === true;
+        if (isLongContextSession) {
+          if (
+            promptTokens > CLAUDE_DEFAULT_CONTEXT_WINDOW_TOKENS &&
+            !context.emittedContextUsageWarnings.has("long-context-premium")
+          ) {
+            context.emittedContextUsageWarnings.add("long-context-premium");
+            yield* emitRuntimeWarning(
+              context,
+              `Claude context passed 200k tokens in the 1M window (~${approxThousands}k tokens per request). Long-context requests bill at a premium and consume usage limits much faster - consider compacting or starting a fresh thread.`,
+            );
+          }
+          return;
+        }
+        const contextWindow =
+          context.lastKnownContextWindow ?? CLAUDE_DEFAULT_CONTEXT_WINDOW_TOKENS;
+        if (
+          promptTokens > contextWindow * CLAUDE_CONTEXT_WARNING_RATIO &&
+          !context.emittedContextUsageWarnings.has("near-window")
+        ) {
+          context.emittedContextUsageWarnings.add("near-window");
+          yield* emitRuntimeWarning(
+            context,
+            `Claude context is above 80% of the ${Math.round(contextWindow / 1000)}k window (~${approxThousands}k tokens per request). Every request re-sends the full history - consider compacting or starting a fresh thread.`,
+          );
+        }
+      });
+
     // Surfaces each distinct unrecognized SDK message kind at most once per session.
     // Without this, high-frequency telemetry the adapter doesn't model (notably the
     // `thinking_tokens` system subtype streamed on every reasoning tick) turns into a
@@ -2445,6 +2540,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         // this reflects the actual prompt + output size for this single API call.
         const perCallUsage = (message.message as { usage?: unknown } | undefined)?.usage;
         if (perCallUsage) {
+          yield* maybeEmitContextUsageWarning(context, perCallUsage as Record<string, unknown>);
           const normalizedPerCallUsage = normalizeClaudeTokenUsage(
             perCallUsage as Record<string, unknown>,
             context.lastKnownContextWindow,
@@ -2532,6 +2628,26 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             payload: message,
           },
         };
+
+        // Safeguard reroute (e.g. Fable 5 refusal -> Opus fallback). Pin the session
+        // to the fallback model: forcing the refused model back on the next turn
+        // costs two full-context cache misses per bounce.
+        const refusalFallback = readClaudeModelRefusalFallback(message);
+        if (refusalFallback) {
+          context.rerouteOriginalApiModelId =
+            context.currentApiModelId ?? refusalFallback.originalModel;
+          context.currentApiModelId = refusalFallback.fallbackModel;
+          yield* offerRuntimeEvent({
+            ...base,
+            type: "model.rerouted",
+            payload: {
+              fromModel: refusalFallback.originalModel,
+              toModel: refusalFallback.fallbackModel,
+              reason: refusalFallback.content ?? "Model safeguards rerouted this request.",
+            },
+          });
+          return;
+        }
 
         switch (message.subtype) {
           case "init":
@@ -3314,6 +3430,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           toPermissionMode(providerOptions?.permissionMode) ??
           (input.runtimeMode === "full-access" ? "bypassPermissions" : undefined);
         const settings = {
+          // Auto-compaction bounds context growth. Without it a long session replays
+          // its entire history as uncached tokens after every prompt-cache expiry,
+          // which is the dominant driver of runaway usage on long threads.
+          autoCompactEnabled: true,
           ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
           ...(fastMode ? { fastMode: true } : {}),
           ...(ultracode ? { ultracode: true } : {}),
@@ -3345,7 +3465,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           ...(providerOptions?.maxThinkingTokens !== undefined
             ? { maxThinkingTokens: providerOptions.maxThinkingTokens }
             : {}),
-          ...(Object.keys(settings).length > 0 ? { settings } : {}),
+          settings,
           ...(existingResumeSessionId ? { resume: existingResumeSessionId } : {}),
           ...(newSessionId ? { sessionId: newSessionId } : {}),
           includePartialMessages: true,
@@ -3446,6 +3566,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           lastKnownTokenUsage: undefined,
           lastAssistantUuid: resumeState?.resumeSessionAt,
           lastThreadStartedId: undefined,
+          rerouteOriginalApiModelId: undefined,
+          emittedContextUsageWarnings: new Set(),
           stopped: false,
           warnedUnhandledSdkKinds: new Set(),
         };
@@ -3536,13 +3658,28 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
 
         if (modelSelection?.model) {
           const apiModelId = resolveApiModelId(modelSelection);
-          yield* Effect.tryPromise({
-            try: () => context.query.setModel(apiModelId),
-            catch: (cause) => toRequestError(input.threadId, "turn/setModel", cause),
-          });
-          context.currentApiModelId = apiModelId;
-          if (requestedContextWindowMaxTokens !== undefined) {
-            context.lastKnownContextWindow = requestedContextWindowMaxTokens;
+          const reroutedFrom = context.rerouteOriginalApiModelId;
+          const requestsReroutedModel =
+            reroutedFrom !== undefined &&
+            stripClaudeContextWindowSuffix(apiModelId) ===
+              stripClaudeContextWindowSuffix(reroutedFrom);
+          if (requestsReroutedModel) {
+            // A safeguard reroute pinned this session to the fallback model. The
+            // thread selection still names the refused model; switching back would
+            // re-ingest the entire context uncached (and likely bounce again), so
+            // stay on the fallback until the user picks a different model.
+          } else {
+            if (apiModelId !== context.currentApiModelId) {
+              yield* Effect.tryPromise({
+                try: () => context.query.setModel(apiModelId),
+                catch: (cause) => toRequestError(input.threadId, "turn/setModel", cause),
+              });
+            }
+            context.currentApiModelId = apiModelId;
+            context.rerouteOriginalApiModelId = undefined;
+            if (requestedContextWindowMaxTokens !== undefined) {
+              context.lastKnownContextWindow = requestedContextWindowMaxTokens;
+            }
           }
         }
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -990,7 +990,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
-  it.effect("refreshes persisted resume cursor from the active session on runtime events", () =>
+  it.effect("refreshes persisted resume cursor immediately on model reroutes", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;
       const runtimeRepository = yield* ProviderSessionRuntimeRepository;
@@ -1005,6 +1005,8 @@ routing.layer("ProviderServiceLive routing", (it) => {
         resume: "550e8400-e29b-41d4-a716-446655440000",
         resumeSessionAt: "assistant-message-refresh",
         turnCount: 2,
+        rerouteOriginalApiModelId: "claude-fable-5",
+        rerouteFallbackApiModelId: "claude-opus-4-8",
       };
 
       routing.claude.updateSession(session.threadId, (existing) => ({
@@ -1012,12 +1014,16 @@ routing.layer("ProviderServiceLive routing", (it) => {
         resumeCursor: updatedResumeCursor,
       }));
       routing.claude.emit({
-        type: "thread.started",
-        eventId: asEventId("runtime-thread-started-refresh"),
+        type: "model.rerouted",
+        eventId: asEventId("runtime-model-rerouted-refresh"),
         provider: "claudeAgent",
         createdAt: "2026-02-27T00:04:00.000Z",
         threadId: session.threadId,
-        payload: { providerThreadId: updatedResumeCursor.resume },
+        payload: {
+          fromModel: "claude-fable-5",
+          toModel: "claude-opus-4-8",
+          reason: "Model safeguards rerouted this request.",
+        },
       });
       yield* sleep(50);
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -214,6 +214,7 @@ function runtimeStatusForEvent(
 function shouldRefreshResumeCursorForEvent(event: ProviderRuntimeEvent): boolean {
   return (
     event.type === "thread.started" ||
+    event.type === "model.rerouted" ||
     (event.type === "thread.state.changed" &&
       event.payload.state === "compacted" &&
       event.turnId === undefined) ||
@@ -523,6 +524,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         case "thread.started":
         case "thread.state.changed":
         case "turn.started":
+        case "model.rerouted":
         case "turn.completed":
         case "turn.aborted":
         case "session.exited":

--- a/apps/web/src/components/chat/TraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.browser.tsx
@@ -294,7 +294,7 @@ describe("TraitsPicker (Claude)", () => {
     });
   });
 
-  it("persists sticky claude context window when changed", async () => {
+  it("keeps the claude context window per-thread instead of sticky", async () => {
     await using _ = await mountClaudePicker({
       model: "claude-opus-4-6",
       options: { contextWindow: "200k" },
@@ -303,14 +303,12 @@ describe("TraitsPicker (Claude)", () => {
     await page.getByRole("button").click();
     await page.getByRole("menuitemradio", { name: "1M" }).click();
 
-    expect(
-      useComposerDraftStore.getState().stickyModelSelectionByProvider.claudeAgent,
-    ).toMatchObject({
-      provider: "claudeAgent",
-      options: {
-        contextWindow: "1m",
-      },
-    });
+    // The 1M window carries a long-context billing premium: the thread keeps the
+    // choice, but it must never leak into the sticky defaults for future threads.
+    const sticky = useComposerDraftStore.getState().stickyModelSelectionByProvider.claudeAgent;
+    expect(sticky?.provider === "claudeAgent" ? sticky.options?.contextWindow : undefined).toBe(
+      undefined,
+    );
   });
 });
 

--- a/apps/web/src/components/chat/TraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.browser.tsx
@@ -303,8 +303,8 @@ describe("TraitsPicker (Claude)", () => {
     await page.getByRole("button").click();
     await page.getByRole("menuitemradio", { name: "1M" }).click();
 
-    // The 1M window carries a long-context billing premium: the thread keeps the
-    // choice, but it must never leak into the sticky defaults for future threads.
+    // A 1M thread can grow far beyond the normal compaction point: keep the explicit
+    // thread choice, but never leak it into sticky defaults for future threads.
     const sticky = useComposerDraftStore.getState().stickyModelSelectionByProvider.claudeAgent;
     expect(sticky?.provider === "claudeAgent" ? sticky.options?.contextWindow : undefined).toBe(
       undefined,

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -2194,6 +2194,87 @@ describe("composerDraftStore sticky composer settings", () => {
       activeProvider: "claudeAgent",
     });
   });
+
+  it("strips the Claude context window from sticky selections", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setStickyModelSelection(
+      modelSelection("claudeAgent", "claude-opus-4-6", {
+        effort: "max",
+        contextWindow: "1m",
+      }),
+    );
+
+    expect(useComposerDraftStore.getState().stickyModelSelectionByProvider.claudeAgent).toEqual(
+      modelSelection("claudeAgent", "claude-opus-4-6", { effort: "max" }),
+    );
+  });
+
+  it("drops sticky Claude options entirely when only the context window was set", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setStickyModelSelection(
+      modelSelection("claudeAgent", "claude-opus-4-6", { contextWindow: "1m" }),
+    );
+
+    expect(useComposerDraftStore.getState().stickyModelSelectionByProvider.claudeAgent).toEqual(
+      modelSelection("claudeAgent", "claude-opus-4-6"),
+    );
+  });
+
+  it("does not persist Claude context window changes through sticky provider options", () => {
+    const store = useComposerDraftStore.getState();
+    const threadId = ThreadId.makeUnsafe("thread-sticky-context-window");
+
+    store.setProviderModelOptions(
+      threadId,
+      "claudeAgent",
+      { effort: "xhigh", contextWindow: "1m" },
+      { persistSticky: true, model: "claude-opus-4-7" },
+    );
+
+    const state = useComposerDraftStore.getState();
+    // The thread keeps its own context window choice.
+    expect(state.draftsByThreadId[threadId]?.modelSelectionByProvider.claudeAgent?.options).toEqual(
+      {
+        effort: "xhigh",
+        contextWindow: "1m",
+      },
+    );
+    // The sticky snapshot only carries options that are safe to inherit.
+    expect(state.stickyModelSelectionByProvider.claudeAgent).toEqual(
+      modelSelection("claudeAgent", "claude-opus-4-7", { effort: "xhigh" }),
+    );
+  });
+
+  it("sanitizes a persisted sticky Claude context window during hydration", () => {
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        merge: (persistedState: unknown, currentState: unknown) => unknown;
+      };
+    };
+    const merged = persistApi.getOptions().merge(
+      {
+        draftsByThreadId: {},
+        draftThreadsByThreadId: {},
+        projectDraftThreadIdByProjectId: {},
+        stickyModelSelectionByProvider: {
+          claudeAgent: modelSelection("claudeAgent", "claude-opus-4-6", {
+            effort: "max",
+            contextWindow: "1m",
+          }),
+        },
+        stickyActiveProvider: "claudeAgent",
+      },
+      useComposerDraftStore.getState(),
+    ) as {
+      stickyModelSelectionByProvider: Partial<Record<ModelSelection["provider"], ModelSelection>>;
+    };
+
+    expect(merged.stickyModelSelectionByProvider.claudeAgent).toEqual(
+      modelSelection("claudeAgent", "claude-opus-4-6", { effort: "max" }),
+    );
+  });
 });
 
 describe("composerDraftStore provider-scoped option updates", () => {

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1536,9 +1536,9 @@ function normalizeModelSelection(
 
 // ── Sticky selection sanitization ─────────────────────────────────────
 
-// The Claude context window must stay a per-thread choice: the 1M window carries a
-// long-context billing premium and disables effective compaction, so a one-off pick
-// must never silently become the default for every future thread via sticky state.
+// The Claude context window must stay a per-thread choice: a 1M thread can grow far
+// beyond the normal 200k compaction point and consume usage limits much faster, so a
+// one-off pick must never silently become every future thread's sticky default.
 function stripNonStickyModelOptions(selection: ModelSelection): ModelSelection {
   if (selection.provider !== "claudeAgent" || !selection.options?.contextWindow) {
     return selection;

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1534,6 +1534,33 @@ function normalizeModelSelection(
   return makeModelSelection(provider, model, options);
 }
 
+// ── Sticky selection sanitization ─────────────────────────────────────
+
+// The Claude context window must stay a per-thread choice: the 1M window carries a
+// long-context billing premium and disables effective compaction, so a one-off pick
+// must never silently become the default for every future thread via sticky state.
+function stripNonStickyModelOptions(selection: ModelSelection): ModelSelection {
+  if (selection.provider !== "claudeAgent" || !selection.options?.contextWindow) {
+    return selection;
+  }
+  const { contextWindow: _contextWindow, ...rest } = selection.options;
+  return makeModelSelection(
+    selection.provider,
+    selection.model,
+    Object.keys(rest).length > 0 ? rest : undefined,
+  );
+}
+
+function sanitizeStickyModelSelectionMap(
+  map: Partial<Record<ProviderKind, ModelSelection>>,
+): Partial<Record<ProviderKind, ModelSelection>> {
+  const claude = map.claudeAgent;
+  if (claude?.provider !== "claudeAgent" || !claude.options?.contextWindow) {
+    return map;
+  }
+  return { ...map, claudeAgent: stripNonStickyModelOptions(claude) };
+}
+
 // ── Legacy sync helpers (used only during migration from v2 storage) ──
 
 function legacySyncModelSelectionOptions(
@@ -2794,7 +2821,7 @@ function normalizeCurrentPersistedComposerDraftStoreState(
     draftsByThreadId: normalizePersistedDraftsByThreadId(normalizedPersistedState.draftsByThreadId),
     draftThreadsByThreadId,
     projectDraftThreadIdByProjectId,
-    stickyModelSelectionByProvider,
+    stickyModelSelectionByProvider: sanitizeStickyModelSelectionMap(stickyModelSelectionByProvider),
     stickyActiveProvider,
   };
 }
@@ -3457,7 +3484,8 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
         });
       },
       setStickyModelSelection: (modelSelection) => {
-        const normalized = normalizeModelSelection(modelSelection);
+        const rawNormalized = normalizeModelSelection(modelSelection);
+        const normalized = rawNormalized ? stripNonStickyModelOptions(rawNormalized) : null;
         set((state) => {
           if (!normalized) {
             return state;
@@ -3868,10 +3896,8 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
               return state;
             }
             if (providerOpts) {
-              nextStickyMap[normalizedProvider] = makeModelSelection(
-                normalizedProvider,
-                stickyBase.model,
-                providerOpts,
+              nextStickyMap[normalizedProvider] = stripNonStickyModelOptions(
+                makeModelSelection(normalizedProvider, stickyBase.model, providerOpts),
               );
             } else if (stickyBase.options) {
               nextStickyMap[normalizedProvider] = buildModelSelection(

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/desktop": {
       "name": "@t3tools/desktop",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "effect": "catalog:",
         "electron": "40.6.0",
@@ -43,7 +43,7 @@
     },
     "apps/server": {
       "name": "t3",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "bin": {
         "t3": "./dist/index.mjs",
       },
@@ -81,7 +81,7 @@
     },
     "apps/web": {
       "name": "@t3tools/web",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@dnd-kit/core": "^6.3.1",
@@ -152,7 +152,7 @@
     },
     "packages/contracts": {
       "name": "@t3tools/contracts",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "effect": "catalog:",
       },

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -654,6 +654,33 @@ describe("claudeSelectionRequiresRestart", () => {
     ).toBe(false);
   });
 
+  it("does not restart when a model switch carries an unsupported thinking override", () => {
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-haiku-4-5", { thinking: false }),
+        selection("claude-opus-4-8", { thinking: false }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not restart when a model switch carries an unsupported fast-mode flag", () => {
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-opus-4-8", { effort: "high", fastMode: true }),
+        selection("claude-sonnet-5", { effort: "high", fastMode: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("still restarts when spawn-fixed options change together with the model", () => {
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-opus-4-8", { effort: "high" }),
+        selection("claude-sonnet-5", { effort: "max" }),
+      ),
+    ).toBe(true);
+  });
+
   it("does not restart for a context-window-only change", () => {
     expect(
       claudeSelectionRequiresRestart(

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   applyClaudePromptEffortPrefix,
+  claudeSelectionRequiresRestart,
   formatModelDisplayName,
   getDefaultContextWindow,
   getDefaultModel,
@@ -615,6 +616,108 @@ describe("resolveApiModelId", () => {
         options: { contextWindow: "200k" },
       }),
     ).toBe("claude-opus-4-6");
+  });
+});
+
+describe("claudeSelectionRequiresRestart", () => {
+  const selection = (
+    model: string,
+    options?: { effort?: string; contextWindow?: string; fastMode?: boolean; thinking?: boolean },
+  ) =>
+    ({
+      provider: "claudeAgent",
+      model,
+      ...(options ? { options } : {}),
+    }) as Parameters<typeof claudeSelectionRequiresRestart>[1];
+
+  it("never restarts for non-Claude selections", () => {
+    expect(
+      claudeSelectionRequiresRestart(
+        { provider: "codex", model: "gpt-5.5" },
+        { provider: "codex", model: "gpt-5.4" },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not restart on the first observed selection", () => {
+    expect(
+      claudeSelectionRequiresRestart(undefined, selection("claude-opus-4-8", { effort: "max" })),
+    ).toBe(false);
+  });
+
+  it("does not restart for a model-only change", () => {
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-opus-4-8", { effort: "max" }),
+        selection("claude-fable-5", { effort: "max" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not restart for a context-window-only change", () => {
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-opus-4-8", { effort: "xhigh", contextWindow: "200k" }),
+        selection("claude-opus-4-8", { effort: "xhigh", contextWindow: "1m" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("restarts when the effective effort changes", () => {
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-opus-4-8", { effort: "high" }),
+        selection("claude-opus-4-8", { effort: "max" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats ultrathink as prompt-injected, not a spawn change", () => {
+    // ultrathink carries no API effort, so switching from no effort to ultrathink
+    // must not respawn the subprocess.
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-opus-4-8"),
+        selection("claude-opus-4-8", { effort: "ultrathink" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("restarts when ultracode toggles", () => {
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-opus-4-8", { effort: "xhigh" }),
+        selection("claude-opus-4-8", { effort: "ultracode" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("restarts when fast mode toggles", () => {
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-opus-4-8", { effort: "high" }),
+        selection("claude-opus-4-8", { effort: "high", fastMode: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("restarts when the thinking toggle changes on a supported model", () => {
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-haiku-4-5"),
+        selection("claude-haiku-4-5", { thinking: false }),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores options the target model does not support", () => {
+    // fastMode is not supported on Sonnet models, so toggling it is a no-op.
+    expect(
+      claudeSelectionRequiresRestart(
+        selection("claude-sonnet-5", { effort: "high" }),
+        selection("claude-sonnet-5", { effort: "high", fastMode: true }),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -736,6 +736,36 @@ interface ClaudeSpawnProfile {
   readonly ultracode: boolean;
 }
 
+interface ClaudeRequestedSpawnOptions {
+  readonly effort: string | null;
+  readonly thinking: boolean | undefined;
+  readonly fastMode: boolean;
+}
+
+function claudeRequestedSpawnOptions(
+  selection: Extract<ModelSelection, { provider: "claudeAgent" }>,
+): ClaudeRequestedSpawnOptions {
+  return {
+    effort: trimOrNull(selection.options?.effort ?? null),
+    thinking:
+      typeof selection.options?.thinking === "boolean" ? selection.options.thinking : undefined,
+    fastMode: selection.options?.fastMode === true,
+  };
+}
+
+function sameClaudeRequestedSpawnOptions(
+  previous: Extract<ModelSelection, { provider: "claudeAgent" }>,
+  next: Extract<ModelSelection, { provider: "claudeAgent" }>,
+): boolean {
+  const prev = claudeRequestedSpawnOptions(previous);
+  const desired = claudeRequestedSpawnOptions(next);
+  return (
+    prev.effort === desired.effort &&
+    prev.thinking === desired.thinking &&
+    prev.fastMode === desired.fastMode
+  );
+}
+
 // Mirrors the spawn-time option derivation in the Claude adapter's startSession:
 // only these inputs are fixed at subprocess spawn (query `effort` + `settings`).
 // Model and context window switch in-session via `setModel`.
@@ -775,6 +805,13 @@ export function claudeSelectionRequiresRestart(
   }
   if (previous.provider !== "claudeAgent") {
     return true;
+  }
+  if (previous.model !== next.model && sameClaudeRequestedSpawnOptions(previous, next)) {
+    // A model switch is handled by setModel. Do not interpret the new model's
+    // different capabilities as a spawn-setting change when the requested
+    // options themselves are unchanged (for example, a stale Haiku `thinking`
+    // override or Opus `fastMode` flag carried into the next selection).
+    return false;
   }
   const prev = claudeSpawnProfile(previous);
   const desired = claudeSpawnProfile(next);

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -3,6 +3,7 @@ import {
   MODEL_CAPABILITIES_INDEX,
   MODEL_OPTIONS_BY_PROVIDER,
   MODEL_SLUG_ALIASES_BY_PROVIDER,
+  type ClaudeApiEffort,
   type ClaudeModelOptions,
   type ClaudeCodeEffort,
   type CodexModelOptions,
@@ -712,6 +713,77 @@ export function resolveApiModelId(modelSelection: ModelSelection): string {
     default:
       return modelSelection.model;
   }
+}
+
+/**
+ * Map a requested Claude Code effort to the API effort passed at session spawn.
+ * `ultrathink` is prompt-injected (no API effort); `ultracode` runs as xhigh plus
+ * the `ultracode` session setting.
+ */
+export function getEffectiveClaudeCodeEffort(
+  effort: ClaudeCodeEffort | null | undefined,
+): ClaudeApiEffort | null {
+  if (!effort || effort === "ultrathink") {
+    return null;
+  }
+  return effort === "ultracode" ? "xhigh" : effort;
+}
+
+interface ClaudeSpawnProfile {
+  readonly effectiveEffort: ClaudeApiEffort | null;
+  readonly thinking: boolean | undefined;
+  readonly fastMode: boolean;
+  readonly ultracode: boolean;
+}
+
+// Mirrors the spawn-time option derivation in the Claude adapter's startSession:
+// only these inputs are fixed at subprocess spawn (query `effort` + `settings`).
+// Model and context window switch in-session via `setModel`.
+function claudeSpawnProfile(selection: Extract<ModelSelection, { provider: "claudeAgent" }>) {
+  const caps = getModelCapabilities("claudeAgent", selection.model);
+  const requestedEffort = trimOrNull(selection.options?.effort ?? null);
+  const effort = requestedEffort && hasEffortLevel(caps, requestedEffort) ? requestedEffort : null;
+  return {
+    effectiveEffort: getEffectiveClaudeCodeEffort(effort),
+    thinking:
+      typeof selection.options?.thinking === "boolean" && caps.supportsThinkingToggle
+        ? selection.options.thinking
+        : undefined,
+    fastMode: selection.options?.fastMode === true && caps.supportsFastMode,
+    ultracode: effort === "ultracode" && hasEffortLevel(caps, "xhigh"),
+  } satisfies ClaudeSpawnProfile;
+}
+
+/**
+ * Whether switching from `previous` to `next` requires restarting the Claude
+ * subprocess. Restarting resumes via `--resume`, which replays the whole
+ * conversation as uncached input tokens, so it must only happen for options
+ * fixed at spawn (effort/settings). Model and context-window changes flow
+ * through the in-session `setModel` path instead.
+ */
+export function claudeSelectionRequiresRestart(
+  previous: ModelSelection | undefined,
+  next: ModelSelection,
+): boolean {
+  if (next.provider !== "claudeAgent") {
+    return false;
+  }
+  if (previous === undefined) {
+    // First observation in this process: the live session was started from the
+    // same selection source, so treat it as unchanged rather than replaying.
+    return false;
+  }
+  if (previous.provider !== "claudeAgent") {
+    return true;
+  }
+  const prev = claudeSpawnProfile(previous);
+  const desired = claudeSpawnProfile(next);
+  return (
+    prev.effectiveEffort !== desired.effectiveEffort ||
+    prev.thinking !== desired.thinking ||
+    prev.fastMode !== desired.fastMode ||
+    prev.ultracode !== desired.ultracode
+  );
 }
 
 export function normalizeGeminiModelOptions(


### PR DESCRIPTION
## What Changed

This PR fixes several independent ways Claude sessions could consume far more subscription usage in Synara than in Claude Code CLI:

1. **The 1M context window is per-thread, never sticky.** Claude `contextWindow` is stripped from sticky composer state on write and from previously persisted sticky defaults on hydration. Choosing 1M once no longer silently enables it for every future thread.
2. **Compaction and usage warnings are explicit.** Claude SDK sessions always enable auto-compaction. A thread that starts on 1M now warns immediately that its compaction threshold is much larger, and prompts above 200k warn using plan-neutral usage language.
3. **Safeguard fallbacks stay on the effective model.** Real SDK `model_refusal_fallback` messages use snake_case fields; the adapter now decodes that wire shape, preserves the first refused model across repeated notifications, reports the actual serving model, and applies context-window changes to the fallback rather than flipping back.
4. **Fallback routing survives recovery.** The refused/effective model pair is stored in the Claude resume cursor, persisted immediately on `model.rerouted`, and restored across effort changes, idle runtime stops, app restarts, and other resume paths.
5. **Session replacement cannot orphan the old Claude runtime.** A replacement query is created first, then installed under a per-thread lifecycle lock after the previous query is closed. Failed replacement spawns leave the current session alive, and stale cleanup cannot delete a newer session.
6. **Claude restarts are limited to settings fixed at process spawn.** Model and context-window changes use in-session `setModel`; effort, thinking, fast mode, and ultracode still restart. The reactor tracks the selection actually applied to the live subprocess, including directly imported sessions and settings changed during an active turn.

Existing threads that intentionally or accidentally already use 1M keep their per-thread selection, but now receive an immediate warning telling the user how to switch that thread back to 200k. This avoids silently overriding intentional 1M choices while making inherited high-usage state visible.

## Why

Users reported simple Claude turns consuming 8–25% of their rolling usage window. Local session metadata showed Synara SDK prompts reaching roughly 300k–630k tokens without compaction, while Claude Code CLI sessions were much less likely to reach those sizes. A Fable refusal could also make the same large context pass through Fable and its Opus fallback in one turn, then repeat on later turns.

The dominant general cause was a one-off 1M choice leaking into future threads through sticky state. Fallback bouncing, unnecessary restarts, and unsafe same-thread replacement could further amplify usage or leave work running in an unreachable runtime.

## Verification

Focused verification on the latest head passes **359 tests**:

- Claude adapter, provider service, and command reactor: 175
- Shared model selection logic: 73
- Composer draft store: 89
- Traits picker browser suite: 22

Coverage includes the real snake_case fallback event, repeated fallbacks, fallback resume/restart, failed and successful same-thread replacement, actual-model turn reporting, pinned context changes, immediate 1M warnings, direct-start selection changes, mid-turn spawn-profile changes, sticky sanitization, and restart narrowing.

## Checklist

- [x] The runaway-usage causes are documented
- [x] Existing intentional per-thread 1M choices are preserved and warned
- [x] Production wire shapes and session lifecycle paths have regression coverage
- [x] Focused server, shared, web, and browser tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Claude session lifecycle, resume cursors, restart heuristics, and model fallback pinning—core paths that affect token usage, recovery after app restart, and which model actually serves a turn.
> 
> **Overview**
> Addresses runaway Claude subscription usage by changing how model selection, sessions, and composer defaults interact.
> 
> **Composer / sticky state:** Claude `contextWindow` is no longer written to sticky defaults (including hydration of old persisted state), so a one-off 1M choice stays on that thread only.
> 
> **Provider command reactor:** Tracks the selection actually applied to the live subprocess (`threadSessionModelSelections`), seeds from projection and `thread.created`, and uses shared `claudeSelectionRequiresRestart` so only spawn-fixed options (effort, thinking, fast mode, ultracode) restart Claude—not model or context-window changes (those use in-session `setModel`). Mid-turn metadata updates defer restart until the turn ends.
> 
> **Claude adapter:** Always enables SDK auto-compaction; warns on 1M thread start and when per-request prompt size crosses usage thresholds. Handles `model_refusal_fallback` SDK messages, emits `model.rerouted`, pins the session to the fallback model (with context applied on the fallback), persists the pair in the resume cursor, and restores it on resume. Session replacement is serialized with a per-thread lock, spawns the new query before retiring the old one, and cleans up failed installs without dropping a working session. Skips redundant `setModel` when unchanged.
> 
> **Provider service / ingestion:** Persists resume cursor immediately on `model.rerouted`; surfaces reroutes in the activity timeline.
> 
> **Shared:** New `claudeSelectionRequiresRestart` and moved `getEffectiveClaudeCodeEffort` for consistent restart rules.
> 
> **Version bump:** `0.4.1` → `0.4.2` in lockfile for affected packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 419daf984fb275439b3cc7282538587bc5698231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->