### PR TITLE
Fix Synara update feed manifests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           BRIDGE_TAG: ${{ steps.release_meta.outputs.bridge_tag }}
+          UPDATE_CHANNEL: ${{ steps.release_meta.outputs.update_channel }}
         run: |
           actual_latest="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq .tag_name)"
           if [[ "$actual_latest" != "$BRIDGE_TAG" ]]; then
@@ -89,8 +90,21 @@ jobs:
             exit 1
           fi
 
-          bridge_assets="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${BRIDGE_TAG}" --jq '.assets[].name')"
-          for required_asset in latest-mac.yml latest.yml latest-linux.yml; do
+          bridge_release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${BRIDGE_TAG}" --jq .id)"
+          bridge_assets="$(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/releases/${bridge_release_id}/assets?per_page=100" \
+              --jq '.[].name'
+          )"
+          required_assets=(
+            latest-mac.yml
+            latest.yml
+            latest-linux.yml
+            "${UPDATE_CHANNEL}-mac.yml"
+            "${UPDATE_CHANNEL}.yml"
+            "${UPDATE_CHANNEL}-linux.yml"
+          )
+          for required_asset in "${required_assets[@]}"; do
             if ! grep -Fxq "$required_asset" <<< "$bridge_assets"; then
               echo "Pinned compatibility feed is missing $required_asset." >&2
               exit 1
@@ -355,6 +369,70 @@ jobs:
 
       - name: Prepare updater feed metadata
         run: node scripts/prepare-release-update-feed.ts release-assets
+
+      - name: Prevent compatibility channel rollback
+        if: ${{ needs.preflight.outputs.release_lane == 'bridge' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRIDGE_TAG: ${{ needs.preflight.outputs.bridge_tag }}
+          BRIDGE_VERSION: ${{ needs.preflight.outputs.version }}
+          UPDATE_CHANNEL: ${{ needs.preflight.outputs.update_channel }}
+        run: |
+          set -euo pipefail
+
+          if ! bridge_release_json="$(
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${BRIDGE_TAG}" 2>&1
+          )"; then
+            if grep -q "HTTP 404" <<< "$bridge_release_json"; then
+              exit 0
+            fi
+            echo "$bridge_release_json" >&2
+            exit 1
+          fi
+          bridge_release_id="$(jq -r .id <<< "$bridge_release_json")"
+
+          bridge_assets="$(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/releases/${bridge_release_id}/assets?per_page=100" \
+              --jq '.[].name'
+          )"
+          channel_manifests=(
+            "${UPDATE_CHANNEL}-mac.yml"
+            "${UPDATE_CHANNEL}.yml"
+            "${UPDATE_CHANNEL}-linux.yml"
+          )
+          existing_manifests=()
+          for manifest in "${channel_manifests[@]}"; do
+            if grep -Fxq "$manifest" <<< "$bridge_assets"; then
+              existing_manifests+=("$manifest")
+            fi
+          done
+
+          if [[ "${#existing_manifests[@]}" -eq 0 ]]; then
+            exit 0
+          fi
+          if [[ "${#existing_manifests[@]}" -ne "${#channel_manifests[@]}" ]]; then
+            echo "Compatibility feed has a partial dedicated-channel manifest set: ${existing_manifests[*]}." >&2
+            exit 1
+          fi
+
+          manifest_directory="$(mktemp -d)"
+          trap 'rm -rf "$manifest_directory"' EXIT
+          for manifest in "${channel_manifests[@]}"; do
+            gh release download "$BRIDGE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "$manifest" \
+              --dir "$manifest_directory"
+            manifest_version="$(
+              sed -n 's/^version:[[:space:]]*//p' "$manifest_directory/$manifest" \
+                | head -n 1 \
+                | tr -d "[:space:]'\""
+            )"
+            if [[ "$manifest_version" != "$BRIDGE_VERSION" ]]; then
+              echo "Refusing to replace $manifest version ${manifest_version:-unknown} with compatibility version $BRIDGE_VERSION." >&2
+              exit 1
+            fi
+          done
 
       - name: Recheck pinned compatibility feed
         if: ${{ needs.preflight.outputs.release_lane == 'clean' }}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1691,8 +1691,7 @@ function startBundleSwapWatcher(): void {
     return;
   }
   let baseline =
-    startupBundleIdentity &&
-    Path.resolve(startupBundleIdentity.path) === Path.resolve(bundlePath)
+    startupBundleIdentity && Path.resolve(startupBundleIdentity.path) === Path.resolve(bundlePath)
       ? (startupBundleIdentity.signature ?? readBundleSignature(bundlePath))
       : readBundleSignature(bundlePath);
   if (!baseline) {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -826,11 +826,7 @@ describe("deriveMessagesTimelineRows", () => {
   });
 
   it("folds settled reasoning traces into the terminal turn disclosure", () => {
-    const reasoning = workEntry(
-      "reasoning-1",
-      "2026-01-01T00:00:02Z",
-      "Reasoning trace",
-    );
+    const reasoning = workEntry("reasoning-1", "2026-01-01T00:00:02Z", "Reasoning trace");
     if (reasoning.kind === "work") {
       reasoning.entry = {
         ...reasoning.entry,

--- a/apps/web/src/components/chat/agentActivity.logic.ts
+++ b/apps/web/src/components/chat/agentActivity.logic.ts
@@ -40,8 +40,7 @@ export function isCodexActivityStatusWorkEntry(entry: WorkLogEntry): boolean {
   const isStatusOnlyCommand =
     entry.itemType === "command_execution" && !entry.command && !entry.rawCommand;
   return (
-    isStatusOnlyCommand ||
-    normalizeWorkText(entry.toolTitle ?? entry.label) === "command execution"
+    isStatusOnlyCommand || normalizeWorkText(entry.toolTitle ?? entry.label) === "command execution"
   );
 }
 

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -2556,11 +2556,7 @@ describe("store read model sync", () => {
     });
 
     const next = applyOrchestrationEventsHotPath(makeState(makeThread()), [
-      makeDomainEvent(
-        "thread.activity-appended",
-        { threadId, activity: started },
-        { sequence: 1 },
-      ),
+      makeDomainEvent("thread.activity-appended", { threadId, activity: started }, { sequence: 1 }),
       makeDomainEvent(
         "thread.activity-appended",
         { threadId, activity: completed },

--- a/docs/release.md
+++ b/docs/release.md
@@ -18,7 +18,7 @@ This document covers build-only native validation and publishing desktop release
   - Versions with a suffix after `X.Y.Z` (for example `1.2.3-alpha.1`) are published as GitHub prereleases.
 - Publishes the CLI package (`apps/server`, npm package `t3`) with OIDC trusted publishing.
   - The compatibility release is marked as GitHub Latest permanently; later clean releases never replace it.
-- Publishes default-channel compatibility metadata, then uses the dedicated `synara` channel after migration.
+- Publishes default-channel compatibility metadata plus same-version `synara` placeholders, then advances the dedicated channel after migration.
 - Signing is optional and auto-detected per platform from secrets.
 
 ## Desktop auto-update notes
@@ -37,17 +37,19 @@ This document covers build-only native validation and publishing desktop release
 - Required Synara release assets for updater:
   - platform installers (`.exe`, `.dmg`, `.AppImage`, plus macOS `.zip` for Squirrel.Mac update payloads)
   - `synara-mac.yml`, `synara.yml`, and `synara-linux.yml` metadata
+  - the compatibility release also retains `latest-mac.yml`, `latest.yml`, and `latest-linux.yml`
   - `*.blockmap` files, except the macOS update `.zip.blockmap` removed after zip repack
 - Enforced upgrade path:
-  - The compatibility version from `scripts/release-update-policy.json` remains GitHub Latest permanently and owns `latest*.yml`.
+  - The compatibility version from `scripts/release-update-policy.json` remains GitHub Latest permanently and owns `latest*.yml` plus byte-identical, same-version `synara*.yml` placeholders.
   - Predecessor installations can therefore see only that compatibility version on their default channel.
-  - The compatibility build migrates local state and then checks the dedicated `synara` channel.
+  - The compatibility build migrates local state and then checks the dedicated `synara` channel, whose placeholders report that the compatibility build is already current.
   - Every clean Synara release is created with `make_latest=false`. Its payloads are uploaded to the pinned compatibility release first, and its three channel manifests are uploaded last.
-  - Both preflight and publication fail closed if GitHub Latest is not the configured compatibility tag.
+  - Re-publishing the compatibility release fails closed once its dedicated-channel manifests advertise a newer version, preventing an accidental channel rollback.
+  - Clean-release preflight also requires all six compatibility/default and dedicated-channel manifests, and both preflight and publication fail closed if GitHub Latest is not the configured compatibility tag.
 - Production desktop builds omit web/server/desktop source maps by default to keep update payloads small. Set `SYNARA_WEB_SOURCEMAP=1`, `SYNARA_SERVER_SOURCEMAP=1`, or `SYNARA_DESKTOP_SOURCEMAP=1` only for a diagnostic release that needs them.
 - macOS metadata note:
   - The build initially emits `latest-mac.yml` for both Intel and Apple Silicon.
-  - The workflow merges the per-arch manifests and then renames the merged file to `synara-mac.yml` before publication.
+  - The workflow merges the per-arch macOS metadata, then copies the merged manifest to `synara-mac.yml` for the compatibility release or renames it for a clean release.
   - The desktop build script repacks the macOS update `.zip` with `ditto`, verifies Electron framework symlinks, extracts the zip, validates the extracted app signature, patches the matching `latest-mac*.yml` hash/size, and removes the stale `.zip.blockmap`.
   - macOS updater downloads intentionally use the full zip payload so Squirrel.Mac installs the exact signed archive validated by release build.
 - Local smoke test:

--- a/scripts/lib/release-update-policy.ts
+++ b/scripts/lib/release-update-policy.ts
@@ -1,7 +1,14 @@
 // FILE: release-update-policy.ts
 // Purpose: Enforces the permanent compatibility hop and prepares channel manifests.
 
-import { existsSync, readFileSync, renameSync, readdirSync } from "node:fs";
+import {
+  constants,
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+} from "node:fs";
 import { resolve } from "node:path";
 
 export type ReleaseLane = "bridge" | "clean";
@@ -113,15 +120,28 @@ export function prepareReleaseUpdateManifests(
 ): readonly string[] {
   const normalizedConfig = validateReleaseUpdatePolicyConfig(config);
   const sourceNames = ["latest-mac.yml", "latest.yml", "latest-linux.yml"] as const;
+  const destinationNames = channelManifestNames(normalizedConfig.channel);
   if (normalizedConfig.lane === "bridge") {
     const missing = sourceNames.filter((name) => !existsSync(resolve(assetDirectory, name)));
     if (missing.length > 0) {
       throw new Error(`Compatibility release is missing update manifests: ${missing.join(", ")}`);
     }
-    return sourceNames;
+    const existing = destinationNames.filter((name) => existsSync(resolve(assetDirectory, name)));
+    if (existing.length > 0) {
+      throw new Error(`Refusing to overwrite existing update manifest: ${existing.join(", ")}`);
+    }
+    for (const [index, sourceName] of sourceNames.entries()) {
+      const destinationName = destinationNames[index];
+      if (!destinationName) throw new Error(`Missing channel manifest mapping for ${sourceName}.`);
+      copyFileSync(
+        resolve(assetDirectory, sourceName),
+        resolve(assetDirectory, destinationName),
+        constants.COPYFILE_EXCL,
+      );
+    }
+    return [...sourceNames, ...destinationNames];
   }
 
-  const destinationNames = channelManifestNames(normalizedConfig.channel);
   const renamed: string[] = [];
   for (const [index, sourceName] of sourceNames.entries()) {
     const sourcePath = resolve(assetDirectory, sourceName);

--- a/scripts/prepare-release-update-feed.ts
+++ b/scripts/prepare-release-update-feed.ts
@@ -1,5 +1,5 @@
 // FILE: prepare-release-update-feed.ts
-// Purpose: Renames clean-release updater metadata onto the dedicated Synara channel.
+// Purpose: Prepares default and dedicated-channel metadata for bridge and clean releases.
 
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/scripts/release-update-policy.test.ts
+++ b/scripts/release-update-policy.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -15,6 +15,7 @@ const cleanConfig: ReleaseUpdatePolicyConfig = {
   bridgeVersion: "0.4.2",
   channel: "synara",
 };
+const defaultManifestNames = ["latest-mac.yml", "latest.yml", "latest-linux.yml"] as const;
 
 describe("release update policy", () => {
   it("keeps the compatibility release latest and every clean release off latest", () => {
@@ -52,7 +53,7 @@ describe("release update policy", () => {
     const root = mkdtempSync(join(tmpdir(), "synara-release-policy-"));
     try {
       mkdirSync(root, { recursive: true });
-      for (const name of ["latest-mac.yml", "latest.yml", "latest-linux.yml"]) {
+      for (const name of defaultManifestNames) {
         writeFileSync(resolve(root, name), name);
       }
 
@@ -62,6 +63,9 @@ describe("release update policy", () => {
       for (const name of channelManifestNames("synara")) {
         expect(readFileSync(resolve(root, name), "utf8")).toContain("latest");
       }
+      for (const name of defaultManifestNames) {
+        expect(existsSync(resolve(root, name))).toBe(false);
+      }
       expect(() => prepareReleaseUpdateManifests(root, cleanConfig)).toThrow(
         "Expected 3 update manifests",
       );
@@ -70,17 +74,57 @@ describe("release update policy", () => {
     }
   });
 
-  it("leaves default metadata in place on the compatibility release", () => {
+  it("keeps default metadata and copies same-version channel placeholders on the compatibility release", () => {
     const root = mkdtempSync(join(tmpdir(), "synara-release-policy-"));
     try {
-      for (const name of ["latest-mac.yml", "latest.yml", "latest-linux.yml"]) {
-        writeFileSync(resolve(root, name), "bridge");
+      for (const name of defaultManifestNames) {
+        writeFileSync(resolve(root, name), `bridge:${name}`);
       }
       expect(prepareReleaseUpdateManifests(root, { ...cleanConfig, lane: "bridge" })).toEqual([
-        "latest-mac.yml",
-        "latest.yml",
-        "latest-linux.yml",
+        ...defaultManifestNames,
+        ...channelManifestNames("synara"),
       ]);
+      for (const [index, channelName] of channelManifestNames("synara").entries()) {
+        const defaultName = defaultManifestNames[index];
+        if (!defaultName) throw new Error(`Missing default manifest mapping for ${channelName}`);
+        expect(readFileSync(resolve(root, channelName), "utf8")).toBe(
+          readFileSync(resolve(root, defaultName), "utf8"),
+        );
+      }
+      for (const name of defaultManifestNames) {
+        expect(existsSync(resolve(root, name))).toBe(true);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to overwrite a compatibility channel placeholder", () => {
+    const root = mkdtempSync(join(tmpdir(), "synara-release-policy-"));
+    try {
+      for (const name of defaultManifestNames) {
+        writeFileSync(resolve(root, name), "bridge");
+      }
+      writeFileSync(resolve(root, "synara-mac.yml"), "existing");
+
+      expect(() => prepareReleaseUpdateManifests(root, { ...cleanConfig, lane: "bridge" })).toThrow(
+        "Refusing to overwrite existing update manifest: synara-mac.yml",
+      );
+      expect(existsSync(resolve(root, "synara.yml"))).toBe(false);
+      expect(existsSync(resolve(root, "synara-linux.yml"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a compatibility release with missing default metadata", () => {
+    const root = mkdtempSync(join(tmpdir(), "synara-release-policy-"));
+    try {
+      writeFileSync(resolve(root, "latest-mac.yml"), "bridge");
+
+      expect(() => prepareReleaseUpdateManifests(root, { ...cleanConfig, lane: "bridge" })).toThrow(
+        "Compatibility release is missing update manifests: latest.yml, latest-linux.yml",
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- publish same-version `synara*` placeholders alongside `latest*` manifests on compatibility releases
- require all six manifests before clean releases and paginate bridge asset discovery
- prevent compatibility re-publishes from rolling an already-advanced `synara` channel back
- document the bridge/clean feed behavior and cover copy, collision, and missing-manifest cases

## Root cause

Synara v0.4.2 switches `electron-updater` to the `synara` channel, while the compatibility release originally published only `latest-mac.yml`, `latest.yml`, and `latest-linux.yml`. Update checks therefore requested missing `synara*` manifests and failed with 404.

The live v0.4.2 release has already been repaired with byte-identical `synara*` copies. This PR makes future bridge publication durable and fail-closed.

## Verification

- `bun run --cwd scripts test` — 43 tests passed
- focused `oxfmt --check` on changed TypeScript files
- `git diff --check`
- release workflow parsed as YAML
- rollback guard exercised against the live v0.4.2 feed
- verified 404 is treated as first publish while non-404 GitHub failures stop publication

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release publication and updater metadata on the pinned compatibility feed; mistakes could block releases or affect desktop update checks, but behavior is fail-closed with tests.
> 
> **Overview**
> Fixes desktop auto-update **404s on the `synara` channel** after the compatibility build switched `electron-updater` away from default `latest*` manifests.
> 
> **Bridge (compatibility) releases** now **keep `latest-mac.yml` / `latest.yml` / `latest-linux.yml` and add byte-identical `synara*` copies** via `prepareReleaseUpdateManifests`, with **fail-closed** rules if channel placeholders already exist or default manifests are missing. **Clean releases** still rename build output to dedicated channel filenames only.
> 
> The **release workflow** paginates bridge release asset discovery, **requires all six** default + channel manifests before clean publishes, and adds **“Prevent compatibility channel rollback”** on bridge republish: if existing `synara*` assets advertise a **different version** than the bridge being published, publication aborts (404 on first publish is allowed).
> 
> **`docs/release.md`** and **`scripts/release-update-policy.test.ts`** document and cover the new behavior. Unrelated diffs are **formatting-only** in a few web/desktop files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1834e41fa741b916d66dc94489e490659ac7e085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->