### PR TITLE
Fix Windows Codex CLI resolution and spawning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,33 @@ jobs:
           test -f apps/desktop/dist-electron/preload.js
           grep -nE "desktopBridge|getWsUrl|PICK_FOLDER_CHANNEL|wsUrl" apps/desktop/dist-electron/preload.js
 
+  windows_process:
+    name: Windows Process Regression
+    runs-on: windows-2022
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test Windows process planning
+        run: bun run --cwd packages/shared test src/windowsProcess.test.ts
+
+      - name: Test Effect Windows process spawn
+        run: bun run --cwd apps/server test src/windowsProcessEffect.test.ts
+
   release_smoke:
     name: Release Smoke
     runs-on: ubuntu-24.04

--- a/apps/desktop/src/electronUpdaterSecurity.ts
+++ b/apps/desktop/src/electronUpdaterSecurity.ts
@@ -405,6 +405,7 @@ export function hardenElectronUpdater(
         encoding: "utf8",
         shell: prepared.shell,
         windowsHide: prepared.windowsHide,
+        windowsVerbatimArguments: prepared.windowsVerbatimArguments,
       });
       const { error, status, stdout, stderr } = response;
       if (error) {

--- a/apps/desktop/src/voiceTranscription.ts
+++ b/apps/desktop/src/voiceTranscription.ts
@@ -92,6 +92,7 @@ async function resolveDesktopVoiceAuth(
       stdio: ["pipe", "pipe", "pipe"],
       shell: prepared.shell,
       windowsHide: prepared.windowsHide,
+      windowsVerbatimArguments: prepared.windowsVerbatimArguments,
     });
 
     let settled = false;

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -579,6 +579,7 @@ function spawnCodexAppServer(input: {
     stdio: ["pipe", "pipe", "pipe"],
     shell: prepared.shell,
     windowsHide: prepared.windowsHide,
+    windowsVerbatimArguments: prepared.windowsVerbatimArguments,
   });
 }
 
@@ -3397,6 +3398,7 @@ function assertSupportedCodexCliVersion(input: {
     timeout: CODEX_VERSION_CHECK_TIMEOUT_MS,
     maxBuffer: 1024 * 1024,
     windowsHide: prepared.windowsHide,
+    windowsVerbatimArguments: prepared.windowsVerbatimArguments,
   });
 
   if (result.error) {

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -327,6 +327,7 @@ const makeCodexTextGeneration = Effect.gen(function* () {
           cwd,
           env,
           shell: prepared.shell,
+          ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
           stdin: {
             stream: Stream.make(new TextEncoder().encode(prompt)),
           },

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -539,6 +539,7 @@ export const launchDetached = (launch: EditorLaunch) =>
           stdio: "ignore",
           shell: prepared.shell,
           windowsHide: prepared.windowsHide,
+          windowsVerbatimArguments: prepared.windowsVerbatimArguments,
         });
       } catch (error) {
         return resume(

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -143,6 +143,7 @@ export async function runProcess(
       stdio: "pipe",
       shell: prepared.shell,
       windowsHide: prepared.windowsHide,
+      windowsVerbatimArguments: prepared.windowsVerbatimArguments,
     });
 
     let stdout = "";

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -1492,6 +1492,7 @@ export function makeCursorAdapter(
         const child = yield* childProcessSpawner.spawn(
           ChildProcess.make(prepared.command, prepared.args, {
             shell: prepared.shell,
+            ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
             env,
           }),
         );

--- a/apps/server/src/provider/Layers/GeminiAdapter.ts
+++ b/apps/server/src/provider/Layers/GeminiAdapter.ts
@@ -797,6 +797,7 @@ const makeGeminiAdapter = Effect.fn("makeGeminiAdapter")(function* (
           stdio: ["pipe", "pipe", "pipe"],
           shell: prepared.shell,
           windowsHide: prepared.windowsHide,
+          windowsVerbatimArguments: prepared.windowsVerbatimArguments,
         });
       },
       catch: (cause) =>

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -2318,6 +2318,7 @@ export function makeGrokAdapter(
           const child = yield* childProcessSpawner.spawn(
             ChildProcess.make(prepared.command, prepared.args, {
               shell: prepared.shell,
+              ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
               env: process.env,
             }),
           );

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -5,6 +5,7 @@ import { describe, it, assert } from "@effect/vitest";
 import { Effect, FileSystem, Layer, Path, Sink, Stream } from "effect";
 import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
+import { vi } from "vitest";
 
 import { SYNARA_CODEX_HOME_OVERLAY_DIR } from "../../codexHomePaths";
 import { ServerConfig } from "../../config";
@@ -63,6 +64,12 @@ function mockSpawnerLayer(
     args: ReadonlyArray<string>,
     command: string,
     env: NodeJS.ProcessEnv | undefined,
+    options:
+      | {
+          readonly env?: NodeJS.ProcessEnv;
+          readonly windowsVerbatimArguments?: boolean;
+        }
+      | undefined,
   ) => {
     stdout: string;
     stderr: string;
@@ -75,9 +82,14 @@ function mockSpawnerLayer(
       const cmd = command as unknown as {
         command: string;
         args: ReadonlyArray<string>;
-        options?: { env?: NodeJS.ProcessEnv };
+        options?: {
+          env?: NodeJS.ProcessEnv;
+          windowsVerbatimArguments?: boolean;
+        };
       };
-      return Effect.succeed(mockHandle(handler(cmd.args, cmd.command, cmd.options?.env)));
+      return Effect.succeed(
+        mockHandle(handler(cmd.args, cmd.command, cmd.options?.env, cmd.options)),
+      );
     }),
   );
 }
@@ -630,6 +642,31 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
         ),
       ),
     );
+
+    it.effect("propagates verbatim Windows arguments through the Effect command", () => {
+      const platform = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      return Effect.gen(function* () {
+        yield* withTempCodexHome();
+        const status = yield* makeCheckCodexProviderStatus("C:\\tools(x86)\\codex.cmd");
+        assert.strictEqual(status.status, "ready");
+      }).pipe(
+        Effect.provide(
+          mockSpawnerLayer((args, command, _env, options) => {
+            assert.strictEqual(command, "C:\\Windows\\System32\\cmd.exe");
+            assert.strictEqual(options?.windowsVerbatimArguments, true);
+            const commandLine = args.at(-1) ?? "";
+            if (commandLine.includes('"--version"')) {
+              return { stdout: "codex 1.0.0\n", stderr: "", code: 0 };
+            }
+            if (commandLine.includes('"login" "status"')) {
+              return { stdout: "Logged in\n", stderr: "", code: 0 };
+            }
+            throw new Error(`Unexpected args: ${args.join(" ")}`);
+          }),
+        ),
+        Effect.ensuring(Effect.sync(() => platform.mockRestore())),
+      );
+    });
 
     it.effect("uses configured codex home for version, config, and auth probes", () => {
       let sawLoginStatusProbe = false;

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -604,6 +604,7 @@ const runProviderCommand = (
     const prepared = prepareWindowsSafeProcess(executable, args, { env });
     const command = ChildProcess.make(prepared.command, prepared.args, {
       shell: prepared.shell,
+      ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
       env,
     });
 
@@ -2334,6 +2335,7 @@ export const ProviderHealthLive = Layer.effect(
       const child = yield* spawner.spawn(
         ChildProcess.make(prepared.command, prepared.args, {
           shell: prepared.shell,
+          ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
           env: process.env,
         }),
       );

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -242,6 +242,7 @@ const makeAcpSessionRuntime = (
           ...(options.spawn.cwd ? { cwd: options.spawn.cwd } : {}),
           env,
           shell: prepared.shell,
+          ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
         }),
       )
       .pipe(

--- a/apps/server/src/provider/geminiAcpProbe.ts
+++ b/apps/server/src/provider/geminiAcpProbe.ts
@@ -250,6 +250,7 @@ export const probeGeminiCapabilities = (input: {
           env,
           shell: prepared.shell,
           windowsHide: prepared.windowsHide,
+          windowsVerbatimArguments: prepared.windowsVerbatimArguments,
           stdio: ["pipe", "pipe", "pipe"],
         });
 

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -840,6 +840,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       const child = yield* spawner.spawn(
         ChildProcess.make(prepared.command, prepared.args, {
           shell: prepared.shell,
+          ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
           ...(input.cwd ? { cwd: input.cwd } : {}),
           env: process.env,
         }),

--- a/apps/server/src/windowsProcessEffect.test.ts
+++ b/apps/server/src/windowsProcessEffect.test.ts
@@ -1,0 +1,70 @@
+// FILE: windowsProcessEffect.test.ts
+// Purpose: Verifies Effect forwards verbatim Windows command lines to Node spawn.
+// Layer: Server process integration test
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as Path from "node:path";
+
+import { Effect } from "effect";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { expect, it } from "vitest";
+
+it.runIf(process.platform === "win32")(
+  "forwards encoded Codex arguments verbatim through the Effect Node spawner",
+  async () => {
+    const root = mkdtempSync(Path.join(tmpdir(), "synara-effect-windows-process-"));
+    const commandDir = Path.join(root, "tools(x86)");
+    const scriptPath = Path.join(commandDir, "capture.mjs");
+    const commandPath = Path.join(commandDir, "codex.cmd");
+    const outputPath = Path.join(root, "args.json");
+    const expectedArgs = [
+      "exec",
+      "--config",
+      'approval_policy="never"',
+      "--config",
+      'model_reasoning_effort="high"',
+    ];
+
+    try {
+      mkdirSync(commandDir);
+      writeFileSync(
+        scriptPath,
+        [
+          'import { writeFileSync } from "node:fs";',
+          "writeFileSync(process.env.SYNARA_CAPTURE_PATH, JSON.stringify(process.argv.slice(2)));",
+          "",
+        ].join("\n"),
+      );
+      writeFileSync(commandPath, `@echo off\r\n"${process.execPath}" "%~dp0capture.mjs" %*\r\n`);
+
+      const env = { ...process.env, SYNARA_CAPTURE_PATH: outputPath };
+      const prepared = prepareWindowsSafeProcess(commandPath, expectedArgs, {
+        platform: "win32",
+        env,
+      });
+      const options = {
+        env,
+        shell: prepared.shell,
+        ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
+      };
+
+      const exitCode = await Effect.runPromise(
+        Effect.gen(function* () {
+          const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+          const child = yield* spawner.spawn(
+            ChildProcess.make(prepared.command, prepared.args, options),
+          );
+          return yield* child.exitCode;
+        }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+      );
+
+      expect(Number(exitCode)).toBe(0);
+      expect(JSON.parse(readFileSync(outputPath, "utf8"))).toEqual(expectedArgs);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  },
+);

--- a/bun.lock
+++ b/bun.lock
@@ -212,6 +212,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@effect/platform-node-shared@https://pkg.pr.new/Effect-TS/effect-smol/@effect/platform-node-shared@8881a9b606d84a6f5eb6615279138322984f5368": "patches/@effect%2Fplatform-node-shared@8881a9b.patch",
+  },
   "overrides": {
     "vite": "^8.0.0",
   },

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     "workerDirectory": [
       "apps/web/public"
     ]
+  },
+  "patchedDependencies": {
+    "@effect/platform-node-shared@https://pkg.pr.new/Effect-TS/effect-smol/@effect/platform-node-shared@8881a9b606d84a6f5eb6615279138322984f5368": "patches/@effect%2Fplatform-node-shared@8881a9b.patch"
   }
 }

--- a/packages/shared/src/windowsProcess.test.ts
+++ b/packages/shared/src/windowsProcess.test.ts
@@ -2,6 +2,11 @@
 // Purpose: Verifies Windows process preparation avoids Node shell-mode deprecations.
 // Layer: Shared Node runtime utility tests
 
+import { spawnSync as spawnChildSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as Path from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -194,9 +199,7 @@ describe("windowsProcess", () => {
         "/s",
         "/v:off",
         "/c",
-        "call",
-        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
-        "app-server",
+        'call "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
       ],
       shell: false,
       windowsHide: true,
@@ -226,9 +229,7 @@ describe("windowsProcess", () => {
         "/s",
         "/v:off",
         "/c",
-        "call",
-        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
-        "app-server",
+        'call "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
       ],
       shell: false,
       windowsHide: true,
@@ -248,14 +249,20 @@ describe("windowsProcess", () => {
       }),
     ).toEqual({
       command: "C:\\Windows\\System32\\cmd.exe",
-      args: ["/d", "/s", "/v:off", "/c", "call", customPath, "app-server"],
+      args: [
+        "/d",
+        "/s",
+        "/v:off",
+        "/c",
+        'call "C:\\Users\\Test User\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
+      ],
       shell: false,
       windowsHide: true,
     });
     expect(spawnSync).not.toHaveBeenCalled();
   });
 
-  it("passes batch commands and arguments separately to cmd.exe call", () => {
+  it("encodes one cmd.exe command line with quoted command and argument tokens", () => {
     expect(
       buildWindowsBatchCommandArgs("C:\\Users\\Test User\\npm\\tool.cmd", [
         "path with spaces",
@@ -266,10 +273,25 @@ describe("windowsProcess", () => {
       "/s",
       "/v:off",
       "/c",
-      "call",
-      "C:\\Users\\Test User\\npm\\tool.cmd",
-      "path with spaces",
-      "flag=value",
+      'call "C:\\Users\\Test User\\npm\\tool.cmd" "path with spaces" "flag=value"',
+    ]);
+  });
+
+  it("preserves literal quotes in existing Codex config arguments", () => {
+    expect(
+      buildWindowsBatchCommandArgs("C:\\tools\\codex.cmd", [
+        "exec",
+        "--config",
+        'approval_policy="never"',
+        "--config",
+        'model_reasoning_effort="high"',
+      ]),
+    ).toEqual([
+      "/d",
+      "/s",
+      "/v:off",
+      "/c",
+      'call "C:\\tools\\codex.cmd" "exec" "--config" "approval_policy=^"never^"" "--config" "model_reasoning_effort=^"high^""',
     ]);
   });
 
@@ -290,11 +312,58 @@ describe("windowsProcess", () => {
       "/s",
       "/v:off",
       "/c",
-      "call",
-      "C:\\Program Files (x86)\\Tool\\tool.cmd",
-      "--version",
+      'call "C:\\Program Files (x86)\\Tool\\tool.cmd" "--version"',
     ]);
   });
+
+  it("quotes batch paths containing parentheses even without spaces", () => {
+    expect(buildWindowsBatchCommandArgs("C:\\tools(x86)\\codex.cmd", ["--version"])).toEqual([
+      "/d",
+      "/s",
+      "/v:off",
+      "/c",
+      'call "C:\\tools(x86)\\codex.cmd" "--version"',
+    ]);
+  });
+
+  it.runIf(process.platform === "win32")(
+    "preserves quoted Codex arguments through a real cmd.exe batch launch",
+    () => {
+      const root = mkdtempSync(Path.join(tmpdir(), "synara-windows-process-"));
+      const commandDir = Path.join(root, "tools(x86)");
+      const scriptPath = Path.join(commandDir, "capture.mjs");
+      const commandPath = Path.join(commandDir, "codex.cmd");
+      const expectedArgs = [
+        "exec",
+        "--config",
+        'approval_policy="never"',
+        "--config",
+        'model_reasoning_effort="high"',
+      ];
+
+      try {
+        mkdirSync(commandDir);
+        writeFileSync(scriptPath, "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n");
+        writeFileSync(commandPath, `@echo off\r\n"${process.execPath}" "%~dp0capture.mjs" %*\r\n`);
+
+        const prepared = prepareWindowsSafeProcess(commandPath, expectedArgs, {
+          platform: "win32",
+          env: process.env,
+        });
+        const result = spawnChildSync(prepared.command, prepared.args, {
+          encoding: "utf8",
+          shell: false,
+          windowsHide: true,
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(0);
+        expect(JSON.parse(result.stdout)).toEqual(expectedArgs);
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    },
+  );
 
   it("rejects batch tokens with line breaks", () => {
     expect(() => buildWindowsBatchCommandArgs("C:\\tools\\codex.cmd", ["line\nbreak"])).toThrow(

--- a/packages/shared/src/windowsProcess.test.ts
+++ b/packages/shared/src/windowsProcess.test.ts
@@ -46,10 +46,49 @@ describe("windowsProcess", () => {
     );
   });
 
+  it("prefers .cmd over extensionless npm shims from where.exe", () => {
+    const spawnSync = vi.fn(() => ({
+      stdout: [
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+      ].join("\r\n"),
+      status: 0,
+    }));
+
+    expect(
+      resolveWindowsCommandPath("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toBe("C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd");
+  });
+
   it("skips current-directory command hits from where.exe", () => {
     const spawnSync = vi.fn(() => ({
       stdout: [
         "C:\\projects\\synara\\codex.cmd",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+      ].join("\r\n"),
+      status: 0,
+    }));
+
+    expect(
+      resolveWindowsCommandPath("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toBe("C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd");
+  });
+
+  it("filters current-directory hits before preferring spawn-safe candidates", () => {
+    const spawnSync = vi.fn(() => ({
+      stdout: [
+        "C:\\projects\\synara\\codex.cmd",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
         "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
       ].join("\r\n"),
       status: 0,
@@ -91,7 +130,10 @@ describe("windowsProcess", () => {
 
   it("resolves extensionless path-like Windows shims before spawning", () => {
     const spawnSync = vi.fn(() => ({
-      stdout: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd\r\n",
+      stdout: [
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+      ].join("\r\n"),
       status: 0,
     }));
 
@@ -152,7 +194,9 @@ describe("windowsProcess", () => {
         "/s",
         "/v:off",
         "/c",
-        '"C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
+        "call",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+        "app-server",
       ],
       shell: false,
       windowsHide: true,
@@ -161,7 +205,10 @@ describe("windowsProcess", () => {
 
   it("wraps resolved extensionless path-like shims through cmd.exe", () => {
     const spawnSync = vi.fn(() => ({
-      stdout: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd\r\n",
+      stdout: [
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+      ].join("\r\n"),
       status: 0,
     }));
 
@@ -179,14 +226,16 @@ describe("windowsProcess", () => {
         "/s",
         "/v:off",
         "/c",
-        '"C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
+        "call",
+        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+        "app-server",
       ],
       shell: false,
       windowsHide: true,
     });
   });
 
-  it("quotes batch commands and arguments in a single cmd.exe command line", () => {
+  it("passes batch commands and arguments separately to cmd.exe call", () => {
     expect(
       buildWindowsBatchCommandArgs("C:\\Users\\Test User\\npm\\tool.cmd", [
         "path with spaces",
@@ -197,24 +246,33 @@ describe("windowsProcess", () => {
       "/s",
       "/v:off",
       "/c",
-      '"C:\\Users\\Test User\\npm\\tool.cmd" "path with spaces" "flag=value"',
+      "call",
+      "C:\\Users\\Test User\\npm\\tool.cmd",
+      "path with spaces",
+      "flag=value",
     ]);
   });
 
-  it("escapes batch arguments that cmd.exe can expand or reinterpret", () => {
+  it("rejects batch tokens with cmd.exe control characters", () => {
+    expect(() => buildWindowsBatchCommandArgs("C:\\tools\\bad%path\\codex.cmd", [])).toThrow(
+      /Cannot safely execute Windows batch command/,
+    );
+    expect(() => buildWindowsBatchCommandArgs("C:\\tools\\codex.cmd", ["one&two"])).toThrow(
+      /Cannot safely execute Windows batch argument/,
+    );
+  });
+
+  it("allows batch paths with spaces and parentheses", () => {
     expect(
-      buildWindowsBatchCommandArgs("C:\\tools\\bad%path\\codex.cmd", [
-        "%PATH%",
-        'approval_policy="never"',
-        "one&two",
-        "bang!value",
-      ]),
+      buildWindowsBatchCommandArgs("C:\\Program Files (x86)\\Tool\\tool.cmd", ["--version"]),
     ).toEqual([
       "/d",
       "/s",
       "/v:off",
       "/c",
-      '"C:\\tools\\bad%%path\\codex.cmd" "%%PATH%%" "approval_policy=^"never^"" "one^&two" "bang^!value"',
+      "call",
+      "C:\\Program Files (x86)\\Tool\\tool.cmd",
+      "--version",
     ]);
   });
 
@@ -243,6 +301,29 @@ describe("windowsProcess", () => {
       shell: false,
       windowsHide: true,
     });
+  });
+
+  it("keeps a configured native Codex executable path intact", () => {
+    const spawnSync = vi.fn();
+
+    expect(
+      prepareWindowsSafeProcess(
+        "C:\\Users\\test\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.exe",
+        ["app-server"],
+        {
+          platform: "win32",
+          cwd: "C:\\projects\\synara",
+          env: { SystemRoot: "C:\\Windows" },
+          spawnSync,
+        },
+      ),
+    ).toEqual({
+      command: "C:\\Users\\test\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.exe",
+      args: ["app-server"],
+      shell: false,
+      windowsHide: true,
+    });
+    expect(spawnSync).not.toHaveBeenCalled();
   });
 
   it("resolves ComSpec from environment before falling back", () => {

--- a/packages/shared/src/windowsProcess.test.ts
+++ b/packages/shared/src/windowsProcess.test.ts
@@ -203,6 +203,7 @@ describe("windowsProcess", () => {
       ],
       shell: false,
       windowsHide: true,
+      windowsVerbatimArguments: true,
     });
   });
 
@@ -233,6 +234,7 @@ describe("windowsProcess", () => {
       ],
       shell: false,
       windowsHide: true,
+      windowsVerbatimArguments: true,
     });
   });
 
@@ -258,6 +260,7 @@ describe("windowsProcess", () => {
       ],
       shell: false,
       windowsHide: true,
+      windowsVerbatimArguments: true,
     });
     expect(spawnSync).not.toHaveBeenCalled();
   });
@@ -354,6 +357,7 @@ describe("windowsProcess", () => {
           encoding: "utf8",
           shell: false,
           windowsHide: true,
+          windowsVerbatimArguments: prepared.windowsVerbatimArguments,
         });
 
         expect(result.error).toBeUndefined();

--- a/packages/shared/src/windowsProcess.test.ts
+++ b/packages/shared/src/windowsProcess.test.ts
@@ -235,6 +235,26 @@ describe("windowsProcess", () => {
     });
   });
 
+  it("wraps a configured .cmd Codex path without truncating it", () => {
+    const spawnSync = vi.fn();
+    const customPath = "C:\\Users\\Test User\\AppData\\Roaming\\npm\\codex.cmd";
+
+    expect(
+      prepareWindowsSafeProcess(customPath, ["app-server"], {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { ComSpec: "C:\\Windows\\System32\\cmd.exe", SystemRoot: "C:\\Windows" },
+        spawnSync,
+      }),
+    ).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/v:off", "/c", "call", customPath, "app-server"],
+      shell: false,
+      windowsHide: true,
+    });
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
   it("passes batch commands and arguments separately to cmd.exe call", () => {
     expect(
       buildWindowsBatchCommandArgs("C:\\Users\\Test User\\npm\\tool.cmd", [

--- a/packages/shared/src/windowsProcess.test.ts
+++ b/packages/shared/src/windowsProcess.test.ts
@@ -294,7 +294,7 @@ describe("windowsProcess", () => {
       "/s",
       "/v:off",
       "/c",
-      'call "C:\\tools\\codex.cmd" "exec" "--config" "approval_policy=^"never^"" "--config" "model_reasoning_effort=^"high^""',
+      'call "C:\\tools\\codex.cmd" "exec" "--config" "approval_policy=""never""" "--config" "model_reasoning_effort=""high"""',
     ]);
   });
 

--- a/packages/shared/src/windowsProcess.ts
+++ b/packages/shared/src/windowsProcess.ts
@@ -65,28 +65,28 @@ export function isWindowsBatchCommand(command: string): boolean {
   return WINDOWS_BATCH_EXTENSION_PATTERN.test(command);
 }
 
-function validateWindowsBatchToken(token: string, label: string): string {
+function quoteWindowsBatchToken(token: string, label: string): string {
   if (WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN.test(token)) {
     throw new Error(
       `Cannot safely execute Windows batch ${label} containing cmd.exe control characters.`,
     );
   }
-  return token;
+  return `"${token.replaceAll('"', '^"')}"`;
 }
 
 export function buildWindowsBatchCommandArgs(
   command: string,
   args: ReadonlyArray<string>,
 ): string[] {
-  return [
-    "/d",
-    "/s",
-    "/v:off",
-    "/c",
+  // Keep cmd.exe's semantic command line together so quote-bearing arguments
+  // are encoded for cmd instead of independently escaped as C-runtime argv.
+  // The call prefix also keeps /s from stripping the executable's outer quotes.
+  const commandLine = [
     "call",
-    validateWindowsBatchToken(command, "command"),
-    ...args.map((arg) => validateWindowsBatchToken(arg, "argument")),
-  ];
+    quoteWindowsBatchToken(command, "command"),
+    ...args.map((arg) => quoteWindowsBatchToken(arg, "argument")),
+  ].join(" ");
+  return ["/d", "/s", "/v:off", "/c", commandLine];
 }
 
 function isPathLikeCommand(command: string): boolean {

--- a/packages/shared/src/windowsProcess.ts
+++ b/packages/shared/src/windowsProcess.ts
@@ -35,9 +35,9 @@ export interface WindowsSafeProcessCommand {
 }
 
 const WINDOWS_BATCH_EXTENSION_PATTERN = /\.(?:cmd|bat)$/i;
+const WINDOWS_SPAWN_SAFE_EXTENSION_PATTERN = /\.(?:exe|com|cmd|bat)$/i;
 const WINDOWS_PATH_SEPARATOR_PATTERN = /[\\/]/;
-const WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN = /[\r\n]/;
-const WINDOWS_BATCH_CARET_ESCAPE_PATTERN = /[&|<>()^"!]/g;
+const WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN = /[\r\n&|<>^%]/;
 const WHERE_TIMEOUT_MS = 2_000;
 
 function trimNonEmpty(value: string | null | undefined): string | null {
@@ -67,23 +67,26 @@ export function isWindowsBatchCommand(command: string): boolean {
 
 function quoteWindowsBatchToken(token: string, label: string): string {
   if (WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN.test(token)) {
-    throw new Error(`Cannot safely execute Windows batch ${label} containing line breaks.`);
+    throw new Error(
+      `Cannot safely execute Windows batch ${label} containing cmd.exe control characters.`,
+    );
   }
-  const escaped = token
-    .replace(/%/g, "%%")
-    .replace(WINDOWS_BATCH_CARET_ESCAPE_PATTERN, (match) => `^${match}`);
-  return `"${escaped}"`;
+  return token;
 }
 
 export function buildWindowsBatchCommandArgs(
   command: string,
   args: ReadonlyArray<string>,
 ): string[] {
-  const commandLine = [
+  return [
+    "/d",
+    "/s",
+    "/v:off",
+    "/c",
+    "call",
     quoteWindowsBatchToken(command, "command"),
     ...args.map((arg) => quoteWindowsBatchToken(arg, "argument")),
-  ].join(" ");
-  return ["/d", "/s", "/v:off", "/c", commandLine];
+  ];
 }
 
 function isPathLikeCommand(command: string): boolean {
@@ -103,9 +106,25 @@ function isFromCurrentDirectory(candidate: string, cwd: string | undefined): boo
   return candidateDir === currentDir;
 }
 
+function isWindowsSpawnSafeResolvedCommand(command: string): boolean {
+  return WINDOWS_SPAWN_SAFE_EXTENSION_PATTERN.test(command);
+}
+
+function selectWindowsCommandCandidate(
+  candidates: ReadonlyArray<string>,
+  cwd: string | undefined,
+  pathLikeCommand: boolean,
+): string | undefined {
+  const allowedCandidates = pathLikeCommand
+    ? candidates
+    : candidates.filter((candidate) => !isFromCurrentDirectory(candidate, cwd));
+  return allowedCandidates.find(isWindowsSpawnSafeResolvedCommand) ?? allowedCandidates[0];
+}
+
 // Resolve PATH/PATHEXT commands through where.exe so `.cmd` shims can be wrapped
-// explicitly. We skip current-directory hits to avoid restoring shell-style CWD
-// command hijacking.
+// explicitly. Prefer candidates that native spawn can execute or that we can
+// wrap, and skip current-directory hits for PATH commands to avoid restoring
+// shell-style CWD command hijacking.
 export function resolveWindowsCommandPath(
   command: string,
   input: WindowsSafeProcessInput = {},
@@ -135,10 +154,7 @@ export function resolveWindowsCommandPath(
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
-  if (pathLikeCommand) {
-    return candidates[0] ?? command;
-  }
-  return candidates.find((candidate) => !isFromCurrentDirectory(candidate, cwd)) ?? command;
+  return selectWindowsCommandCandidate(candidates, cwd, pathLikeCommand) ?? command;
 }
 
 export function prepareWindowsSafeProcess(

--- a/packages/shared/src/windowsProcess.ts
+++ b/packages/shared/src/windowsProcess.ts
@@ -65,7 +65,7 @@ export function isWindowsBatchCommand(command: string): boolean {
   return WINDOWS_BATCH_EXTENSION_PATTERN.test(command);
 }
 
-function quoteWindowsBatchToken(token: string, label: string): string {
+function validateWindowsBatchToken(token: string, label: string): string {
   if (WINDOWS_BATCH_UNSAFE_TOKEN_PATTERN.test(token)) {
     throw new Error(
       `Cannot safely execute Windows batch ${label} containing cmd.exe control characters.`,
@@ -84,8 +84,8 @@ export function buildWindowsBatchCommandArgs(
     "/v:off",
     "/c",
     "call",
-    quoteWindowsBatchToken(command, "command"),
-    ...args.map((arg) => quoteWindowsBatchToken(arg, "argument")),
+    validateWindowsBatchToken(command, "command"),
+    ...args.map((arg) => validateWindowsBatchToken(arg, "argument")),
   ];
 }
 

--- a/packages/shared/src/windowsProcess.ts
+++ b/packages/shared/src/windowsProcess.ts
@@ -32,6 +32,7 @@ export interface WindowsSafeProcessCommand {
   readonly args: string[];
   readonly shell: false;
   readonly windowsHide?: true;
+  readonly windowsVerbatimArguments?: true;
 }
 
 const WINDOWS_BATCH_EXTENSION_PATTERN = /\.(?:cmd|bat)$/i;
@@ -183,5 +184,6 @@ export function prepareWindowsSafeProcess(
     args: buildWindowsBatchCommandArgs(resolvedCommand, args),
     shell: false,
     windowsHide: true,
+    windowsVerbatimArguments: true,
   };
 }

--- a/packages/shared/src/windowsProcess.ts
+++ b/packages/shared/src/windowsProcess.ts
@@ -72,7 +72,7 @@ function quoteWindowsBatchToken(token: string, label: string): string {
       `Cannot safely execute Windows batch ${label} containing cmd.exe control characters.`,
     );
   }
-  return `"${token.replaceAll('"', '^"')}"`;
+  return `"${token.replaceAll('"', '""')}"`;
 }
 
 export function buildWindowsBatchCommandArgs(

--- a/patches/@effect%2Fplatform-node-shared@8881a9b.patch
+++ b/patches/@effect%2Fplatform-node-shared@8881a9b.patch
@@ -1,0 +1,32 @@
+diff --git a/dist/NodeChildProcessSpawner.js b/dist/NodeChildProcessSpawner.js
+index ff15212e4..e7cf12c4d 100644
+--- a/dist/NodeChildProcessSpawner.js
++++ b/dist/NodeChildProcessSpawner.js
+@@ -314,7 +314,8 @@ const make = /*#__PURE__*/Effect.gen(function* () {
+             env,
+             stdio,
+             detached: cmd.options.detached ?? process.platform !== "win32",
+-            shell: cmd.options.shell
++            shell: cmd.options.shell,
++            windowsVerbatimArguments: cmd.options.windowsVerbatimArguments
+           }), Effect.fnUntraced(function* ([childProcess, exitSignal]) {
+             const exited = yield* Deferred.isDone(exitSignal);
+             const killWithTimeout = withTimeout(childProcess, cmd, cmd.options);
+diff --git a/src/NodeChildProcessSpawner.ts b/src/NodeChildProcessSpawner.ts
+index dc53bafb7..fe867fbfc 100644
+--- a/src/NodeChildProcessSpawner.ts
++++ b/src/NodeChildProcessSpawner.ts
+@@ -430,7 +430,12 @@ const make = Effect.gen(function*() {
+             env,
+             stdio,
+             detached: cmd.options.detached ?? process.platform !== "win32",
+-            shell: cmd.options.shell
++            shell: cmd.options.shell,
++            windowsVerbatimArguments: (
++              cmd.options as ChildProcess.CommandOptions & {
++                readonly windowsVerbatimArguments?: boolean | undefined
++              }
++            ).windowsVerbatimArguments
+           }),
+           Effect.fnUntraced(function*([childProcess, exitSignal]) {
+             const exited = yield* Deferred.isDone(exitSignal)

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -42,6 +42,7 @@ function copyWorkspaceManifestFixture(targetRoot: string): void {
     mkdirSync(dirname(destinationPath), { recursive: true });
     cpSync(sourcePath, destinationPath);
   }
+  cpSync(resolve(repoRoot, "patches"), resolve(targetRoot, "patches"), { recursive: true });
 }
 
 function writeMacManifestFixtures(targetRoot: string): { arm64Path: string; x64Path: string } {


### PR DESCRIPTION
## Problem

On Windows, an installed and authenticated Codex CLI could still appear unavailable or fail to launch. `where.exe` can return an extensionless npm shim before `codex.cmd`, configured batch paths could be misparsed by `cmd.exe`, and quote-bearing Codex arguments could be changed by Node's default Windows argv serialization.

## Root cause

- Windows command resolution selected the first `where.exe` result even when it was not directly spawnable.
- Batch commands were not planned as one deliberately encoded `cmd.exe` command line.
- The encoded command line was not consistently passed with `windowsVerbatimArguments`, including through Effect's Node child-process spawner.
- The real Windows batch regression was not exercised by blocking CI.

## Solution

- Prefer spawn-safe `.exe`, `.com`, `.cmd`, and `.bat` candidates while preserving current-directory hijack filtering.
- Keep native executables and non-Windows launches direct and shell-free.
- Quote and encode Windows batch commands and arguments as one `cmd.exe /c` payload, rejecting unsafe control characters.
- Propagate `windowsVerbatimArguments: true` through every Node and Effect consumer, with a tracked patch for the pinned Effect Node spawner.
- Add focused unit and real Windows integration coverage, plus a blocking `windows-2022` CI job.

## Validation

- Shared Windows process tests: 21 passed locally; 1 Windows-only runtime test is exercised by the new CI job.
- Focused server tests: 169 passed, 3 platform/live skips.
- Focused desktop tests: 8 passed.
- Shared, server, and desktop typechecks passed.
- Targeted lint passed with no errors.
- Frozen dependency installation and tracked Effect patch application verified.
- `git diff --check` passed.

PR #312 was inspected as technical context only. This branch and implementation were produced independently from the current `main` base.

Fixes #288

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all Windows child-process launches for Codex and related CLIs; incorrect quoting or verbatim handling could break provider health, spawning, or updates on Windows, though coverage is expanded on win32 CI.
> 
> **Overview**
> Fixes Windows cases where Codex could look missing or launch with mangled arguments when npm shims, `.cmd` paths, or quote-heavy `--config` flags are involved.
> 
> **`prepareWindowsSafeProcess`** now prefers spawn-safe `where.exe` hits (e.g. `.cmd` over extensionless shims), builds batch launches as a single `cmd.exe /c call "…"` line with cmd-oriented quoting, sets **`windowsVerbatimArguments: true`** for those wraps, and rejects unsafe cmd control characters instead of caret-escaping.
> 
> That flag is threaded through **Node `spawn`/`spawnSync`** (desktop updater/voice, server Codex app-server, providers, git text generation, etc.) and **Effect `ChildProcess`** paths, via a **patched `@effect/platform-node-shared`** so the Node spawner forwards the option.
> 
> **CI** adds a blocking **`windows-2022`** job for shared Windows process tests and a real Effect spawn integration test; release smoke copies **`patches`** with the workspace fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99281a659539460377101182af99af2a00d054a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->