### PR TITLE
fix: preserve chat history when undoing file changes

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -263,6 +263,7 @@ describe("CheckpointReactor", () => {
     readonly threadWorktreePath?: string | null;
     readonly providerSessionCwd?: string;
     readonly providerName?: ProviderKind;
+    readonly startReactor?: boolean;
   }) {
     const cwd = createGitRepository();
     tempDirs.push(cwd);
@@ -299,7 +300,10 @@ describe("CheckpointReactor", () => {
     const reactor = await runtime.runPromise(Effect.service(CheckpointReactor));
     const checkpointStore = await runtime.runPromise(Effect.service(CheckpointStore));
     scope = await Effect.runPromise(Scope.make("sequential"));
-    await Effect.runPromise(reactor.start.pipe(Scope.provide(scope)));
+    const startReactor = () => Effect.runPromise(reactor.start.pipe(Scope.provide(scope!)));
+    if (options?.startReactor ?? true) {
+      await startReactor();
+    }
     const drain = () => Effect.runPromise(reactor.drain);
 
     const createdAt = new Date().toISOString();
@@ -364,6 +368,7 @@ describe("CheckpointReactor", () => {
       provider,
       cwd,
       drain,
+      startReactor,
     };
   }
 
@@ -1763,5 +1768,74 @@ describe("CheckpointReactor", () => {
       true,
     );
     expect(harness.provider.rollbackConversation).not.toHaveBeenCalled();
+  });
+
+  it("emits a correlated failure when file restore has no active session", async () => {
+    const harness = await createHarness({ hasSession: false });
+    const createdAt = new Date().toISOString();
+    const requestCommandId = CommandId.makeUnsafe("cmd-files-restore-no-session");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: requestCommandId,
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        messageId: MessageId.makeUnsafe("message-files-restore-no-session"),
+        turnCount: 0,
+        createdAt,
+      }),
+    );
+
+    const events = await waitForEvent(
+      harness.engine,
+      (event) =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === requestCommandId,
+    );
+    const failure = events.find((event) => event.type === "thread.checkpoint-files-restore-failed");
+    expect(failure?.payload.detail).toContain("No active provider session");
+    expect(harness.provider.rollbackConversation).not.toHaveBeenCalled();
+  });
+
+  it("does not replay an ambiguous persisted file restore when the reactor starts", async () => {
+    const harness = await createHarness({ startReactor: false });
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const messageId = MessageId.makeUnsafe("message-persisted-restore");
+    runGit(harness.cwd, [
+      "update-ref",
+      checkpointRefForThreadMessageStart(threadId, messageId),
+      "HEAD",
+    ]);
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "newer unconfirmed work\n", "utf8");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: CommandId.makeUnsafe("cmd-persisted-files-restore"),
+        threadId,
+        messageId,
+        turnCount: 0,
+        createdAt,
+      }),
+    );
+    await harness.startReactor();
+    await harness.drain();
+
+    expect(fs.readFileSync(path.join(harness.cwd, "README.md"), "utf8")).toBe(
+      "newer unconfirmed work\n",
+    );
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.type === "thread.checkpoint-files-restored" ||
+          event.type === "thread.checkpoint-files-restore-failed",
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -3,7 +3,12 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 
-import type { ProviderKind, ProviderRuntimeEvent, ProviderSession } from "@synara/contracts";
+import type {
+  OrchestrationEvent,
+  ProviderKind,
+  ProviderRuntimeEvent,
+  ProviderSession,
+} from "@synara/contracts";
 import {
   CheckpointRef,
   CommandId,
@@ -159,7 +164,7 @@ async function waitForThread(
 
 async function waitForEvent(
   engine: OrchestrationEngineShape,
-  predicate: (event: { type: string }) => boolean,
+  predicate: (event: OrchestrationEvent) => boolean,
   timeoutMs = 30_000,
 ) {
   const deadline = Date.now() + timeoutMs;
@@ -1406,6 +1411,107 @@ describe("CheckpointReactor", () => {
     expect(
       gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 2)),
     ).toBe(false);
+  });
+
+  it("restores files without trimming chat history for diff-card undo requests", async () => {
+    const harness = await createHarness();
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const firstMessageId = MessageId.makeUnsafe("message-files-only-1");
+    const secondMessageId = MessageId.makeUnsafe("message-files-only-2");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-files-only-session-set"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "claudeAgent",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+    for (const checkpointTurnCount of [1, 2]) {
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.makeUnsafe(`cmd-files-only-diff-${checkpointTurnCount}`),
+          threadId,
+          turnId: asTurnId(`turn-${checkpointTurnCount}`),
+          completedAt: createdAt,
+          checkpointRef: checkpointRefForThreadTurn(threadId, checkpointTurnCount),
+          status: "ready",
+          files: [],
+          checkpointTurnCount,
+          createdAt,
+        }),
+      );
+    }
+
+    runGit(harness.cwd, [
+      "update-ref",
+      checkpointRefForThreadMessageStart(threadId, firstMessageId),
+      checkpointRefForThreadTurn(threadId, 0),
+    ]);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: CommandId.makeUnsafe("cmd-files-only-revert"),
+        threadId,
+        messageId: firstMessageId,
+        turnCount: 0,
+        createdAt,
+      }),
+    );
+
+    await waitForEvent(
+      harness.engine,
+      (event) => event.type === "thread.checkpoint-files-restored",
+    );
+    expect(fs.readFileSync(path.join(harness.cwd, "README.md"), "utf8")).toBe("v1\n");
+
+    // A later card must restore the actual post-undo baseline, not numbered
+    // checkpoint 1 (which still contains the first turn's now-undone files).
+    runGit(harness.cwd, [
+      "update-ref",
+      checkpointRefForThreadMessageStart(threadId, secondMessageId),
+      "HEAD",
+    ]);
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "later turn\n", "utf8");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: CommandId.makeUnsafe("cmd-files-only-revert-2"),
+        threadId,
+        messageId: secondMessageId,
+        turnCount: 2,
+        createdAt,
+      }),
+    );
+    await waitForEvent(
+      harness.engine,
+      (event) =>
+        event.type === "thread.checkpoint-files-restored" &&
+        event.payload.messageId === secondMessageId,
+    );
+    expect(fs.readFileSync(path.join(harness.cwd, "README.md"), "utf8")).toBe("v1\n");
+    const thread = await waitForThread(harness.engine, (entry) => entry.checkpoints.length === 2);
+    expect(thread.checkpoints).toHaveLength(2);
+    expect(harness.provider.rollbackConversation).not.toHaveBeenCalled();
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    expect(events.some((event) => event.type === "thread.reverted")).toBe(false);
+    expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 2))).toBe(true);
   });
 
   it("restores turn zero from the persisted checkpoint family", async () => {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1527,6 +1527,100 @@ describe("CheckpointReactor", () => {
     expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 2))).toBe(true);
   });
 
+  it("uses numbered checkpoints for legacy file restores only before prior file-restore side effects", async () => {
+    const harness = await createHarness();
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const firstMessageId = MessageId.makeUnsafe("message-legacy-files-only-1");
+    const secondMessageId = MessageId.makeUnsafe("message-legacy-files-only-2");
+    const firstRequestCommandId = CommandId.makeUnsafe("cmd-legacy-files-only-1");
+    const secondRequestCommandId = CommandId.makeUnsafe("cmd-legacy-files-only-2");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-legacy-files-only-session-set"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "claudeAgent",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+    for (const checkpointTurnCount of [1, 2]) {
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.makeUnsafe(`cmd-legacy-files-only-diff-${checkpointTurnCount}`),
+          threadId,
+          turnId: asTurnId(`turn-legacy-files-only-${checkpointTurnCount}`),
+          completedAt: createdAt,
+          checkpointRef: checkpointRefForThreadTurn(threadId, checkpointTurnCount),
+          status: "ready",
+          files: [],
+          checkpointTurnCount,
+          createdAt,
+        }),
+      );
+    }
+
+    expect(
+      gitRefExists(harness.cwd, checkpointRefForThreadMessageStart(threadId, firstMessageId)),
+    ).toBe(false);
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: firstRequestCommandId,
+        threadId,
+        messageId: firstMessageId,
+        turnCount: 1,
+        createdAt,
+      }),
+    );
+
+    await waitForEvent(
+      harness.engine,
+      (event) =>
+        event.type === "thread.checkpoint-files-restored" &&
+        event.payload.requestCommandId === firstRequestCommandId,
+    );
+    expect(fs.readFileSync(path.join(harness.cwd, "README.md"), "utf8")).toBe("v2\n");
+
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "newer after legacy restore\n", "utf8");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: secondRequestCommandId,
+        threadId,
+        messageId: secondMessageId,
+        turnCount: 2,
+        createdAt,
+      }),
+    );
+
+    const events = await waitForEvent(
+      harness.engine,
+      (event) =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === secondRequestCommandId,
+    );
+    const secondTerminalSuccess = events.find(
+      (event) =>
+        event.type === "thread.checkpoint-files-restored" &&
+        event.payload.requestCommandId === secondRequestCommandId,
+    );
+    expect(secondTerminalSuccess).toBeUndefined();
+    expect(fs.readFileSync(path.join(harness.cwd, "README.md"), "utf8")).toBe(
+      "newer after legacy restore\n",
+    );
+  });
+
   it("restores turn zero from the persisted checkpoint family", async () => {
     const harness = await createHarness({ seedFilesystemCheckpoints: false });
     const createdAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -25,6 +25,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CheckpointStoreLive } from "../../checkpointing/Layers/CheckpointStore.ts";
 import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts";
+import { CheckpointInvariantError } from "../../checkpointing/Errors.ts";
 import { GitCoreLive } from "../../git/Layers/GitCore.ts";
 import { CheckpointReactorLive } from "./CheckpointReactor.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
@@ -369,6 +370,7 @@ describe("CheckpointReactor", () => {
       cwd,
       drain,
       startReactor,
+      checkpointStore,
     };
   }
 
@@ -1794,10 +1796,141 @@ describe("CheckpointReactor", () => {
     );
     const failure = events.find((event) => event.type === "thread.checkpoint-files-restore-failed");
     expect(failure?.payload.detail).toContain("No active provider session");
+    expect(failure?.payload.requiresWorkspaceReview).toBe(false);
     expect(harness.provider.rollbackConversation).not.toHaveBeenCalled();
   });
 
-  it("does not replay an ambiguous persisted file restore when the reactor starts", async () => {
+  it("requires workspace review when a restore fails after partially changing files", async () => {
+    const harness = await createHarness();
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const messageId = MessageId.makeUnsafe("message-partial-file-restore");
+    const requestCommandId = CommandId.makeUnsafe("cmd-partial-file-restore");
+    runGit(harness.cwd, [
+      "update-ref",
+      checkpointRefForThreadMessageStart(threadId, messageId),
+      "HEAD",
+    ]);
+    vi.spyOn(harness.checkpointStore, "restoreCheckpoint").mockImplementation(() =>
+      Effect.sync(() => {
+        fs.writeFileSync(path.join(harness.cwd, "README.md"), "partially restored\n", "utf8");
+      }).pipe(
+        Effect.flatMap(() =>
+          Effect.fail(
+            new CheckpointInvariantError({
+              operation: "CheckpointStore.restoreCheckpoint",
+              detail: "clean failed after restore",
+            }),
+          ),
+        ),
+      ),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: requestCommandId,
+        threadId,
+        messageId,
+        turnCount: 0,
+        createdAt,
+      }),
+    );
+    const events = await waitForEvent(
+      harness.engine,
+      (event) =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === requestCommandId,
+    );
+    const failure = events.find(
+      (
+        event,
+      ): event is Extract<
+        (typeof events)[number],
+        { type: "thread.checkpoint-files-restore-failed" }
+      > =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === requestCommandId,
+    );
+
+    expect(fs.readFileSync(path.join(harness.cwd, "README.md"), "utf8")).toBe(
+      "partially restored\n",
+    );
+    expect(failure?.payload.requiresWorkspaceReview).toBe(true);
+  });
+
+  it("reconciles an unobserved dispatch without allowing a late destructive restore", async () => {
+    const harness = await createHarness();
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const messageId = MessageId.makeUnsafe("message-ambiguous-dispatch");
+    const requestCommandId = CommandId.makeUnsafe("cmd-ambiguous-dispatch");
+    runGit(harness.cwd, [
+      "update-ref",
+      checkpointRefForThreadMessageStart(threadId, messageId),
+      "HEAD",
+    ]);
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "newer guarded work\n", "utf8");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore.reconcile",
+        commandId: CommandId.makeUnsafe("cmd-reconcile-ambiguous-dispatch"),
+        requestCommandId,
+        threadId,
+        messageId,
+        turnCount: 0,
+        createdAt,
+      }),
+    );
+    const reconciledEvents = await waitForEvent(
+      harness.engine,
+      (event) =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === requestCommandId,
+    );
+    const reconciliationFailure = reconciledEvents.find(
+      (
+        event,
+      ): event is Extract<
+        (typeof reconciledEvents)[number],
+        { type: "thread.checkpoint-files-restore-failed" }
+      > =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === requestCommandId,
+    );
+    expect(reconciliationFailure?.payload.requiresWorkspaceReview).toBe(true);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: requestCommandId,
+        threadId,
+        messageId,
+        turnCount: 0,
+        createdAt,
+      }),
+    );
+    await harness.drain();
+
+    expect(fs.readFileSync(path.join(harness.cwd, "README.md"), "utf8")).toBe(
+      "newer guarded work\n",
+    );
+    const allEvents = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    expect(
+      allEvents.some(
+        (event) =>
+          event.type === "thread.checkpoint-files-restored" &&
+          event.payload.requestCommandId === requestCommandId,
+      ),
+    ).toBe(false);
+  });
+
+  it("fails an ambiguous persisted file restore without replaying it when the reactor starts", async () => {
     const harness = await createHarness({ startReactor: false });
     const createdAt = new Date().toISOString();
     const threadId = ThreadId.makeUnsafe("thread-1");
@@ -1830,12 +1963,64 @@ describe("CheckpointReactor", () => {
         Effect.map((chunk) => Array.from(chunk)),
       ),
     );
-    expect(
-      events.some(
-        (event) =>
-          event.type === "thread.checkpoint-files-restored" ||
-          event.type === "thread.checkpoint-files-restore-failed",
+    const failure = events.find(
+      (
+        event,
+      ): event is Extract<
+        (typeof events)[number],
+        { type: "thread.checkpoint-files-restore-failed" }
+      > =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === CommandId.makeUnsafe("cmd-persisted-files-restore"),
+    );
+    expect(failure?.payload.detail).toContain("No automatic retry was run");
+    expect(failure?.payload.requiresWorkspaceReview).toBe(true);
+    expect(events.some((event) => event.type === "thread.checkpoint-files-restored")).toBe(false);
+  });
+
+  it("persists a correlated terminal failure when the restore thread was deleted", async () => {
+    const harness = await createHarness({ startReactor: false });
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const requestCommandId = CommandId.makeUnsafe("cmd-deleted-thread-files-restore");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: requestCommandId,
+        threadId,
+        messageId: MessageId.makeUnsafe("message-deleted-thread-files-restore"),
+        turnCount: 0,
+        createdAt,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.delete",
+        commandId: CommandId.makeUnsafe("cmd-delete-restore-thread"),
+        threadId,
+      }),
+    );
+
+    await harness.startReactor();
+    await harness.drain();
+
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
       ),
-    ).toBe(false);
+    );
+    const failure = events.find(
+      (
+        event,
+      ): event is Extract<
+        (typeof events)[number],
+        { type: "thread.checkpoint-files-restore-failed" }
+      > =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === requestCommandId,
+    );
+    expect(failure?.payload.requiresWorkspaceReview).toBe(true);
+    expect(harness.provider.rollbackConversation).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -33,6 +33,7 @@ import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import { RuntimeReceiptBusLive } from "./RuntimeReceiptBus.ts";
 import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
+import { OrchestrationEventStore } from "../../persistence/Services/OrchestrationEventStore.ts";
 import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
 import {
@@ -40,6 +41,8 @@ import {
   type OrchestrationEngineShape,
 } from "../Services/OrchestrationEngine.ts";
 import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
+import { OrchestrationCommandInternalError } from "../Errors.ts";
+import { hasPendingCheckpointFileRestore } from "../checkpointFileRestoreGate.ts";
 import {
   ProviderService,
   type ProviderServiceShape,
@@ -234,7 +237,7 @@ async function waitForGitRefExists(cwd: string, ref: string, timeoutMs = 30_000)
 
 describe("CheckpointReactor", () => {
   let runtime: ManagedRuntime.ManagedRuntime<
-    OrchestrationEngineService | CheckpointReactor | CheckpointStore,
+    OrchestrationEngineService | CheckpointReactor | CheckpointStore | OrchestrationEventStore,
     unknown
   > | null = null;
   let scope: Scope.Closeable | null = null;
@@ -291,6 +294,7 @@ describe("CheckpointReactor", () => {
       Layer.provideMerge(RuntimeReceiptBusLive),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
       Layer.provideMerge(CheckpointStoreLive.pipe(Layer.provide(GitCoreLive))),
+      Layer.provideMerge(OrchestrationEventStoreLive),
       Layer.provideMerge(ServerConfigLayer),
       Layer.provideMerge(NodeServices.layer),
       Layer.provideMerge(SqlitePersistenceMemory),
@@ -300,6 +304,7 @@ describe("CheckpointReactor", () => {
     const engine = await runtime.runPromise(Effect.service(OrchestrationEngineService));
     const reactor = await runtime.runPromise(Effect.service(CheckpointReactor));
     const checkpointStore = await runtime.runPromise(Effect.service(CheckpointStore));
+    const eventStore = await runtime.runPromise(Effect.service(OrchestrationEventStore));
     scope = await Effect.runPromise(Scope.make("sequential"));
     const startReactor = () => Effect.runPromise(reactor.start.pipe(Scope.provide(scope!)));
     if (options?.startReactor ?? true) {
@@ -371,6 +376,7 @@ describe("CheckpointReactor", () => {
       drain,
       startReactor,
       checkpointStore,
+      eventStore,
     };
   }
 
@@ -1859,6 +1865,80 @@ describe("CheckpointReactor", () => {
     expect(failure?.payload.requiresWorkspaceReview).toBe(true);
   });
 
+  it("persists a review-required terminal when success completion cannot be saved", async () => {
+    const harness = await createHarness();
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const messageId = MessageId.makeUnsafe("message-complete-terminal-fails");
+    const requestCommandId = CommandId.makeUnsafe("cmd-complete-terminal-fails");
+    runGit(harness.cwd, [
+      "update-ref",
+      checkpointRefForThreadMessageStart(threadId, messageId),
+      "HEAD",
+    ]);
+
+    const originalDispatch = harness.engine.dispatch;
+    let fallbackFailureAttempts = 0;
+    vi.spyOn(harness.engine, "dispatch").mockImplementation((command) => {
+      if (command.type === "thread.checkpoint.files.restore.complete") {
+        return Effect.fail(
+          new OrchestrationCommandInternalError({
+            commandId: command.commandId,
+            commandType: command.type,
+            detail: "simulated terminal persistence failure",
+          }),
+        );
+      }
+      if (
+        command.type === "thread.checkpoint.files.restore.fail" &&
+        command.requestCommandId === requestCommandId &&
+        fallbackFailureAttempts < 4
+      ) {
+        fallbackFailureAttempts += 1;
+        return Effect.fail(
+          new OrchestrationCommandInternalError({
+            commandId: command.commandId,
+            commandType: command.type,
+            detail: "simulated fallback terminal persistence failure",
+          }),
+        );
+      }
+      return originalDispatch(command);
+    });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: requestCommandId,
+        threadId,
+        messageId,
+        turnCount: 0,
+        createdAt,
+      }),
+    );
+
+    const events = await waitForEvent(
+      harness.engine,
+      (event) =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === requestCommandId,
+    );
+    const failure = events.find(
+      (
+        event,
+      ): event is Extract<
+        (typeof events)[number],
+        { type: "thread.checkpoint-files-restore-failed" }
+      > =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === requestCommandId,
+    );
+
+    expect(failure?.payload.detail).toContain("could not persist the success terminal");
+    expect(failure?.payload.requiresWorkspaceReview).toBe(true);
+    expect(fallbackFailureAttempts).toBe(4);
+  });
+
   it("reconciles an unobserved dispatch without allowing a late destructive restore", async () => {
     const harness = await createHarness();
     const createdAt = new Date().toISOString();
@@ -1978,7 +2058,56 @@ describe("CheckpointReactor", () => {
     expect(events.some((event) => event.type === "thread.checkpoint-files-restored")).toBe(false);
   });
 
-  it("persists a correlated terminal failure when the restore thread was deleted", async () => {
+  it("does not restore files or leave a pending gate for legacy requests without command ids", async () => {
+    const harness = await createHarness({ startReactor: false });
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const messageId = MessageId.makeUnsafe("message-null-command-files-restore");
+    runGit(harness.cwd, [
+      "update-ref",
+      checkpointRefForThreadMessageStart(threadId, messageId),
+      "HEAD",
+    ]);
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "newer work must survive\n", "utf8");
+    const restoreSpy = vi.spyOn(harness.checkpointStore, "restoreCheckpoint");
+
+    await Effect.runPromise(
+      harness.eventStore.append({
+        eventId: EventId.makeUnsafe("evt-null-command-files-restore"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: createdAt,
+        commandId: null,
+        causationEventId: null,
+        correlationId: null,
+        metadata: {},
+        type: "thread.checkpoint-files-restore-requested",
+        payload: {
+          threadId,
+          messageId,
+          turnCount: 0,
+          createdAt,
+        },
+      }),
+    );
+
+    await harness.startReactor();
+    await harness.drain();
+
+    expect(restoreSpy).not.toHaveBeenCalled();
+    expect(fs.readFileSync(path.join(harness.cwd, "README.md"), "utf8")).toBe(
+      "newer work must survive\n",
+    );
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    expect(hasPendingCheckpointFileRestore(events)).toBe(false);
+    expect(events.some((event) => event.type === "thread.checkpoint-files-restored")).toBe(false);
+  });
+
+  it("persists a correlated terminal failure for legacy restore requests whose thread was deleted", async () => {
     const harness = await createHarness({ startReactor: false });
     const createdAt = new Date().toISOString();
     const threadId = ThreadId.makeUnsafe("thread-1");
@@ -1995,12 +2124,23 @@ describe("CheckpointReactor", () => {
       }),
     );
     await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.delete",
+      harness.eventStore.append({
+        eventId: EventId.makeUnsafe("evt-legacy-delete-restore-thread"),
+        aggregateKind: "thread",
+        aggregateId: threadId,
+        occurredAt: createdAt,
         commandId: CommandId.makeUnsafe("cmd-delete-restore-thread"),
-        threadId,
+        causationEventId: null,
+        correlationId: CommandId.makeUnsafe("cmd-delete-restore-thread"),
+        metadata: {},
+        type: "thread.deleted",
+        payload: {
+          threadId,
+          deletedAt: createdAt,
+        },
       }),
     );
+    await Effect.runPromise(harness.engine.repairState());
 
     await harness.startReactor();
     await harness.drain();

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -2152,6 +2152,48 @@ describe("CheckpointReactor", () => {
     expect(events.some((event) => event.type === "thread.checkpoint-files-restored")).toBe(false);
   });
 
+  it("terminalizes an interrupted prepared-only restore on startup without restoring files", async () => {
+    const harness = await createHarness({ startReactor: false });
+    const createdAt = new Date().toISOString();
+    const requestCommandId = CommandId.makeUnsafe("cmd-prepared-only-files-restore");
+    const restoreSpy = vi.spyOn(harness.checkpointStore, "restoreCheckpoint");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.files.restore.prepare",
+        commandId: CommandId.makeUnsafe("cmd-prepared-only-files-restore-prepare"),
+        requestCommandId,
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        messageId: MessageId.makeUnsafe("message-prepared-only-files-restore"),
+        turnCount: 0,
+        createdAt,
+      }),
+    );
+
+    await harness.startReactor();
+    await harness.drain();
+
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    const failure = events.find(
+      (
+        event,
+      ): event is Extract<
+        (typeof events)[number],
+        { type: "thread.checkpoint-files-restore-failed" }
+      > =>
+        event.type === "thread.checkpoint-files-restore-failed" &&
+        event.payload.requestCommandId === requestCommandId,
+    );
+    expect(restoreSpy).not.toHaveBeenCalled();
+    expect(failure?.payload.detail).toContain("No restore was run");
+    expect(failure?.payload.requiresWorkspaceReview).toBe(false);
+    expect(hasPendingCheckpointFileRestore(events)).toBe(false);
+  });
+
   it("does not restore files or leave a pending gate for legacy requests without command ids", async () => {
     const harness = await createHarness({ startReactor: false });
     const createdAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -838,7 +838,12 @@ const make = Effect.gen(function* () {
   });
 
   const handleRevertRequested = Effect.fnUntraced(function* (
-    event: Extract<OrchestrationEvent, { type: "thread.checkpoint-revert-requested" }>,
+    event: Extract<
+      OrchestrationEvent,
+      {
+        type: "thread.checkpoint-revert-requested" | "thread.checkpoint-files-restore-requested";
+      }
+    >,
   ) {
     const now = new Date().toISOString();
 
@@ -898,8 +903,10 @@ const make = Effect.gen(function* () {
         ),
       )
       .find((checkpointRef) => checkpointRef !== null);
-    const targetCheckpointRef =
-      event.payload.turnCount === 0
+    const filesOnly = event.type === "thread.checkpoint-files-restore-requested";
+    const targetCheckpointRef = filesOnly
+      ? checkpointRefForThreadMessageStart(event.payload.threadId, event.payload.messageId)
+      : event.payload.turnCount === 0
         ? (earliestManagedBaselineRef ?? checkpointRefForThreadTurn(event.payload.threadId, 0))
         : thread.checkpoints.find(
             (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
@@ -918,7 +925,7 @@ const make = Effect.gen(function* () {
     const restored = yield* checkpointStore.restoreCheckpoint({
       cwd: sessionRuntime.value.cwd,
       checkpointRef: targetCheckpointRef,
-      fallbackToHead: event.payload.turnCount === 0,
+      fallbackToHead: !filesOnly && event.payload.turnCount === 0,
     });
     if (!restored) {
       yield* appendRevertFailureActivity({
@@ -933,6 +940,30 @@ const make = Effect.gen(function* () {
     // Invalidate the workspace entry cache so the @-mention file picker
     // reflects the reverted filesystem state.
     clearWorkspaceIndexCache(sessionRuntime.value.cwd);
+
+    // The diff-card action restores the immutable baseline captured for that
+    // exact user message. This remains correct after earlier file-only undos.
+    if (filesOnly) {
+      if (event.commandId === null) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: "File restore request is missing its command id.",
+          createdAt: now,
+        });
+        return;
+      }
+      yield* orchestrationEngine.dispatch({
+        type: "thread.checkpoint.files.restore.complete",
+        commandId: serverCommandId("checkpoint-files-restore-complete"),
+        requestCommandId: event.commandId,
+        threadId: event.payload.threadId,
+        messageId: event.payload.messageId,
+        turnCount: event.payload.turnCount,
+        createdAt: now,
+      });
+      return;
+    }
 
     const rolledBackTurns = Math.max(0, currentTurnCount - event.payload.turnCount);
     if (rolledBackTurns > 0) {
@@ -980,7 +1011,10 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    if (event.type === "thread.checkpoint-revert-requested") {
+    if (
+      event.type === "thread.checkpoint-revert-requested" ||
+      event.type === "thread.checkpoint-files-restore-requested"
+    ) {
       yield* handleRevertRequested(event).pipe(
         Effect.catch((error) =>
           appendRevertFailureActivity({
@@ -1054,6 +1088,17 @@ const make = Effect.gen(function* () {
     );
 
   const worker = yield* makeDrainableWorker(processInputSafely);
+  const observedFileRestoreRequestIds = new Set<string>();
+
+  const enqueueDomainEvent = (event: OrchestrationEvent) => {
+    if (event.type === "thread.checkpoint-files-restore-requested") {
+      if (event.commandId === null || observedFileRestoreRequestIds.has(event.commandId)) {
+        return Effect.void;
+      }
+      observedFileRestoreRequestIds.add(event.commandId);
+    }
+    return worker.enqueue({ source: "domain" as const, event });
+  };
 
   const start: CheckpointReactorShape["start"] = Effect.gen(function* () {
     yield* Effect.forkScoped(
@@ -1062,12 +1107,35 @@ const make = Effect.gen(function* () {
           event.type !== "thread.turn-start-requested" &&
           event.type !== "thread.message-sent" &&
           event.type !== "thread.checkpoint-revert-requested" &&
+          event.type !== "thread.checkpoint-files-restore-requested" &&
           event.type !== "thread.turn-diff-completed"
         ) {
           return Effect.void;
         }
-        return worker.enqueue({ source: "domain", event });
+        return enqueueDomainEvent(event);
       }),
+    );
+
+    // Reconcile accepted file-restore commands that were persisted before a
+    // server crash but never reached their durable completion event. Restore
+    // is idempotent, including the ambiguous crash-after-git-before-complete case.
+    const persistedEvents = yield* Stream.runCollect(orchestrationEngine.readEvents(0)).pipe(
+      Effect.orDie,
+    );
+    const completedRequestIds = new Set(
+      Array.from(persistedEvents)
+        .filter((event) => event.type === "thread.checkpoint-files-restored")
+        .map((event) => event.payload.requestCommandId),
+    );
+    yield* Effect.forEach(
+      Array.from(persistedEvents),
+      (event) =>
+        event.type === "thread.checkpoint-files-restore-requested" &&
+        event.commandId !== null &&
+        !completedRequestIds.has(event.commandId)
+          ? enqueueDomainEvent(event)
+          : Effect.void,
+      { concurrency: 1, discard: true },
     );
 
     yield* Effect.forkScoped(

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -179,24 +179,42 @@ const make = Effect.gen(function* () {
     readonly turnCount: number;
     readonly detail: string;
     readonly createdAt: string;
+    readonly filesRestore?: {
+      readonly requestCommandId: CommandId;
+      readonly messageId: MessageId;
+    };
   }) =>
-    orchestrationEngine.dispatch({
-      type: "thread.activity.append",
-      commandId: serverCommandId("checkpoint-revert-failure"),
-      threadId: input.threadId,
-      activity: {
-        id: EventId.makeUnsafe(crypto.randomUUID()),
-        tone: "error",
-        kind: "checkpoint.revert.failed",
-        summary: "Checkpoint revert failed",
-        payload: {
+    Effect.gen(function* () {
+      yield* orchestrationEngine.dispatch({
+        type: "thread.activity.append",
+        commandId: serverCommandId("checkpoint-revert-failure"),
+        threadId: input.threadId,
+        activity: {
+          id: EventId.makeUnsafe(crypto.randomUUID()),
+          tone: "error",
+          kind: "checkpoint.revert.failed",
+          summary: "Checkpoint revert failed",
+          payload: {
+            turnCount: input.turnCount,
+            detail: input.detail,
+          },
+          turnId: null,
+          createdAt: input.createdAt,
+        },
+        createdAt: input.createdAt,
+      });
+      if (input.filesRestore) {
+        yield* orchestrationEngine.dispatch({
+          type: "thread.checkpoint.files.restore.fail",
+          commandId: serverCommandId("checkpoint-files-restore-failed"),
+          requestCommandId: input.filesRestore.requestCommandId,
+          threadId: input.threadId,
+          messageId: input.filesRestore.messageId,
           turnCount: input.turnCount,
           detail: input.detail,
-        },
-        turnId: null,
-        createdAt: input.createdAt,
-      },
-      createdAt: input.createdAt,
+          createdAt: input.createdAt,
+        });
+      }
     });
 
   const appendCaptureFailureActivity = (input: {
@@ -846,6 +864,11 @@ const make = Effect.gen(function* () {
     >,
   ) {
     const now = new Date().toISOString();
+    const filesOnly = event.type === "thread.checkpoint-files-restore-requested";
+    const filesRestore =
+      filesOnly && event.commandId !== null
+        ? { requestCommandId: event.commandId, messageId: event.payload.messageId }
+        : undefined;
 
     const thread = yield* getThreadDetail(event.payload.threadId);
     if (!thread) {
@@ -854,6 +877,7 @@ const make = Effect.gen(function* () {
         turnCount: event.payload.turnCount,
         detail: "Thread was not found in projection state.",
         createdAt: now,
+        ...(filesRestore ? { filesRestore } : {}),
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
@@ -865,6 +889,7 @@ const make = Effect.gen(function* () {
         turnCount: event.payload.turnCount,
         detail: "No active provider session with workspace cwd is bound to this thread.",
         createdAt: now,
+        ...(filesRestore ? { filesRestore } : {}),
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
@@ -874,6 +899,7 @@ const make = Effect.gen(function* () {
         turnCount: event.payload.turnCount,
         detail: "Checkpoints are unavailable because this project is not a git repository.",
         createdAt: now,
+        ...(filesRestore ? { filesRestore } : {}),
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
@@ -889,6 +915,7 @@ const make = Effect.gen(function* () {
         turnCount: event.payload.turnCount,
         detail: `Checkpoint turn count ${event.payload.turnCount} exceeds current turn count ${currentTurnCount}.`,
         createdAt: now,
+        ...(filesRestore ? { filesRestore } : {}),
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
@@ -903,7 +930,6 @@ const make = Effect.gen(function* () {
         ),
       )
       .find((checkpointRef) => checkpointRef !== null);
-    const filesOnly = event.type === "thread.checkpoint-files-restore-requested";
     const targetCheckpointRef = filesOnly
       ? checkpointRefForThreadMessageStart(event.payload.threadId, event.payload.messageId)
       : event.payload.turnCount === 0
@@ -918,6 +944,7 @@ const make = Effect.gen(function* () {
         turnCount: event.payload.turnCount,
         detail: `Checkpoint ref for turn ${event.payload.turnCount} is unavailable in read model.`,
         createdAt: now,
+        ...(filesRestore ? { filesRestore } : {}),
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
@@ -933,6 +960,7 @@ const make = Effect.gen(function* () {
         turnCount: event.payload.turnCount,
         detail: `Filesystem checkpoint is unavailable for turn ${event.payload.turnCount}.`,
         createdAt: now,
+        ...(filesRestore ? { filesRestore } : {}),
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
@@ -1022,6 +1050,15 @@ const make = Effect.gen(function* () {
             turnCount: event.payload.turnCount,
             detail: error.message,
             createdAt: new Date().toISOString(),
+            ...(event.type === "thread.checkpoint-files-restore-requested" &&
+            event.commandId !== null
+              ? {
+                  filesRestore: {
+                    requestCommandId: event.commandId,
+                    messageId: event.payload.messageId,
+                  },
+                }
+              : {}),
           }),
         ),
       );
@@ -1088,17 +1125,6 @@ const make = Effect.gen(function* () {
     );
 
   const worker = yield* makeDrainableWorker(processInputSafely);
-  const observedFileRestoreRequestIds = new Set<string>();
-
-  const enqueueDomainEvent = (event: OrchestrationEvent) => {
-    if (event.type === "thread.checkpoint-files-restore-requested") {
-      if (event.commandId === null || observedFileRestoreRequestIds.has(event.commandId)) {
-        return Effect.void;
-      }
-      observedFileRestoreRequestIds.add(event.commandId);
-    }
-    return worker.enqueue({ source: "domain" as const, event });
-  };
 
   const start: CheckpointReactorShape["start"] = Effect.gen(function* () {
     yield* Effect.forkScoped(
@@ -1112,30 +1138,8 @@ const make = Effect.gen(function* () {
         ) {
           return Effect.void;
         }
-        return enqueueDomainEvent(event);
+        return worker.enqueue({ source: "domain", event });
       }),
-    );
-
-    // Reconcile accepted file-restore commands that were persisted before a
-    // server crash but never reached their durable completion event. Restore
-    // is idempotent, including the ambiguous crash-after-git-before-complete case.
-    const persistedEvents = yield* Stream.runCollect(orchestrationEngine.readEvents(0)).pipe(
-      Effect.orDie,
-    );
-    const completedRequestIds = new Set(
-      Array.from(persistedEvents)
-        .filter((event) => event.type === "thread.checkpoint-files-restored")
-        .map((event) => event.payload.requestCommandId),
-    );
-    yield* Effect.forEach(
-      Array.from(persistedEvents),
-      (event) =>
-        event.type === "thread.checkpoint-files-restore-requested" &&
-        event.commandId !== null &&
-        !completedRequestIds.has(event.commandId)
-          ? enqueueDomainEvent(event)
-          : Effect.void,
-      { concurrency: 1, discard: true },
     );
 
     yield* Effect.forkScoped(

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -178,6 +178,7 @@ const make = Effect.gen(function* () {
     readonly threadId: ThreadId;
     readonly turnCount: number;
     readonly detail: string;
+    readonly requiresWorkspaceReview?: boolean;
     readonly createdAt: string;
     readonly filesRestore?: {
       readonly requestCommandId: CommandId;
@@ -185,7 +186,7 @@ const make = Effect.gen(function* () {
     };
   }) =>
     Effect.gen(function* () {
-      yield* orchestrationEngine.dispatch({
+      const appendActivity = orchestrationEngine.dispatch({
         type: "thread.activity.append",
         commandId: serverCommandId("checkpoint-revert-failure"),
         threadId: input.threadId,
@@ -204,17 +205,42 @@ const make = Effect.gen(function* () {
         createdAt: input.createdAt,
       });
       if (input.filesRestore) {
-        yield* orchestrationEngine.dispatch({
-          type: "thread.checkpoint.files.restore.fail",
-          commandId: serverCommandId("checkpoint-files-restore-failed"),
-          requestCommandId: input.filesRestore.requestCommandId,
+        yield* appendActivity.pipe(Effect.catch(() => Effect.void));
+        yield* appendFilesRestoreFailureTerminal({
           threadId: input.threadId,
-          messageId: input.filesRestore.messageId,
           turnCount: input.turnCount,
           detail: input.detail,
+          requiresWorkspaceReview: input.requiresWorkspaceReview ?? false,
           createdAt: input.createdAt,
+          filesRestore: input.filesRestore,
         });
+        return;
       }
+
+      yield* appendActivity;
+    });
+
+  const appendFilesRestoreFailureTerminal = (input: {
+    readonly threadId: ThreadId;
+    readonly turnCount: number;
+    readonly detail: string;
+    readonly requiresWorkspaceReview: boolean;
+    readonly createdAt: string;
+    readonly filesRestore: {
+      readonly requestCommandId: CommandId;
+      readonly messageId: MessageId;
+    };
+  }) =>
+    orchestrationEngine.dispatch({
+      type: "thread.checkpoint.files.restore.fail",
+      commandId: serverCommandId("checkpoint-files-restore-failed"),
+      requestCommandId: input.filesRestore.requestCommandId,
+      threadId: input.threadId,
+      messageId: input.filesRestore.messageId,
+      turnCount: input.turnCount,
+      detail: input.detail,
+      requiresWorkspaceReview: input.requiresWorkspaceReview,
+      createdAt: input.createdAt,
     });
 
   const appendCaptureFailureActivity = (input: {
@@ -881,6 +907,16 @@ const make = Effect.gen(function* () {
       }).pipe(Effect.catch(() => Effect.void));
       return;
     }
+    if (thread.deletedAt !== null) {
+      yield* appendRevertFailureActivity({
+        threadId: event.payload.threadId,
+        turnCount: event.payload.turnCount,
+        detail: "Thread was deleted before the checkpoint restore could run.",
+        createdAt: now,
+        ...(filesRestore ? { filesRestore } : {}),
+      }).pipe(Effect.catch(() => Effect.void));
+      return;
+    }
 
     const sessionRuntime = yield* resolveSessionRuntimeForThread(event.payload.threadId);
     if (Option.isNone(sessionRuntime)) {
@@ -1033,9 +1069,128 @@ const make = Effect.gen(function* () {
       );
   });
 
+  const failInterruptedFileRestoresOnStart = Effect.fnUntraced(function* () {
+    const events = yield* Stream.runCollect(orchestrationEngine.readEvents(0)).pipe(
+      Effect.map((chunk): OrchestrationEvent[] => Array.from(chunk)),
+    );
+    type RestoreState = {
+      request?: Extract<OrchestrationEvent, { type: "thread.checkpoint-files-restore-requested" }>;
+      reconciliation?: Extract<
+        OrchestrationEvent,
+        { type: "thread.checkpoint-files-restore-reconciliation-requested" }
+      >;
+      terminal: boolean;
+    };
+    const restoreStates = new Map<CommandId, RestoreState>();
+    const stateFor = (requestCommandId: CommandId) => {
+      const existing = restoreStates.get(requestCommandId);
+      if (existing) return existing;
+      const created: RestoreState = { terminal: false };
+      restoreStates.set(requestCommandId, created);
+      return created;
+    };
+
+    for (const event of events) {
+      if (event.type === "thread.checkpoint-files-restore-requested" && event.commandId !== null) {
+        stateFor(event.commandId).request = event;
+        continue;
+      }
+      if (event.type === "thread.checkpoint-files-restore-reconciliation-requested") {
+        stateFor(event.payload.requestCommandId).reconciliation = event;
+        continue;
+      }
+      if (
+        event.type === "thread.checkpoint-files-restored" ||
+        event.type === "thread.checkpoint-files-restore-failed"
+      ) {
+        stateFor(event.payload.requestCommandId).terminal = true;
+      }
+    }
+
+    const now = new Date().toISOString();
+    yield* Effect.forEach(
+      restoreStates.entries(),
+      ([requestCommandId, state]) => {
+        if (state.terminal) return Effect.void;
+        const source = state.request ?? state.reconciliation;
+        if (!source) return Effect.void;
+        return appendFilesRestoreFailureTerminal({
+          threadId: source.payload.threadId,
+          turnCount: source.payload.turnCount,
+          detail: state.request
+            ? "File restore did not finish before Synara restarted. No automatic retry was run; inspect the working tree before continuing."
+            : "Synara restarted before file restore acceptance could be confirmed. No restore was replayed; inspect the working tree before continuing.",
+          requiresWorkspaceReview: true,
+          createdAt: now,
+          filesRestore: {
+            requestCommandId,
+            messageId: source.payload.messageId,
+          },
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logWarning(
+              "failed to append interrupted checkpoint files restore terminal",
+            ).pipe(
+              Effect.annotateLogs({
+                threadId: source.payload.threadId,
+                requestCommandId,
+                error: error.message,
+              }),
+            ),
+          ),
+        );
+      },
+      { concurrency: 1 },
+    );
+  });
+
+  const readFileRestoreEventState = Effect.fnUntraced(function* (requestCommandId: CommandId) {
+    const events = yield* Stream.runCollect(orchestrationEngine.readEvents(0)).pipe(
+      Effect.map((chunk): OrchestrationEvent[] => Array.from(chunk)),
+    );
+    let requested = false;
+    let terminal = false;
+    for (const event of events) {
+      if (
+        event.type === "thread.checkpoint-files-restore-requested" &&
+        event.commandId === requestCommandId
+      ) {
+        requested = true;
+        continue;
+      }
+      if (
+        (event.type === "thread.checkpoint-files-restored" ||
+          event.type === "thread.checkpoint-files-restore-failed") &&
+        event.payload.requestCommandId === requestCommandId
+      ) {
+        terminal = true;
+      }
+    }
+    return { requested, terminal } as const;
+  });
+
   const processDomainEvent = Effect.fnUntraced(function* (event: OrchestrationEvent) {
     if (event.type === "thread.turn-start-requested" || event.type === "thread.message-sent") {
       yield* ensurePreTurnBaselineFromDomainTurnStart(event);
+      return;
+    }
+
+    if (event.type === "thread.checkpoint-files-restore-reconciliation-requested") {
+      const state = yield* readFileRestoreEventState(event.payload.requestCommandId);
+      if (!state.requested && !state.terminal) {
+        yield* appendFilesRestoreFailureTerminal({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail:
+            "Synara could not confirm that the file restore was accepted. No restore was replayed; inspect the working tree before continuing.",
+          requiresWorkspaceReview: true,
+          createdAt: new Date().toISOString(),
+          filesRestore: {
+            requestCommandId: event.payload.requestCommandId,
+            messageId: event.payload.messageId,
+          },
+        });
+      }
       return;
     }
 
@@ -1043,12 +1198,21 @@ const make = Effect.gen(function* () {
       event.type === "thread.checkpoint-revert-requested" ||
       event.type === "thread.checkpoint-files-restore-requested"
     ) {
+      if (event.type === "thread.checkpoint-files-restore-requested" && event.commandId !== null) {
+        const state = yield* readFileRestoreEventState(event.commandId);
+        if (state.terminal) {
+          return;
+        }
+      }
       yield* handleRevertRequested(event).pipe(
         Effect.catch((error) =>
           appendRevertFailureActivity({
             threadId: event.payload.threadId,
             turnCount: event.payload.turnCount,
             detail: error.message,
+            ...(event.type === "thread.checkpoint-files-restore-requested"
+              ? { requiresWorkspaceReview: true }
+              : {}),
             createdAt: new Date().toISOString(),
             ...(event.type === "thread.checkpoint-files-restore-requested" &&
             event.commandId !== null
@@ -1127,6 +1291,14 @@ const make = Effect.gen(function* () {
   const worker = yield* makeDrainableWorker(processInputSafely);
 
   const start: CheckpointReactorShape["start"] = Effect.gen(function* () {
+    yield* failInterruptedFileRestoresOnStart().pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("failed to reconcile interrupted file restores on checkpoint startup", {
+          cause: Cause.pretty(cause),
+        }),
+      ),
+    );
+
     yield* Effect.forkScoped(
       Stream.runForEach(orchestrationEngine.streamDomainEvents, (event) => {
         if (
@@ -1134,6 +1306,7 @@ const make = Effect.gen(function* () {
           event.type !== "thread.message-sent" &&
           event.type !== "thread.checkpoint-revert-requested" &&
           event.type !== "thread.checkpoint-files-restore-requested" &&
+          event.type !== "thread.checkpoint-files-restore-reconciliation-requested" &&
           event.type !== "thread.turn-diff-completed"
         ) {
           return Effect.void;

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -1179,6 +1179,7 @@ const make = Effect.gen(function* () {
       Effect.map((chunk): OrchestrationEvent[] => Array.from(chunk)),
     );
     type RestoreState = {
+      prepared?: Extract<OrchestrationEvent, { type: "thread.checkpoint-files-restore-prepared" }>;
       request?: Extract<OrchestrationEvent, { type: "thread.checkpoint-files-restore-requested" }>;
       reconciliation?: Extract<
         OrchestrationEvent,
@@ -1196,6 +1197,10 @@ const make = Effect.gen(function* () {
     };
 
     for (const event of events) {
+      if (event.type === "thread.checkpoint-files-restore-prepared") {
+        stateFor(event.payload.requestCommandId).prepared = event;
+        continue;
+      }
       if (event.type === "thread.checkpoint-files-restore-requested" && event.commandId !== null) {
         stateFor(event.commandId).request = event;
         continue;
@@ -1206,7 +1211,8 @@ const make = Effect.gen(function* () {
       }
       if (
         event.type === "thread.checkpoint-files-restored" ||
-        event.type === "thread.checkpoint-files-restore-failed"
+        event.type === "thread.checkpoint-files-restore-failed" ||
+        event.type === "thread.checkpoint-files-restore-reviewed"
       ) {
         stateFor(event.payload.requestCommandId).terminal = true;
       }
@@ -1217,16 +1223,19 @@ const make = Effect.gen(function* () {
       restoreStates.entries(),
       ([requestCommandId, state]) => {
         if (state.terminal) return Effect.void;
-        const source = state.request ?? state.reconciliation;
+        const source = state.request ?? state.reconciliation ?? state.prepared;
         if (!source) return Effect.void;
+        const preparedOnly = state.request === undefined && state.prepared !== undefined;
         return appendFilesRestoreFailureTerminalEventually(
           {
             threadId: source.payload.threadId,
             turnCount: source.payload.turnCount,
-            detail: state.request
-              ? "File restore did not finish before Synara restarted. No automatic retry was run; inspect the working tree before continuing."
-              : "Synara restarted before file restore acceptance could be confirmed. No restore was replayed; inspect the working tree before continuing.",
-            requiresWorkspaceReview: true,
+            detail: preparedOnly
+              ? "File restore confirmation did not finish before Synara restarted. No restore was run."
+              : state.request
+                ? "File restore did not finish before Synara restarted. No automatic retry was run; inspect the working tree before continuing."
+                : "Synara restarted before file restore acceptance could be confirmed. No restore was replayed; inspect the working tree before continuing.",
+            requiresWorkspaceReview: !preparedOnly,
             createdAt: now,
             filesRestore: {
               requestCommandId,
@@ -1248,6 +1257,13 @@ const make = Effect.gen(function* () {
     let terminal = false;
     for (const event of events) {
       if (
+        event.type === "thread.checkpoint-files-restore-prepared" &&
+        event.payload.requestCommandId === requestCommandId
+      ) {
+        requested = true;
+        continue;
+      }
+      if (
         event.type === "thread.checkpoint-files-restore-requested" &&
         event.commandId === requestCommandId
       ) {
@@ -1256,7 +1272,8 @@ const make = Effect.gen(function* () {
       }
       if (
         (event.type === "thread.checkpoint-files-restored" ||
-          event.type === "thread.checkpoint-files-restore-failed") &&
+          event.type === "thread.checkpoint-files-restore-failed" ||
+          event.type === "thread.checkpoint-files-restore-reviewed") &&
         event.payload.requestCommandId === requestCommandId
       ) {
         terminal = true;
@@ -1393,9 +1410,11 @@ const make = Effect.gen(function* () {
   const start: CheckpointReactorShape["start"] = Effect.gen(function* () {
     yield* failInterruptedFileRestoresOnStart().pipe(
       Effect.catchCause((cause) =>
-        Effect.logWarning("failed to reconcile interrupted file restores on checkpoint startup", {
-          cause: Cause.pretty(cause),
-        }),
+        Effect.die(
+          new Error(
+            `Failed to reconcile interrupted file restores before checkpoint startup: ${Cause.pretty(cause)}`,
+          ),
+        ),
       ),
     );
 

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -11,7 +11,7 @@ import {
   type OrchestrationThread,
   type ProviderRuntimeEvent,
 } from "@synara/contracts";
-import { Cause, Effect, Layer, Option, Stream } from "effect";
+import { Cause, Effect, Layer, Option, Schedule, Stream } from "effect";
 import { makeDrainableWorker } from "@synara/shared/DrainableWorker";
 
 import { parseCheckpointFilesFromUnifiedDiff } from "../../checkpointing/Diffs.ts";
@@ -35,6 +35,7 @@ import { RuntimeReceiptBus } from "../Services/RuntimeReceiptBus.ts";
 import { CheckpointStoreError } from "../../checkpointing/Errors.ts";
 import { OrchestrationDispatchError } from "../Errors.ts";
 import { isGitRepository } from "../../git/isRepo.ts";
+import { withCheckpointFileRestoreInterlock } from "../checkpointFileRestoreInterlock.ts";
 
 type ReactorInput =
   | {
@@ -57,6 +58,10 @@ function sameId(left: string | null | undefined, right: string | null | undefine
   return left === right;
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function checkpointStatusFromRuntime(status: string | undefined): "ready" | "missing" | "error" {
   switch (status) {
     case "failed":
@@ -75,6 +80,24 @@ const serverCommandId = (tag: string): CommandId =>
 
 const ASSISTANT_MESSAGE_ID_RETRY_DELAY_MS = 20;
 const ASSISTANT_MESSAGE_ID_RETRY_ATTEMPTS = 6;
+const FILE_RESTORE_TERMINAL_INITIAL_RETRY_SCHEDULE = Schedule.exponential("100 millis").pipe(
+  Schedule.take(5),
+);
+const FILE_RESTORE_TERMINAL_EVENTUAL_RETRY_SCHEDULE = Schedule.spaced("1 second");
+
+type FilesRestoreTerminalTarget = {
+  readonly requestCommandId: CommandId;
+  readonly messageId: MessageId;
+};
+
+type FilesRestoreFailureTerminalInput = {
+  readonly threadId: ThreadId;
+  readonly turnCount: number;
+  readonly detail: string;
+  readonly requiresWorkspaceReview: boolean;
+  readonly createdAt: string;
+  readonly filesRestore: FilesRestoreTerminalTarget;
+};
 
 function resolveExistingAssistantMessageIdForTurn(
   thread:
@@ -206,41 +229,50 @@ const make = Effect.gen(function* () {
       });
       if (input.filesRestore) {
         yield* appendActivity.pipe(Effect.catch(() => Effect.void));
-        yield* appendFilesRestoreFailureTerminal({
-          threadId: input.threadId,
-          turnCount: input.turnCount,
-          detail: input.detail,
-          requiresWorkspaceReview: input.requiresWorkspaceReview ?? false,
-          createdAt: input.createdAt,
-          filesRestore: input.filesRestore,
-        });
+        yield* appendFilesRestoreFailureTerminalEventually(
+          {
+            threadId: input.threadId,
+            turnCount: input.turnCount,
+            detail: input.detail,
+            requiresWorkspaceReview: input.requiresWorkspaceReview ?? false,
+            createdAt: input.createdAt,
+            filesRestore: input.filesRestore,
+          },
+          "checkpoint restore failure",
+        );
         return;
       }
 
       yield* appendActivity;
     });
 
-  const appendFilesRestoreFailureTerminal = (input: {
-    readonly threadId: ThreadId;
-    readonly turnCount: number;
-    readonly detail: string;
-    readonly requiresWorkspaceReview: boolean;
-    readonly createdAt: string;
-    readonly filesRestore: {
-      readonly requestCommandId: CommandId;
-      readonly messageId: MessageId;
-    };
-  }) =>
-    orchestrationEngine.dispatch({
-      type: "thread.checkpoint.files.restore.fail",
-      commandId: serverCommandId("checkpoint-files-restore-failed"),
-      requestCommandId: input.filesRestore.requestCommandId,
-      threadId: input.threadId,
-      messageId: input.filesRestore.messageId,
-      turnCount: input.turnCount,
-      detail: input.detail,
-      requiresWorkspaceReview: input.requiresWorkspaceReview,
-      createdAt: input.createdAt,
+  const dispatchFilesRestoreFailureTerminal = (
+    input: FilesRestoreFailureTerminalInput,
+    commandId: CommandId,
+  ) =>
+    Effect.suspend(() =>
+      orchestrationEngine.dispatch({
+        type: "thread.checkpoint.files.restore.fail",
+        commandId,
+        requestCommandId: input.filesRestore.requestCommandId,
+        threadId: input.threadId,
+        messageId: input.filesRestore.messageId,
+        turnCount: input.turnCount,
+        detail: input.detail,
+        requiresWorkspaceReview: input.requiresWorkspaceReview,
+        createdAt: input.createdAt,
+      }),
+    ).pipe(Effect.asVoid);
+
+  const appendFilesRestoreFailureTerminalEventually = (
+    input: FilesRestoreFailureTerminalInput,
+    _context: string,
+  ) =>
+    Effect.gen(function* () {
+      const terminalCommandId = serverCommandId("checkpoint-files-restore-failed");
+      yield* dispatchFilesRestoreFailureTerminal(input, terminalCommandId).pipe(
+        Effect.retry(FILE_RESTORE_TERMINAL_EVENTUAL_RETRY_SCHEDULE),
+      );
     });
 
   const appendCaptureFailureActivity = (input: {
@@ -890,11 +922,29 @@ const make = Effect.gen(function* () {
     >,
   ) {
     const now = new Date().toISOString();
-    const filesOnly = event.type === "thread.checkpoint-files-restore-requested";
-    const filesRestore =
-      filesOnly && event.commandId !== null
-        ? { requestCommandId: event.commandId, messageId: event.payload.messageId }
-        : undefined;
+    let filesRestore:
+      | {
+          readonly requestCommandId: CommandId;
+          readonly messageId: MessageId;
+        }
+      | undefined;
+    if (event.type === "thread.checkpoint-files-restore-requested") {
+      if (event.commandId === null) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: "File restore request is missing its command id.",
+          requiresWorkspaceReview: true,
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+      filesRestore = {
+        requestCommandId: event.commandId,
+        messageId: event.payload.messageId,
+      };
+    }
+    const filesOnly = filesRestore !== undefined;
 
     const thread = yield* getThreadDetail(event.payload.threadId);
     if (!thread) {
@@ -966,8 +1016,8 @@ const make = Effect.gen(function* () {
         ),
       )
       .find((checkpointRef) => checkpointRef !== null);
-    const targetCheckpointRef = filesOnly
-      ? checkpointRefForThreadMessageStart(event.payload.threadId, event.payload.messageId)
+    const targetCheckpointRef = filesRestore
+      ? checkpointRefForThreadMessageStart(event.payload.threadId, filesRestore.messageId)
       : event.payload.turnCount === 0
         ? (earliestManagedBaselineRef ?? checkpointRefForThreadTurn(event.payload.threadId, 0))
         : thread.checkpoints.find(
@@ -985,11 +1035,13 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const restored = yield* checkpointStore.restoreCheckpoint({
-      cwd: sessionRuntime.value.cwd,
-      checkpointRef: targetCheckpointRef,
-      fallbackToHead: !filesOnly && event.payload.turnCount === 0,
-    });
+    const restored = yield* withCheckpointFileRestoreInterlock(
+      checkpointStore.restoreCheckpoint({
+        cwd: sessionRuntime.value.cwd,
+        checkpointRef: targetCheckpointRef,
+        fallbackToHead: !filesOnly && event.payload.turnCount === 0,
+      }),
+    );
     if (!restored) {
       yield* appendRevertFailureActivity({
         threadId: event.payload.threadId,
@@ -1007,25 +1059,34 @@ const make = Effect.gen(function* () {
 
     // The diff-card action restores the immutable baseline captured for that
     // exact user message. This remains correct after earlier file-only undos.
-    if (filesOnly) {
-      if (event.commandId === null) {
-        yield* appendRevertFailureActivity({
+    if (filesRestore) {
+      const completeCommandId = serverCommandId("checkpoint-files-restore-complete");
+      yield* Effect.suspend(() =>
+        orchestrationEngine.dispatch({
+          type: "thread.checkpoint.files.restore.complete",
+          commandId: completeCommandId,
+          requestCommandId: filesRestore.requestCommandId,
           threadId: event.payload.threadId,
+          messageId: filesRestore.messageId,
           turnCount: event.payload.turnCount,
-          detail: "File restore request is missing its command id.",
           createdAt: now,
-        });
-        return;
-      }
-      yield* orchestrationEngine.dispatch({
-        type: "thread.checkpoint.files.restore.complete",
-        commandId: serverCommandId("checkpoint-files-restore-complete"),
-        requestCommandId: event.commandId,
-        threadId: event.payload.threadId,
-        messageId: event.payload.messageId,
-        turnCount: event.payload.turnCount,
-        createdAt: now,
-      });
+        }),
+      ).pipe(
+        Effect.retry(FILE_RESTORE_TERMINAL_INITIAL_RETRY_SCHEDULE),
+        Effect.catch((error) =>
+          appendFilesRestoreFailureTerminalEventually(
+            {
+              threadId: event.payload.threadId,
+              turnCount: event.payload.turnCount,
+              detail: `File restore changed files, but Synara could not persist the success terminal: ${error.message}`,
+              requiresWorkspaceReview: true,
+              createdAt: now,
+              filesRestore,
+            },
+            "checkpoint file restore success terminal fallback",
+          ),
+        ),
+      );
       return;
     }
 
@@ -1114,30 +1175,21 @@ const make = Effect.gen(function* () {
         if (state.terminal) return Effect.void;
         const source = state.request ?? state.reconciliation;
         if (!source) return Effect.void;
-        return appendFilesRestoreFailureTerminal({
-          threadId: source.payload.threadId,
-          turnCount: source.payload.turnCount,
-          detail: state.request
-            ? "File restore did not finish before Synara restarted. No automatic retry was run; inspect the working tree before continuing."
-            : "Synara restarted before file restore acceptance could be confirmed. No restore was replayed; inspect the working tree before continuing.",
-          requiresWorkspaceReview: true,
-          createdAt: now,
-          filesRestore: {
-            requestCommandId,
-            messageId: source.payload.messageId,
+        return appendFilesRestoreFailureTerminalEventually(
+          {
+            threadId: source.payload.threadId,
+            turnCount: source.payload.turnCount,
+            detail: state.request
+              ? "File restore did not finish before Synara restarted. No automatic retry was run; inspect the working tree before continuing."
+              : "Synara restarted before file restore acceptance could be confirmed. No restore was replayed; inspect the working tree before continuing.",
+            requiresWorkspaceReview: true,
+            createdAt: now,
+            filesRestore: {
+              requestCommandId,
+              messageId: source.payload.messageId,
+            },
           },
-        }).pipe(
-          Effect.catch((error) =>
-            Effect.logWarning(
-              "failed to append interrupted checkpoint files restore terminal",
-            ).pipe(
-              Effect.annotateLogs({
-                threadId: source.payload.threadId,
-                requestCommandId,
-                error: error.message,
-              }),
-            ),
-          ),
+          "checkpoint startup interrupted file restore reconciliation",
         );
       },
       { concurrency: 1 },
@@ -1177,19 +1229,23 @@ const make = Effect.gen(function* () {
 
     if (event.type === "thread.checkpoint-files-restore-reconciliation-requested") {
       const state = yield* readFileRestoreEventState(event.payload.requestCommandId);
-      if (!state.requested && !state.terminal) {
-        yield* appendFilesRestoreFailureTerminal({
-          threadId: event.payload.threadId,
-          turnCount: event.payload.turnCount,
-          detail:
-            "Synara could not confirm that the file restore was accepted. No restore was replayed; inspect the working tree before continuing.",
-          requiresWorkspaceReview: true,
-          createdAt: new Date().toISOString(),
-          filesRestore: {
-            requestCommandId: event.payload.requestCommandId,
-            messageId: event.payload.messageId,
+      if (!state.terminal) {
+        yield* appendFilesRestoreFailureTerminalEventually(
+          {
+            threadId: event.payload.threadId,
+            turnCount: event.payload.turnCount,
+            detail: state.requested
+              ? "Synara found a file restore request without a durable terminal event. No restore was replayed; inspect the working tree before continuing."
+              : "Synara could not confirm that the file restore was accepted. No restore was replayed; inspect the working tree before continuing.",
+            requiresWorkspaceReview: true,
+            createdAt: new Date().toISOString(),
+            filesRestore: {
+              requestCommandId: event.payload.requestCommandId,
+              messageId: event.payload.messageId,
+            },
           },
-        });
+          "checkpoint explicit file restore reconciliation",
+        );
       }
       return;
     }
@@ -1209,7 +1265,7 @@ const make = Effect.gen(function* () {
           appendRevertFailureActivity({
             threadId: event.payload.threadId,
             turnCount: event.payload.turnCount,
-            detail: error.message,
+            detail: errorMessage(error),
             ...(event.type === "thread.checkpoint-files-restore-requested"
               ? { requiresWorkspaceReview: true }
               : {}),

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -913,6 +913,24 @@ const make = Effect.gen(function* () {
     });
   });
 
+  const hasPriorFilesRestoreSideEffect = Effect.fnUntraced(function* (
+    threadId: ThreadId,
+    beforeSequence: number,
+  ) {
+    const events = yield* Stream.runCollect(orchestrationEngine.readEvents(0)).pipe(
+      Effect.map((chunk): OrchestrationEvent[] => Array.from(chunk)),
+    );
+    return events.some(
+      (candidate) =>
+        candidate.aggregateKind === "thread" &&
+        candidate.aggregateId === threadId &&
+        candidate.sequence < beforeSequence &&
+        (candidate.type === "thread.checkpoint-files-restored" ||
+          (candidate.type === "thread.checkpoint-files-restore-failed" &&
+            candidate.payload.requiresWorkspaceReview)),
+    );
+  });
+
   const handleRevertRequested = Effect.fnUntraced(function* (
     event: Extract<
       OrchestrationEvent,
@@ -1016,13 +1034,21 @@ const make = Effect.gen(function* () {
         ),
       )
       .find((checkpointRef) => checkpointRef !== null);
-    const targetCheckpointRef = filesRestore
-      ? checkpointRefForThreadMessageStart(event.payload.threadId, filesRestore.messageId)
-      : event.payload.turnCount === 0
+    const numberedTurnCheckpointRef =
+      event.payload.turnCount === 0
         ? (earliestManagedBaselineRef ?? checkpointRefForThreadTurn(event.payload.threadId, 0))
         : thread.checkpoints.find(
             (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
           )?.checkpointRef;
+    const targetCheckpointRef = filesRestore
+      ? checkpointRefForThreadMessageStart(event.payload.threadId, filesRestore.messageId)
+      : numberedTurnCheckpointRef;
+    const legacyFilesRestoreFallbackRef =
+      filesRestore &&
+      numberedTurnCheckpointRef &&
+      !(yield* hasPriorFilesRestoreSideEffect(event.payload.threadId, event.sequence))
+        ? numberedTurnCheckpointRef
+        : null;
 
     if (!targetCheckpointRef) {
       yield* appendRevertFailureActivity({
@@ -1035,13 +1061,31 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const restored = yield* withCheckpointFileRestoreInterlock(
-      checkpointStore.restoreCheckpoint({
-        cwd: sessionRuntime.value.cwd,
-        checkpointRef: targetCheckpointRef,
-        fallbackToHead: !filesOnly && event.payload.turnCount === 0,
-      }),
+    const restoreTargetCheckpointRef = (checkpointRef: CheckpointRef, fallbackToHead: boolean) =>
+      withCheckpointFileRestoreInterlock(
+        checkpointStore.restoreCheckpoint({
+          cwd: sessionRuntime.value.cwd,
+          checkpointRef,
+          fallbackToHead,
+        }),
+      );
+
+    let restored = yield* restoreTargetCheckpointRef(
+      targetCheckpointRef,
+      !filesOnly && event.payload.turnCount === 0,
     );
+    if (
+      !restored &&
+      filesRestore &&
+      legacyFilesRestoreFallbackRef !== null &&
+      legacyFilesRestoreFallbackRef !== targetCheckpointRef
+    ) {
+      // Older histories predate message-start checkpoint refs. Before any
+      // successful file-only undo, the persisted numbered turn checkpoint is
+      // still the best known message-start baseline; after one undo it is no
+      // longer safe because sequential undo must preserve the post-undo state.
+      restored = yield* restoreTargetCheckpointRef(legacyFilesRestoreFallbackRef, false);
+    }
     if (!restored) {
       yield* appendRevertFailureActivity({
         threadId: event.payload.threadId,

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -229,6 +229,22 @@ describe("OrchestrationEngine", () => {
         createdAt,
       }),
     );
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "thread.checkpoint.files.restore",
+          commandId: requestCommandId,
+          threadId,
+          messageId: asMessageId("msg-restore-gate"),
+          turnCount: 1,
+          createdAt,
+        }),
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        sequence: expect.any(Number),
+      }),
+    );
 
     await expect(
       system.run(
@@ -328,6 +344,37 @@ describe("OrchestrationEngine", () => {
         turnCount: 1,
         detail: "Restore outcome requires review.",
         requiresWorkspaceReview: true,
+        createdAt,
+      }),
+    );
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.makeUnsafe("cmd-restore-gate-turn-review-blocked"),
+          threadId,
+          message: {
+            messageId: asMessageId("msg-restore-gate-review-blocked"),
+            role: "user",
+            text: "review-required restore should still gate",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt,
+        }),
+      ),
+    ).rejects.toThrow("A checkpoint file restore is still pending");
+
+    await system.run(
+      engine.dispatch({
+        type: "thread.checkpoint.files.restore.reviewed",
+        commandId: CommandId.makeUnsafe("cmd-restore-gate-reviewed"),
+        requestCommandId,
+        threadId,
+        messageId: asMessageId("msg-restore-gate"),
+        turnCount: 1,
         createdAt,
       }),
     );

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -180,6 +180,184 @@ describe("OrchestrationEngine", () => {
     await system.dispose();
   });
 
+  it("blocks new destructive work while a checkpoint files restore is pending", async () => {
+    const system = await createOrchestrationSystem();
+    const { engine } = system;
+    const createdAt = now();
+    const threadId = ThreadId.makeUnsafe("thread-restore-gate");
+    const requestCommandId = CommandId.makeUnsafe("cmd-restore-gate-request");
+
+    await system.run(
+      engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.makeUnsafe("cmd-restore-gate-project"),
+        projectId: asProjectId("project-restore-gate"),
+        title: "Restore Gate Project",
+        workspaceRoot: "/tmp/project-restore-gate",
+        defaultModelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.makeUnsafe("cmd-restore-gate-thread"),
+        threadId,
+        projectId: asProjectId("project-restore-gate"),
+        title: "restore-gate",
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.checkpoint.files.restore",
+        commandId: requestCommandId,
+        threadId,
+        messageId: asMessageId("msg-restore-gate"),
+        turnCount: 1,
+        createdAt,
+      }),
+    );
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.makeUnsafe("cmd-restore-gate-turn-blocked"),
+          threadId,
+          message: {
+            messageId: asMessageId("msg-restore-gate-blocked"),
+            role: "user",
+            text: "new work should wait",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt,
+        }),
+      ),
+    ).rejects.toThrow("A checkpoint file restore is still pending");
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "thread.checkpoint.files.restore",
+          commandId: CommandId.makeUnsafe("cmd-restore-gate-second-restore"),
+          threadId,
+          messageId: asMessageId("msg-restore-gate-second"),
+          turnCount: 1,
+          createdAt,
+        }),
+      ),
+    ).rejects.toThrow("A checkpoint file restore is still pending");
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "project.create",
+          commandId: CommandId.makeUnsafe("cmd-restore-gate-project-blocked"),
+          projectId: asProjectId("project-restore-gate-blocked"),
+          title: "Blocked Restore Gate Project",
+          workspaceRoot: "/tmp/project-restore-gate-blocked",
+          defaultModelSelection: {
+            provider: "codex",
+            model: "gpt-5-codex",
+          },
+          createdAt,
+        }),
+      ),
+    ).rejects.toThrow("A checkpoint file restore is still pending");
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "project.meta.update",
+          commandId: CommandId.makeUnsafe("cmd-restore-gate-project-update-blocked"),
+          projectId: asProjectId("project-restore-gate"),
+          workspaceRoot: "/tmp/project-restore-gate-updated",
+        }),
+      ),
+    ).rejects.toThrow("A checkpoint file restore is still pending");
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "thread.delete",
+          commandId: CommandId.makeUnsafe("cmd-restore-gate-thread-delete-blocked"),
+          threadId,
+        }),
+      ),
+    ).rejects.toThrow("A checkpoint file restore is still pending");
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "thread.checkpoint.files.restore.reconcile",
+          commandId: CommandId.makeUnsafe("cmd-restore-gate-reconcile"),
+          requestCommandId,
+          threadId,
+          messageId: asMessageId("msg-restore-gate"),
+          turnCount: 1,
+          createdAt,
+        }),
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        sequence: expect.any(Number),
+      }),
+    );
+
+    await system.run(
+      engine.dispatch({
+        type: "thread.checkpoint.files.restore.fail",
+        commandId: CommandId.makeUnsafe("cmd-restore-gate-fail"),
+        requestCommandId,
+        threadId,
+        messageId: asMessageId("msg-restore-gate"),
+        turnCount: 1,
+        detail: "Restore outcome requires review.",
+        requiresWorkspaceReview: true,
+        createdAt,
+      }),
+    );
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "thread.turn.start",
+          commandId: CommandId.makeUnsafe("cmd-restore-gate-turn-after-terminal"),
+          threadId,
+          message: {
+            messageId: asMessageId("msg-restore-gate-after-terminal"),
+            role: "user",
+            text: "new work can resume",
+            attachments: [],
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          createdAt,
+        }),
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        sequence: expect.any(Number),
+      }),
+    );
+
+    await system.dispose();
+  });
+
   it("streams persisted domain events in order", async () => {
     const system = await createOrchestrationSystem();
     const { engine } = system;

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -31,6 +31,11 @@ import {
   OrchestrationCommandTimeoutError,
   type OrchestrationDispatchError,
 } from "../Errors.ts";
+import {
+  isOrchestrationCommandBlockedByPendingCheckpointFileRestore,
+  makePendingCheckpointFileRestoreCommandError,
+  shouldBlockCommandForPendingCheckpointFileRestore,
+} from "../checkpointFileRestoreGate.ts";
 import { decideOrchestrationCommand } from "../decider.ts";
 import type { ProjectMetadataOrchestrationEvent } from "../projectMetadataProjection.ts";
 import { PROJECT_METADATA_SNAPSHOT_PROJECTORS } from "../projectMetadataProjection.ts";
@@ -378,6 +383,15 @@ const makeOrchestrationEngine = Effect.gen(function* () {
           }),
         );
         return;
+      }
+
+      if (isOrchestrationCommandBlockedByPendingCheckpointFileRestore(envelope.command)) {
+        const events = yield* Stream.runCollect(eventStore.readFromSequence(0)).pipe(
+          Effect.map((chunk): OrchestrationEvent[] => Array.from(chunk)),
+        );
+        if (shouldBlockCommandForPendingCheckpointFileRestore(events, envelope.command.type)) {
+          return yield* makePendingCheckpointFileRestoreCommandError(envelope.command.type);
+        }
       }
 
       const deciderReadModel = yield* buildDeciderReadModel(envelope.command);

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -389,7 +389,18 @@ const makeOrchestrationEngine = Effect.gen(function* () {
         const events = yield* Stream.runCollect(eventStore.readFromSequence(0)).pipe(
           Effect.map((chunk): OrchestrationEvent[] => Array.from(chunk)),
         );
-        if (shouldBlockCommandForPendingCheckpointFileRestore(events, envelope.command.type)) {
+        const allowedRequestCommandId =
+          envelope.command.type === "thread.checkpoint.files.restore"
+            ? envelope.command.commandId
+            : undefined;
+        if (
+          shouldBlockCommandForPendingCheckpointFileRestore(events, envelope.command.type, {
+            allowRecordedCommandId: envelope.command.commandId,
+            ...(allowedRequestCommandId !== undefined
+              ? { allowRequestCommandId: allowedRequestCommandId }
+              : {}),
+          })
+        ) {
           return yield* makePendingCheckpointFileRestoreCommandError(envelope.command.type);
         }
       }

--- a/apps/server/src/orchestration/checkpointFileRestoreGate.test.ts
+++ b/apps/server/src/orchestration/checkpointFileRestoreGate.test.ts
@@ -1,0 +1,131 @@
+import {
+  CommandId,
+  EventId,
+  MessageId,
+  ThreadId,
+  type OrchestrationEvent,
+} from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  hasPendingCheckpointFileRestore,
+  isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore,
+  shouldBlockCommandForPendingCheckpointFileRestore,
+} from "./checkpointFileRestoreGate.ts";
+
+const threadId = ThreadId.makeUnsafe("thread-gate-test");
+const messageId = MessageId.makeUnsafe("message-gate-test");
+const requestCommandId = CommandId.makeUnsafe("cmd-gate-request");
+const createdAt = "2026-07-12T13:00:00.000Z";
+
+function base(sequence: number, commandId: CommandId | null) {
+  return {
+    sequence,
+    eventId: EventId.makeUnsafe(`evt-gate-${sequence}`),
+    aggregateKind: "thread" as const,
+    aggregateId: threadId,
+    occurredAt: createdAt,
+    commandId,
+    causationEventId: null,
+    correlationId: commandId,
+    metadata: {},
+  };
+}
+
+function requested(sequence: number): OrchestrationEvent {
+  return {
+    ...base(sequence, requestCommandId),
+    type: "thread.checkpoint-files-restore-requested",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 0,
+      createdAt,
+    },
+  };
+}
+
+function restored(sequence: number): OrchestrationEvent {
+  return {
+    ...base(sequence, CommandId.makeUnsafe(`cmd-terminal-${sequence}`)),
+    type: "thread.checkpoint-files-restored",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 0,
+      requestCommandId,
+    },
+  };
+}
+
+function reconcile(sequence: number): OrchestrationEvent {
+  return {
+    ...base(sequence, CommandId.makeUnsafe(`cmd-reconcile-${sequence}`)),
+    type: "thread.checkpoint-files-restore-reconciliation-requested",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 0,
+      requestCommandId,
+      createdAt,
+    },
+  };
+}
+
+describe("checkpoint file restore gate", () => {
+  it("keeps pending restores pending until a correlated terminal event", () => {
+    expect(hasPendingCheckpointFileRestore([requested(1)])).toBe(true);
+    expect(hasPendingCheckpointFileRestore([requested(1), restored(2)])).toBe(false);
+  });
+
+  it("does not reopen the gate when reconciliation is logged after terminal state", () => {
+    expect(hasPendingCheckpointFileRestore([requested(1), restored(2), reconcile(3)])).toBe(false);
+  });
+
+  it("allows recorded command ids to reach receipt-based idempotency", () => {
+    expect(
+      shouldBlockCommandForPendingCheckpointFileRestore(
+        [requested(1)],
+        "thread.checkpoint.files.restore",
+        { allowRecordedCommandId: requestCommandId },
+      ),
+    ).toBe(false);
+    expect(
+      shouldBlockCommandForPendingCheckpointFileRestore(
+        [requested(1)],
+        "thread.checkpoint.files.restore",
+        { allowRecordedCommandId: CommandId.makeUnsafe("cmd-unrecorded-retry") },
+      ),
+    ).toBe(true);
+    expect(
+      shouldBlockCommandForPendingCheckpointFileRestore(
+        [requested(1), restored(2)],
+        "thread.checkpoint.files.restore",
+        { allowRecordedCommandId: CommandId.makeUnsafe("cmd-unrecorded-after-terminal") },
+      ),
+    ).toBe(false);
+  });
+
+  it("blocks orchestration commands that can start workspace or provider mutations", () => {
+    expect(isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore("project.create")).toBe(
+      true,
+    );
+    expect(
+      isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore("project.meta.update"),
+    ).toBe(true);
+    expect(
+      isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore("thread.turn.start"),
+    ).toBe(true);
+    expect(isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore("thread.delete")).toBe(
+      true,
+    );
+    expect(
+      isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore(
+        "thread.checkpoint.files.restore",
+      ),
+    ).toBe(true);
+    expect(isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore("thread.archive")).toBe(
+      false,
+    );
+  });
+});

--- a/apps/server/src/orchestration/checkpointFileRestoreGate.test.ts
+++ b/apps/server/src/orchestration/checkpointFileRestoreGate.test.ts
@@ -45,6 +45,20 @@ function requested(sequence: number): OrchestrationEvent {
   };
 }
 
+function prepared(sequence: number): OrchestrationEvent {
+  return {
+    ...base(sequence, CommandId.makeUnsafe(`cmd-prepare-${sequence}`)),
+    type: "thread.checkpoint-files-restore-prepared",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 0,
+      requestCommandId,
+      createdAt,
+    },
+  };
+}
+
 function restored(sequence: number): OrchestrationEvent {
   return {
     ...base(sequence, CommandId.makeUnsafe(`cmd-terminal-${sequence}`)),
@@ -54,6 +68,35 @@ function restored(sequence: number): OrchestrationEvent {
       messageId,
       turnCount: 0,
       requestCommandId,
+    },
+  };
+}
+
+function failed(sequence: number, requiresWorkspaceReview: boolean): OrchestrationEvent {
+  return {
+    ...base(sequence, CommandId.makeUnsafe(`cmd-failed-${sequence}`)),
+    type: "thread.checkpoint-files-restore-failed",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 0,
+      requestCommandId,
+      detail: "File restore failed.",
+      requiresWorkspaceReview,
+    },
+  };
+}
+
+function reviewed(sequence: number): OrchestrationEvent {
+  return {
+    ...base(sequence, CommandId.makeUnsafe(`cmd-reviewed-${sequence}`)),
+    type: "thread.checkpoint-files-restore-reviewed",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 0,
+      requestCommandId,
+      createdAt,
     },
   };
 }
@@ -78,8 +121,25 @@ describe("checkpoint file restore gate", () => {
     expect(hasPendingCheckpointFileRestore([requested(1), restored(2)])).toBe(false);
   });
 
+  it("keeps server reservations pending until they are used or explicitly reviewed", () => {
+    expect(hasPendingCheckpointFileRestore([prepared(1)])).toBe(true);
+    expect(hasPendingCheckpointFileRestore([prepared(1), reviewed(2)])).toBe(false);
+    expect(hasPendingCheckpointFileRestore([prepared(1), requested(2), restored(3)])).toBe(false);
+  });
+
+  it("keeps review-required failures gated until explicit review unlock", () => {
+    expect(hasPendingCheckpointFileRestore([requested(1), failed(2, true)])).toBe(true);
+    expect(hasPendingCheckpointFileRestore([requested(1), failed(2, false)])).toBe(false);
+    expect(hasPendingCheckpointFileRestore([requested(1), failed(2, true), reviewed(3)])).toBe(
+      false,
+    );
+  });
+
   it("does not reopen the gate when reconciliation is logged after terminal state", () => {
     expect(hasPendingCheckpointFileRestore([requested(1), restored(2), reconcile(3)])).toBe(false);
+    expect(
+      hasPendingCheckpointFileRestore([requested(1), failed(2, true), reviewed(3), reconcile(4)]),
+    ).toBe(false);
   });
 
   it("allows recorded command ids to reach receipt-based idempotency", () => {
@@ -95,6 +155,20 @@ describe("checkpoint file restore gate", () => {
         [requested(1)],
         "thread.checkpoint.files.restore",
         { allowRecordedCommandId: CommandId.makeUnsafe("cmd-unrecorded-retry") },
+      ),
+    ).toBe(true);
+    expect(
+      shouldBlockCommandForPendingCheckpointFileRestore(
+        [prepared(1)],
+        "thread.checkpoint.files.restore",
+        { allowRequestCommandId: requestCommandId },
+      ),
+    ).toBe(false);
+    expect(
+      shouldBlockCommandForPendingCheckpointFileRestore(
+        [prepared(1)],
+        "thread.checkpoint.files.restore",
+        { allowRequestCommandId: CommandId.makeUnsafe("cmd-other-request") },
       ),
     ).toBe(true);
     expect(
@@ -122,6 +196,11 @@ describe("checkpoint file restore gate", () => {
     expect(
       isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore(
         "thread.checkpoint.files.restore",
+      ),
+    ).toBe(true);
+    expect(
+      isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore(
+        "thread.checkpoint.files.restore.prepare",
       ),
     ).toBe(true);
     expect(isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore("thread.archive")).toBe(

--- a/apps/server/src/orchestration/checkpointFileRestoreGate.ts
+++ b/apps/server/src/orchestration/checkpointFileRestoreGate.ts
@@ -15,17 +15,25 @@ const BLOCKED_ORCHESTRATION_COMMAND_TYPES = new Set<OrchestrationCommand["type"]
   "thread.approval.respond",
   "thread.user-input.respond",
   "thread.checkpoint.revert",
+  "thread.checkpoint.files.restore.prepare",
   "thread.checkpoint.files.restore",
   "thread.conversation.rollback",
   "thread.message.edit-and-resend",
 ]);
 
-export function hasPendingCheckpointFileRestore(events: Iterable<OrchestrationEvent>): boolean {
+function pendingCheckpointFileRestoreRequestCommandIds(
+  events: Iterable<OrchestrationEvent>,
+): Set<CommandId> {
   const pendingRequestCommandIds = new Set<CommandId>();
   const terminalRequestCommandIds = new Set<CommandId>();
 
   for (const event of events) {
     switch (event.type) {
+      case "thread.checkpoint-files-restore-prepared":
+        if (!terminalRequestCommandIds.has(event.payload.requestCommandId)) {
+          pendingRequestCommandIds.add(event.payload.requestCommandId);
+        }
+        break;
       case "thread.checkpoint-files-restore-requested":
         if (event.commandId !== null && !terminalRequestCommandIds.has(event.commandId)) {
           pendingRequestCommandIds.add(event.commandId);
@@ -37,7 +45,20 @@ export function hasPendingCheckpointFileRestore(events: Iterable<OrchestrationEv
         }
         break;
       case "thread.checkpoint-files-restored":
+        terminalRequestCommandIds.add(event.payload.requestCommandId);
+        pendingRequestCommandIds.delete(event.payload.requestCommandId);
+        break;
       case "thread.checkpoint-files-restore-failed":
+        if (event.payload.requiresWorkspaceReview) {
+          if (!terminalRequestCommandIds.has(event.payload.requestCommandId)) {
+            pendingRequestCommandIds.add(event.payload.requestCommandId);
+          }
+        } else {
+          terminalRequestCommandIds.add(event.payload.requestCommandId);
+          pendingRequestCommandIds.delete(event.payload.requestCommandId);
+        }
+        break;
+      case "thread.checkpoint-files-restore-reviewed":
         terminalRequestCommandIds.add(event.payload.requestCommandId);
         pendingRequestCommandIds.delete(event.payload.requestCommandId);
         break;
@@ -46,6 +67,11 @@ export function hasPendingCheckpointFileRestore(events: Iterable<OrchestrationEv
     }
   }
 
+  return pendingRequestCommandIds;
+}
+
+export function hasPendingCheckpointFileRestore(events: Iterable<OrchestrationEvent>): boolean {
+  const pendingRequestCommandIds = pendingCheckpointFileRestoreRequestCommandIds(events);
   return pendingRequestCommandIds.size > 0;
 }
 
@@ -64,18 +90,33 @@ export function hasRecordedOrchestrationCommand(
 export function shouldBlockCommandForPendingCheckpointFileRestore(
   events: Iterable<OrchestrationEvent>,
   commandType: string,
-  options?: { readonly allowRecordedCommandId?: CommandId },
+  options?: {
+    readonly allowRecordedCommandId?: CommandId;
+    readonly allowRequestCommandId?: CommandId;
+  },
 ): boolean {
   const eventList = Array.from(events);
   if (!isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore(commandType)) {
     return false;
   }
-  if (!hasPendingCheckpointFileRestore(eventList)) {
+  const pendingRequestCommandIds = pendingCheckpointFileRestoreRequestCommandIds(eventList);
+  if (pendingRequestCommandIds.size === 0) {
     return false;
   }
-  return options?.allowRecordedCommandId === undefined
-    ? true
-    : !hasRecordedOrchestrationCommand(eventList, options.allowRecordedCommandId);
+  if (
+    options?.allowRequestCommandId !== undefined &&
+    pendingRequestCommandIds.size === 1 &&
+    pendingRequestCommandIds.has(options.allowRequestCommandId)
+  ) {
+    return false;
+  }
+  if (
+    options?.allowRecordedCommandId !== undefined &&
+    hasRecordedOrchestrationCommand(eventList, options.allowRecordedCommandId)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function isOrchestrationCommandBlockedByPendingCheckpointFileRestore(

--- a/apps/server/src/orchestration/checkpointFileRestoreGate.ts
+++ b/apps/server/src/orchestration/checkpointFileRestoreGate.ts
@@ -1,0 +1,98 @@
+import type { OrchestrationCommand, OrchestrationEvent } from "@synara/contracts";
+import { CommandId } from "@synara/contracts";
+
+import { OrchestrationCommandInvariantError } from "./Errors.ts";
+
+export const CHECKPOINT_FILE_RESTORE_PENDING_DETAIL =
+  "A checkpoint file restore is still pending. Wait for Synara to confirm it is safe to continue before starting workspace or provider mutations.";
+
+const BLOCKED_ORCHESTRATION_COMMAND_TYPES = new Set<OrchestrationCommand["type"]>([
+  "project.create",
+  "project.meta.update",
+  "thread.delete",
+  "thread.turn.start",
+  "thread.turn.dispatch-queued",
+  "thread.approval.respond",
+  "thread.user-input.respond",
+  "thread.checkpoint.revert",
+  "thread.checkpoint.files.restore",
+  "thread.conversation.rollback",
+  "thread.message.edit-and-resend",
+]);
+
+export function hasPendingCheckpointFileRestore(events: Iterable<OrchestrationEvent>): boolean {
+  const pendingRequestCommandIds = new Set<CommandId>();
+  const terminalRequestCommandIds = new Set<CommandId>();
+
+  for (const event of events) {
+    switch (event.type) {
+      case "thread.checkpoint-files-restore-requested":
+        if (event.commandId !== null && !terminalRequestCommandIds.has(event.commandId)) {
+          pendingRequestCommandIds.add(event.commandId);
+        }
+        break;
+      case "thread.checkpoint-files-restore-reconciliation-requested":
+        if (!terminalRequestCommandIds.has(event.payload.requestCommandId)) {
+          pendingRequestCommandIds.add(event.payload.requestCommandId);
+        }
+        break;
+      case "thread.checkpoint-files-restored":
+      case "thread.checkpoint-files-restore-failed":
+        terminalRequestCommandIds.add(event.payload.requestCommandId);
+        pendingRequestCommandIds.delete(event.payload.requestCommandId);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return pendingRequestCommandIds.size > 0;
+}
+
+export function hasRecordedOrchestrationCommand(
+  events: Iterable<OrchestrationEvent>,
+  commandId: CommandId,
+): boolean {
+  for (const event of events) {
+    if (event.commandId === commandId) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function shouldBlockCommandForPendingCheckpointFileRestore(
+  events: Iterable<OrchestrationEvent>,
+  commandType: string,
+  options?: { readonly allowRecordedCommandId?: CommandId },
+): boolean {
+  const eventList = Array.from(events);
+  if (!isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore(commandType)) {
+    return false;
+  }
+  if (!hasPendingCheckpointFileRestore(eventList)) {
+    return false;
+  }
+  return options?.allowRecordedCommandId === undefined
+    ? true
+    : !hasRecordedOrchestrationCommand(eventList, options.allowRecordedCommandId);
+}
+
+export function isOrchestrationCommandBlockedByPendingCheckpointFileRestore(
+  command: OrchestrationCommand,
+): boolean {
+  return isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore(command.type);
+}
+
+export function isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore(
+  commandType: string,
+): boolean {
+  return BLOCKED_ORCHESTRATION_COMMAND_TYPES.has(commandType as OrchestrationCommand["type"]);
+}
+
+export function makePendingCheckpointFileRestoreCommandError(commandType: string) {
+  return new OrchestrationCommandInvariantError({
+    commandType,
+    detail: CHECKPOINT_FILE_RESTORE_PENDING_DETAIL,
+  });
+}

--- a/apps/server/src/orchestration/checkpointFileRestoreInterlock.ts
+++ b/apps/server/src/orchestration/checkpointFileRestoreInterlock.ts
@@ -1,0 +1,9 @@
+import { Effect, Semaphore } from "effect";
+
+const checkpointFileRestoreInterlock = Semaphore.makeUnsafe(1);
+
+export function withCheckpointFileRestoreInterlock<A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  return checkpointFileRestoreInterlock.withPermits(1)(effect);
+}

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1352,6 +1352,25 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.checkpoint.files.restore": {
+      yield* requireThread({ readModel, command, threadId: command.threadId });
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.checkpoint-files-restore-requested",
+        payload: {
+          threadId: command.threadId,
+          messageId: command.messageId,
+          turnCount: command.turnCount,
+          createdAt: command.createdAt,
+        },
+      };
+    }
+
     case "thread.conversation.rollback": {
       const thread = yield* requireThread({
         readModel,
@@ -1635,6 +1654,25 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           turnCount: command.turnCount,
+        },
+      };
+    }
+
+    case "thread.checkpoint.files.restore.complete": {
+      yield* requireThread({ readModel, command, threadId: command.threadId });
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.checkpoint-files-restored",
+        payload: {
+          threadId: command.threadId,
+          messageId: command.messageId,
+          turnCount: command.turnCount,
+          requestCommandId: command.requestCommandId,
         },
       };
     }

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1677,6 +1677,26 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.checkpoint.files.restore.fail": {
+      yield* requireThread({ readModel, command, threadId: command.threadId });
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.checkpoint-files-restore-failed",
+        payload: {
+          threadId: command.threadId,
+          messageId: command.messageId,
+          turnCount: command.turnCount,
+          requestCommandId: command.requestCommandId,
+          detail: command.detail,
+        },
+      };
+    }
+
     case "thread.conversation.rollback.complete": {
       yield* requireThread({
         readModel,

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1371,6 +1371,26 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.checkpoint.files.restore.prepare": {
+      yield* requireThread({ readModel, command, threadId: command.threadId });
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.checkpoint-files-restore-prepared",
+        payload: {
+          threadId: command.threadId,
+          messageId: command.messageId,
+          turnCount: command.turnCount,
+          requestCommandId: command.requestCommandId,
+          createdAt: command.createdAt,
+        },
+      };
+    }
+
     case "thread.checkpoint.files.restore.reconcile": {
       return {
         ...withEventBase({
@@ -1380,6 +1400,25 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           commandId: command.commandId,
         }),
         type: "thread.checkpoint-files-restore-reconciliation-requested",
+        payload: {
+          threadId: command.threadId,
+          messageId: command.messageId,
+          turnCount: command.turnCount,
+          requestCommandId: command.requestCommandId,
+          createdAt: command.createdAt,
+        },
+      };
+    }
+
+    case "thread.checkpoint.files.restore.reviewed": {
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.checkpoint-files-restore-reviewed",
         payload: {
           threadId: command.threadId,
           messageId: command.messageId,

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1371,6 +1371,25 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.checkpoint.files.restore.reconcile": {
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.checkpoint-files-restore-reconciliation-requested",
+        payload: {
+          threadId: command.threadId,
+          messageId: command.messageId,
+          turnCount: command.turnCount,
+          requestCommandId: command.requestCommandId,
+          createdAt: command.createdAt,
+        },
+      };
+    }
+
     case "thread.conversation.rollback": {
       const thread = yield* requireThread({
         readModel,
@@ -1678,7 +1697,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.checkpoint.files.restore.fail": {
-      yield* requireThread({ readModel, command, threadId: command.threadId });
+      // Correlated failure cleanup must remain appendable even after the owning
+      // thread is deleted. Otherwise restart reconciliation can leave a
+      // destructive files-only restore permanently pending with no safe unlock.
       return {
         ...withEventBase({
           aggregateKind: "thread",
@@ -1693,6 +1714,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           turnCount: command.turnCount,
           requestCommandId: command.requestCommandId,
           detail: command.detail,
+          requiresWorkspaceReview: command.requiresWorkspaceReview,
         },
       };
     }

--- a/apps/server/src/orchestration/dispatchRejectionClassification.test.ts
+++ b/apps/server/src/orchestration/dispatchRejectionClassification.test.ts
@@ -1,0 +1,65 @@
+import { CommandId } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import { ServerRuntimeStartupError } from "../serverRuntimeStartup.ts";
+import {
+  OrchestrationCommandDecodeError,
+  OrchestrationCommandInternalError,
+  OrchestrationCommandInvariantError,
+  OrchestrationCommandPreviouslyRejectedError,
+  OrchestrationCommandTimeoutError,
+} from "./Errors.ts";
+import { isDefinitiveDispatchRejection } from "./dispatchRejectionClassification.ts";
+
+describe("dispatch rejection classification", () => {
+  it("tags only structured failures that prove dispatch was not accepted", () => {
+    expect(
+      isDefinitiveDispatchRejection(
+        new OrchestrationCommandInvariantError({
+          commandType: "thread.turn.start",
+          detail: "Thread was not found.",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isDefinitiveDispatchRejection(
+        new OrchestrationCommandPreviouslyRejectedError({
+          commandId: CommandId.makeUnsafe("cmd-previously-rejected"),
+          detail: "Previously rejected.",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isDefinitiveDispatchRejection(
+        new OrchestrationCommandDecodeError({
+          issue: "Invalid payload.",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isDefinitiveDispatchRejection(new ServerRuntimeStartupError({ message: "startup failed" })),
+    ).toBe(true);
+
+    expect(
+      isDefinitiveDispatchRejection(
+        new OrchestrationCommandTimeoutError({
+          commandId: CommandId.makeUnsafe("cmd-timeout"),
+          commandType: "thread.checkpoint.files.restore",
+          timeoutMs: 45_000,
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isDefinitiveDispatchRejection(
+        new OrchestrationCommandInternalError({
+          commandId: CommandId.makeUnsafe("cmd-internal"),
+          commandType: "thread.checkpoint.files.restore",
+          detail: "Outcome is ambiguous.",
+        }),
+      ),
+    ).toBe(false);
+    expect(isDefinitiveDispatchRejection(new Error("post-accept workspace prep failed"))).toBe(
+      false,
+    );
+  });
+});

--- a/apps/server/src/orchestration/dispatchRejectionClassification.ts
+++ b/apps/server/src/orchestration/dispatchRejectionClassification.ts
@@ -1,0 +1,17 @@
+import { Schema } from "effect";
+
+import { ServerRuntimeStartupError } from "../serverRuntimeStartup.ts";
+import {
+  OrchestrationCommandDecodeError,
+  OrchestrationCommandInvariantError,
+  OrchestrationCommandPreviouslyRejectedError,
+} from "./Errors.ts";
+
+export function isDefinitiveDispatchRejection(cause: unknown): boolean {
+  return (
+    Schema.is(OrchestrationCommandInvariantError)(cause) ||
+    Schema.is(OrchestrationCommandDecodeError)(cause) ||
+    Schema.is(OrchestrationCommandPreviouslyRejectedError)(cause) ||
+    cause instanceof ServerRuntimeStartupError
+  );
+}

--- a/apps/server/src/wsRpc.test.ts
+++ b/apps/server/src/wsRpc.test.ts
@@ -1,0 +1,18 @@
+import { ORCHESTRATION_WS_METHODS } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import { isRpcMethodBlockedByPendingCheckpointFileRestore } from "./wsRpc.ts";
+
+describe("wsRpc checkpoint file restore gate", () => {
+  it("gates importThread while a destructive file restore is pending", () => {
+    expect(
+      isRpcMethodBlockedByPendingCheckpointFileRestore(ORCHESTRATION_WS_METHODS.importThread),
+    ).toBe(true);
+  });
+
+  it("does not gate read-only snapshot RPCs", () => {
+    expect(
+      isRpcMethodBlockedByPendingCheckpointFileRestore(ORCHESTRATION_WS_METHODS.getSnapshot),
+    ).toBe(false);
+  });
+});

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -6,7 +6,9 @@ import {
   ORCHESTRATION_WS_METHODS,
   ThreadId,
   WS_METHODS,
+  WS_RPC_ERROR_CODES,
   WsRpcError,
+  type WsRpcErrorCode,
   WsRpcGroup,
   type GitActionProgressEvent,
   type OrchestrationEvent,
@@ -257,14 +259,26 @@ function readDescendantProcesses(rootPid: number): Promise<ProcessTableRow[]> {
   });
 }
 
-function toWsRpcError(cause: unknown, fallbackMessage: string) {
-  return Schema.is(WsRpcError)(cause)
-    ? cause
-    : new WsRpcError({
-        message:
-          cause instanceof Error && cause.message.length > 0 ? cause.message : fallbackMessage,
-        cause,
-      });
+function toWsRpcError(
+  cause: unknown,
+  fallbackMessage: string,
+  options?: { readonly code?: WsRpcErrorCode },
+) {
+  if (Schema.is(WsRpcError)(cause)) {
+    if (options?.code === undefined || cause.code === options.code) {
+      return cause;
+    }
+    return new WsRpcError({
+      message: cause.message,
+      code: options.code,
+      cause: cause.cause,
+    });
+  }
+  return new WsRpcError({
+    message: cause instanceof Error && cause.message.length > 0 ? cause.message : fallbackMessage,
+    code: options?.code,
+    cause,
+  });
 }
 
 const failLiveUiStreamForSnapshotResync = (report: LiveUiStreamDropReport) =>
@@ -609,8 +623,11 @@ export const makeWsRpcLayer = () =>
         event.aggregateId === threadId &&
         isThreadDetailEvent(event);
 
-      const rpcEffect = <A, E, R>(effect: Effect.Effect<A, E, R>, fallbackMessage: string) =>
-        effect.pipe(Effect.mapError((cause) => toWsRpcError(cause, fallbackMessage)));
+      const rpcEffect = <A, E, R>(
+        effect: Effect.Effect<A, E, R>,
+        fallbackMessage: string,
+        options?: { readonly code?: WsRpcErrorCode },
+      ) => effect.pipe(Effect.mapError((cause) => toWsRpcError(cause, fallbackMessage, options)));
 
       return WsRpcGroup.of({
         [ORCHESTRATION_WS_METHODS.dispatchCommand]: (command) =>
@@ -630,6 +647,7 @@ export const makeWsRpcLayer = () =>
               return result;
             }),
             "Failed to dispatch orchestration command",
+            { code: WS_RPC_ERROR_CODES.orchestrationDispatchRejected },
           ),
         [ORCHESTRATION_WS_METHODS.importThread]: (input) =>
           rpcEffect(importThread(input), "Failed to import thread"),

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -81,6 +81,13 @@ import { bufferLiveUiStream, type LiveUiStreamDropReport } from "./wsStreamBackp
 
 const MAX_DIAGNOSTIC_CHILD_PROCESSES = 80;
 const MAX_DIAGNOSTIC_ARGS_CHARS = 500;
+const CHECKPOINT_FILE_RESTORE_GATED_RPC_METHODS = new Set<string>([
+  ORCHESTRATION_WS_METHODS.importThread,
+]);
+
+export function isRpcMethodBlockedByPendingCheckpointFileRestore(method: string): boolean {
+  return CHECKPOINT_FILE_RESTORE_GATED_RPC_METHODS.has(method);
+}
 
 // Relative subdirectories scaffolded under a freshly created chat container workspace root.
 // The Studio layout lives in studioWorkspaceScaffold.ts alongside its instruction files.
@@ -640,7 +647,10 @@ export const makeWsRpcLayer = () =>
 
       const requireNoPendingCheckpointFileRestore = (
         operation: string,
-        options?: { readonly allowRecordedCommandId?: CommandId },
+        options?: {
+          readonly allowRecordedCommandId?: CommandId;
+          readonly allowRequestCommandId?: CommandId;
+        },
       ) =>
         Stream.runCollect(orchestrationEngine.readEvents(0)).pipe(
           Effect.map((events): OrchestrationEvent[] => Array.from(events)),
@@ -659,14 +669,14 @@ export const makeWsRpcLayer = () =>
         effect: Effect.Effect<A, E, R>,
         fallbackMessage: string,
         options?: { readonly code?: WsRpcErrorCode },
-      ): Effect.Effect<A, WsRpcError, R> =>
-        rpcEffect(
-          withCheckpointFileRestoreInterlock(
-            requireNoPendingCheckpointFileRestore(operation).pipe(Effect.flatMap(() => effect)),
-          ),
-          fallbackMessage,
-          options,
-        );
+      ): Effect.Effect<A, WsRpcError, R> => {
+        const protectedEffect = isRpcMethodBlockedByPendingCheckpointFileRestore(operation)
+          ? withCheckpointFileRestoreInterlock(
+              requireNoPendingCheckpointFileRestore(operation).pipe(Effect.flatMap(() => effect)),
+            )
+          : effect;
+        return rpcEffect(protectedEffect, fallbackMessage, options);
+      };
 
       const gateDispatchCommandIfPotentiallyMutating = <A, E, R>(
         command: ClientOrchestrationCommand,
@@ -676,6 +686,9 @@ export const makeWsRpcLayer = () =>
           ? withCheckpointFileRestoreInterlock(
               requireNoPendingCheckpointFileRestore(command.type, {
                 allowRecordedCommandId: command.commandId,
+                ...(command.type === "thread.checkpoint.files.restore"
+                  ? { allowRequestCommandId: command.commandId }
+                  : {}),
               }).pipe(Effect.flatMap(() => effect)),
             )
           : effect;
@@ -710,7 +723,11 @@ export const makeWsRpcLayer = () =>
             ),
           ),
         [ORCHESTRATION_WS_METHODS.importThread]: (input) =>
-          rpcEffect(importThread(input), "Failed to import thread"),
+          gatedRpcEffect(
+            ORCHESTRATION_WS_METHODS.importThread,
+            importThread(input),
+            "Failed to import thread",
+          ),
         [ORCHESTRATION_WS_METHODS.getSnapshot]: () =>
           rpcEffect(
             projectionReadModelQuery.getSnapshot(),

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 
 import {
   CommandId,
+  type ClientOrchestrationCommand,
   DEFAULT_TERMINAL_ID,
   ORCHESTRATION_WS_METHODS,
   ThreadId,
@@ -47,9 +48,17 @@ import { createLocalPreviewGrant } from "./localImageFiles";
 import { listLocalServers, stopLocalServer } from "./localServerMonitor";
 import { Open, resolveAvailableEditors } from "./open";
 import { makeDispatchCommandNormalizer } from "./orchestration/dispatchCommandNormalization";
+import { isDefinitiveDispatchRejection } from "./orchestration/dispatchRejectionClassification";
 import { makeImportThreadHandler } from "./orchestration/importThreadRoute";
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
+import {
+  hasPendingCheckpointFileRestore,
+  isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore,
+  makePendingCheckpointFileRestoreCommandError,
+  shouldBlockCommandForPendingCheckpointFileRestore,
+} from "./orchestration/checkpointFileRestoreGate";
+import { withCheckpointFileRestoreInterlock } from "./orchestration/checkpointFileRestoreInterlock";
 import { shouldPublishThreadShellForEvent } from "./orchestration/threadShellEvents";
 import { ProviderDiscoveryService } from "./provider/Services/ProviderDiscoveryService";
 import { discoverSkillsCatalog, synaraSkillsDir } from "./provider/skillsCatalog";
@@ -629,9 +638,52 @@ export const makeWsRpcLayer = () =>
         options?: { readonly code?: WsRpcErrorCode },
       ) => effect.pipe(Effect.mapError((cause) => toWsRpcError(cause, fallbackMessage, options)));
 
+      const requireNoPendingCheckpointFileRestore = (
+        operation: string,
+        options?: { readonly allowRecordedCommandId?: CommandId },
+      ) =>
+        Stream.runCollect(orchestrationEngine.readEvents(0)).pipe(
+          Effect.map((events): OrchestrationEvent[] => Array.from(events)),
+          Effect.flatMap((events) => {
+            const blocked = options
+              ? shouldBlockCommandForPendingCheckpointFileRestore(events, operation, options)
+              : hasPendingCheckpointFileRestore(events);
+            return blocked
+              ? Effect.fail(makePendingCheckpointFileRestoreCommandError(operation))
+              : Effect.void;
+          }),
+        );
+
+      const gatedRpcEffect = <A, E, R>(
+        operation: string,
+        effect: Effect.Effect<A, E, R>,
+        fallbackMessage: string,
+        options?: { readonly code?: WsRpcErrorCode },
+      ): Effect.Effect<A, WsRpcError, R> =>
+        rpcEffect(
+          withCheckpointFileRestoreInterlock(
+            requireNoPendingCheckpointFileRestore(operation).pipe(Effect.flatMap(() => effect)),
+          ),
+          fallbackMessage,
+          options,
+        );
+
+      const gateDispatchCommandIfPotentiallyMutating = <A, E, R>(
+        command: ClientOrchestrationCommand,
+        effect: Effect.Effect<A, E, R>,
+      ) =>
+        isOrchestrationCommandTypeBlockedByPendingCheckpointFileRestore(command.type)
+          ? withCheckpointFileRestoreInterlock(
+              requireNoPendingCheckpointFileRestore(command.type, {
+                allowRecordedCommandId: command.commandId,
+              }).pipe(Effect.flatMap(() => effect)),
+            )
+          : effect;
+
       return WsRpcGroup.of({
         [ORCHESTRATION_WS_METHODS.dispatchCommand]: (command) =>
-          rpcEffect(
+          gateDispatchCommandIfPotentiallyMutating(
+            command,
             Effect.gen(function* () {
               const { command: normalizedCommand, prepareWorkspaceRoot } =
                 yield* normalizeDispatchCommand({ command });
@@ -646,8 +698,16 @@ export const makeWsRpcLayer = () =>
               }
               return result;
             }),
-            "Failed to dispatch orchestration command",
-            { code: WS_RPC_ERROR_CODES.orchestrationDispatchRejected },
+          ).pipe(
+            Effect.mapError((cause) =>
+              toWsRpcError(
+                cause,
+                "Failed to dispatch orchestration command",
+                isDefinitiveDispatchRejection(cause)
+                  ? { code: WS_RPC_ERROR_CODES.orchestrationDispatchRejected }
+                  : undefined,
+              ),
+            ),
           ),
         [ORCHESTRATION_WS_METHODS.importThread]: (input) =>
           rpcEffect(importThread(input), "Failed to import thread"),
@@ -768,9 +828,17 @@ export const makeWsRpcLayer = () =>
             "Failed to create local file preview grant",
           ),
         [WS_METHODS.projectsWriteFile]: (input) =>
-          rpcEffect(workspaceFileSystem.writeFile(input), "Failed to write workspace file"),
+          gatedRpcEffect(
+            WS_METHODS.projectsWriteFile,
+            workspaceFileSystem.writeFile(input),
+            "Failed to write workspace file",
+          ),
         [WS_METHODS.projectsRunDevServer]: (input) =>
-          rpcEffect(devServerManager.run(input), "Failed to start dev server"),
+          gatedRpcEffect(
+            WS_METHODS.projectsRunDevServer,
+            devServerManager.run(input),
+            "Failed to start dev server",
+          ),
         [WS_METHODS.projectsStopDevServer]: (input) =>
           rpcEffect(devServerManager.stop(input), "Failed to stop dev server"),
         [WS_METHODS.projectsListDevServers]: () =>
@@ -793,7 +861,8 @@ export const makeWsRpcLayer = () =>
             }),
           ),
         [WS_METHODS.studioListThreadOutputs]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.studioListThreadOutputs,
             Effect.gen(function* () {
               // Self-heal the Studio folder tree: an accepted create whose deferred scaffold
               // failed (crash, transient FS error) must not leave Studio without its Outbox
@@ -853,28 +922,32 @@ export const makeWsRpcLayer = () =>
         [WS_METHODS.gitSummarizeDiff]: (input) =>
           rpcEffect(gitManager.summarizeDiff(input), "Failed to summarize diff"),
         [WS_METHODS.gitPull]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitPull,
             git.pullCurrentBranch(input.cwd).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             "Failed to pull branch",
           ),
         [WS_METHODS.gitRunStackedAction]: (input) =>
           bufferLiveUiStream(
             Stream.callback<GitActionProgressEvent, WsRpcError>((queue) =>
-              gitManager
-                .runStackedAction(input, {
-                  actionId: input.actionId,
-                  progressReporter: {
-                    publish: (event) => Queue.offer(queue, event).pipe(Effect.asVoid),
-                  },
-                })
-                .pipe(
-                  Effect.tap(() => refreshGitStatus(input.cwd)),
-                  Effect.matchCauseEffect({
-                    onFailure: (cause) =>
-                      Queue.fail(queue, toWsRpcError(cause, "Git action failed")),
-                    onSuccess: () => Queue.end(queue).pipe(Effect.asVoid),
-                  }),
+              withCheckpointFileRestoreInterlock(
+                requireNoPendingCheckpointFileRestore(WS_METHODS.gitRunStackedAction).pipe(
+                  Effect.flatMap(() =>
+                    gitManager.runStackedAction(input, {
+                      actionId: input.actionId,
+                      progressReporter: {
+                        publish: (event) => Queue.offer(queue, event).pipe(Effect.asVoid),
+                      },
+                    }),
+                  ),
                 ),
+              ).pipe(
+                Effect.tap(() => refreshGitStatus(input.cwd)),
+                Effect.matchCauseEffect({
+                  onFailure: (cause) => Queue.fail(queue, toWsRpcError(cause, "Git action failed")),
+                  onSuccess: () => Queue.end(queue).pipe(Effect.asVoid),
+                }),
+              ),
             ),
             { label: "git.stacked-action" },
           ),
@@ -886,7 +959,8 @@ export const makeWsRpcLayer = () =>
             "Failed to load pull request checks and comments",
           ),
         [WS_METHODS.gitPreparePullRequestThread]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitPreparePullRequestThread,
             gitManager
               .preparePullRequestThread(input)
               .pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
@@ -895,55 +969,68 @@ export const makeWsRpcLayer = () =>
         [WS_METHODS.gitListBranches]: (input) =>
           rpcEffect(git.listBranches(input), "Failed to list branches"),
         [WS_METHODS.gitCreateWorktree]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitCreateWorktree,
             git.createWorktree(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             "Failed to create worktree",
           ),
         [WS_METHODS.gitCreateDetachedWorktree]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitCreateDetachedWorktree,
             git.createDetachedWorktree(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             "Failed to create detached worktree",
           ),
         [WS_METHODS.gitRemoveWorktree]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitRemoveWorktree,
             git.removeWorktree(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             "Failed to remove worktree",
           ),
         [WS_METHODS.gitCreateBranch]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitCreateBranch,
             git.createBranch(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             "Failed to create branch",
           ),
         [WS_METHODS.gitCheckout]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitCheckout,
             Effect.scoped(git.checkoutBranch(input)).pipe(
               Effect.tap(() => refreshGitStatus(input.cwd)),
             ),
             "Failed to checkout branch",
           ),
         [WS_METHODS.gitStashAndCheckout]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitStashAndCheckout,
             Effect.scoped(git.stashAndCheckout(input)).pipe(
               Effect.tap(() => refreshGitStatus(input.cwd)),
             ),
             "Failed to stash and checkout",
           ),
         [WS_METHODS.gitStashDrop]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitStashDrop,
             git.stashDrop(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             "Failed to drop stash",
           ),
         [WS_METHODS.gitStashInfo]: (input) =>
           rpcEffect(git.stashInfo(input), "Failed to read stash"),
         [WS_METHODS.gitRemoveIndexLock]: (input) =>
-          rpcEffect(git.removeIndexLock(input), "Failed to remove Git index lock"),
+          gatedRpcEffect(
+            WS_METHODS.gitRemoveIndexLock,
+            git.removeIndexLock(input),
+            "Failed to remove Git index lock",
+          ),
         [WS_METHODS.gitInit]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitInit,
             git.initRepo(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             "Failed to initialize repository",
           ),
         [WS_METHODS.gitStageFiles]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitStageFiles,
             git.stageFiles(input.cwd, input.paths).pipe(
               Effect.tap(() => refreshGitStatus(input.cwd)),
               Effect.as({ ok: true }),
@@ -951,7 +1038,8 @@ export const makeWsRpcLayer = () =>
             "Failed to stage files",
           ),
         [WS_METHODS.gitUnstageFiles]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitUnstageFiles,
             git.unstageFiles(input.cwd, input.paths).pipe(
               Effect.tap(() => refreshGitStatus(input.cwd)),
               Effect.as({ ok: true }),
@@ -959,20 +1047,23 @@ export const makeWsRpcLayer = () =>
             "Failed to unstage files",
           ),
         [WS_METHODS.gitHandoffThread]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.gitHandoffThread,
             gitManager.handoffThread(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             "Failed to hand off thread",
           ),
 
         [WS_METHODS.terminalOpen]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.terminalOpen,
             resetTerminalTitleBuffer(input.threadId, input.terminalId ?? DEFAULT_TERMINAL_ID).pipe(
               Effect.andThen(terminalManager.open(input)),
             ),
             "Failed to open terminal",
           ),
         [WS_METHODS.terminalWrite]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.terminalWrite,
             terminalManager.write(input).pipe(
               Effect.tap(() =>
                 maybeAutoRenameTerminalThread({
@@ -991,7 +1082,8 @@ export const makeWsRpcLayer = () =>
         [WS_METHODS.terminalClear]: (input) =>
           rpcEffect(terminalManager.clear(input), "Failed to clear terminal"),
         [WS_METHODS.terminalRestart]: (input) =>
-          rpcEffect(
+          gatedRpcEffect(
+            WS_METHODS.terminalRestart,
             resetTerminalTitleBuffer(input.threadId, input.terminalId ?? DEFAULT_TERMINAL_ID).pipe(
               Effect.andThen(terminalManager.restart(input)),
             ),
@@ -1240,7 +1332,11 @@ export const makeWsRpcLayer = () =>
             "Failed to get composer capabilities",
           ),
         [WS_METHODS.providerCompactThread]: (input) =>
-          rpcEffect(providerService.compactThread(input), "Failed to compact thread"),
+          gatedRpcEffect(
+            WS_METHODS.providerCompactThread,
+            providerService.compactThread(input),
+            "Failed to compact thread",
+          ),
         [WS_METHODS.providerListCommands]: (input) =>
           rpcEffect(providerDiscoveryService.listCommands(input), "Failed to list commands"),
         [WS_METHODS.providerListSkills]: (input) =>
@@ -1279,7 +1375,11 @@ export const makeWsRpcLayer = () =>
         [WS_METHODS.automationDelete]: (input) =>
           rpcEffect(automationService.delete(input), "Failed to delete automation"),
         [WS_METHODS.automationRunNow]: (input) =>
-          rpcEffect(automationService.runNow(input), "Failed to run automation"),
+          gatedRpcEffect(
+            WS_METHODS.automationRunNow,
+            automationService.runNow(input),
+            "Failed to run automation",
+          ),
         [WS_METHODS.automationCancelRun]: (input) =>
           rpcEffect(automationService.cancelRun(input), "Failed to cancel automation run"),
         [WS_METHODS.automationMarkRunRead]: (input) =>

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -27,6 +27,10 @@ import {
   gitStatusQueryOptions,
   invalidateGitQueries,
 } from "../lib/gitReactQuery";
+import {
+  CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  hasPendingCheckpointFileRestore,
+} from "../lib/checkpointFileRestore";
 import { readNativeApi } from "../nativeApi";
 import { parsePullRequestReference } from "../pullRequestReference";
 import {
@@ -120,6 +124,16 @@ function addBranchRecoveryToast(input: Parameters<typeof toastManager.add>[0]) {
   return activeBranchRecoveryToastId;
 }
 
+function blockIfCheckpointFileRestorePending(): boolean {
+  if (!hasPendingCheckpointFileRestore()) return false;
+  toastManager.add({
+    type: "error",
+    title: "File restore in progress",
+    description: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  });
+  return true;
+}
+
 function parseDirtyWorktreeError(error: unknown): { branch: string; files: string[] } | null {
   const detail = error instanceof Error ? error.message : String(error);
   const match = DIRTY_WORKTREE_ERROR_PATTERN.exec(detail);
@@ -182,6 +196,7 @@ function handleCheckoutError(
   },
 ): void {
   const retryStashAndCheckout = async (): Promise<void> => {
+    if (blockIfCheckpointFileRestorePending()) return;
     await input.api.git.stashAndCheckout({ cwd: input.cwd, branch: input.branch });
     await invalidateGitQueries(input.queryClient);
     input.onSuccess();
@@ -203,6 +218,7 @@ function handleCheckoutError(
         onClick: () => {
           input.runBranchAction(async () => {
             try {
+              if (blockIfCheckpointFileRestorePending()) return;
               await input.api.git.removeIndexLock({ cwd: input.cwd });
               await retryStashAndCheckout();
             } catch (retryError) {
@@ -513,10 +529,11 @@ export function BranchToolbarBranchSelector({
   const discardStashFromDialog = useCallback(() => {
     const dialog = stashDiscardDialog;
     const api = readNativeApi();
-    if (!dialog || !api || isDroppingStash) return;
+    if (!dialog || !api || isDroppingStash || blockIfCheckpointFileRestorePending()) return;
     setIsDroppingStash(true);
     runBranchAction(async () => {
       try {
+        if (blockIfCheckpointFileRestorePending()) return;
         await api.git.stashDrop({ cwd: dialog.cwd });
         setStashDiscardDialog(null);
       } finally {
@@ -527,7 +544,9 @@ export function BranchToolbarBranchSelector({
 
   const selectBranch = (branch: GitBranch) => {
     const api = readNativeApi();
-    if (!api || !branchCwd || isBranchActionPending) return;
+    if (!api || !branchCwd || isBranchActionPending || blockIfCheckpointFileRestorePending()) {
+      return;
+    }
 
     // In new-worktree mode, selecting a branch sets the base branch.
     if (isSelectingWorktreeBase) {
@@ -562,6 +581,7 @@ export function BranchToolbarBranchSelector({
     onComposerFocusRequest?.();
 
     runBranchAction(async () => {
+      if (blockIfCheckpointFileRestorePending()) return;
       setOptimisticBranch(selectedBranchName);
       try {
         await api.git.checkout({ cwd: selectionTarget.checkoutCwd, branch: branch.name });
@@ -605,16 +625,26 @@ export function BranchToolbarBranchSelector({
   const createBranch = (rawName: string) => {
     const name = rawName.trim();
     const api = readNativeApi();
-    if (!api || !branchCwd || !name || isBranchActionPending) return;
+    if (
+      !api ||
+      !branchCwd ||
+      !name ||
+      isBranchActionPending ||
+      blockIfCheckpointFileRestorePending()
+    ) {
+      return;
+    }
 
     setIsBranchMenuOpen(false);
     onComposerFocusRequest?.();
 
     runBranchAction(async () => {
+      if (blockIfCheckpointFileRestorePending()) return;
       setOptimisticBranch(name);
 
       try {
         await api.git.createBranch({ cwd: branchCwd, branch: name, publish: hasOriginRemote });
+        if (blockIfCheckpointFileRestorePending()) return;
         try {
           await api.git.checkout({ cwd: branchCwd, branch: name });
         } catch (error) {

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -5,9 +5,11 @@ import {
   AutomationId,
   type AutomationCreateInput,
   type AutomationDefinition,
+  CommandId,
   EventId,
   MessageId,
   ORCHESTRATION_WS_METHODS,
+  type OrchestrationEvent,
   type OrchestrationReadModel,
   type ProjectId,
   type ServerConfig,
@@ -34,6 +36,10 @@ import {
   type TerminalContextDraft,
   removeInlineTerminalContextPlaceholder,
 } from "../lib/terminalContext";
+import {
+  readPendingCheckpointFileRestore,
+  savePendingCheckpointFileRestore,
+} from "../lib/checkpointFileRestore";
 import { isMacPlatform } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
 import { resetHomeChatProjectPrewarmStateForTests } from "../lib/chatProjects";
@@ -85,6 +91,7 @@ interface TestFixture {
 
 let fixture: TestFixture;
 const wsRequests: WsRequestEnvelope["body"][] = [];
+let orchestrationReplayEvents: OrchestrationEvent[] = [];
 const wsLink = ws.link(/ws(s)?:\/\/.*/);
 
 interface ViewportSpec {
@@ -979,6 +986,9 @@ function resolveWsRpc(body: WsRequestEnvelope["body"]): unknown {
   if (tag === ORCHESTRATION_WS_METHODS.getSnapshot) {
     return fixture.snapshot;
   }
+  if (tag === ORCHESTRATION_WS_METHODS.replayEvents) {
+    return orchestrationReplayEvents;
+  }
   if (tag === ORCHESTRATION_WS_METHODS.dispatchCommand) {
     if (recordProjectCreateCommand(body.command)) {
       return { sequence: fixture.snapshot.snapshotSequence };
@@ -1658,6 +1668,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     localStorage.clear();
     document.body.innerHTML = "";
     wsRequests.length = 0;
+    orchestrationReplayEvents = [];
     useComposerDraftStore.setState({
       draftsByThreadId: {},
       draftThreadsByThreadId: {},
@@ -1689,6 +1700,272 @@ describe("ChatView timeline estimator parity (full app)", () => {
     resetRetainedThreadDetailSubscriptionsForTests();
     resetWsNativeApiForTest();
     document.body.innerHTML = "";
+  });
+
+  it("keeps every composer gated until a reloaded file restore reaches terminal success", async () => {
+    const messageId = MessageId.makeUnsafe("msg-user-pending-file-restore");
+    const requestCommandId = CommandId.makeUnsafe("cmd-pending-file-restore");
+    savePendingCheckpointFileRestore({
+      threadId: THREAD_ID,
+      messageId,
+      turnCount: 0,
+      requestCommandId,
+      createdAt: NOW_ISO,
+      phase: "dispatched",
+    });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: addThreadToSnapshot(
+        createSnapshotForTargetUser({
+          targetMessageId: messageId,
+          targetText: "restore this turn",
+        }),
+        OTHER_THREAD_ID,
+      ),
+      initialEntry: `/${OTHER_THREAD_ID}`,
+    });
+
+    try {
+      let editor = await waitForElement(
+        () => document.querySelector<HTMLElement>("[data-testid='composer-editor']"),
+        "Unable to find composer editor.",
+      );
+      await vi.waitFor(() => {
+        expect(editor.getAttribute("contenteditable")).toBe("false");
+      });
+
+      await mounted.router.navigate({
+        to: "/$threadId",
+        params: { threadId: THREAD_ID },
+      });
+      await waitForLayout();
+      editor = await waitForElement(
+        () => document.querySelector<HTMLElement>("[data-testid='composer-editor']"),
+        "Unable to find composer editor after switching threads.",
+      );
+
+      await vi.waitFor(() => {
+        expect(mounted.router.state.location.pathname).toBe(`/${THREAD_ID}`);
+        expect(editor.getAttribute("contenteditable")).toBe("false");
+        expect(
+          wsRequests.some((request) => request._tag === ORCHESTRATION_WS_METHODS.replayEvents),
+        ).toBe(true);
+      });
+      await waitForLayout();
+      expect(editor.getAttribute("contenteditable")).toBe("false");
+
+      orchestrationReplayEvents = [
+        {
+          sequence: 1,
+          eventId: EventId.makeUnsafe("event-pending-file-restore-requested"),
+          aggregateKind: "thread",
+          aggregateId: THREAD_ID,
+          occurredAt: NOW_ISO,
+          commandId: requestCommandId,
+          causationEventId: null,
+          correlationId: requestCommandId,
+          metadata: {},
+          type: "thread.checkpoint-files-restore-requested",
+          payload: {
+            threadId: THREAD_ID,
+            messageId,
+            turnCount: 0,
+            createdAt: NOW_ISO,
+          },
+        },
+        {
+          sequence: 2,
+          eventId: EventId.makeUnsafe("event-pending-file-restore-succeeded"),
+          aggregateKind: "thread",
+          aggregateId: THREAD_ID,
+          occurredAt: NOW_ISO,
+          commandId: CommandId.makeUnsafe("cmd-pending-file-restore-complete"),
+          causationEventId: null,
+          correlationId: requestCommandId,
+          metadata: {},
+          type: "thread.checkpoint-files-restored",
+          payload: {
+            threadId: THREAD_ID,
+            messageId,
+            turnCount: 0,
+            requestCommandId,
+          },
+        },
+      ];
+
+      await vi.waitFor(
+        () => {
+          expect(editor.getAttribute("contenteditable")).toBe("true");
+          expect(readPendingCheckpointFileRestore()).toBeNull();
+        },
+        { timeout: 5_000, interval: 50 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("does not auto-dispatch a queued turn during initial restore-gate rehydration", async () => {
+    const queuedPrompt = "queued prompt that must wait for file restore";
+    const messageId = MessageId.makeUnsafe("msg-user-pending-file-restore-queued");
+    savePendingCheckpointFileRestore({
+      threadId: THREAD_ID,
+      messageId,
+      turnCount: 0,
+      requestCommandId: CommandId.makeUnsafe("cmd-pending-file-restore-queued"),
+      createdAt: NOW_ISO,
+      phase: "dispatched",
+    });
+    useComposerDraftStore.getState().enqueueQueuedTurn(THREAD_ID, {
+      id: "queued-turn-file-restore-gated",
+      kind: "chat",
+      createdAt: NOW_ISO,
+      previewText: queuedPrompt,
+      prompt: queuedPrompt,
+      images: [],
+      files: [],
+      assistantSelections: [],
+      terminalContexts: [],
+      fileComments: [],
+      pastedTexts: [],
+      skills: [],
+      mentions: [],
+      selectedProvider: "codex",
+      selectedModel: "gpt-5",
+      selectedPromptEffort: null,
+      modelSelection: {
+        provider: "codex",
+        model: "gpt-5",
+      },
+      runtimeMode: "full-access",
+      interactionMode: "default",
+      envMode: "local",
+    });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: messageId,
+        targetText: "restore this turn before draining queue",
+        sessionStatus: "ready",
+      }),
+    });
+
+    try {
+      const editor = await waitForElement(
+        () => document.querySelector<HTMLElement>("[data-testid='composer-editor']"),
+        "Unable to find composer editor.",
+      );
+
+      await vi.waitFor(() => {
+        expect(editor.getAttribute("contenteditable")).toBe("false");
+        expect(document.querySelectorAll('[data-testid="queued-follow-up-row"]')).toHaveLength(1);
+      });
+      await waitForLayout();
+      expect(
+        wsRequests.some((request) => {
+          const command = readDispatchedCommand(request);
+          return command?.type === "thread.turn.start";
+        }),
+      ).toBe(false);
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("requires explicit working-tree review before unlocking an interrupted restore", async () => {
+    const messageId = MessageId.makeUnsafe("msg-user-interrupted-file-restore");
+    const requestCommandId = CommandId.makeUnsafe("cmd-interrupted-file-restore");
+    savePendingCheckpointFileRestore({
+      threadId: THREAD_ID,
+      messageId,
+      turnCount: 0,
+      requestCommandId,
+      createdAt: NOW_ISO,
+      phase: "dispatched",
+    });
+    orchestrationReplayEvents = [
+      {
+        sequence: 1,
+        eventId: EventId.makeUnsafe("event-interrupted-file-restore-requested"),
+        aggregateKind: "thread",
+        aggregateId: THREAD_ID,
+        occurredAt: NOW_ISO,
+        commandId: requestCommandId,
+        causationEventId: null,
+        correlationId: requestCommandId,
+        metadata: {},
+        type: "thread.checkpoint-files-restore-requested",
+        payload: {
+          threadId: THREAD_ID,
+          messageId,
+          turnCount: 0,
+          createdAt: NOW_ISO,
+        },
+      },
+      {
+        sequence: 2,
+        eventId: EventId.makeUnsafe("event-interrupted-file-restore-failed"),
+        aggregateKind: "thread",
+        aggregateId: THREAD_ID,
+        occurredAt: NOW_ISO,
+        commandId: CommandId.makeUnsafe("cmd-interrupted-file-restore-failed"),
+        causationEventId: null,
+        correlationId: requestCommandId,
+        metadata: {},
+        type: "thread.checkpoint-files-restore-failed",
+        payload: {
+          threadId: THREAD_ID,
+          messageId,
+          turnCount: 0,
+          requestCommandId,
+          detail: "File restore was interrupted by a restart.",
+          requiresWorkspaceReview: true,
+        },
+      },
+    ];
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: messageId,
+        targetText: "restore this turn",
+      }),
+    });
+
+    try {
+      const editor = await waitForElement(
+        () => document.querySelector<HTMLElement>("[data-testid='composer-editor']"),
+        "Unable to find composer editor.",
+      );
+      const reviewButton = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+            (button) => button.textContent?.trim() === "Review and unlock",
+          ) ?? null,
+        "Unable to find working-tree review action.",
+      );
+      expect(editor.getAttribute("contenteditable")).toBe("false");
+      expect(readPendingCheckpointFileRestore()?.requestCommandId).toBe(requestCommandId);
+
+      reviewButton.click();
+      const confirmButton = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+            (button) => button.textContent?.trim() === "Confirm",
+          ) ?? null,
+        "Unable to find review confirmation action.",
+      );
+      confirmButton.click();
+
+      await vi.waitFor(() => {
+        expect(editor.getAttribute("contenteditable")).toBe("true");
+        expect(readPendingCheckpointFileRestore()).toBeNull();
+      });
+    } finally {
+      await mounted.cleanup();
+    }
   });
 
   it.each(TEXT_VIEWPORT_MATRIX)(

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1754,6 +1754,10 @@ describe("ChatView timeline estimator parity (full app)", () => {
       });
       await waitForLayout();
       expect(editor.getAttribute("contenteditable")).toBe("false");
+      const workspaceQueryRequestsBeforeReplay = wsRequests.filter(
+        (request) =>
+          request._tag === WS_METHODS.gitListBranches || request._tag === WS_METHODS.gitStatus,
+      ).length;
 
       orchestrationReplayEvents = [
         {
@@ -1798,6 +1802,13 @@ describe("ChatView timeline estimator parity (full app)", () => {
         () => {
           expect(editor.getAttribute("contenteditable")).toBe("true");
           expect(readPendingCheckpointFileRestore()).toBeNull();
+          expect(
+            wsRequests.filter(
+              (request) =>
+                request._tag === WS_METHODS.gitListBranches ||
+                request._tag === WS_METHODS.gitStatus,
+            ).length,
+          ).toBeGreaterThan(workspaceQueryRequestsBeforeReplay);
         },
         { timeout: 5_000, interval: 50 },
       );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -90,6 +90,7 @@ import {
 } from "~/lib/providerDiscoveryReactQuery";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
+import { waitForCheckpointFileRestore } from "~/lib/checkpointFileRestore";
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
 import { SINGLE_CHAT_PANE_SCOPE_ID } from "~/lib/chatPaneScope";
 import {
@@ -6257,32 +6258,16 @@ export default function ChatView({
       setIsRevertingCheckpoint(true);
       setThreadError(activeThread.id, null);
       const commandId = newCommandId();
-      let stopWaitingForCompletion: (() => void) | undefined;
+      let cancelCompletionWait: (() => void) | undefined;
       try {
         const completion =
           scope === "files"
-            ? new Promise<void>((resolve, reject) => {
-                const timeoutId = window.setTimeout(() => {
-                  unsubscribe();
-                  reject(new Error("Timed out waiting for file changes to be restored."));
-                }, 120_000);
-                const unsubscribe = api.orchestration.onDomainEvent((event) => {
-                  if (
-                    event.type !== "thread.checkpoint-files-restored" ||
-                    event.payload.requestCommandId !== commandId
-                  ) {
-                    return;
-                  }
-                  window.clearTimeout(timeoutId);
-                  unsubscribe();
-                  resolve();
-                });
-                stopWaitingForCompletion = () => {
-                  window.clearTimeout(timeoutId);
-                  unsubscribe();
-                };
+            ? waitForCheckpointFileRestore({
+                requestCommandId: commandId,
+                subscribe: api.orchestration.onDomainEvent,
               })
             : null;
+        cancelCompletionWait = completion?.cancel;
         await api.orchestration.dispatchCommand(
           scope === "files"
             ? {
@@ -6301,14 +6286,14 @@ export default function ChatView({
                 createdAt: new Date().toISOString(),
               },
         );
-        await completion;
+        await completion?.promise;
       } catch (err) {
         setThreadError(
           activeThread.id,
           err instanceof Error ? err.message : "Failed to revert thread state.",
         );
       }
-      stopWaitingForCompletion?.();
+      cancelCompletionWait?.();
       setIsRevertingCheckpoint(false);
     },
     [activeThread, hasLiveTurn, isConnecting, isRevertingCheckpoint, isSendBusy, setThreadError],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6228,20 +6228,27 @@ export default function ChatView({
   });
 
   const onRevertToTurnCount = useCallback(
-    async (turnCount: number) => {
+    async (turnCount: number, scope?: "files", messageId?: MessageId) => {
       const api = readNativeApi();
       if (!api || !activeThread || isRevertingCheckpoint) return;
+      if (scope === "files" && messageId === undefined) return;
 
       if (hasLiveTurn || isSendBusy || isConnecting) {
         setThreadError(activeThread.id, "Interrupt the current turn before reverting checkpoints.");
         return;
       }
       const confirmed = await api.dialogs.confirm(
-        [
-          `Revert this thread to checkpoint ${turnCount}?`,
-          "This will discard newer messages and turn diffs in this thread.",
-          "This action cannot be undone.",
-        ].join("\n"),
+        scope === "files"
+          ? [
+              "Undo these file changes?",
+              "Files will be restored to their state before this turn. Your chat history will stay.",
+              "This action cannot be undone.",
+            ].join("\n")
+          : [
+              `Revert this thread to checkpoint ${turnCount}?`,
+              "This will discard newer messages and turn diffs in this thread.",
+              "This action cannot be undone.",
+            ].join("\n"),
       );
       if (!confirmed) {
         return;
@@ -6249,20 +6256,59 @@ export default function ChatView({
 
       setIsRevertingCheckpoint(true);
       setThreadError(activeThread.id, null);
+      const commandId = newCommandId();
+      let stopWaitingForCompletion: (() => void) | undefined;
       try {
-        await api.orchestration.dispatchCommand({
-          type: "thread.checkpoint.revert",
-          commandId: newCommandId(),
-          threadId: activeThread.id,
-          turnCount,
-          createdAt: new Date().toISOString(),
-        });
+        const completion =
+          scope === "files"
+            ? new Promise<void>((resolve, reject) => {
+                const timeoutId = window.setTimeout(() => {
+                  unsubscribe();
+                  reject(new Error("Timed out waiting for file changes to be restored."));
+                }, 120_000);
+                const unsubscribe = api.orchestration.onDomainEvent((event) => {
+                  if (
+                    event.type !== "thread.checkpoint-files-restored" ||
+                    event.payload.requestCommandId !== commandId
+                  ) {
+                    return;
+                  }
+                  window.clearTimeout(timeoutId);
+                  unsubscribe();
+                  resolve();
+                });
+                stopWaitingForCompletion = () => {
+                  window.clearTimeout(timeoutId);
+                  unsubscribe();
+                };
+              })
+            : null;
+        await api.orchestration.dispatchCommand(
+          scope === "files"
+            ? {
+                type: "thread.checkpoint.files.restore",
+                commandId,
+                threadId: activeThread.id,
+                messageId: messageId!,
+                turnCount,
+                createdAt: new Date().toISOString(),
+              }
+            : {
+                type: "thread.checkpoint.revert",
+                commandId,
+                threadId: activeThread.id,
+                turnCount,
+                createdAt: new Date().toISOString(),
+              },
+        );
+        await completion;
       } catch (err) {
         setThreadError(
           activeThread.id,
           err instanceof Error ? err.message : "Failed to revert thread state.",
         );
       }
+      stopWaitingForCompletion?.();
       setIsRevertingCheckpoint(false);
     },
     [activeThread, hasLiveTurn, isConnecting, isRevertingCheckpoint, isSendBusy, setThreadError],
@@ -9807,12 +9853,12 @@ export default function ChatView({
     void closeTerminal(terminalState.activeTerminalId);
   }, [closeTerminal, terminalState.activeTerminalId]);
   const onRevertUserMessage = useCallback(
-    (messageId: MessageId) => {
+    (messageId: MessageId, scope?: "files") => {
       const targetTurnCount = revertTurnCountByUserMessageId.get(messageId);
       if (typeof targetTurnCount !== "number") {
         return;
       }
-      void onRevertToTurnCount(targetTurnCount);
+      void onRevertToTurnCount(targetTurnCount, scope, messageId);
     },
     [onRevertToTurnCount, revertTurnCountByUserMessageId],
   );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6258,42 +6258,57 @@ export default function ChatView({
       setIsRevertingCheckpoint(true);
       setThreadError(activeThread.id, null);
       const commandId = newCommandId();
-      let cancelCompletionWait: (() => void) | undefined;
+      if (scope === "files") {
+        const completion = waitForCheckpointFileRestore({
+          requestCommandId: commandId,
+          subscribe: api.orchestration.onDomainEvent,
+        });
+        try {
+          await api.orchestration.dispatchCommand({
+            type: "thread.checkpoint.files.restore",
+            commandId,
+            threadId: activeThread.id,
+            messageId: messageId!,
+            turnCount,
+            createdAt: new Date().toISOString(),
+          });
+        } catch {
+          // The request may have been accepted before the transport failed.
+          // Keep the destructive-operation gate closed until a durable terminal
+          // event arrives; reconnecting is the explicit escape hatch.
+          setThreadError(
+            activeThread.id,
+            "File restore status is indeterminate. Wait for completion or reconnect before continuing.",
+          );
+        }
+        try {
+          await completion.promise;
+          setThreadError(activeThread.id, null);
+        } catch (err) {
+          setThreadError(
+            activeThread.id,
+            err instanceof Error ? err.message : "Failed to restore file changes.",
+          );
+        }
+        completion.cancel();
+        setIsRevertingCheckpoint(false);
+        return;
+      }
+
       try {
-        const completion =
-          scope === "files"
-            ? waitForCheckpointFileRestore({
-                requestCommandId: commandId,
-                subscribe: api.orchestration.onDomainEvent,
-              })
-            : null;
-        cancelCompletionWait = completion?.cancel;
-        await api.orchestration.dispatchCommand(
-          scope === "files"
-            ? {
-                type: "thread.checkpoint.files.restore",
-                commandId,
-                threadId: activeThread.id,
-                messageId: messageId!,
-                turnCount,
-                createdAt: new Date().toISOString(),
-              }
-            : {
-                type: "thread.checkpoint.revert",
-                commandId,
-                threadId: activeThread.id,
-                turnCount,
-                createdAt: new Date().toISOString(),
-              },
-        );
-        await completion?.promise;
+        await api.orchestration.dispatchCommand({
+          type: "thread.checkpoint.revert",
+          commandId,
+          threadId: activeThread.id,
+          turnCount,
+          createdAt: new Date().toISOString(),
+        });
       } catch (err) {
         setThreadError(
           activeThread.id,
           err instanceof Error ? err.message : "Failed to revert thread state.",
         );
       }
-      cancelCompletionWait?.();
       setIsRevertingCheckpoint(false);
     },
     [activeThread, hasLiveTurn, isConnecting, isRevertingCheckpoint, isSendBusy, setThreadError],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -75,6 +75,8 @@ import {
   gitCreateWorktreeMutationOptions,
   gitGithubRepositoryQueryOptions,
   gitBranchesQueryOptions,
+  invalidateGitQueries,
+  invalidateGitQueriesForCwds,
 } from "~/lib/gitReactQuery";
 import { resolveProviderDiscoveryCwd } from "~/lib/providerDiscovery";
 import {
@@ -89,7 +91,12 @@ import {
   supportsSkillDiscovery,
   supportsThreadCompaction,
 } from "~/lib/providerDiscoveryReactQuery";
-import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
+import { providerQueryKeys } from "~/lib/providerReactQuery";
+import {
+  invalidateProjectFileQueriesForCwds,
+  projectQueryKeys,
+  projectSearchEntriesQueryOptions,
+} from "~/lib/projectReactQuery";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
 import {
   CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
@@ -3814,6 +3821,39 @@ export default function ChatView({
       throw new Error(CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE);
     }
   }, []);
+  const invalidateCheckpointFileRestoreWorkspace = useCallback(
+    (targetThreadId: ThreadId) => {
+      void queryClient.invalidateQueries({ queryKey: providerQueryKeys.all });
+      void queryClient.invalidateQueries({
+        queryKey: serverQueryKeys.studioThreadOutputs(targetThreadId),
+      });
+
+      const state = useStore.getState();
+      const thread =
+        getThreadFromState(state, targetThreadId) ??
+        state.threads.find((candidate) => candidate.id === targetThreadId);
+      const projectCwd =
+        state.projects.find((project) => project.id === thread?.projectId)?.cwd ?? null;
+      const workspaceCwd =
+        thread && projectCwd
+          ? resolveSharedThreadWorkspaceCwd({
+              projectCwd,
+              envMode: thread.envMode,
+              worktreePath: thread.worktreePath,
+            })
+          : null;
+
+      if (workspaceCwd) {
+        void invalidateProjectFileQueriesForCwds(queryClient, [workspaceCwd]);
+        void invalidateGitQueriesForCwds(queryClient, [workspaceCwd]);
+        return;
+      }
+
+      void queryClient.invalidateQueries({ queryKey: projectQueryKeys.all });
+      void invalidateGitQueries(queryClient);
+    },
+    [queryClient],
+  );
 
   useEffect(() => {
     const pending = readPendingCheckpointFileRestore();
@@ -3891,6 +3931,7 @@ export default function ChatView({
     void completion.promise
       .then(() => {
         if (cancelled) return;
+        invalidateCheckpointFileRestoreWorkspace(pending.threadId);
         clearPendingCheckpointFileRestore(pending.requestCommandId);
         setCheckpointFileRestoreReviewMessage(null);
         setThreadError(pending.threadId, null);
@@ -3902,6 +3943,7 @@ export default function ChatView({
         if (cancelled) return;
         const message = error instanceof Error ? error.message : "Failed to restore file changes.";
         if (isCheckpointFileRestoreReviewRequiredError(error)) {
+          invalidateCheckpointFileRestoreWorkspace(pending.threadId);
           const reviewMessage = `${message} Inspect the working tree, then use “Review and unlock” before starting new work.`;
           setCheckpointFileRestoreReviewMessage(reviewMessage);
           setThreadError(activeThreadId ?? pending.threadId, reviewMessage);
@@ -3922,7 +3964,12 @@ export default function ChatView({
       cancelled = true;
       completion.cancel();
     };
-  }, [activeThreadId, pendingCheckpointFileRestoreSnapshot, setThreadError]);
+  }, [
+    activeThreadId,
+    invalidateCheckpointFileRestoreWorkspace,
+    pendingCheckpointFileRestoreSnapshot,
+    setThreadError,
+  ]);
 
   const focusComposer = useCallback(() => {
     // Secondary chrome is deferred during thread switches; replay focus once it

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -62,6 +62,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type MouseEvent,
 } from "react";
 import { GoTasklist } from "react-icons/go";
@@ -90,7 +91,22 @@ import {
 } from "~/lib/providerDiscoveryReactQuery";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
-import { waitForCheckpointFileRestore } from "~/lib/checkpointFileRestore";
+import {
+  CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  clearPendingCheckpointFileRestore,
+  getCheckpointFileRestoreClientId,
+  getCheckpointFileRestoreStatus,
+  getPendingCheckpointFileRestoreSnapshot,
+  hasPendingCheckpointFileRestore,
+  isCheckpointFileRestoreReviewRequiredError,
+  isStaleCheckpointFileRestoreConfirmation,
+  isDefinitiveDispatchRejection,
+  readPendingCheckpointFileRestore,
+  savePendingCheckpointFileRestore,
+  shouldReconcileCheckpointFileRestoreAcceptance,
+  subscribePendingCheckpointFileRestore,
+  waitForCheckpointFileRestore,
+} from "~/lib/checkpointFileRestore";
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
 import { SINGLE_CHAT_PANE_SCOPE_ID } from "~/lib/chatPaneScope";
 import {
@@ -1191,7 +1207,20 @@ export default function ChatView({
   const [localDispatch, setLocalDispatch] = useState<LocalDispatchSnapshot | null>(null);
   const failedWorktreeSetupDispatchStartedAtRef = useRef<string | null>(null);
   const [isLocalConnecting, _setIsLocalConnecting] = useState(false);
-  const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
+  const pendingCheckpointFileRestoreSnapshot = useSyncExternalStore(
+    subscribePendingCheckpointFileRestore,
+    getPendingCheckpointFileRestoreSnapshot,
+    () => null,
+  );
+  const [isRevertingCheckpointLocal, setIsRevertingCheckpoint] = useState(
+    () => pendingCheckpointFileRestoreSnapshot !== null,
+  );
+  const [checkpointFileRestoreReviewMessage, setCheckpointFileRestoreReviewMessage] = useState<
+    string | null
+  >(null);
+  const checkpointFileRestoreRequiresReview = checkpointFileRestoreReviewMessage !== null;
+  const isRevertingCheckpoint =
+    isRevertingCheckpointLocal || pendingCheckpointFileRestoreSnapshot !== null;
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [respondingRequestIds, setRespondingRequestIds] = useState<ApprovalRequestId[]>([]);
   const [respondingUserInputRequestIds, setRespondingUserInputRequestIds] = useState<
@@ -2643,7 +2672,7 @@ export default function ChatView({
     activeThreadId === null ? null : `${activeThreadId}:${activeLatestTurn?.turnId ?? "idle"}`;
   const activeTurnInProgress = activeTurnLayoutLive || keepSettledActiveTurnLayout;
   const isComposerApprovalState = activePendingApproval !== null;
-  const isComposerEditorDisabled = isConnecting || isComposerApprovalState;
+  const isComposerEditorDisabled = isConnecting || isComposerApprovalState || isRevertingCheckpoint;
   const canCollapsePastedTextToDraft = shouldEnableComposerPastedTextCollapse({
     isComposerApprovalState,
     hasPendingUserInput: pendingUserInputs.length > 0,
@@ -3775,6 +3804,125 @@ export default function ChatView({
     },
     [setStoreThreadError],
   );
+  const checkpointFileRestoreClientIdRef = useRef(getCheckpointFileRestoreClientId());
+  const isCheckpointFileRestoreGateActiveNow = useCallback(
+    () => isRevertingCheckpointLocal || hasPendingCheckpointFileRestore(),
+    [isRevertingCheckpointLocal],
+  );
+  const assertCheckpointFileRestoreMutationAllowed = useCallback(() => {
+    if (hasPendingCheckpointFileRestore()) {
+      throw new Error(CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE);
+    }
+  }, []);
+
+  useEffect(() => {
+    const pending = readPendingCheckpointFileRestore();
+    if (!pending) {
+      setIsRevertingCheckpoint(false);
+      setCheckpointFileRestoreReviewMessage(null);
+      return;
+    }
+    if (isStaleCheckpointFileRestoreConfirmation(pending)) {
+      clearPendingCheckpointFileRestore(pending.requestCommandId);
+      setIsRevertingCheckpoint(false);
+      setThreadError(
+        activeThreadId,
+        "The previous file-restore confirmation was interrupted before dispatch; no files were changed.",
+      );
+      return;
+    }
+
+    let cancelled = false;
+    if (pending.phase === "confirming") {
+      setIsRevertingCheckpoint(pending.clientId === checkpointFileRestoreClientIdRef.current);
+      if (pending.clientId !== checkpointFileRestoreClientIdRef.current) {
+        const reviewMessage =
+          "A file restore confirmation was interrupted before Synara sent it. If no confirmation dialog is still open, inspect the working tree, then use “Review and unlock” before starting new work.";
+        setCheckpointFileRestoreReviewMessage(reviewMessage);
+        setThreadError(activeThreadId ?? pending.threadId, reviewMessage);
+      }
+      return;
+    }
+
+    setIsRevertingCheckpoint(true);
+    setThreadError(
+      activeThreadId ?? pending.threadId,
+      pending.threadId === activeThreadId
+        ? "Reconciling file restore status. Wait for Synara to confirm it is safe to continue."
+        : "A file restore in another thread is still being reconciled. Wait for Synara to confirm it is safe to continue.",
+    );
+    const api = readNativeApi();
+    if (!api) return;
+
+    const completion = waitForCheckpointFileRestore({
+      requestCommandId: pending.requestCommandId,
+      subscribe: api.orchestration.onDomainEvent,
+      getStatus: () =>
+        getCheckpointFileRestoreStatus({
+          api: api.orchestration,
+          threadId: pending.threadId,
+          requestCommandId: pending.requestCommandId,
+        }).then(async (status) => {
+          const reconciliationCommandId = pending.reconciliationCommandId;
+          if (
+            status.status === "not-found" &&
+            reconciliationCommandId !== undefined &&
+            shouldReconcileCheckpointFileRestoreAcceptance(pending)
+          ) {
+            await api.orchestration
+              .dispatchCommand({
+                type: "thread.checkpoint.files.restore.reconcile",
+                commandId: reconciliationCommandId,
+                requestCommandId: pending.requestCommandId,
+                threadId: pending.threadId,
+                messageId: pending.messageId,
+                turnCount: pending.turnCount,
+                createdAt: pending.createdAt,
+              })
+              .catch(() => {
+                // Reconciliation is non-destructive and idempotent. A later
+                // poll retries it after transport recovery.
+              });
+          }
+          return status;
+        }),
+    });
+
+    void completion.promise
+      .then(() => {
+        if (cancelled) return;
+        clearPendingCheckpointFileRestore(pending.requestCommandId);
+        setCheckpointFileRestoreReviewMessage(null);
+        setThreadError(pending.threadId, null);
+        if (activeThreadId && pending.threadId !== activeThreadId) {
+          setThreadError(activeThreadId, null);
+        }
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        const message = error instanceof Error ? error.message : "Failed to restore file changes.";
+        if (isCheckpointFileRestoreReviewRequiredError(error)) {
+          const reviewMessage = `${message} Inspect the working tree, then use “Review and unlock” before starting new work.`;
+          setCheckpointFileRestoreReviewMessage(reviewMessage);
+          setThreadError(activeThreadId ?? pending.threadId, reviewMessage);
+          return;
+        }
+        clearPendingCheckpointFileRestore(pending.requestCommandId);
+        setCheckpointFileRestoreReviewMessage(null);
+        const failedOnActiveThread = pending.threadId === activeThreadId || !activeThreadId;
+        setThreadError(
+          failedOnActiveThread ? pending.threadId : activeThreadId,
+          failedOnActiveThread
+            ? message
+            : `A pending file restore in another thread failed: ${message}`,
+        );
+      });
+
+    return () => {
+      cancelled = true;
+      completion.cancel();
+    };
+  }, [activeThreadId, pendingCheckpointFileRestoreSnapshot, setThreadError]);
 
   const focusComposer = useCallback(() => {
     // Secondary chrome is deferred during thread switches; replay focus once it
@@ -4357,6 +4505,10 @@ export default function ChatView({
     ): Promise<ProjectScriptRunResult | null> => {
       const api = readNativeApi();
       if (!api || !activeThreadId || !activeProject || !activeThread) return null;
+      if (isCheckpointFileRestoreGateActiveNow()) {
+        setThreadError(activeThreadId, CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE);
+        return null;
+      }
       if (options?.rememberAsLastInvoked !== false) {
         setLastInvokedScriptByProjectId((current) => {
           if (current[activeProject.id] === script.id) return current;
@@ -4386,6 +4538,7 @@ export default function ChatView({
       setTerminalFocusRequestId((value) => value + 1);
 
       try {
+        assertCheckpointFileRestoreMutationAllowed();
         const { metadata } = await runProjectCommandInTerminal({
           api,
           threadId: activeThreadId,
@@ -4422,7 +4575,9 @@ export default function ChatView({
       activeProject,
       activeThread,
       activeThreadId,
+      assertCheckpointFileRestoreMutationAllowed,
       gitCwd,
+      isCheckpointFileRestoreGateActiveNow,
       setTerminalOpen,
       setThreadError,
       storeNewTerminal,
@@ -4441,6 +4596,7 @@ export default function ChatView({
       !api ||
       !isServerThread ||
       !activeThread ||
+      isCheckpointFileRestoreGateActiveNow() ||
       activeThread.session === null ||
       activeThread.session.status === "closed"
     ) {
@@ -4453,7 +4609,7 @@ export default function ChatView({
       threadId: activeThread.id,
       createdAt: new Date().toISOString(),
     });
-  }, [activeThread, isServerThread]);
+  }, [activeThread, isCheckpointFileRestoreGateActiveNow, isServerThread]);
   const {
     handoffBusy,
     worktreeHandoffDialogOpen,
@@ -5154,10 +5310,6 @@ export default function ChatView({
   }, [composerMenuItems, composerMenuOpen]);
 
   useEffect(() => {
-    setIsRevertingCheckpoint(false);
-  }, [activeThread?.id]);
-
-  useEffect(() => {
     if (!activeThread?.id || terminalState.terminalOpen || isInactiveSplitPane) return;
     const frame = window.requestAnimationFrame(() => {
       focusComposer();
@@ -5695,14 +5847,14 @@ export default function ChatView({
 
   const onInterrupt = useCallback(async () => {
     const api = readNativeApi();
-    if (!api || !activeThread) return;
+    if (!api || !activeThread || isCheckpointFileRestoreGateActiveNow()) return;
     await api.orchestration.dispatchCommand({
       type: "thread.turn.interrupt",
       commandId: newCommandId(),
       threadId: activeThread.id,
       createdAt: new Date().toISOString(),
     });
-  }, [activeThread]);
+  }, [activeThread, isCheckpointFileRestoreGateActiveNow]);
 
   useEffect(() => {
     if (surfaceMode === "split" && !isFocusedPane) {
@@ -6231,38 +6383,97 @@ export default function ChatView({
   const onRevertToTurnCount = useCallback(
     async (turnCount: number, scope?: "files", messageId?: MessageId) => {
       const api = readNativeApi();
-      if (!api || !activeThread || isRevertingCheckpoint) return;
+      if (
+        !api ||
+        !activeThread ||
+        isRevertingCheckpoint ||
+        isCheckpointFileRestoreGateActiveNow()
+      ) {
+        return;
+      }
       if (scope === "files" && messageId === undefined) return;
 
       if (hasLiveTurn || isSendBusy || isConnecting) {
         setThreadError(activeThread.id, "Interrupt the current turn before reverting checkpoints.");
         return;
       }
-      const confirmed = await api.dialogs.confirm(
+      const commandId = newCommandId();
+      const pendingConfirmation =
         scope === "files"
-          ? [
-              "Undo these file changes?",
-              "Files will be restored to their state before this turn. Your chat history will stay.",
-              "This action cannot be undone.",
-            ].join("\n")
-          : [
-              `Revert this thread to checkpoint ${turnCount}?`,
-              "This will discard newer messages and turn diffs in this thread.",
-              "This action cannot be undone.",
-            ].join("\n"),
-      );
+          ? {
+              threadId: activeThread.id,
+              messageId: messageId!,
+              turnCount,
+              requestCommandId: commandId,
+              reconciliationCommandId: newCommandId(),
+              createdAt: new Date().toISOString(),
+              phase: "confirming" as const,
+              clientId: checkpointFileRestoreClientIdRef.current,
+            }
+          : null;
+      if (pendingConfirmation && !savePendingCheckpointFileRestore(pendingConfirmation)) {
+        setThreadError(
+          activeThread.id,
+          "Another file restore is already pending, or its safety lock could not be persisted.",
+        );
+        return;
+      }
+      if (pendingConfirmation) {
+        setIsRevertingCheckpoint(true);
+      }
+      let confirmed = false;
+      try {
+        confirmed = await api.dialogs.confirm(
+          scope === "files"
+            ? [
+                "Undo these file changes?",
+                "Files will be restored to their state before this turn. Your chat history will stay.",
+                "This action cannot be undone.",
+              ].join("\n")
+            : [
+                `Revert this thread to checkpoint ${turnCount}?`,
+                "This will discard newer messages and turn diffs in this thread.",
+                "This action cannot be undone.",
+              ].join("\n"),
+        );
+      } catch (error) {
+        if (pendingConfirmation) {
+          clearPendingCheckpointFileRestore(commandId);
+          setIsRevertingCheckpoint(false);
+        }
+        setThreadError(
+          activeThread.id,
+          error instanceof Error ? error.message : "Could not confirm the file restore.",
+        );
+        return;
+      }
       if (!confirmed) {
+        if (pendingConfirmation) {
+          clearPendingCheckpointFileRestore(commandId);
+          setIsRevertingCheckpoint(false);
+        }
         return;
       }
 
       setIsRevertingCheckpoint(true);
       setThreadError(activeThread.id, null);
-      const commandId = newCommandId();
       if (scope === "files") {
-        const completion = waitForCheckpointFileRestore({
-          requestCommandId: commandId,
-          subscribe: api.orchestration.onDomainEvent,
-        });
+        const storedPending = readPendingCheckpointFileRestore();
+        if (storedPending?.requestCommandId !== commandId || storedPending.phase !== "confirming") {
+          setIsRevertingCheckpoint(false);
+          setThreadError(activeThread.id, CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE);
+          return;
+        }
+        const pendingRestore = {
+          ...pendingConfirmation!,
+          phase: "dispatched" as const,
+        };
+        if (!savePendingCheckpointFileRestore(pendingRestore)) {
+          clearPendingCheckpointFileRestore(commandId);
+          setThreadError(activeThread.id, "The file restore safety lock could not be updated.");
+          setIsRevertingCheckpoint(false);
+          return;
+        }
         try {
           await api.orchestration.dispatchCommand({
             type: "thread.checkpoint.files.restore",
@@ -6270,28 +6481,33 @@ export default function ChatView({
             threadId: activeThread.id,
             messageId: messageId!,
             turnCount,
-            createdAt: new Date().toISOString(),
+            createdAt: pendingRestore.createdAt,
           });
-        } catch {
+        } catch (error) {
+          if (isDefinitiveDispatchRejection(error)) {
+            clearPendingCheckpointFileRestore(commandId);
+            setThreadError(
+              activeThread.id,
+              error instanceof Error ? error.message : "File restore was rejected.",
+            );
+            setIsRevertingCheckpoint(false);
+            return;
+          }
           // The request may have been accepted before the transport failed.
-          // Keep the destructive-operation gate closed until a durable terminal
-          // event arrives; reconnecting is the explicit escape hatch.
+          // Keep the destructive-operation gate closed until durable state
+          // proves success or failure.
+          void savePendingCheckpointFileRestore({
+            ...pendingRestore,
+            acceptanceAmbiguous: true,
+          });
           setThreadError(
             activeThread.id,
-            "File restore status is indeterminate. Wait for completion or reconnect before continuing.",
+            "File restore status is indeterminate. Wait for Synara to confirm it is safe to continue.",
           );
         }
-        try {
-          await completion.promise;
-          setThreadError(activeThread.id, null);
-        } catch (err) {
-          setThreadError(
-            activeThread.id,
-            err instanceof Error ? err.message : "Failed to restore file changes.",
-          );
-        }
-        completion.cancel();
-        setIsRevertingCheckpoint(false);
+
+        // The single lifecycle reconciler above owns correlated completion,
+        // reconnect polling, cleanup, and the mutation gate for every pane.
         return;
       }
 
@@ -6311,7 +6527,15 @@ export default function ChatView({
       }
       setIsRevertingCheckpoint(false);
     },
-    [activeThread, hasLiveTurn, isConnecting, isRevertingCheckpoint, isSendBusy, setThreadError],
+    [
+      activeThread,
+      hasLiveTurn,
+      isCheckpointFileRestoreGateActiveNow,
+      isConnecting,
+      isRevertingCheckpoint,
+      isSendBusy,
+      setThreadError,
+    ],
   );
 
   const onCreateHandoffThread = useCallback(
@@ -6866,6 +7090,8 @@ export default function ChatView({
       !activeThread ||
       isSendBusy ||
       isConnecting ||
+      isRevertingCheckpoint ||
+      isCheckpointFileRestoreGateActiveNow() ||
       isVoiceTranscribing ||
       sendPreflightInFlightRef.current ||
       sendInFlightRef.current
@@ -7067,6 +7293,13 @@ export default function ChatView({
         cwd: activeProject.cwd,
         generateIntent: (request) => api.server.generateAutomationIntent(request),
       });
+      if (isCheckpointFileRestoreGateActiveNow()) {
+        setThreadError(
+          activeThread.id,
+          "A file restore started during send preparation. Wait for reconciliation before retrying.",
+        );
+        return false;
+      }
       // Drop a stale resolve: bail if the user switched threads, or cancelled/changed the
       // setup, while generateAutomationIntent was awaiting.
       if (
@@ -7166,6 +7399,13 @@ export default function ChatView({
         if (!preparedAutomation) {
           return true;
         }
+        if (isCheckpointFileRestoreGateActiveNow()) {
+          setThreadError(
+            activeThread.id,
+            "A file restore started during automation preparation. Wait before creating it.",
+          );
+          return false;
+        }
         await createAutomationFromForm({
           form: preparedAutomation.form,
           warnings: automationDraft.warnings,
@@ -7196,6 +7436,13 @@ export default function ChatView({
         sendPreflightInFlightRef.current = false;
       }
     })();
+    if (isCheckpointFileRestoreGateActiveNow()) {
+      setThreadError(
+        activeThread.id,
+        "A file restore started during send preparation. Wait for reconciliation before retrying.",
+      );
+      return false;
+    }
     if (!sendProviderAvailability.usable) {
       toastManager.add({
         type: "error",
@@ -7215,6 +7462,13 @@ export default function ChatView({
           image: null,
         }),
       );
+    if (isCheckpointFileRestoreGateActiveNow()) {
+      setThreadError(
+        activeThread.id,
+        "A file restore started during send preparation. Wait for reconciliation before retrying.",
+      );
+      return false;
+    }
     if (browserPromptAttachment.image) {
       const nextAttachmentCount =
         composerImagesForSend.length +
@@ -7248,8 +7502,6 @@ export default function ChatView({
     }
 
     if (hasLiveTurn && dispatchMode === "queue" && queuedChatTurn === null) {
-      clearComposerInput(activeThread.id);
-      scheduleComposerFocus();
       const queuedImagesForPersistence = await Promise.all(
         composerImagesForSend.map(async (image) => {
           try {
@@ -7262,6 +7514,15 @@ export default function ChatView({
           }
         }),
       );
+      if (isCheckpointFileRestoreGateActiveNow()) {
+        setThreadError(
+          activeThread.id,
+          "A file restore started while the queued turn was being prepared. Retry after reconciliation.",
+        );
+        return false;
+      }
+      clearComposerInput(activeThread.id);
+      scheduleComposerFocus();
       enqueueQueuedComposerTurn(activeThread.id, {
         id: randomUUID(),
         kind: "chat",
@@ -7459,6 +7720,14 @@ export default function ChatView({
       : null;
     const worktreeSetupScriptName = setupScriptForWorktree?.name ?? null;
 
+    if (isCheckpointFileRestoreGateActiveNow()) {
+      setThreadError(
+        threadIdForSend,
+        "A file restore started during send preparation. Wait for reconciliation before retrying.",
+      );
+      return false;
+    }
+
     sendInFlightRef.current = true;
     beginLocalDispatch(
       baseBranchForWorktree
@@ -7591,8 +7860,12 @@ export default function ChatView({
     let createdServerThreadForLocalDraft = false;
     let turnStartSucceeded = false;
     await (async () => {
+      const throwIfFileRestoreStarted = () => {
+        assertCheckpointFileRestoreMutationAllowed();
+      };
       // On first message: lock in branch + create worktree if needed.
       if (baseBranchForWorktree) {
+        throwIfFileRestoreStarted();
         const result = await createWorktreeMutation.mutateAsync({
           cwd: targetProjectCwdForSend,
           branch: baseBranchForWorktree,
@@ -7609,6 +7882,7 @@ export default function ChatView({
           worktreePath: result.worktree.path,
         });
         if (isServerThread) {
+          throwIfFileRestoreStarted();
           await api.orchestration.dispatchCommand({
             type: "thread.meta.update",
             commandId: newCommandId(),
@@ -7641,6 +7915,7 @@ export default function ChatView({
       );
 
       if (isLocalDraftThread) {
+        throwIfFileRestoreStarted();
         const inheritedProjectInstructions =
           useProjectInstructionsStore.getState().instructionsByProjectId[targetProjectIdForSend] ??
           "";
@@ -7678,6 +7953,7 @@ export default function ChatView({
           }
         }
         if (targetProjectKindForSend === "chat") {
+          throwIfFileRestoreStarted();
           await api.orchestration.dispatchCommand({
             type: "project.meta.update",
             commandId: newCommandId(),
@@ -7699,6 +7975,7 @@ export default function ChatView({
           }
         }
         if (shouldRunSetupScript) {
+          throwIfFileRestoreStarted();
           beginLocalDispatch({
             worktreeSetupStepId: "run-setup-action",
             setupScriptName: setupScript.name,
@@ -7722,6 +7999,7 @@ export default function ChatView({
       }
 
       if (isServerThread) {
+        throwIfFileRestoreStarted();
         await persistThreadSettingsForNextTurn({
           threadId: threadIdForSend,
           createdAt: messageCreatedAt,
@@ -7737,6 +8015,7 @@ export default function ChatView({
           : undefined,
       );
       const turnAttachments = await turnAttachmentsPromise;
+      throwIfFileRestoreStarted();
       rememberCustomBinaryPathForDispatch({
         threadId: threadIdForSend,
         provider: selectedModelSelectionForSend.provider,
@@ -7856,7 +8135,7 @@ export default function ChatView({
   const onRespondToApproval = useCallback(
     async (requestId: ApprovalRequestId, decision: ProviderApprovalDecision) => {
       const api = readNativeApi();
-      if (!api || !activeThreadId) return;
+      if (!api || !activeThreadId || isCheckpointFileRestoreGateActiveNow()) return;
 
       setRespondingRequestIds((existing) =>
         existing.includes(requestId) ? existing : [...existing, requestId],
@@ -7885,13 +8164,19 @@ export default function ChatView({
         });
       setRespondingRequestIds((existing) => existing.filter((id) => id !== requestId));
     },
-    [activeThreadId, runtimeMode, setComposerDraftRuntimeMode, setStoreThreadError],
+    [
+      activeThreadId,
+      isCheckpointFileRestoreGateActiveNow,
+      runtimeMode,
+      setComposerDraftRuntimeMode,
+      setStoreThreadError,
+    ],
   );
 
   const onRespondToUserInput = useCallback(
     async (requestId: ApprovalRequestId, answers: ProviderUserInputAnswers) => {
       const api = readNativeApi();
-      if (!api || !activeThreadId) return;
+      if (!api || !activeThreadId || isCheckpointFileRestoreGateActiveNow()) return;
       const dispatchAnswers = hasCompletePendingUserInputAnswers(answers)
         ? answers
         : omitNullPendingUserInputAnswers(answers);
@@ -7916,11 +8201,15 @@ export default function ChatView({
         });
       setRespondingUserInputRequestIds((existing) => existing.filter((id) => id !== requestId));
     },
-    [activeThreadId, setStoreThreadError],
+    [activeThreadId, isCheckpointFileRestoreGateActiveNow, setStoreThreadError],
   );
 
   const onCancelActivePendingUserInput = useCallback(() => {
-    if (!activePendingUserInput || activePendingIsResponding) {
+    if (
+      !activePendingUserInput ||
+      activePendingIsResponding ||
+      isCheckpointFileRestoreGateActiveNow()
+    ) {
       return;
     }
     promptRef.current = "";
@@ -7928,7 +8217,13 @@ export default function ChatView({
     setComposerCursor(0);
     setComposerTrigger(null);
     void onRespondToUserInput(activePendingUserInput.requestId, {});
-  }, [activePendingIsResponding, activePendingUserInput, onRespondToUserInput, setPrompt]);
+  }, [
+    activePendingIsResponding,
+    activePendingUserInput,
+    isCheckpointFileRestoreGateActiveNow,
+    onRespondToUserInput,
+    setPrompt,
+  ]);
 
   const setActivePendingUserInputQuestionIndex = useCallback(
     (nextQuestionIndex: number) => {
@@ -7945,7 +8240,7 @@ export default function ChatView({
 
   const onToggleActivePendingUserInputOption = useCallback(
     (questionId: string, optionLabel: string) => {
-      if (!activePendingUserInput) {
+      if (!activePendingUserInput || isCheckpointFileRestoreGateActiveNow()) {
         return null;
       }
       const question = activePendingUserInput.questions.find((entry) => entry.id === questionId);
@@ -7976,7 +8271,7 @@ export default function ChatView({
       setComposerTrigger(null);
       return nextDraftAnswer;
     },
-    [activePendingUserInput],
+    [activePendingUserInput, isCheckpointFileRestoreGateActiveNow],
   );
 
   const onChangeActivePendingUserInputCustomAnswer = useCallback(
@@ -7987,7 +8282,7 @@ export default function ChatView({
       expandedCursor: number,
       cursorAdjacentToMention: boolean,
     ) => {
-      if (!activePendingUserInput) {
+      if (!activePendingUserInput || isCheckpointFileRestoreGateActiveNow()) {
         return;
       }
       promptRef.current = value;
@@ -8014,12 +8309,16 @@ export default function ChatView({
         cursorAdjacentToMention ? null : detectComposerTrigger(value, expandedCursor),
       );
     },
-    [activePendingUserInput],
+    [activePendingUserInput, isCheckpointFileRestoreGateActiveNow],
   );
 
   const onAdvanceActivePendingUserInput = useCallback(
     (answerOverrides?: Record<string, PendingUserInputDraftAnswer>): boolean => {
-      if (!activePendingUserInput || !activePendingProgress) {
+      if (
+        !activePendingUserInput ||
+        !activePendingProgress ||
+        isCheckpointFileRestoreGateActiveNow()
+      ) {
         return false;
       }
       const pendingDraftAnswers =
@@ -8065,17 +8364,22 @@ export default function ChatView({
       activePendingDraftAnswers,
       activePendingProgress,
       activePendingUserInput,
+      isCheckpointFileRestoreGateActiveNow,
       onRespondToUserInput,
       setActivePendingUserInputQuestionIndex,
     ],
   );
 
   const onPreviousActivePendingUserInputQuestion = useCallback(() => {
-    if (!activePendingProgress) {
+    if (!activePendingProgress || isCheckpointFileRestoreGateActiveNow()) {
       return;
     }
     setActivePendingUserInputQuestionIndex(Math.max(activePendingProgress.questionIndex - 1, 0));
-  }, [activePendingProgress, setActivePendingUserInputQuestionIndex]);
+  }, [
+    activePendingProgress,
+    isCheckpointFileRestoreGateActiveNow,
+    setActivePendingUserInputQuestionIndex,
+  ]);
 
   async function onSubmitPlanFollowUp({
     text,
@@ -8095,6 +8399,8 @@ export default function ChatView({
       !isServerThread ||
       isSendBusy ||
       isConnecting ||
+      isRevertingCheckpoint ||
+      isCheckpointFileRestoreGateActiveNow() ||
       sendInFlightRef.current
     ) {
       return false;
@@ -8140,6 +8446,11 @@ export default function ChatView({
         runtimeMode: queuedTurn?.runtimeMode ?? runtimeMode,
         interactionMode: nextInteractionMode,
       });
+      if (isCheckpointFileRestoreGateActiveNow()) {
+        throw new Error(
+          "A file restore started while this plan follow-up was being prepared. Retry after reconciliation.",
+        );
+      }
 
       // Keep the mode toggle and plan-follow-up banner in sync immediately
       // while the same-thread implementation turn is starting.
@@ -8214,7 +8525,13 @@ export default function ChatView({
   const onEditUserMessage = useCallback(
     async (messageId: MessageId, text: string): Promise<boolean> => {
       const api = readNativeApi();
-      if (!api || !activeThread || !isServerThread || isRevertingCheckpoint) {
+      if (
+        !api ||
+        !activeThread ||
+        !isServerThread ||
+        isRevertingCheckpoint ||
+        isCheckpointFileRestoreGateActiveNow()
+      ) {
         return false;
       }
       const editTarget = resolveTailUserMessageEditTarget({
@@ -8287,6 +8604,7 @@ export default function ChatView({
     [
       activeThread,
       isConnecting,
+      isCheckpointFileRestoreGateActiveNow,
       isRevertingCheckpoint,
       isSendBusy,
       isServerThread,
@@ -8390,6 +8708,8 @@ export default function ChatView({
       phase === "disconnected" ||
       isSendBusy ||
       isConnecting ||
+      isRevertingCheckpoint ||
+      isCheckpointFileRestoreGateActiveNow() ||
       queuedSteerGate !== null ||
       activePendingApproval !== null ||
       activePendingProgress !== null ||
@@ -8427,6 +8747,8 @@ export default function ChatView({
     dispatchQueuedComposerTurn,
     phase,
     isConnecting,
+    isCheckpointFileRestoreGateActiveNow,
+    isRevertingCheckpoint,
     isSendBusy,
     pendingUserInputs.length,
     hasLiveTurn,
@@ -8447,6 +8769,8 @@ export default function ChatView({
       !isServerThread ||
       isSendBusy ||
       isConnecting ||
+      isRevertingCheckpoint ||
+      isCheckpointFileRestoreGateActiveNow() ||
       sendInFlightRef.current
     ) {
       return;
@@ -8562,6 +8886,8 @@ export default function ChatView({
     activeThreadAssociatedWorktree,
     beginLocalDispatch,
     isConnecting,
+    isCheckpointFileRestoreGateActiveNow,
+    isRevertingCheckpoint,
     isSendBusy,
     isServerThread,
     navigate,
@@ -9872,6 +10198,25 @@ export default function ChatView({
     if (!activeThread) return;
     setThreadError(activeThread.id, null);
   }, [activeThread, setThreadError]);
+  const acknowledgeCheckpointFileRestoreReview = useCallback(async () => {
+    const pending = readPendingCheckpointFileRestore();
+    const api = readNativeApi();
+    if (!pending || !api) return;
+    const confirmed = await api.dialogs.confirm(
+      [
+        "Review the working tree before unlocking",
+        "Synara restarted while Undo may have been modifying files. Inspect git status and the working tree for partial changes first.",
+        "Confirm only when you are ready to allow new file-changing actions.",
+      ].join("\n"),
+    );
+    if (!confirmed) return;
+    clearPendingCheckpointFileRestore(pending.requestCommandId);
+    setCheckpointFileRestoreReviewMessage(null);
+    setThreadError(pending.threadId, null);
+    if (activeThreadId !== pending.threadId) {
+      setThreadError(activeThreadId, null);
+    }
+  }, [activeThreadId, setThreadError]);
   const dismissActiveProviderHealthBanner = useCallback(() => {
     if (!activeProviderHealthBannerDismissalKey) return;
     setDismissedProviderHealthBannerKeys((current) => {
@@ -10268,6 +10613,7 @@ export default function ChatView({
                     approval={activePendingApproval}
                     pendingCount={pendingApprovals.length}
                     isResponding={respondingRequestIds.includes(activePendingApproval.requestId)}
+                    disabled={isRevertingCheckpoint}
                     onRespond={onRespondToApproval}
                   />
                 </div>
@@ -10278,6 +10624,7 @@ export default function ChatView({
                     respondingRequestIds={respondingUserInputRequestIds}
                     answers={activePendingDraftAnswers}
                     questionIndex={activePendingQuestionIndex}
+                    disabled={isRevertingCheckpoint}
                     onToggleOption={onToggleActivePendingUserInputOption}
                     onAdvance={onAdvanceActivePendingUserInput}
                     onPrevious={onPreviousActivePendingUserInputQuestion}
@@ -10519,7 +10866,12 @@ export default function ChatView({
                       {!isVoiceRecording && !isVoiceTranscribing ? composerPickerControls : null}
                       {showVoiceNotesControl && (isVoiceRecording || isVoiceTranscribing) ? (
                         <ComposerVoiceRecorderBar
-                          disabled={isComposerApprovalState || isConnecting || isSendBusy}
+                          disabled={
+                            isComposerApprovalState ||
+                            isConnecting ||
+                            isSendBusy ||
+                            isRevertingCheckpoint
+                          }
                           isRecording={isVoiceRecording}
                           isTranscribing={isVoiceTranscribing}
                           durationLabel={voiceRecordingDurationLabel}
@@ -10542,6 +10894,7 @@ export default function ChatView({
                           size="sm"
                           className="rounded-full px-4"
                           disabled={
+                            isRevertingCheckpoint ||
                             activePendingIsResponding ||
                             (activePendingProgress.isLastQuestion
                               ? !activePendingResolvedAnswers
@@ -10560,6 +10913,7 @@ export default function ChatView({
                           variant="prominent"
                           size="icon-xs"
                           className="sm:size-[26px]"
+                          disabled={isRevertingCheckpoint}
                           onClick={() => void onInterrupt()}
                           aria-label="Stop generation"
                           title="Stop the current response. On Mac, press Ctrl+C to interrupt."
@@ -10578,7 +10932,7 @@ export default function ChatView({
                               type="submit"
                               size="sm"
                               className="h-9 rounded-full px-4 sm:h-8"
-                              disabled={isSendBusy || isConnecting}
+                              disabled={isSendBusy || isConnecting || isRevertingCheckpoint}
                             >
                               {isConnecting || isSendBusy ? "Sending..." : "Refine"}
                             </Button>
@@ -10588,7 +10942,7 @@ export default function ChatView({
                                 type="submit"
                                 size="sm"
                                 className="h-9 rounded-l-full rounded-r-none px-4 sm:h-8"
-                                disabled={isSendBusy || isConnecting}
+                                disabled={isSendBusy || isConnecting || isRevertingCheckpoint}
                               >
                                 {isConnecting || isSendBusy ? "Sending..." : "Implement"}
                               </Button>
@@ -10600,7 +10954,7 @@ export default function ChatView({
                                       variant="default"
                                       className="h-9 rounded-l-none rounded-r-full border-l-white/12 px-2 sm:h-8"
                                       aria-label="Implementation actions"
-                                      disabled={isSendBusy || isConnecting}
+                                      disabled={isSendBusy || isConnecting || isRevertingCheckpoint}
                                     />
                                   }
                                 >
@@ -10608,7 +10962,7 @@ export default function ChatView({
                                 </MenuTrigger>
                                 <MenuPopup align="end" side="top">
                                   <MenuItem
-                                    disabled={isSendBusy || isConnecting}
+                                    disabled={isSendBusy || isConnecting || isRevertingCheckpoint}
                                     onClick={() => void onImplementPlanInNewThread()}
                                   >
                                     Implement in a new thread
@@ -10621,7 +10975,12 @@ export default function ChatView({
                           <>
                             {showVoiceNotesControl ? (
                               <ComposerVoiceButton
-                                disabled={isComposerApprovalState || isConnecting || isSendBusy}
+                                disabled={
+                                  isComposerApprovalState ||
+                                  isConnecting ||
+                                  isSendBusy ||
+                                  isRevertingCheckpoint
+                                }
                                 isRecording={isVoiceRecording}
                                 isTranscribing={isVoiceTranscribing}
                                 durationLabel={voiceRecordingDurationLabel}
@@ -10636,19 +10995,22 @@ export default function ChatView({
                               disabled={
                                 isSendBusy ||
                                 isConnecting ||
+                                isRevertingCheckpoint ||
                                 isVoiceTranscribing ||
                                 !composerSendState.hasSendableContent
                               }
                               aria-label={
-                                isConnecting
-                                  ? "Connecting"
-                                  : isVoiceTranscribing
-                                    ? "Transcribing voice note"
-                                    : isPreparingWorktree
-                                      ? "Preparing worktree"
-                                      : isSendBusy
-                                        ? "Sending"
-                                        : "Send message"
+                                isRevertingCheckpoint
+                                  ? "Restoring files"
+                                  : isConnecting
+                                    ? "Connecting"
+                                    : isVoiceTranscribing
+                                      ? "Transcribing voice note"
+                                      : isPreparingWorktree
+                                        ? "Preparing worktree"
+                                        : isSendBusy
+                                          ? "Sending"
+                                          : "Send message"
                               }
                             >
                               {isConnecting || isSendBusy ? (
@@ -10860,7 +11222,15 @@ export default function ChatView({
         status={shouldShowProviderHealthBanner ? visibleActiveProviderStatus : null}
         onDismiss={dismissActiveProviderHealthBanner}
       />
-      <ThreadErrorBanner error={activeThread.error} onDismiss={dismissActiveThreadError} />
+      <ThreadErrorBanner
+        error={checkpointFileRestoreReviewMessage ?? activeThread.error}
+        {...(checkpointFileRestoreRequiresReview
+          ? {
+              actionLabel: "Review and unlock",
+              onAction: () => void acknowledgeCheckpointFileRestoreReview(),
+            }
+          : { onDismiss: dismissActiveThreadError })}
+      />
       <RateLimitBanner
         rateLimitStatus={visibleActiveRateLimitStatus}
         onDismiss={dismissActiveRateLimitBanner}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -113,6 +113,7 @@ import {
   shouldReconcileCheckpointFileRestoreAcceptance,
   subscribePendingCheckpointFileRestore,
   waitForCheckpointFileRestore,
+  type PendingCheckpointFileRestore,
 } from "~/lib/checkpointFileRestore";
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
 import { SINGLE_CHAT_PANE_SCOPE_ID } from "~/lib/chatPaneScope";
@@ -3854,6 +3855,27 @@ export default function ChatView({
     },
     [queryClient],
   );
+  const releaseCheckpointFileRestoreReservation = useCallback(
+    async (pending: PendingCheckpointFileRestore): Promise<boolean> => {
+      const api = readNativeApi();
+      if (!api) return false;
+      try {
+        await api.orchestration.dispatchCommand({
+          type: "thread.checkpoint.files.restore.reviewed",
+          commandId: newCommandId(),
+          requestCommandId: pending.requestCommandId,
+          threadId: pending.threadId,
+          messageId: pending.messageId,
+          turnCount: pending.turnCount,
+          createdAt: new Date().toISOString(),
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     const pending = readPendingCheckpointFileRestore();
@@ -6467,6 +6489,38 @@ export default function ChatView({
       }
       if (pendingConfirmation) {
         setIsRevertingCheckpoint(true);
+        try {
+          await api.orchestration.dispatchCommand({
+            type: "thread.checkpoint.files.restore.prepare",
+            commandId: newCommandId(),
+            requestCommandId: commandId,
+            threadId: activeThread.id,
+            messageId: messageId!,
+            turnCount,
+            createdAt: pendingConfirmation.createdAt,
+          });
+        } catch (error) {
+          if (isDefinitiveDispatchRejection(error)) {
+            clearPendingCheckpointFileRestore(commandId);
+            setIsRevertingCheckpoint(false);
+            setThreadError(
+              activeThread.id,
+              error instanceof Error
+                ? error.message
+                : "File restore could not reserve the workspace.",
+            );
+            return;
+          }
+          void savePendingCheckpointFileRestore({
+            ...pendingConfirmation,
+            acceptanceAmbiguous: true,
+          });
+          const reviewMessage =
+            "File restore reservation status is indeterminate. Inspect the working tree, then use “Review and unlock” before starting new work.";
+          setCheckpointFileRestoreReviewMessage(reviewMessage);
+          setThreadError(activeThread.id, reviewMessage);
+          return;
+        }
       }
       let confirmed = false;
       try {
@@ -6485,9 +6539,17 @@ export default function ChatView({
         );
       } catch (error) {
         if (pendingConfirmation) {
+          const released = await releaseCheckpointFileRestoreReservation(pendingConfirmation);
+          if (!released) {
+            const reviewMessage =
+              "File restore confirmation was interrupted, but Synara could not confirm the server-side safety lock was released. Use “Review and unlock” before starting new work.";
+            setCheckpointFileRestoreReviewMessage(reviewMessage);
+            setThreadError(activeThread.id, reviewMessage);
+            return;
+          }
           clearPendingCheckpointFileRestore(commandId);
-          setIsRevertingCheckpoint(false);
         }
+        setIsRevertingCheckpoint(false);
         setThreadError(
           activeThread.id,
           error instanceof Error ? error.message : "Could not confirm the file restore.",
@@ -6496,9 +6558,17 @@ export default function ChatView({
       }
       if (!confirmed) {
         if (pendingConfirmation) {
+          const released = await releaseCheckpointFileRestoreReservation(pendingConfirmation);
+          if (!released) {
+            const reviewMessage =
+              "File restore was cancelled, but Synara could not confirm the server-side safety lock was released. Use “Review and unlock” before starting new work.";
+            setCheckpointFileRestoreReviewMessage(reviewMessage);
+            setThreadError(activeThread.id, reviewMessage);
+            return;
+          }
           clearPendingCheckpointFileRestore(commandId);
-          setIsRevertingCheckpoint(false);
         }
+        setIsRevertingCheckpoint(false);
         return;
       }
 
@@ -6516,9 +6586,17 @@ export default function ChatView({
           phase: "dispatched" as const,
         };
         if (!savePendingCheckpointFileRestore(pendingRestore)) {
-          clearPendingCheckpointFileRestore(commandId);
-          setThreadError(activeThread.id, "The file restore safety lock could not be updated.");
-          setIsRevertingCheckpoint(false);
+          const released = await releaseCheckpointFileRestoreReservation(pendingConfirmation!);
+          if (released) {
+            clearPendingCheckpointFileRestore(commandId);
+            setIsRevertingCheckpoint(false);
+            setThreadError(activeThread.id, "The file restore safety lock could not be updated.");
+          } else {
+            const reviewMessage =
+              "The file restore safety lock could not be updated, and Synara could not confirm the server-side lock was released. Use “Review and unlock” before starting new work.";
+            setCheckpointFileRestoreReviewMessage(reviewMessage);
+            setThreadError(activeThread.id, reviewMessage);
+          }
           return;
         }
         try {
@@ -6532,12 +6610,20 @@ export default function ChatView({
           });
         } catch (error) {
           if (isDefinitiveDispatchRejection(error)) {
-            clearPendingCheckpointFileRestore(commandId);
-            setThreadError(
-              activeThread.id,
-              error instanceof Error ? error.message : "File restore was rejected.",
-            );
-            setIsRevertingCheckpoint(false);
+            const released = await releaseCheckpointFileRestoreReservation(pendingRestore);
+            if (released) {
+              clearPendingCheckpointFileRestore(commandId);
+              setThreadError(
+                activeThread.id,
+                error instanceof Error ? error.message : "File restore was rejected.",
+              );
+              setIsRevertingCheckpoint(false);
+            } else {
+              const reviewMessage =
+                "File restore was rejected, but Synara could not confirm the server-side safety lock was released. Use “Review and unlock” before starting new work.";
+              setCheckpointFileRestoreReviewMessage(reviewMessage);
+              setThreadError(activeThread.id, reviewMessage);
+            }
             return;
           }
           // The request may have been accepted before the transport failed.
@@ -10257,13 +10343,21 @@ export default function ChatView({
       ].join("\n"),
     );
     if (!confirmed) return;
+    const released = await releaseCheckpointFileRestoreReservation(pending);
+    if (!released) {
+      const reviewMessage =
+        "Synara could not persist the file-restore unlock. Keep the working tree paused and try “Review and unlock” again.";
+      setCheckpointFileRestoreReviewMessage(reviewMessage);
+      setThreadError(pending.threadId, reviewMessage);
+      return;
+    }
     clearPendingCheckpointFileRestore(pending.requestCommandId);
     setCheckpointFileRestoreReviewMessage(null);
     setThreadError(pending.threadId, null);
     if (activeThreadId !== pending.threadId) {
       setThreadError(activeThreadId, null);
     }
-  }, [activeThreadId, setThreadError]);
+  }, [activeThreadId, releaseCheckpointFileRestoreReservation, setThreadError]);
   const dismissActiveProviderHealthBanner = useCallback(() => {
     if (!activeProviderHealthBannerDismissalKey) return;
     setDismissedProviderHealthBannerKeys((current) => {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -22,6 +22,10 @@ import {
   type LucideIcon,
   PushIcon,
 } from "~/lib/icons";
+import {
+  CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  hasPendingCheckpointFileRestore,
+} from "~/lib/checkpointFileRestore";
 import { Input } from "~/components/ui/input";
 import { GitHubIcon } from "./Icons";
 import {
@@ -143,6 +147,16 @@ interface RunGitActionWithToastInput {
   isDefaultBranchOverride?: boolean;
   progressToastId?: GitActionToastId;
   filePaths?: string[];
+}
+
+function blockIfCheckpointFileRestorePending(): boolean {
+  if (!hasPendingCheckpointFileRestore()) return false;
+  toastManager.add({
+    type: "error",
+    title: "File restore in progress",
+    description: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  });
+  return true;
 }
 
 interface GitPickerMenuItem {
@@ -626,6 +640,7 @@ export default function GitActionsControl({
   }, [gitStatusForActions, threadToastData]);
 
   const runSyncWithRemote = useCallback(() => {
+    if (blockIfCheckpointFileRestorePending()) return;
     const promise = pullMutation.mutateAsync();
     toastManager.promise(promise, {
       loading: { title: "Syncing with remote...", data: threadToastData },
@@ -659,6 +674,7 @@ export default function GitActionsControl({
       progressToastId,
       filePaths,
     }: RunGitActionWithToastInput) => {
+      if (blockIfCheckpointFileRestorePending()) return;
       const actionStatus = statusOverride ?? gitStatusForActions;
       const actionBranch = actionStatus?.branch ?? null;
       const actionIsDefaultBranch =
@@ -746,6 +762,16 @@ export default function GitActionsControl({
         });
       }
 
+      if (hasPendingCheckpointFileRestore()) {
+        activeGitActionProgressRef.current = null;
+        toastManager.update(resolvedProgressToastId, {
+          type: "error",
+          title: "File restore in progress",
+          description: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+          data: threadToastData,
+        });
+        return;
+      }
       const promise = runImmediateGitActionMutation.mutateAsync({
         actionId,
         action,
@@ -980,7 +1006,7 @@ export default function GitActionsControl({
   const createAndCheckoutBranch = useCallback(
     async (branchName: string) => {
       const api = readNativeApi();
-      if (!api || !gitCwd) return;
+      if (!api || !gitCwd || blockIfCheckpointFileRestorePending()) return;
 
       const trimmedName = branchName.trim();
       if (!trimmedName) return;
@@ -1023,7 +1049,25 @@ export default function GitActionsControl({
       });
 
       try {
+        if (hasPendingCheckpointFileRestore()) {
+          toastManager.update(toastId, {
+            type: "error",
+            title: "File restore in progress",
+            description: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+            data: threadToastData,
+          });
+          return;
+        }
         await api.git.createBranch({ cwd: gitCwd, branch: trimmedName, publish: hasOriginRemote });
+        if (hasPendingCheckpointFileRestore()) {
+          toastManager.update(toastId, {
+            type: "error",
+            title: `Created ${trimmedName}, but did not switch`,
+            description: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+            data: threadToastData,
+          });
+          return;
+        }
         await api.git.checkout({ cwd: gitCwd, branch: trimmedName });
         if (activeThreadId) {
           void api.orchestration

--- a/apps/web/src/components/WorkspaceFilePreview.tsx
+++ b/apps/web/src/components/WorkspaceFilePreview.tsx
@@ -34,6 +34,10 @@ import {
 import { basenameOfPath } from "~/file-icons";
 import { useTheme } from "~/hooks/useTheme";
 import { getSelectionWithin, type ChatFileReference } from "~/lib/chatReferences";
+import {
+  CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  hasPendingCheckpointFileRestore,
+} from "~/lib/checkpointFileRestore";
 import { resolveDiffThemeName, type DiffThemeName } from "~/lib/diffRendering";
 import { formatFileCommentRange, type FileCommentSelection } from "~/lib/fileComments";
 import { showFileReferenceContextMenu } from "~/lib/fileReferenceContextMenu";
@@ -65,6 +69,7 @@ import { useCodeSelectionAction } from "./chat/useCodeSelectionAction";
 import { LocalImagePreview } from "./LocalImagePreview";
 import { PdfFilePreview } from "./PdfFilePreview";
 import { Skeleton } from "./ui/skeleton";
+import { toastManager } from "./ui/toast";
 
 const MARKDOWN_PREVIEW_EXTENSIONS = new Set([".markdown", ".md", ".mdx"]);
 
@@ -461,6 +466,14 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
       if (!api) {
         return;
       }
+      if (hasPendingCheckpointFileRestore()) {
+        toastManager.add({
+          type: "error",
+          title: "File restore in progress",
+          description: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+        });
+        return;
+      }
       queryClient.setQueryData(options.queryKey, { ...current, contents: nextContents });
       // The read RPC may have resolved a bare/partial reference (e.g. a clicked
       // `notes.md`) to its real nested path. Write back to that resolved path,
@@ -475,13 +488,16 @@ export function WorkspaceFilePreview(props: WorkspaceFilePreviewProps) {
       latestTaskWriteVersionRef.current.byFile.set(fileKey, writeVersion);
       taskWriteQueueRef.current = taskWriteQueueRef.current
         .catch(() => undefined)
-        .then(() =>
-          api.projects.writeFile({
+        .then(() => {
+          if (hasPendingCheckpointFileRestore()) {
+            throw new Error(CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE);
+          }
+          return api.projects.writeFile({
             cwd: workspaceRoot,
             relativePath: writeRelativePath,
             contents: nextContents,
-          }),
-        )
+          });
+        })
         .then(() => undefined)
         .catch(() => {
           if (latestTaskWriteVersionRef.current.byFile.get(fileKey) !== writeVersion) {

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -74,7 +74,7 @@ interface ChatTranscriptPaneProps {
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
   onOpenThread: (threadId: ThreadId) => void;
   onOpenAutomation?: ComponentProps<typeof MessagesTimeline>["onOpenAutomation"];
-  onRevertUserMessage: (messageId: MessageId) => void;
+  onRevertUserMessage: (messageId: MessageId, scope?: "files") => void;
   onEditUserMessage?: (messageId: MessageId, text: string) => boolean | Promise<boolean>;
   onScrollToBottom: () => void;
   onToggleWorkGroup?: (groupId: string) => void;

--- a/apps/web/src/components/chat/ComposerPendingApprovalPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingApprovalPanel.tsx
@@ -18,6 +18,7 @@ interface ComposerPendingApprovalPanelProps {
   approval: PendingApproval;
   pendingCount: number;
   isResponding: boolean;
+  disabled?: boolean;
   onRespond: (requestId: ApprovalRequestId, decision: ProviderApprovalDecision) => Promise<void>;
 }
 
@@ -74,6 +75,7 @@ export const ComposerPendingApprovalPanel = memo(function ComposerPendingApprova
   approval,
   pendingCount,
   isResponding,
+  disabled = false,
   onRespond,
 }: ComposerPendingApprovalPanelProps) {
   const parsed = useMemo(() => parseApprovalDetail(approval.detail), [approval.detail]);
@@ -82,7 +84,7 @@ export const ComposerPendingApprovalPanel = memo(function ComposerPendingApprova
   // Digit shortcuts bubble from focused controls inside this card only; a bare
   // number key elsewhere in the app must never approve a tool request.
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (isResponding || event.metaKey || event.ctrlKey || event.altKey) return;
+    if (disabled || isResponding || event.metaKey || event.ctrlKey || event.altKey) return;
     const target = event.target;
     if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) return;
     if (
@@ -128,8 +130,12 @@ export const ComposerPendingApprovalPanel = memo(function ComposerPendingApprova
             label={action.label}
             description={action.description}
             tone={action.tone}
-            disabled={isResponding}
-            onSelect={() => void onRespond(requestId, action.decision)}
+            disabled={disabled || isResponding}
+            onSelect={() => {
+              if (!disabled && !isResponding) {
+                void onRespond(requestId, action.decision);
+              }
+            }}
           />
         ))}
       </div>

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -20,6 +20,7 @@ interface PendingUserInputPanelProps {
   respondingRequestIds: ApprovalRequestId[];
   answers: Record<string, PendingUserInputDraftAnswer>;
   questionIndex: number;
+  disabled?: boolean;
   onToggleOption: (questionId: string, optionLabel: string) => PendingUserInputDraftAnswer | null;
   onAdvance: (answerOverrides?: Record<string, PendingUserInputDraftAnswer>) => void;
   onPrevious: () => void;
@@ -35,6 +36,7 @@ export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserIn
   respondingRequestIds,
   answers,
   questionIndex,
+  disabled = false,
   onToggleOption,
   onAdvance,
   onPrevious,
@@ -51,6 +53,7 @@ export const ComposerPendingUserInputPanel = memo(function ComposerPendingUserIn
       isResponding={respondingRequestIds.includes(activePrompt.requestId)}
       answers={answers}
       questionIndex={questionIndex}
+      disabled={disabled}
       onToggleOption={onToggleOption}
       onAdvance={onAdvance}
       onPrevious={onPrevious}
@@ -64,6 +67,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   isResponding,
   answers,
   questionIndex,
+  disabled,
   onToggleOption,
   onAdvance,
   onPrevious,
@@ -73,6 +77,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   isResponding: boolean;
   answers: Record<string, PendingUserInputDraftAnswer>;
   questionIndex: number;
+  disabled: boolean;
   onToggleOption: (questionId: string, optionLabel: string) => PendingUserInputDraftAnswer | null;
   onAdvance: (answerOverrides?: Record<string, PendingUserInputDraftAnswer>) => void;
   onPrevious: () => void;
@@ -96,9 +101,12 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
         autoAdvanceTimerRef.current = null;
       }
     };
-  }, [activeQuestion?.id, isResponding]);
+  }, [activeQuestion?.id, disabled, isResponding]);
 
   const handleOptionSelection = useEffectEvent((questionId: string, optionLabel: string) => {
+    if (disabled || isResponding) {
+      return;
+    }
     const nextDraftAnswer = onToggleOption(questionId, optionLabel);
     if (activeQuestion?.multiSelect) {
       return;
@@ -115,7 +123,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   // Keyboard shortcut: digits toggle options for multi-select prompts and preserve
   // the current auto-advance behavior for single-select questions.
   useEffect(() => {
-    if (!activeQuestion || isResponding) return;
+    if (!activeQuestion || disabled || isResponding) return;
     const handler = (event: globalThis.KeyboardEvent) => {
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       const target = event.target;
@@ -141,7 +149,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [activeQuestion, isResponding]);
+  }, [activeQuestion, disabled, isResponding]);
 
   if (!activeQuestion) {
     return null;
@@ -162,7 +170,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
           <div className="flex shrink-0 items-center gap-0.5 pt-px text-muted-foreground/70">
             <button
               type="button"
-              disabled={!canGoBack || isResponding}
+              disabled={!canGoBack || disabled || isResponding}
               onClick={onPrevious}
               className={NAV_BUTTON_CLASS_NAME}
               aria-label="Previous question"
@@ -174,7 +182,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
             </span>
             <button
               type="button"
-              disabled={!canGoForward || isResponding}
+              disabled={!canGoForward || disabled || isResponding}
               onClick={() => onAdvance()}
               className={NAV_BUTTON_CLASS_NAME}
               aria-label="Next question"
@@ -199,7 +207,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
                 label={option.label}
                 description={option.description}
                 selected={isSelected}
-                disabled={isResponding}
+                disabled={disabled || isResponding}
                 onSelect={() => handleOptionSelection(activeQuestion.id, option.label)}
                 trailing={
                   isSelected ? (
@@ -214,11 +222,15 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
         <div className="mt-2.5 flex justify-end">
           <button
             type="button"
-            disabled={isResponding}
-            onClick={onCancel}
+            disabled={disabled || isResponding}
+            onClick={() => {
+              if (!disabled && !isResponding) {
+                onCancel();
+              }
+            }}
             className={cn(
               "rounded-md px-2 py-1 text-[12px] text-[var(--color-text-foreground-secondary)] transition-colors duration-150 hover:bg-[var(--color-background-button-secondary-hover)] hover:text-[var(--color-text-foreground)]",
-              isResponding && "cursor-not-allowed opacity-50",
+              (disabled || isResponding) && "cursor-not-allowed opacity-50",
             )}
           >
             Cancel

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -2435,6 +2435,7 @@ describe("MessagesTimeline", () => {
 
   it("anchors the changed-files summary at the end of a collapsed file-change turn", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
+    const userMessageId = MessageId.makeUnsafe("message-user-inline-multi-edit");
     const assistantMessageId = MessageId.makeUnsafe("message-assistant-inline-multi-edit");
     const markup = renderToStaticMarkup(
       <MessagesTimeline
@@ -2443,6 +2444,18 @@ describe("MessagesTimeline", () => {
         activeTurnInProgress={false}
         activeTurnStartedAt={null}
         timelineEntries={[
+          {
+            id: "entry-user-inline-multi-edit",
+            kind: "message",
+            createdAt: "2026-03-17T19:12:27.000Z",
+            message: {
+              id: userMessageId,
+              role: "user",
+              text: "edit both files",
+              createdAt: "2026-03-17T19:12:27.000Z",
+              streaming: false,
+            },
+          },
           {
             id: "entry-inline-multi-file-change",
             kind: "work",
@@ -2501,7 +2514,7 @@ describe("MessagesTimeline", () => {
         expandedWorkGroups={{}}
         onToggleWorkGroup={() => {}}
         onOpenTurnDiff={() => {}}
-        revertTurnCountByUserMessageId={new Map()}
+        revertTurnCountByUserMessageId={new Map([[userMessageId, 0]])}
         onRevertUserMessage={() => {}}
         isRevertingCheckpoint={false}
         onImageExpand={() => {}}
@@ -2521,6 +2534,8 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("+1");
     expect(markup).toContain("-1");
     expect(markup).toContain("+2");
+    expect(markup).toContain("Undo files");
+    expect(markup).toContain('aria-label="Undo file changes and keep chat history"');
     expect(markup).not.toContain(">apps/web/src/components/chat<");
   });
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -406,7 +406,7 @@ interface MessagesTimelineProps {
   /** Open an automation's detail page from a "created automation" transcript card. */
   onOpenAutomation?: (automationId: string) => void;
   revertTurnCountByUserMessageId: Map<MessageId, number>;
-  onRevertUserMessage: (messageId: MessageId) => void;
+  onRevertUserMessage: (messageId: MessageId, scope?: "files") => void;
   onEditUserMessage?: (messageId: MessageId, text: string) => boolean | Promise<boolean>;
   activeTurnId?: TurnId | null;
   isRevertingCheckpoint: boolean;
@@ -1687,9 +1687,12 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                               type="button"
                               className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
                               style={{ fontSize: chatTypographyStyle.fontSize }}
-                              onClick={() => onRevertUserMessage(correspondingUserMessageId)}
+                              aria-label="Undo file changes and keep chat history"
+                              onClick={() =>
+                                onRevertUserMessage(correspondingUserMessageId, "files")
+                              }
                             >
-                              Undo
+                              Undo files
                               <Undo2Icon className="size-3" />
                             </button>
                           )}

--- a/apps/web/src/components/chat/ProposedPlanActions.tsx
+++ b/apps/web/src/components/chat/ProposedPlanActions.tsx
@@ -4,6 +4,10 @@ import {
   normalizePlanMarkdownForExport,
 } from "../../proposedPlan";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import {
+  CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  hasPendingCheckpointFileRestore,
+} from "~/lib/checkpointFileRestore";
 import { ArrowDownIcon, ArrowUpIcon, CopyIcon } from "~/lib/icons";
 import { cn } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
@@ -57,6 +61,14 @@ export const ProposedPlanActions = memo(function ProposedPlanActions({
         type: "error",
         title: "Workspace path is unavailable",
         description: "This thread does not have a workspace path to download into.",
+      });
+      return;
+    }
+    if (hasPendingCheckpointFileRestore()) {
+      toastManager.add({
+        type: "error",
+        title: "File restore in progress",
+        description: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
       });
       return;
     }

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -5,6 +5,7 @@
 
 import { memo } from "react";
 import { Alert, AlertAction, AlertDescription } from "../ui/alert";
+import { Button } from "../ui/button";
 import { IconButton } from "../ui/icon-button";
 import { CircleAlertIcon, XIcon } from "~/lib/icons";
 import { ChatColumnBannerFrame } from "./ChatColumnBannerFrame";
@@ -12,9 +13,13 @@ import { ChatColumnBannerFrame } from "./ChatColumnBannerFrame";
 export const ThreadErrorBanner = memo(function ThreadErrorBanner({
   error,
   onDismiss,
+  actionLabel,
+  onAction,
 }: {
   error: string | null;
   onDismiss?: () => void;
+  actionLabel?: string;
+  onAction?: () => void;
 }) {
   if (!error) return null;
   return (
@@ -24,15 +29,24 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
         <AlertDescription className="line-clamp-3" title={error}>
           {error}
         </AlertDescription>
-        {onDismiss && (
+        {(onAction || onDismiss) && (
           <AlertAction>
-            <IconButton
-              label="Dismiss error"
-              className="size-6 text-destructive/60 hover:text-destructive sm:size-6"
-              onClick={onDismiss}
-            >
-              <XIcon className="size-3.5" />
-            </IconButton>
+            <div className="flex items-center gap-1.5">
+              {onAction && actionLabel ? (
+                <Button type="button" size="sm" variant="outline" onClick={onAction}>
+                  {actionLabel}
+                </Button>
+              ) : null}
+              {onDismiss ? (
+                <IconButton
+                  label="Dismiss error"
+                  className="size-6 text-destructive/60 hover:text-destructive sm:size-6"
+                  onClick={onDismiss}
+                >
+                  <XIcon className="size-3.5" />
+                </IconButton>
+              ) : null}
+            </div>
           </AlertAction>
         )}
       </Alert>

--- a/apps/web/src/hooks/useComposerSlashCommands.ts
+++ b/apps/web/src/hooks/useComposerSlashCommands.ts
@@ -28,6 +28,10 @@ import {
 } from "../composerSlashCommands";
 import { buildThreadHandoffImportedMessages } from "../lib/threadHandoff";
 import { toastManager } from "../components/ui/toast";
+import {
+  CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  hasPendingCheckpointFileRestore,
+} from "../lib/checkpointFileRestore";
 import type { ComposerCommandItem } from "../components/chat/ComposerCommandMenu";
 import { buildNextProviderOptions } from "../providerModelOptions";
 import { resolveForkThreadEnvironment } from "../lib/threadEnvironment";
@@ -47,6 +51,16 @@ type SlashCommandItem = Extract<ComposerCommandItem, { type: "slash-command" }>;
 
 function wasPromptReplacementApplied(result: number | false): boolean {
   return result !== false;
+}
+
+function blockIfCheckpointFileRestorePending(): boolean {
+  if (!hasPendingCheckpointFileRestore()) return false;
+  toastManager.add({
+    type: "error",
+    title: "File restore in progress",
+    description: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  });
+  return true;
 }
 
 export function useComposerSlashCommands(input: {
@@ -152,6 +166,9 @@ export function useComposerSlashCommands(input: {
         title: "Compact is unavailable",
         description: "Open an active supported server thread before compacting context.",
       });
+      return false;
+    }
+    if (blockIfCheckpointFileRestorePending()) {
       return false;
     }
 
@@ -309,6 +326,9 @@ export function useComposerSlashCommands(input: {
         });
         return true;
       }
+      if (blockIfCheckpointFileRestorePending()) {
+        return true;
+      }
 
       const importedMessages = buildThreadHandoffImportedMessages(activeThread);
       const nextThreadId = newThreadId();
@@ -341,6 +361,9 @@ export function useComposerSlashCommands(input: {
       });
 
       if (initialPrompt.length > 0) {
+        if (blockIfCheckpointFileRestorePending()) {
+          return true;
+        }
         await api.orchestration.dispatchCommand({
           type: "thread.turn.start",
           commandId: newCommandId(),
@@ -407,6 +430,9 @@ export function useComposerSlashCommands(input: {
         });
         return false;
       }
+      if (blockIfCheckpointFileRestorePending()) {
+        return false;
+      }
 
       const messageText =
         target === "base-branch" && activeRootBranch
@@ -442,6 +468,9 @@ export function useComposerSlashCommands(input: {
           ...associatedWorktree,
           createdAt,
         });
+        if (blockIfCheckpointFileRestorePending()) {
+          return false;
+        }
         await api.orchestration.dispatchCommand({
           type: "thread.turn.start",
           commandId: newCommandId(),

--- a/apps/web/src/lib/checkpointFileRestore.test.ts
+++ b/apps/web/src/lib/checkpointFileRestore.test.ts
@@ -1,0 +1,74 @@
+import { CommandId, EventId, MessageId, ThreadId } from "@synara/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { waitForCheckpointFileRestore } from "./checkpointFileRestore";
+
+const requestCommandId = CommandId.makeUnsafe("restore-request");
+
+function makeHarness() {
+  let listener: Parameters<
+    Parameters<typeof waitForCheckpointFileRestore>[0]["subscribe"]
+  >[0] = () => {};
+  const wait = waitForCheckpointFileRestore({
+    requestCommandId,
+    subscribe: (next) => {
+      listener = next;
+      return () => {};
+    },
+    timeoutMs: 10,
+  });
+  const base = {
+    sequence: 1,
+    eventId: EventId.makeUnsafe("event-1"),
+    aggregateKind: "thread" as const,
+    aggregateId: ThreadId.makeUnsafe("thread-1"),
+    occurredAt: "2026-07-12T00:00:00.000Z",
+    commandId: null,
+    causationEventId: null,
+    correlationId: null,
+    metadata: {},
+  };
+  return { wait, listener, base };
+}
+
+describe("waitForCheckpointFileRestore", () => {
+  it("resolves matching success and rejects matching failure immediately", async () => {
+    const success = makeHarness();
+    success.listener({
+      ...success.base,
+      type: "thread.checkpoint-files-restored",
+      payload: {
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        messageId: MessageId.makeUnsafe("message-1"),
+        turnCount: 0,
+        requestCommandId,
+      },
+    });
+    await expect(success.wait.promise).resolves.toBeUndefined();
+
+    const failure = makeHarness();
+    failure.listener({
+      ...failure.base,
+      type: "thread.checkpoint-files-restore-failed",
+      payload: {
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        messageId: MessageId.makeUnsafe("message-1"),
+        turnCount: 0,
+        requestCommandId,
+        detail: "Checkpoint is unavailable.",
+      },
+    });
+    await expect(failure.wait.promise).rejects.toThrow("Checkpoint is unavailable.");
+  });
+
+  it("rejects when no terminal event arrives before the timeout", async () => {
+    vi.useFakeTimers();
+    const harness = makeHarness();
+    const rejection = expect(harness.wait.promise).rejects.toThrow(
+      "Timed out waiting for file changes to be restored.",
+    );
+    await vi.advanceTimersByTimeAsync(10);
+    await rejection;
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/src/lib/checkpointFileRestore.test.ts
+++ b/apps/web/src/lib/checkpointFileRestore.test.ts
@@ -85,6 +85,20 @@ function requestedEvent(sequence = 1): OrchestrationEvent {
   };
 }
 
+function preparedEvent(sequence = 1): OrchestrationEvent {
+  return {
+    ...eventBase(sequence),
+    type: "thread.checkpoint-files-restore-prepared",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 1,
+      requestCommandId,
+      createdAt: "2026-07-12T00:00:00.000Z",
+    },
+  };
+}
+
 function successEvent(sequence = 2, commandId = requestCommandId): OrchestrationEvent {
   return {
     ...eventBase(sequence),
@@ -94,6 +108,20 @@ function successEvent(sequence = 2, commandId = requestCommandId): Orchestration
       messageId,
       turnCount: 1,
       requestCommandId: commandId,
+    },
+  };
+}
+
+function reviewedEvent(sequence = 2): OrchestrationEvent {
+  return {
+    ...eventBase(sequence),
+    type: "thread.checkpoint-files-restore-reviewed",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 1,
+      requestCommandId,
+      createdAt: "2026-07-12T00:00:00.000Z",
     },
   };
 }
@@ -309,6 +337,22 @@ describe("checkpoint file restore status", () => {
         requestCommandId,
       }),
     ).toEqual({ status: "pending", sequence: 1 });
+
+    expect(
+      checkpointFileRestoreStatusFromEvents({
+        events: [preparedEvent()],
+        threadId,
+        requestCommandId,
+      }),
+    ).toEqual({ status: "pending", sequence: 1 });
+
+    expect(
+      checkpointFileRestoreStatusFromEvents({
+        events: [preparedEvent(1), reviewedEvent(2)],
+        threadId,
+        requestCommandId,
+      }),
+    ).toEqual({ status: "not-found" });
 
     expect(
       checkpointFileRestoreStatusFromEvents({

--- a/apps/web/src/lib/checkpointFileRestore.test.ts
+++ b/apps/web/src/lib/checkpointFileRestore.test.ts
@@ -509,7 +509,7 @@ describe("checkpoint file restore pending storage", () => {
     ).toBe(true);
   });
 
-  it("recognizes a confirmation abandoned by a previous client instance", () => {
+  it("does not treat another tab's confirmation lock as stale", () => {
     const pending = {
       threadId,
       messageId,
@@ -520,8 +520,9 @@ describe("checkpoint file restore pending storage", () => {
       clientId: "client-before-reload",
     };
 
-    expect(isStaleCheckpointFileRestoreConfirmation(pending, "client-before-reload")).toBe(false);
-    expect(isStaleCheckpointFileRestoreConfirmation(pending, "client-after-reload")).toBe(true);
+    expect(isStaleCheckpointFileRestoreConfirmation(pending)).toBe(false);
+    const { clientId: _clientId, ...ownerlessPending } = pending;
+    expect(isStaleCheckpointFileRestoreConfirmation(ownerlessPending)).toBe(true);
   });
 
   it("rejects storage writes that cannot be read back", () => {

--- a/apps/web/src/lib/checkpointFileRestore.test.ts
+++ b/apps/web/src/lib/checkpointFileRestore.test.ts
@@ -15,7 +15,6 @@ function makeHarness() {
       listener = next;
       return () => {};
     },
-    timeoutMs: 10,
   });
   const base = {
     sequence: 1,
@@ -61,14 +60,29 @@ describe("waitForCheckpointFileRestore", () => {
     await expect(failure.wait.promise).rejects.toThrow("Checkpoint is unavailable.");
   });
 
-  it("rejects when no terminal event arrives before the timeout", async () => {
+  it("stays pending regardless of queue time until a terminal event arrives", async () => {
     vi.useFakeTimers();
     const harness = makeHarness();
-    const rejection = expect(harness.wait.promise).rejects.toThrow(
-      "Timed out waiting for file changes to be restored.",
-    );
-    await vi.advanceTimersByTimeAsync(10);
-    await rejection;
+    let settled = false;
+    void harness.wait.promise.finally(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(settled).toBe(false);
+
+    harness.listener({
+      ...harness.base,
+      type: "thread.checkpoint-files-restored",
+      payload: {
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        messageId: MessageId.makeUnsafe("message-1"),
+        turnCount: 0,
+        requestCommandId,
+      },
+    });
+    await expect(harness.wait.promise).resolves.toBeUndefined();
+    expect(settled).toBe(true);
     vi.useRealTimers();
   });
 });

--- a/apps/web/src/lib/checkpointFileRestore.test.ts
+++ b/apps/web/src/lib/checkpointFileRestore.test.ts
@@ -1,9 +1,121 @@
-import { CommandId, EventId, MessageId, ThreadId } from "@synara/contracts";
+import {
+  CommandId,
+  EventId,
+  MessageId,
+  ThreadId,
+  WS_RPC_ERROR_CODES,
+  WsRpcError,
+  type OrchestrationEvent,
+} from "@synara/contracts";
 import { describe, expect, it, vi } from "vitest";
 
-import { waitForCheckpointFileRestore } from "./checkpointFileRestore";
+import {
+  CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  checkpointFileRestoreStatusFromEvents,
+  clearPendingCheckpointFileRestore,
+  getPendingCheckpointFileRestoreSnapshot,
+  hasPendingCheckpointFileRestore,
+  isCheckpointFileRestoreReviewRequiredError,
+  isStaleCheckpointFileRestoreConfirmation,
+  isDefinitiveDispatchRejection,
+  readPendingCheckpointFileRestore,
+  savePendingCheckpointFileRestore,
+  shouldReconcileCheckpointFileRestoreAcceptance,
+  waitForCheckpointFileRestore,
+} from "./checkpointFileRestore";
 
 const requestCommandId = CommandId.makeUnsafe("restore-request");
+const otherRequestCommandId = CommandId.makeUnsafe("other-restore-request");
+const threadId = ThreadId.makeUnsafe("thread-1");
+const messageId = MessageId.makeUnsafe("message-1");
+
+class MemoryStorage implements Storage {
+  private readonly items = new Map<string, string>();
+
+  get length(): number {
+    return this.items.size;
+  }
+
+  clear(): void {
+    this.items.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.items.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.items.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.items.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(key, value);
+  }
+}
+
+function eventBase(sequence: number) {
+  return {
+    sequence,
+    eventId: EventId.makeUnsafe(`event-${sequence}`),
+    aggregateKind: "thread" as const,
+    aggregateId: threadId,
+    occurredAt: "2026-07-12T00:00:00.000Z",
+    commandId: null,
+    causationEventId: null,
+    correlationId: null,
+    metadata: {},
+  };
+}
+
+function requestedEvent(sequence = 1): OrchestrationEvent {
+  return {
+    ...eventBase(sequence),
+    commandId: requestCommandId,
+    type: "thread.checkpoint-files-restore-requested",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 1,
+      createdAt: "2026-07-12T00:00:00.000Z",
+    },
+  };
+}
+
+function successEvent(sequence = 2, commandId = requestCommandId): OrchestrationEvent {
+  return {
+    ...eventBase(sequence),
+    type: "thread.checkpoint-files-restored",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 1,
+      requestCommandId: commandId,
+    },
+  };
+}
+
+function failureEvent(
+  sequence = 2,
+  detail = "Checkpoint is unavailable.",
+  requiresWorkspaceReview = false,
+): OrchestrationEvent {
+  return {
+    ...eventBase(sequence),
+    type: "thread.checkpoint-files-restore-failed",
+    payload: {
+      threadId,
+      messageId,
+      turnCount: 1,
+      requestCommandId,
+      detail,
+      requiresWorkspaceReview,
+    },
+  };
+}
 
 function makeHarness() {
   let listener: Parameters<
@@ -16,47 +128,17 @@ function makeHarness() {
       return () => {};
     },
   });
-  const base = {
-    sequence: 1,
-    eventId: EventId.makeUnsafe("event-1"),
-    aggregateKind: "thread" as const,
-    aggregateId: ThreadId.makeUnsafe("thread-1"),
-    occurredAt: "2026-07-12T00:00:00.000Z",
-    commandId: null,
-    causationEventId: null,
-    correlationId: null,
-    metadata: {},
-  };
-  return { wait, listener, base };
+  return { wait, listener };
 }
 
 describe("waitForCheckpointFileRestore", () => {
   it("resolves matching success and rejects matching failure immediately", async () => {
     const success = makeHarness();
-    success.listener({
-      ...success.base,
-      type: "thread.checkpoint-files-restored",
-      payload: {
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        messageId: MessageId.makeUnsafe("message-1"),
-        turnCount: 0,
-        requestCommandId,
-      },
-    });
+    success.listener(successEvent());
     await expect(success.wait.promise).resolves.toBeUndefined();
 
     const failure = makeHarness();
-    failure.listener({
-      ...failure.base,
-      type: "thread.checkpoint-files-restore-failed",
-      payload: {
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        messageId: MessageId.makeUnsafe("message-1"),
-        turnCount: 0,
-        requestCommandId,
-        detail: "Checkpoint is unavailable.",
-      },
-    });
+    failure.listener(failureEvent());
     await expect(failure.wait.promise).rejects.toThrow("Checkpoint is unavailable.");
   });
 
@@ -71,18 +153,396 @@ describe("waitForCheckpointFileRestore", () => {
     await vi.advanceTimersByTimeAsync(300_000);
     expect(settled).toBe(false);
 
-    harness.listener({
-      ...harness.base,
-      type: "thread.checkpoint-files-restored",
-      payload: {
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        messageId: MessageId.makeUnsafe("message-1"),
-        turnCount: 0,
-        requestCommandId,
-      },
-    });
+    harness.listener(successEvent());
     await expect(harness.wait.promise).resolves.toBeUndefined();
     expect(settled).toBe(true);
     vi.useRealTimers();
+  });
+
+  it("shares one listener and reconciliation loop across mounted consumers", async () => {
+    let listener: (event: OrchestrationEvent) => void = () => {};
+    const unsubscribe = vi.fn();
+    const subscribe = vi.fn((next: (event: OrchestrationEvent) => void) => {
+      listener = next;
+      return unsubscribe;
+    });
+    const first = waitForCheckpointFileRestore({ requestCommandId, subscribe });
+    const second = waitForCheckpointFileRestore({ requestCommandId, subscribe });
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    first.cancel();
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    listener(successEvent());
+    await expect(second.promise).resolves.toBeUndefined();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves a terminal status that was persisted while the live event was missed", async () => {
+    vi.useFakeTimers();
+    let status = checkpointFileRestoreStatusFromEvents({
+      events: [requestedEvent()],
+      threadId,
+      requestCommandId,
+    });
+    const getStatus = vi.fn(async () => status);
+    const wait = waitForCheckpointFileRestore({
+      requestCommandId,
+      subscribe: () => () => {},
+      getStatus,
+      reconcileIntervalMs: 100,
+    });
+
+    let settled = false;
+    void wait.promise.then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    expect(settled).toBe(false);
+
+    status = checkpointFileRestoreStatusFromEvents({
+      events: [requestedEvent(), successEvent()],
+      threadId,
+      requestCommandId,
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(wait.promise).resolves.toBeUndefined();
+    expect(settled).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("rejects a terminal failure found by reconciliation", async () => {
+    const wait = waitForCheckpointFileRestore({
+      requestCommandId,
+      subscribe: () => () => {},
+      getStatus: async () =>
+        checkpointFileRestoreStatusFromEvents({
+          events: [requestedEvent(), failureEvent(2, "Session is inactive.")],
+          threadId,
+          requestCommandId,
+        }),
+    });
+
+    await expect(wait.promise).rejects.toThrow("Session is inactive.");
+  });
+
+  it("preserves structured workspace-review requirements on terminal failure", async () => {
+    const wait = waitForCheckpointFileRestore({
+      requestCommandId,
+      subscribe: (listener) => {
+        listener(failureEvent(2, "Restart interrupted restore.", true));
+        return () => {};
+      },
+    });
+
+    await expect(wait.promise).rejects.toMatchObject({ requiresWorkspaceReview: true });
+    await wait.promise.catch((error: unknown) => {
+      expect(isCheckpointFileRestoreReviewRequiredError(error)).toBe(true);
+    });
+  });
+
+  it("keeps waiting when reconciliation cannot prove a terminal state", async () => {
+    vi.useFakeTimers();
+    const wait = waitForCheckpointFileRestore({
+      requestCommandId,
+      subscribe: () => () => {},
+      getStatus: async () =>
+        checkpointFileRestoreStatusFromEvents({
+          events: [successEvent(2, otherRequestCommandId)],
+          threadId,
+          requestCommandId,
+        }),
+      reconcileIntervalMs: 100,
+    });
+
+    let settled = false;
+    void wait.promise.finally(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(settled).toBe(false);
+    wait.cancel();
+    vi.useRealTimers();
+  });
+
+  it("does not leave a reconciliation interval after synchronous terminal replay", async () => {
+    vi.useFakeTimers();
+    const getStatus = vi.fn(async () =>
+      checkpointFileRestoreStatusFromEvents({
+        events: [requestedEvent()],
+        threadId,
+        requestCommandId,
+      }),
+    );
+    const wait = waitForCheckpointFileRestore({
+      requestCommandId,
+      subscribe: (listener) => {
+        listener(successEvent());
+        return () => {};
+      },
+      getStatus,
+      reconcileIntervalMs: 100,
+    });
+
+    await expect(wait.promise).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(getStatus).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});
+
+describe("checkpoint file restore status", () => {
+  it("derives not-found, pending, succeeded, and failed from the persisted event log", () => {
+    expect(
+      checkpointFileRestoreStatusFromEvents({
+        events: [],
+        threadId,
+        requestCommandId,
+      }),
+    ).toEqual({ status: "not-found" });
+
+    expect(
+      checkpointFileRestoreStatusFromEvents({
+        events: [requestedEvent()],
+        threadId,
+        requestCommandId,
+      }),
+    ).toEqual({ status: "pending", sequence: 1 });
+
+    expect(
+      checkpointFileRestoreStatusFromEvents({
+        events: [requestedEvent(), successEvent()],
+        threadId,
+        requestCommandId,
+      }),
+    ).toEqual({ status: "succeeded", sequence: 2 });
+
+    expect(
+      checkpointFileRestoreStatusFromEvents({
+        events: [requestedEvent(), failureEvent(3, "Missing checkpoint.")],
+        threadId,
+        requestCommandId,
+      }),
+    ).toEqual({
+      status: "failed",
+      sequence: 3,
+      detail: "Missing checkpoint.",
+      requiresWorkspaceReview: false,
+    });
+  });
+});
+
+describe("checkpoint file restore dispatch rejection", () => {
+  it("recognizes only structured server-side dispatch rejection", () => {
+    expect(
+      isDefinitiveDispatchRejection(
+        new WsRpcError({
+          message: "Thread not found.",
+          code: WS_RPC_ERROR_CODES.orchestrationDispatchRejected,
+        }),
+      ),
+    ).toBe(true);
+
+    expect(isDefinitiveDispatchRejection(new WsRpcError({ message: "Other server error." }))).toBe(
+      false,
+    );
+    expect(isDefinitiveDispatchRejection(new Error("Transport closed"))).toBe(false);
+  });
+});
+
+describe("checkpoint file restore pending storage", () => {
+  it("round-trips and clears the pending restore by request id", () => {
+    const storage = new MemoryStorage();
+    expect(
+      savePendingCheckpointFileRestore(
+        {
+          threadId,
+          messageId,
+          requestCommandId,
+          turnCount: 1,
+          createdAt: "2026-07-12T00:00:00.000Z",
+          phase: "dispatched",
+        },
+        storage,
+      ),
+    ).toBe(true);
+
+    expect(hasPendingCheckpointFileRestore(storage)).toBe(true);
+    expect(getPendingCheckpointFileRestoreSnapshot(storage)).toContain("restore-request");
+    expect(readPendingCheckpointFileRestore(storage)).toEqual({
+      threadId,
+      messageId,
+      requestCommandId,
+      turnCount: 1,
+      createdAt: "2026-07-12T00:00:00.000Z",
+      phase: "dispatched",
+    });
+
+    clearPendingCheckpointFileRestore(otherRequestCommandId, storage);
+    expect(readPendingCheckpointFileRestore(storage)?.requestCommandId).toBe(requestCommandId);
+
+    clearPendingCheckpointFileRestore(requestCommandId, storage);
+    expect(readPendingCheckpointFileRestore(storage)).toBeNull();
+    expect(hasPendingCheckpointFileRestore(storage)).toBe(false);
+    expect(getPendingCheckpointFileRestoreSnapshot(storage)).toBeNull();
+  });
+
+  it("requires durable exclusive persistence before a restore can be dispatched", () => {
+    const storage = new MemoryStorage();
+
+    expect(
+      savePendingCheckpointFileRestore(
+        {
+          threadId,
+          messageId,
+          requestCommandId,
+          turnCount: 1,
+          createdAt: "2026-07-12T00:00:00.000Z",
+          phase: "confirming",
+          clientId: "client-a",
+        },
+        storage,
+      ),
+    ).toBe(true);
+    expect(
+      savePendingCheckpointFileRestore(
+        {
+          threadId,
+          messageId,
+          requestCommandId,
+          turnCount: 1,
+          createdAt: "2026-07-12T00:00:00.000Z",
+          phase: "dispatched",
+          reconciliationCommandId: CommandId.makeUnsafe("restore-reconcile"),
+          clientId: "client-a",
+        },
+        storage,
+      ),
+    ).toBe(true);
+
+    expect(
+      savePendingCheckpointFileRestore(
+        {
+          threadId,
+          messageId,
+          requestCommandId: otherRequestCommandId,
+          turnCount: 1,
+          createdAt: "2026-07-12T00:00:00.000Z",
+          phase: "confirming",
+          clientId: "client-b",
+        },
+        storage,
+      ),
+    ).toBe(false);
+
+    expect(readPendingCheckpointFileRestore(storage)).toMatchObject({
+      requestCommandId,
+      phase: "dispatched",
+      reconciliationCommandId: CommandId.makeUnsafe("restore-reconcile"),
+      clientId: "client-a",
+    });
+  });
+
+  it("does not report a pending restore when storage is unavailable", () => {
+    expect(
+      savePendingCheckpointFileRestore(
+        {
+          threadId,
+          messageId,
+          requestCommandId,
+          turnCount: 1,
+          createdAt: "2026-07-12T00:00:00.000Z",
+          phase: "confirming",
+        },
+        null,
+      ),
+    ).toBe(false);
+    expect(hasPendingCheckpointFileRestore(null)).toBe(false);
+    expect(CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE).toContain("file restore");
+  });
+
+  it("defaults older pending records to dispatched so they reconcile conservatively", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      "synara.pendingCheckpointFileRestore.v1",
+      JSON.stringify({
+        threadId,
+        messageId,
+        requestCommandId,
+        turnCount: 1,
+        createdAt: "2026-07-12T00:00:00.000Z",
+      }),
+    );
+
+    expect(readPendingCheckpointFileRestore(storage)).toEqual({
+      threadId,
+      messageId,
+      requestCommandId,
+      turnCount: 1,
+      createdAt: "2026-07-12T00:00:00.000Z",
+      phase: "dispatched",
+    });
+  });
+
+  it("reconciles only ambiguous or reloaded dispatched requests", () => {
+    const pending = {
+      threadId,
+      messageId,
+      requestCommandId,
+      reconciliationCommandId: CommandId.makeUnsafe("restore-reconcile"),
+      turnCount: 1,
+      createdAt: "2026-07-12T00:00:00.000Z",
+      phase: "dispatched" as const,
+      clientId: "client-a",
+    };
+
+    expect(shouldReconcileCheckpointFileRestoreAcceptance(pending, "client-a")).toBe(false);
+    expect(shouldReconcileCheckpointFileRestoreAcceptance(pending, "client-after-reload")).toBe(
+      true,
+    );
+    expect(
+      shouldReconcileCheckpointFileRestoreAcceptance(
+        { ...pending, acceptanceAmbiguous: true },
+        "client-a",
+      ),
+    ).toBe(true);
+  });
+
+  it("recognizes a confirmation abandoned by a previous client instance", () => {
+    const pending = {
+      threadId,
+      messageId,
+      requestCommandId,
+      turnCount: 1,
+      createdAt: "2026-07-12T00:00:00.000Z",
+      phase: "confirming" as const,
+      clientId: "client-before-reload",
+    };
+
+    expect(isStaleCheckpointFileRestoreConfirmation(pending, "client-before-reload")).toBe(false);
+    expect(isStaleCheckpointFileRestoreConfirmation(pending, "client-after-reload")).toBe(true);
+  });
+
+  it("rejects storage writes that cannot be read back", () => {
+    const storage = new (class extends MemoryStorage {
+      override getItem(): string | null {
+        return null;
+      }
+    })();
+
+    expect(
+      savePendingCheckpointFileRestore(
+        {
+          threadId,
+          messageId,
+          requestCommandId,
+          turnCount: 1,
+          createdAt: "2026-07-12T00:00:00.000Z",
+          phase: "confirming",
+        },
+        storage,
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/checkpointFileRestore.ts
+++ b/apps/web/src/lib/checkpointFileRestore.ts
@@ -1,0 +1,48 @@
+import type { CommandId, OrchestrationEvent } from "@synara/contracts";
+
+const FILE_RESTORE_COMPLETION_TIMEOUT_MS = 120_000;
+
+export function waitForCheckpointFileRestore(input: {
+  requestCommandId: CommandId;
+  subscribe: (listener: (event: OrchestrationEvent) => void) => () => void;
+  timeoutMs?: number;
+}): { promise: Promise<void>; cancel: () => void } {
+  let unsubscribe = () => {};
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let settled = false;
+
+  const cleanup = () => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+    unsubscribe();
+  };
+  const promise = new Promise<void>((resolve, reject) => {
+    unsubscribe = input.subscribe((event) => {
+      if (
+        (event.type !== "thread.checkpoint-files-restored" &&
+          event.type !== "thread.checkpoint-files-restore-failed") ||
+        event.payload.requestCommandId !== input.requestCommandId
+      ) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      if (event.type === "thread.checkpoint-files-restore-failed") {
+        reject(new Error(event.payload.detail));
+      } else {
+        resolve();
+      }
+    });
+    timeoutId = setTimeout(() => {
+      settled = true;
+      cleanup();
+      reject(new Error("Timed out waiting for file changes to be restored."));
+    }, input.timeoutMs ?? FILE_RESTORE_COMPLETION_TIMEOUT_MS);
+  });
+
+  return {
+    promise,
+    cancel: () => {
+      if (!settled) cleanup();
+    },
+  };
+}

--- a/apps/web/src/lib/checkpointFileRestore.ts
+++ b/apps/web/src/lib/checkpointFileRestore.ts
@@ -1,19 +1,358 @@
-import type { CommandId, OrchestrationEvent } from "@synara/contracts";
+import {
+  CommandId,
+  MessageId,
+  ThreadId,
+  WS_RPC_ERROR_CODES,
+  type NativeApi,
+  type OrchestrationEvent,
+} from "@synara/contracts";
 
-export function waitForCheckpointFileRestore(input: {
+export type CheckpointFileRestoreStatus =
+  | { readonly status: "not-found" }
+  | {
+      readonly status: "pending";
+      readonly sequence: number;
+    }
+  | {
+      readonly status: "succeeded";
+      readonly sequence: number;
+    }
+  | {
+      readonly status: "failed";
+      readonly sequence: number;
+      readonly detail: string;
+      readonly requiresWorkspaceReview: boolean;
+    };
+
+export class CheckpointFileRestoreFailedError extends Error {
+  readonly requiresWorkspaceReview: boolean;
+
+  constructor(detail: string, requiresWorkspaceReview: boolean) {
+    super(detail);
+    this.name = "CheckpointFileRestoreFailedError";
+    this.requiresWorkspaceReview = requiresWorkspaceReview;
+  }
+}
+
+export function isCheckpointFileRestoreReviewRequiredError(
+  error: unknown,
+): error is CheckpointFileRestoreFailedError {
+  return error instanceof CheckpointFileRestoreFailedError && error.requiresWorkspaceReview;
+}
+
+export interface PendingCheckpointFileRestore {
+  readonly threadId: ThreadId;
+  readonly messageId: MessageId;
+  readonly turnCount: number;
+  readonly requestCommandId: CommandId;
+  readonly reconciliationCommandId?: CommandId;
+  readonly createdAt: string;
+  readonly phase: "confirming" | "dispatched";
+  readonly clientId?: string;
+  readonly acceptanceAmbiguous?: boolean;
+}
+
+const PENDING_CHECKPOINT_FILE_RESTORE_STORAGE_KEY = "synara.pendingCheckpointFileRestore.v1";
+const PENDING_CHECKPOINT_FILE_RESTORE_CHANGE_EVENT =
+  "synara:pending-checkpoint-file-restore-change";
+export const CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE =
+  "A file restore is still being reconciled. Wait for Synara to confirm it is safe to continue.";
+
+const DEFAULT_RECONCILE_INTERVAL_MS = 2_000;
+let checkpointFileRestoreClientId: string | null = null;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function pendingCheckpointFileRestoreFromUnknown(
+  value: unknown,
+): PendingCheckpointFileRestore | null {
+  if (!isObject(value)) return null;
+  if (
+    !isNonEmptyString(value.threadId) ||
+    !isNonEmptyString(value.messageId) ||
+    !isNonEmptyString(value.requestCommandId) ||
+    !isNonEmptyString(value.createdAt) ||
+    typeof value.turnCount !== "number" ||
+    !Number.isInteger(value.turnCount) ||
+    value.turnCount < 0
+  ) {
+    return null;
+  }
+  return {
+    threadId: ThreadId.makeUnsafe(value.threadId),
+    messageId: MessageId.makeUnsafe(value.messageId),
+    requestCommandId: CommandId.makeUnsafe(value.requestCommandId),
+    ...(isNonEmptyString(value.reconciliationCommandId)
+      ? { reconciliationCommandId: CommandId.makeUnsafe(value.reconciliationCommandId) }
+      : {}),
+    turnCount: value.turnCount,
+    createdAt: value.createdAt,
+    phase:
+      value.phase === "confirming" || value.phase === "dispatched" ? value.phase : "dispatched",
+    ...(isNonEmptyString(value.clientId) ? { clientId: value.clientId } : {}),
+    ...(value.acceptanceAmbiguous === true ? { acceptanceAmbiguous: true } : {}),
+  };
+}
+
+export function getCheckpointFileRestoreClientId(): string {
+  if (checkpointFileRestoreClientId) return checkpointFileRestoreClientId;
+  const cryptoApi =
+    typeof globalThis !== "undefined" && "crypto" in globalThis ? globalThis.crypto : null;
+  checkpointFileRestoreClientId =
+    cryptoApi && "randomUUID" in cryptoApi
+      ? cryptoApi.randomUUID()
+      : `checkpoint-file-restore-${Math.random().toString(36).slice(2)}`;
+  return checkpointFileRestoreClientId;
+}
+
+export function shouldReconcileCheckpointFileRestoreAcceptance(
+  pending: PendingCheckpointFileRestore,
+  clientId: string = getCheckpointFileRestoreClientId(),
+): boolean {
+  return (
+    pending.phase === "dispatched" &&
+    pending.reconciliationCommandId !== undefined &&
+    (pending.acceptanceAmbiguous === true || pending.clientId !== clientId)
+  );
+}
+
+export function isStaleCheckpointFileRestoreConfirmation(
+  pending: PendingCheckpointFileRestore,
+  clientId: string = getCheckpointFileRestoreClientId(),
+): boolean {
+  return pending.phase === "confirming" && pending.clientId !== clientId;
+}
+
+export function getCheckpointFileRestoreStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readPendingCheckpointFileRestore(
+  storage: Storage | null = getCheckpointFileRestoreStorage(),
+): PendingCheckpointFileRestore | null {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(PENDING_CHECKPOINT_FILE_RESTORE_STORAGE_KEY);
+    if (!raw) return null;
+    return pendingCheckpointFileRestoreFromUnknown(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function getPendingCheckpointFileRestoreSnapshot(
+  storage: Storage | null = getCheckpointFileRestoreStorage(),
+): string | null {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(PENDING_CHECKPOINT_FILE_RESTORE_STORAGE_KEY);
+    if (!raw) return null;
+    return pendingCheckpointFileRestoreFromUnknown(JSON.parse(raw)) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export function hasPendingCheckpointFileRestore(
+  storage: Storage | null = getCheckpointFileRestoreStorage(),
+): boolean {
+  return getPendingCheckpointFileRestoreSnapshot(storage) !== null;
+}
+
+function notifyPendingCheckpointFileRestoreChanged(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(PENDING_CHECKPOINT_FILE_RESTORE_CHANGE_EVENT));
+}
+
+export function subscribePendingCheckpointFileRestore(listener: () => void): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === PENDING_CHECKPOINT_FILE_RESTORE_STORAGE_KEY) {
+      listener();
+    }
+  };
+  window.addEventListener(PENDING_CHECKPOINT_FILE_RESTORE_CHANGE_EVENT, listener);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(PENDING_CHECKPOINT_FILE_RESTORE_CHANGE_EVENT, listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+export function savePendingCheckpointFileRestore(
+  pending: PendingCheckpointFileRestore,
+  storage: Storage | null = getCheckpointFileRestoreStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    const existing = readPendingCheckpointFileRestore(storage);
+    if (existing && existing.requestCommandId !== pending.requestCommandId) {
+      return false;
+    }
+    storage.setItem(PENDING_CHECKPOINT_FILE_RESTORE_STORAGE_KEY, JSON.stringify(pending));
+    const saved = readPendingCheckpointFileRestore(storage);
+    if (
+      !saved ||
+      saved.requestCommandId !== pending.requestCommandId ||
+      saved.phase !== pending.phase
+    ) {
+      return false;
+    }
+    notifyPendingCheckpointFileRestoreChanged();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearPendingCheckpointFileRestore(
+  requestCommandId: CommandId,
+  storage: Storage | null = getCheckpointFileRestoreStorage(),
+): void {
+  if (!storage) return;
+  try {
+    const pending = readPendingCheckpointFileRestore(storage);
+    if (pending?.requestCommandId === requestCommandId) {
+      storage.removeItem(PENDING_CHECKPOINT_FILE_RESTORE_STORAGE_KEY);
+      notifyPendingCheckpointFileRestoreChanged();
+    }
+  } catch {
+    // Nothing useful to do if localStorage is unavailable.
+  }
+}
+
+export function checkpointFileRestoreStatusFromEvents(input: {
+  readonly events: ReadonlyArray<OrchestrationEvent>;
+  readonly threadId: ThreadId;
+  readonly requestCommandId: CommandId;
+}): CheckpointFileRestoreStatus {
+  let requested: Extract<CheckpointFileRestoreStatus, { status: "pending" }> | null = null;
+  let terminal: CheckpointFileRestoreStatus | null = null;
+
+  for (const event of input.events) {
+    if (event.aggregateKind !== "thread" || event.aggregateId !== input.threadId) {
+      continue;
+    }
+    if (
+      event.type === "thread.checkpoint-files-restore-requested" &&
+      event.commandId === input.requestCommandId
+    ) {
+      requested = { status: "pending", sequence: event.sequence };
+      continue;
+    }
+    if (
+      event.type !== "thread.checkpoint-files-restored" &&
+      event.type !== "thread.checkpoint-files-restore-failed"
+    ) {
+      continue;
+    }
+    if (event.payload.requestCommandId !== input.requestCommandId) {
+      continue;
+    }
+    terminal =
+      event.type === "thread.checkpoint-files-restored"
+        ? { status: "succeeded", sequence: event.sequence }
+        : {
+            status: "failed",
+            sequence: event.sequence,
+            detail: event.payload.detail,
+            requiresWorkspaceReview: event.payload.requiresWorkspaceReview,
+          };
+  }
+
+  return terminal ?? requested ?? { status: "not-found" };
+}
+
+export async function getCheckpointFileRestoreStatus(input: {
+  readonly api: Pick<NativeApi["orchestration"], "replayEvents">;
+  readonly threadId: ThreadId;
+  readonly requestCommandId: CommandId;
+}): Promise<CheckpointFileRestoreStatus> {
+  const events = await input.api.replayEvents(0);
+  return checkpointFileRestoreStatusFromEvents({
+    events,
+    threadId: input.threadId,
+    requestCommandId: input.requestCommandId,
+  });
+}
+
+export function isDefinitiveDispatchRejection(error: unknown): boolean {
+  return (
+    isObject(error) &&
+    error._tag === "WsRpcError" &&
+    error.code === WS_RPC_ERROR_CODES.orchestrationDispatchRejected
+  );
+}
+
+type CheckpointFileRestoreWaitInput = {
   requestCommandId: CommandId;
   subscribe: (listener: (event: OrchestrationEvent) => void) => () => void;
-}): { promise: Promise<void>; cancel: () => void } {
+  getStatus?: () => Promise<CheckpointFileRestoreStatus>;
+  reconcileIntervalMs?: number;
+};
+
+type CheckpointFileRestoreWait = { promise: Promise<void>; cancel: () => void };
+
+function createCheckpointFileRestoreWait(
+  input: CheckpointFileRestoreWaitInput,
+): CheckpointFileRestoreWait {
   // Never release the caller's mutation gate based on elapsed time. The server
   // serializes checkpoint work, so a valid restore can wait behind long captures;
-  // only its correlated durable success/failure proves it is safe to continue.
+  // only its correlated durable success/failure or authoritative dispatch
+  // rejection proves it is safe to continue.
   let unsubscribe = () => {};
   let settled = false;
+  let intervalId: ReturnType<typeof globalThis.setInterval> | null = null;
 
   const cleanup = () => {
     unsubscribe();
+    if (intervalId !== null) {
+      globalThis.clearInterval(intervalId);
+      intervalId = null;
+    }
   };
   const promise = new Promise<void>((resolve, reject) => {
+    const settleSuccess = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const settleFailure = (detail: string, requiresWorkspaceReview: boolean) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new CheckpointFileRestoreFailedError(detail, requiresWorkspaceReview));
+    };
+    const reconcile = () => {
+      if (!input.getStatus || settled) return;
+      void input
+        .getStatus()
+        .then((status) => {
+          if (status.status === "succeeded") {
+            settleSuccess();
+          } else if (status.status === "failed") {
+            settleFailure(status.detail, status.requiresWorkspaceReview);
+          }
+        })
+        .catch(() => {
+          // A failed reconciliation read is transport state, not a terminal
+          // restore result. Keep the gate closed and try again later.
+        });
+    };
+
     unsubscribe = input.subscribe((event) => {
       if (
         (event.type !== "thread.checkpoint-files-restored" &&
@@ -22,20 +361,67 @@ export function waitForCheckpointFileRestore(input: {
       ) {
         return;
       }
-      settled = true;
-      cleanup();
       if (event.type === "thread.checkpoint-files-restore-failed") {
-        reject(new Error(event.payload.detail));
+        settleFailure(event.payload.detail, event.payload.requiresWorkspaceReview);
       } else {
-        resolve();
+        settleSuccess();
       }
     });
+
+    reconcile();
+    if (input.getStatus && !settled) {
+      intervalId = globalThis.setInterval(
+        reconcile,
+        input.reconcileIntervalMs ?? DEFAULT_RECONCILE_INTERVAL_MS,
+      );
+    }
   });
 
   return {
     promise,
     cancel: () => {
       if (!settled) cleanup();
+    },
+  };
+}
+
+const sharedCheckpointFileRestoreWaits = new Map<
+  CommandId,
+  {
+    readonly wait: CheckpointFileRestoreWait;
+    consumers: number;
+  }
+>();
+
+export function waitForCheckpointFileRestore(
+  input: CheckpointFileRestoreWaitInput,
+): CheckpointFileRestoreWait {
+  let shared = sharedCheckpointFileRestoreWaits.get(input.requestCommandId);
+  if (!shared) {
+    const wait = createCheckpointFileRestoreWait(input);
+    shared = { wait, consumers: 0 };
+    sharedCheckpointFileRestoreWaits.set(input.requestCommandId, shared);
+    const clearSharedWait = () => {
+      if (sharedCheckpointFileRestoreWaits.get(input.requestCommandId) === shared) {
+        sharedCheckpointFileRestoreWaits.delete(input.requestCommandId);
+      }
+    };
+    void wait.promise.then(clearSharedWait, clearSharedWait);
+  }
+  shared.consumers += 1;
+
+  let released = false;
+  return {
+    promise: shared.wait.promise,
+    cancel: () => {
+      if (released) return;
+      released = true;
+      shared.consumers -= 1;
+      if (shared.consumers > 0) return;
+      shared.wait.cancel();
+      if (sharedCheckpointFileRestoreWaits.get(input.requestCommandId) === shared) {
+        sharedCheckpointFileRestoreWaits.delete(input.requestCommandId);
+      }
     },
   };
 }

--- a/apps/web/src/lib/checkpointFileRestore.ts
+++ b/apps/web/src/lib/checkpointFileRestore.ts
@@ -124,9 +124,8 @@ export function shouldReconcileCheckpointFileRestoreAcceptance(
 
 export function isStaleCheckpointFileRestoreConfirmation(
   pending: PendingCheckpointFileRestore,
-  clientId: string = getCheckpointFileRestoreClientId(),
 ): boolean {
-  return pending.phase === "confirming" && pending.clientId !== clientId;
+  return pending.phase === "confirming" && pending.clientId === undefined;
 }
 
 export function getCheckpointFileRestoreStorage(): Storage | null {

--- a/apps/web/src/lib/checkpointFileRestore.ts
+++ b/apps/web/src/lib/checkpointFileRestore.ts
@@ -245,6 +245,13 @@ export function checkpointFileRestoreStatusFromEvents(input: {
       continue;
     }
     if (
+      event.type === "thread.checkpoint-files-restore-prepared" &&
+      event.payload.requestCommandId === input.requestCommandId
+    ) {
+      requested = { status: "pending", sequence: event.sequence };
+      continue;
+    }
+    if (
       event.type === "thread.checkpoint-files-restore-requested" &&
       event.commandId === input.requestCommandId
     ) {
@@ -253,8 +260,15 @@ export function checkpointFileRestoreStatusFromEvents(input: {
     }
     if (
       event.type !== "thread.checkpoint-files-restored" &&
-      event.type !== "thread.checkpoint-files-restore-failed"
+      event.type !== "thread.checkpoint-files-restore-failed" &&
+      event.type !== "thread.checkpoint-files-restore-reviewed"
     ) {
+      continue;
+    }
+    if (event.type === "thread.checkpoint-files-restore-reviewed") {
+      if (event.payload.requestCommandId === input.requestCommandId) {
+        requested = null;
+      }
       continue;
     }
     if (event.payload.requestCommandId !== input.requestCommandId) {

--- a/apps/web/src/lib/checkpointFileRestore.ts
+++ b/apps/web/src/lib/checkpointFileRestore.ts
@@ -1,18 +1,16 @@
 import type { CommandId, OrchestrationEvent } from "@synara/contracts";
 
-const FILE_RESTORE_COMPLETION_TIMEOUT_MS = 120_000;
-
 export function waitForCheckpointFileRestore(input: {
   requestCommandId: CommandId;
   subscribe: (listener: (event: OrchestrationEvent) => void) => () => void;
-  timeoutMs?: number;
 }): { promise: Promise<void>; cancel: () => void } {
+  // Never release the caller's mutation gate based on elapsed time. The server
+  // serializes checkpoint work, so a valid restore can wait behind long captures;
+  // only its correlated durable success/failure proves it is safe to continue.
   let unsubscribe = () => {};
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   let settled = false;
 
   const cleanup = () => {
-    if (timeoutId !== undefined) clearTimeout(timeoutId);
     unsubscribe();
   };
   const promise = new Promise<void>((resolve, reject) => {
@@ -32,11 +30,6 @@ export function waitForCheckpointFileRestore(input: {
         resolve();
       }
     });
-    timeoutId = setTimeout(() => {
-      settled = true;
-      cleanup();
-      reject(new Error("Timed out waiting for file changes to be restored."));
-    }, input.timeoutMs ?? FILE_RESTORE_COMPLETION_TIMEOUT_MS);
   });
 
   return {

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -7,6 +7,10 @@ import type {
 } from "@synara/contracts";
 import { mutationOptions, queryOptions, type QueryClient } from "@tanstack/react-query";
 import { ensureNativeApi } from "../nativeApi";
+import {
+  CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  hasPendingCheckpointFileRestore,
+} from "./checkpointFileRestore";
 import { buildPatchCacheKey } from "./diffRendering";
 
 const GIT_STATUS_STALE_TIME_MS = 30_000;
@@ -70,6 +74,12 @@ export function invalidateGitQueries(queryClient: QueryClient) {
     queryClient.invalidateQueries({ queryKey: ["git", "working-tree-diff"] as const }),
     queryClient.invalidateQueries({ queryKey: ["git", "pull-request"] as const }),
   ]);
+}
+
+function assertCheckpointFileRestoreMutationAllowed(): void {
+  if (hasPendingCheckpointFileRestore()) {
+    throw new Error(CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE);
+  }
 }
 
 // Scope live file-change invalidations so unrelated project/worktree git caches stay warm.
@@ -301,6 +311,7 @@ function makeGitMutationOptions<TArgs, TResult>(config: {
     mutationFn: async (args: TArgs) => {
       const api = ensureNativeApi();
       if (!config.cwd) throw new Error(config.unavailableMessage);
+      assertCheckpointFileRestoreMutationAllowed();
       return config.run(api, config.cwd, args);
     },
     ...(invalidateOn === "success"
@@ -431,6 +442,7 @@ export function gitCreateWorktreeMutationOptions(input: { queryClient: QueryClie
     }) => {
       const api = ensureNativeApi();
       if (!cwd) throw new Error("Git worktree creation is unavailable.");
+      assertCheckpointFileRestoreMutationAllowed();
       return api.git.createWorktree({ cwd, branch, newBranch, path: path ?? null });
     },
     mutationKey: ["git", "mutation", "create-worktree"] as const,
@@ -445,6 +457,7 @@ export function gitCreateDetachedWorktreeMutationOptions(input: { queryClient: Q
     mutationFn: async ({ cwd, ref, path }: { cwd: string; ref: string; path?: string | null }) => {
       const api = ensureNativeApi();
       if (!cwd) throw new Error("Git worktree creation is unavailable.");
+      assertCheckpointFileRestoreMutationAllowed();
       return api.git.createDetachedWorktree({ cwd, ref, path: path ?? null });
     },
     mutationKey: ["git", "mutation", "create-detached-worktree"] as const,
@@ -459,6 +472,7 @@ export function gitRemoveWorktreeMutationOptions(input: { queryClient: QueryClie
     mutationFn: async ({ cwd, path, force }: { cwd: string; path: string; force?: boolean }) => {
       const api = ensureNativeApi();
       if (!cwd) throw new Error("Git worktree removal is unavailable.");
+      assertCheckpointFileRestoreMutationAllowed();
       return api.git.removeWorktree({ cwd, path, force });
     },
     mutationKey: ["git", "mutation", "remove-worktree"] as const,

--- a/apps/web/src/lib/kanbanDispatch.ts
+++ b/apps/web/src/lib/kanbanDispatch.ts
@@ -33,6 +33,10 @@ import type { SidebarThreadSummary } from "../types";
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE } from "../types";
 import { appendAssistantSelectionsToPrompt } from "./assistantSelections";
 import {
+  CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE,
+  hasPendingCheckpointFileRestore,
+} from "./checkpointFileRestore";
+import {
   buildUploadComposerAttachments,
   formatOutgoingComposerPrompt,
   resolvePromptEffortFromModelSelection,
@@ -126,6 +130,9 @@ async function dispatchKanbanDraftThreadOnce(
   const api = readNativeApi();
   if (!api) {
     return { kind: "unavailable" };
+  }
+  if (hasPendingCheckpointFileRestore()) {
+    return { kind: "error", message: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE };
   }
 
   // Re-read the composer at drop time: the card snapshot may lag behind edits made
@@ -223,6 +230,10 @@ async function dispatchKanbanDraftThreadOnce(
   const droppedAtMs = Date.now();
   const createdAt = new Date(droppedAtMs).toISOString();
 
+  if (hasPendingCheckpointFileRestore()) {
+    return { kind: "error", message: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE };
+  }
+
   // Optimistic move: show the card In Progress before any round-trip. Provider
   // session init can take seconds; runtime events confirm the move (reconciliation
   // clears the entry) or the failure paths below revert it.
@@ -267,6 +278,10 @@ async function dispatchKanbanDraftThreadOnce(
         },
         api,
       );
+      if (hasPendingCheckpointFileRestore()) {
+        kanbanUi.clearOptimisticDispatch(threadId);
+        return { kind: "error", message: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE };
+      }
       if (promotion === "unavailable") {
         kanbanUi.clearOptimisticDispatch(threadId);
         return { kind: "unavailable" };
@@ -282,6 +297,10 @@ async function dispatchKanbanDraftThreadOnce(
     }
 
     const turnAttachments = await turnAttachmentsPromise;
+    if (hasPendingCheckpointFileRestore()) {
+      kanbanUi.clearOptimisticDispatch(threadId);
+      return { kind: "error", message: CHECKPOINT_FILE_RESTORE_BLOCKED_MESSAGE };
+    }
     await api.orchestration.dispatchCommand({
       type: "thread.turn.start",
       commandId: newCommandId(),

--- a/apps/web/src/routes/-rootEventInvalidation.test.ts
+++ b/apps/web/src/routes/-rootEventInvalidation.test.ts
@@ -33,6 +33,12 @@ describe("root event invalidation", () => {
   });
 
   it("invalidates git queries when checkpoint changes can rewrite files", () => {
+    expect(shouldInvalidateGitQueriesForEvent(event("thread.checkpoint-files-restored"))).toBe(
+      true,
+    );
+    expect(shouldInvalidateProviderQueriesForEvent(event("thread.checkpoint-files-restored"))).toBe(
+      true,
+    );
     expect(shouldInvalidateGitQueriesForEvent(event("thread.reverted"))).toBe(true);
     expect(shouldInvalidateGitQueriesForEvent(event("thread.conversation-rolled-back"))).toBe(true);
   });

--- a/apps/web/src/routes/-rootEventInvalidation.test.ts
+++ b/apps/web/src/routes/-rootEventInvalidation.test.ts
@@ -43,6 +43,25 @@ describe("root event invalidation", () => {
     expect(shouldInvalidateGitQueriesForEvent(event("thread.conversation-rolled-back"))).toBe(true);
   });
 
+  it("invalidates workspace caches for review-required file restore failures", () => {
+    const threadId = ThreadId.makeUnsafe("thread-restore-review");
+    const reviewRequiredFailure = event("thread.checkpoint-files-restore-failed", {
+      threadId,
+      requiresWorkspaceReview: true,
+    });
+    const safeFailure = event("thread.checkpoint-files-restore-failed", {
+      threadId,
+      requiresWorkspaceReview: false,
+    });
+
+    expect(shouldInvalidateGitQueriesForEvent(reviewRequiredFailure)).toBe(true);
+    expect(shouldInvalidateProviderQueriesForEvent(reviewRequiredFailure)).toBe(true);
+    expect(getGitInvalidationThreadIdForEvent(reviewRequiredFailure)).toBe(threadId);
+    expect(getStudioOutputInvalidationThreadIdForEvent(reviewRequiredFailure)).toBe(threadId);
+    expect(shouldInvalidateGitQueriesForEvent(safeFailure)).toBe(false);
+    expect(shouldInvalidateProviderQueriesForEvent(safeFailure)).toBe(false);
+  });
+
   it("invalidates git queries when thread workspace metadata changes", () => {
     expect(
       shouldInvalidateGitQueriesForEvent(event("thread.meta-updated", { branch: "feature/diff" })),

--- a/apps/web/src/routes/-rootEventInvalidation.ts
+++ b/apps/web/src/routes/-rootEventInvalidation.ts
@@ -15,6 +15,7 @@ import { getThreadFromState } from "../threadDerivation";
 
 const FILE_CHANGE_EVENT_TYPES = new Set<OrchestrationEvent["type"]>([
   "thread.turn-diff-completed",
+  "thread.checkpoint-files-restored",
   "thread.reverted",
   "thread.conversation-rolled-back",
 ]);

--- a/apps/web/src/routes/-rootEventInvalidation.ts
+++ b/apps/web/src/routes/-rootEventInvalidation.ts
@@ -20,12 +20,22 @@ const FILE_CHANGE_EVENT_TYPES = new Set<OrchestrationEvent["type"]>([
   "thread.conversation-rolled-back",
 ]);
 
+function isReviewRequiredFileRestoreFailure(event: OrchestrationEvent): boolean {
+  return (
+    event.type === "thread.checkpoint-files-restore-failed" && event.payload.requiresWorkspaceReview
+  );
+}
+
+function shouldInvalidateWorkspaceFileQueriesForEvent(event: OrchestrationEvent): boolean {
+  return FILE_CHANGE_EVENT_TYPES.has(event.type) || isReviewRequiredFileRestoreFailure(event);
+}
+
 export function shouldInvalidateProviderQueriesForEvent(event: OrchestrationEvent): boolean {
-  return FILE_CHANGE_EVENT_TYPES.has(event.type);
+  return shouldInvalidateWorkspaceFileQueriesForEvent(event);
 }
 
 export function shouldInvalidateGitQueriesForEvent(event: OrchestrationEvent): boolean {
-  if (FILE_CHANGE_EVENT_TYPES.has(event.type)) {
+  if (shouldInvalidateWorkspaceFileQueriesForEvent(event)) {
     return true;
   }
 
@@ -83,7 +93,7 @@ export function getStudioOutputInvalidationThreadIdForEvent(
       ? getProjectFileInvalidationThreadIdForEvent(event)
       : null;
   }
-  if (!FILE_CHANGE_EVENT_TYPES.has(event.type)) {
+  if (!shouldInvalidateWorkspaceFileQueriesForEvent(event)) {
     return null;
   }
   return "threadId" in event.payload ? (event.payload.threadId as ThreadId) : null;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -748,6 +748,7 @@ function isThreadDetailEventForThread(event: OrchestrationEvent, threadId: Threa
     event.type === "thread.proposed-plan-upserted" ||
     event.type === "thread.activity-appended" ||
     event.type === "thread.turn-diff-completed" ||
+    event.type === "thread.checkpoint-files-restored" ||
     event.type === "thread.reverted" ||
     event.type === "thread.conversation-rolled-back" ||
     event.type === "thread.session-set" ||

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -749,6 +749,7 @@ function isThreadDetailEventForThread(event: OrchestrationEvent, threadId: Threa
     event.type === "thread.activity-appended" ||
     event.type === "thread.turn-diff-completed" ||
     event.type === "thread.checkpoint-files-restored" ||
+    event.type === "thread.checkpoint-files-restore-failed" ||
     event.type === "thread.reverted" ||
     event.type === "thread.conversation-rolled-back" ||
     event.type === "thread.session-set" ||

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -578,6 +578,17 @@ it.effect("defaults legacy file-restore failures to no workspace review", () =>
 
 it.effect("decodes idempotent file-restore reconciliation commands", () =>
   Effect.gen(function* () {
+    const prepareCommand = yield* decodeClientOrchestrationCommand({
+      type: "thread.checkpoint.files.restore.prepare",
+      commandId: "cmd-file-restore-prepare",
+      requestCommandId: "cmd-file-restore",
+      threadId: "thread-1",
+      messageId: "message-1",
+      turnCount: 0,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    assert.strictEqual(prepareCommand.type, "thread.checkpoint.files.restore.prepare");
+
     const command = yield* decodeClientOrchestrationCommand({
       type: "thread.checkpoint.files.restore.reconcile",
       commandId: "cmd-file-restore-reconcile",
@@ -590,6 +601,59 @@ it.effect("decodes idempotent file-restore reconciliation commands", () =>
 
     assert.strictEqual(command.type, "thread.checkpoint.files.restore.reconcile");
     assert.strictEqual(command.requestCommandId, "cmd-file-restore");
+
+    const reviewedCommand = yield* decodeClientOrchestrationCommand({
+      type: "thread.checkpoint.files.restore.reviewed",
+      commandId: "cmd-file-restore-reviewed",
+      requestCommandId: "cmd-file-restore",
+      threadId: "thread-1",
+      messageId: "message-1",
+      turnCount: 0,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    assert.strictEqual(reviewedCommand.type, "thread.checkpoint.files.restore.reviewed");
+
+    const preparedEvent = yield* decodeOrchestrationEvent({
+      sequence: 1,
+      eventId: "event-file-restore-prepared",
+      aggregateKind: "thread",
+      aggregateId: "thread-1",
+      type: "thread.checkpoint-files-restore-prepared",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      commandId: "cmd-file-restore-prepare",
+      causationEventId: null,
+      correlationId: "cmd-file-restore-prepare",
+      metadata: {},
+      payload: {
+        threadId: "thread-1",
+        messageId: "message-1",
+        turnCount: 0,
+        requestCommandId: "cmd-file-restore",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    assert.strictEqual(preparedEvent.type, "thread.checkpoint-files-restore-prepared");
+
+    const reviewedEvent = yield* decodeOrchestrationEvent({
+      sequence: 2,
+      eventId: "event-file-restore-reviewed",
+      aggregateKind: "thread",
+      aggregateId: "thread-1",
+      type: "thread.checkpoint-files-restore-reviewed",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      commandId: "cmd-file-restore-reviewed",
+      causationEventId: null,
+      correlationId: "cmd-file-restore-reviewed",
+      metadata: {},
+      payload: {
+        threadId: "thread-1",
+        messageId: "message-1",
+        turnCount: 0,
+        requestCommandId: "cmd-file-restore",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    assert.strictEqual(reviewedEvent.type, "thread.checkpoint-files-restore-reviewed");
   }),
 );
 

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -549,6 +549,50 @@ it.effect("decodes pinned-message commands and events", () =>
   }),
 );
 
+it.effect("defaults legacy file-restore failures to no workspace review", () =>
+  Effect.gen(function* () {
+    const event = yield* decodeOrchestrationEvent({
+      sequence: 1,
+      eventId: "event-file-restore-failed",
+      aggregateKind: "thread",
+      aggregateId: "thread-1",
+      type: "thread.checkpoint-files-restore-failed",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      commandId: "cmd-file-restore-failed",
+      causationEventId: null,
+      correlationId: "cmd-file-restore",
+      metadata: {},
+      payload: {
+        threadId: "thread-1",
+        messageId: "message-1",
+        turnCount: 0,
+        requestCommandId: "cmd-file-restore",
+        detail: "Checkpoint was unavailable.",
+      },
+    });
+
+    assert.strictEqual(event.type, "thread.checkpoint-files-restore-failed");
+    assert.strictEqual(event.payload.requiresWorkspaceReview, false);
+  }),
+);
+
+it.effect("decodes idempotent file-restore reconciliation commands", () =>
+  Effect.gen(function* () {
+    const command = yield* decodeClientOrchestrationCommand({
+      type: "thread.checkpoint.files.restore.reconcile",
+      commandId: "cmd-file-restore-reconcile",
+      requestCommandId: "cmd-file-restore",
+      threadId: "thread-1",
+      messageId: "message-1",
+      turnCount: 0,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    assert.strictEqual(command.type, "thread.checkpoint.files.restore.reconcile");
+    assert.strictEqual(command.requestCommandId, "cmd-file-restore");
+  }),
+);
+
 it.effect("decodes thread marker commands and events", () =>
   Effect.gen(function* () {
     const command = yield* decodeClientOrchestrationCommand({

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1337,6 +1337,17 @@ const ThreadCheckpointFilesRestoreCompleteCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadCheckpointFilesRestoreFailCommand = Schema.Struct({
+  type: Schema.Literal("thread.checkpoint.files.restore.fail"),
+  commandId: CommandId,
+  requestCommandId: CommandId,
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  detail: TrimmedNonEmptyString,
+  createdAt: IsoDateTime,
+});
+
 const ThreadConversationRollbackCompleteCommand = Schema.Struct({
   type: Schema.Literal("thread.conversation.rollback.complete"),
   commandId: CommandId,
@@ -1358,6 +1369,7 @@ const InternalOrchestrationCommand = Schema.Union([
   ThreadActivityAppendCommand,
   ThreadRevertCompleteCommand,
   ThreadCheckpointFilesRestoreCompleteCommand,
+  ThreadCheckpointFilesRestoreFailCommand,
   ThreadConversationRollbackCommand,
   ThreadConversationRollbackCompleteCommand,
   ThreadDispatchQueuedTurnCommand,
@@ -1399,6 +1411,7 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.checkpoint-revert-requested",
   "thread.checkpoint-files-restore-requested",
   "thread.checkpoint-files-restored",
+  "thread.checkpoint-files-restore-failed",
   "thread.reverted",
   "thread.conversation-rollback-requested",
   "thread.conversation-rolled-back",
@@ -1677,6 +1690,14 @@ export const ThreadCheckpointFilesRestoredPayload = Schema.Struct({
   requestCommandId: CommandId,
 });
 
+export const ThreadCheckpointFilesRestoreFailedPayload = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  requestCommandId: CommandId,
+  detail: TrimmedNonEmptyString,
+});
+
 export const ThreadRevertedPayload = Schema.Struct({
   threadId: ThreadId,
   turnCount: NonNegativeInt,
@@ -1898,6 +1919,11 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.checkpoint-files-restored"),
     payload: ThreadCheckpointFilesRestoredPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.checkpoint-files-restore-failed"),
+    payload: ThreadCheckpointFilesRestoreFailedPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1148,6 +1148,15 @@ const ThreadCheckpointRevertCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadCheckpointFilesRestoreCommand = Schema.Struct({
+  type: Schema.Literal("thread.checkpoint.files.restore"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  createdAt: IsoDateTime,
+});
+
 const ThreadConversationRollbackCommand = Schema.Struct({
   type: Schema.Literal("thread.conversation.rollback"),
   commandId: CommandId,
@@ -1212,6 +1221,7 @@ const DispatchableClientOrchestrationCommand = Schema.Union([
   ThreadApprovalRespondCommand,
   ThreadUserInputRespondCommand,
   ThreadCheckpointRevertCommand,
+  ThreadCheckpointFilesRestoreCommand,
   ThreadMessageEditAndResendCommand,
   ThreadActivityAppendCommand,
   ThreadSessionStopCommand,
@@ -1245,6 +1255,7 @@ export const ClientOrchestrationCommand = Schema.Union([
   ThreadApprovalRespondCommand,
   ThreadUserInputRespondCommand,
   ThreadCheckpointRevertCommand,
+  ThreadCheckpointFilesRestoreCommand,
   ThreadMessageEditAndResendCommand,
   ThreadActivityAppendCommand,
   ThreadSessionStopCommand,
@@ -1316,6 +1327,16 @@ const ThreadRevertCompleteCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadCheckpointFilesRestoreCompleteCommand = Schema.Struct({
+  type: Schema.Literal("thread.checkpoint.files.restore.complete"),
+  commandId: CommandId,
+  requestCommandId: CommandId,
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  createdAt: IsoDateTime,
+});
+
 const ThreadConversationRollbackCompleteCommand = Schema.Struct({
   type: Schema.Literal("thread.conversation.rollback.complete"),
   commandId: CommandId,
@@ -1336,6 +1357,7 @@ const InternalOrchestrationCommand = Schema.Union([
   ThreadTurnDiffCompleteCommand,
   ThreadActivityAppendCommand,
   ThreadRevertCompleteCommand,
+  ThreadCheckpointFilesRestoreCompleteCommand,
   ThreadConversationRollbackCommand,
   ThreadConversationRollbackCompleteCommand,
   ThreadDispatchQueuedTurnCommand,
@@ -1375,6 +1397,8 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.approval-response-requested",
   "thread.user-input-response-requested",
   "thread.checkpoint-revert-requested",
+  "thread.checkpoint-files-restore-requested",
+  "thread.checkpoint-files-restored",
   "thread.reverted",
   "thread.conversation-rollback-requested",
   "thread.conversation-rolled-back",
@@ -1639,6 +1663,20 @@ export const ThreadCheckpointRevertRequestedPayload = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+export const ThreadCheckpointFilesRestoreRequestedPayload = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  createdAt: IsoDateTime,
+});
+
+export const ThreadCheckpointFilesRestoredPayload = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  requestCommandId: CommandId,
+});
+
 export const ThreadRevertedPayload = Schema.Struct({
   threadId: ThreadId,
   turnCount: NonNegativeInt,
@@ -1850,6 +1888,16 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.checkpoint-revert-requested"),
     payload: ThreadCheckpointRevertRequestedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.checkpoint-files-restore-requested"),
+    payload: ThreadCheckpointFilesRestoreRequestedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.checkpoint-files-restored"),
+    payload: ThreadCheckpointFilesRestoredPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1157,6 +1157,16 @@ const ThreadCheckpointFilesRestoreCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadCheckpointFilesRestoreReconcileCommand = Schema.Struct({
+  type: Schema.Literal("thread.checkpoint.files.restore.reconcile"),
+  commandId: CommandId,
+  requestCommandId: CommandId,
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  createdAt: IsoDateTime,
+});
+
 const ThreadConversationRollbackCommand = Schema.Struct({
   type: Schema.Literal("thread.conversation.rollback"),
   commandId: CommandId,
@@ -1222,6 +1232,7 @@ const DispatchableClientOrchestrationCommand = Schema.Union([
   ThreadUserInputRespondCommand,
   ThreadCheckpointRevertCommand,
   ThreadCheckpointFilesRestoreCommand,
+  ThreadCheckpointFilesRestoreReconcileCommand,
   ThreadMessageEditAndResendCommand,
   ThreadActivityAppendCommand,
   ThreadSessionStopCommand,
@@ -1256,6 +1267,7 @@ export const ClientOrchestrationCommand = Schema.Union([
   ThreadUserInputRespondCommand,
   ThreadCheckpointRevertCommand,
   ThreadCheckpointFilesRestoreCommand,
+  ThreadCheckpointFilesRestoreReconcileCommand,
   ThreadMessageEditAndResendCommand,
   ThreadActivityAppendCommand,
   ThreadSessionStopCommand,
@@ -1345,6 +1357,7 @@ const ThreadCheckpointFilesRestoreFailCommand = Schema.Struct({
   messageId: MessageId,
   turnCount: NonNegativeInt,
   detail: TrimmedNonEmptyString,
+  requiresWorkspaceReview: Schema.Boolean,
   createdAt: IsoDateTime,
 });
 
@@ -1410,6 +1423,7 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.user-input-response-requested",
   "thread.checkpoint-revert-requested",
   "thread.checkpoint-files-restore-requested",
+  "thread.checkpoint-files-restore-reconciliation-requested",
   "thread.checkpoint-files-restored",
   "thread.checkpoint-files-restore-failed",
   "thread.reverted",
@@ -1683,6 +1697,14 @@ export const ThreadCheckpointFilesRestoreRequestedPayload = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+export const ThreadCheckpointFilesRestoreReconciliationRequestedPayload = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  requestCommandId: CommandId,
+  createdAt: IsoDateTime,
+});
+
 export const ThreadCheckpointFilesRestoredPayload = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
@@ -1696,6 +1718,7 @@ export const ThreadCheckpointFilesRestoreFailedPayload = Schema.Struct({
   turnCount: NonNegativeInt,
   requestCommandId: CommandId,
   detail: TrimmedNonEmptyString,
+  requiresWorkspaceReview: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
 });
 
 export const ThreadRevertedPayload = Schema.Struct({
@@ -1914,6 +1937,11 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.checkpoint-files-restore-requested"),
     payload: ThreadCheckpointFilesRestoreRequestedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.checkpoint-files-restore-reconciliation-requested"),
+    payload: ThreadCheckpointFilesRestoreReconciliationRequestedPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1157,8 +1157,28 @@ const ThreadCheckpointFilesRestoreCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadCheckpointFilesRestorePrepareCommand = Schema.Struct({
+  type: Schema.Literal("thread.checkpoint.files.restore.prepare"),
+  commandId: CommandId,
+  requestCommandId: CommandId,
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  createdAt: IsoDateTime,
+});
+
 const ThreadCheckpointFilesRestoreReconcileCommand = Schema.Struct({
   type: Schema.Literal("thread.checkpoint.files.restore.reconcile"),
+  commandId: CommandId,
+  requestCommandId: CommandId,
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  createdAt: IsoDateTime,
+});
+
+const ThreadCheckpointFilesRestoreReviewedCommand = Schema.Struct({
+  type: Schema.Literal("thread.checkpoint.files.restore.reviewed"),
   commandId: CommandId,
   requestCommandId: CommandId,
   threadId: ThreadId,
@@ -1231,8 +1251,10 @@ const DispatchableClientOrchestrationCommand = Schema.Union([
   ThreadApprovalRespondCommand,
   ThreadUserInputRespondCommand,
   ThreadCheckpointRevertCommand,
+  ThreadCheckpointFilesRestorePrepareCommand,
   ThreadCheckpointFilesRestoreCommand,
   ThreadCheckpointFilesRestoreReconcileCommand,
+  ThreadCheckpointFilesRestoreReviewedCommand,
   ThreadMessageEditAndResendCommand,
   ThreadActivityAppendCommand,
   ThreadSessionStopCommand,
@@ -1266,8 +1288,10 @@ export const ClientOrchestrationCommand = Schema.Union([
   ThreadApprovalRespondCommand,
   ThreadUserInputRespondCommand,
   ThreadCheckpointRevertCommand,
+  ThreadCheckpointFilesRestorePrepareCommand,
   ThreadCheckpointFilesRestoreCommand,
   ThreadCheckpointFilesRestoreReconcileCommand,
+  ThreadCheckpointFilesRestoreReviewedCommand,
   ThreadMessageEditAndResendCommand,
   ThreadActivityAppendCommand,
   ThreadSessionStopCommand,
@@ -1422,10 +1446,12 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.approval-response-requested",
   "thread.user-input-response-requested",
   "thread.checkpoint-revert-requested",
+  "thread.checkpoint-files-restore-prepared",
   "thread.checkpoint-files-restore-requested",
   "thread.checkpoint-files-restore-reconciliation-requested",
   "thread.checkpoint-files-restored",
   "thread.checkpoint-files-restore-failed",
+  "thread.checkpoint-files-restore-reviewed",
   "thread.reverted",
   "thread.conversation-rollback-requested",
   "thread.conversation-rolled-back",
@@ -1697,6 +1723,14 @@ export const ThreadCheckpointFilesRestoreRequestedPayload = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+export const ThreadCheckpointFilesRestorePreparedPayload = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  requestCommandId: CommandId,
+  createdAt: IsoDateTime,
+});
+
 export const ThreadCheckpointFilesRestoreReconciliationRequestedPayload = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
@@ -1719,6 +1753,14 @@ export const ThreadCheckpointFilesRestoreFailedPayload = Schema.Struct({
   requestCommandId: CommandId,
   detail: TrimmedNonEmptyString,
   requiresWorkspaceReview: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
+});
+
+export const ThreadCheckpointFilesRestoreReviewedPayload = Schema.Struct({
+  threadId: ThreadId,
+  messageId: MessageId,
+  turnCount: NonNegativeInt,
+  requestCommandId: CommandId,
+  createdAt: IsoDateTime,
 });
 
 export const ThreadRevertedPayload = Schema.Struct({
@@ -1935,6 +1977,11 @@ export const OrchestrationEvent = Schema.Union([
   }),
   Schema.Struct({
     ...EventBaseFields,
+    type: Schema.Literal("thread.checkpoint-files-restore-prepared"),
+    payload: ThreadCheckpointFilesRestorePreparedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
     type: Schema.Literal("thread.checkpoint-files-restore-requested"),
     payload: ThreadCheckpointFilesRestoreRequestedPayload,
   }),
@@ -1952,6 +1999,11 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.checkpoint-files-restore-failed"),
     payload: ThreadCheckpointFilesRestoreFailedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.checkpoint-files-restore-reviewed"),
+    payload: ThreadCheckpointFilesRestoreReviewedPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,

--- a/packages/contracts/src/rpc.test.ts
+++ b/packages/contracts/src/rpc.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { WsAutomationCreateRpc, WsProjectsDiscoverScriptsRpc, WsRpcError, WsRpcGroup } from "./rpc";
+import {
+  WS_RPC_ERROR_CODES,
+  WsAutomationCreateRpc,
+  WsProjectsDiscoverScriptsRpc,
+  WsRpcError,
+  WsRpcGroup,
+} from "./rpc";
 
 describe("WS RPC contracts", () => {
   it("exports the additive Effect RPC group", () => {
@@ -9,6 +15,12 @@ describe("WS RPC contracts", () => {
 
   it("uses a schema-backed transport error", () => {
     expect(new WsRpcError({ message: "failed" }).message).toBe("failed");
+    expect(
+      new WsRpcError({
+        message: "rejected",
+        code: WS_RPC_ERROR_CODES.orchestrationDispatchRejected,
+      }).code,
+    ).toBe(WS_RPC_ERROR_CODES.orchestrationDispatchRejected);
   });
 
   it("exports the project script discovery RPC", () => {

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -162,8 +162,16 @@ import {
 } from "./stats";
 import { WS_METHODS } from "./ws";
 
+export const WS_RPC_ERROR_CODES = {
+  orchestrationDispatchRejected: "orchestration.dispatch.rejected",
+} as const;
+
+export const WsRpcErrorCode = Schema.Literals([WS_RPC_ERROR_CODES.orchestrationDispatchRejected]);
+export type WsRpcErrorCode = typeof WsRpcErrorCode.Type;
+
 export class WsRpcError extends Schema.TaggedErrorClass<WsRpcError>()("WsRpcError", {
   message: Schema.String,
+  code: Schema.optional(WsRpcErrorCode),
   cause: Schema.optional(Schema.Defect),
 }) {}
 


### PR DESCRIPTION
## Summary
- make diff-card Undo restore only the exact message-start file checkpoint
- persist and reconcile correlated restore outcomes across disconnects and restarts
- keep all file-changing actions gated until success, safe failure, or explicit review of an indeterminate restore
- preserve transcript, provider state, checkpoint history, sequential Undo, and message-level revert behavior

## Validation
- focused web, browser, server, and contracts regression tests
- bun fmt
- bun lint
- bun typecheck
- git diff --check
- independent latest-diff review: clean

Fixes #285

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes orchestration, git workspace restore, and broad mutation gating across server and client; incorrect gate or reconciliation logic could block work or allow unsafe concurrent file changes.
> 
> **Overview**
> Diff-card **Undo** now restores files from the **message-start** checkpoint and leaves chat history and provider rollback untouched, instead of following the full thread revert path.
> 
> The server adds a correlated restore lifecycle (`prepare` → `restore` → `complete` / `fail`, plus `reconcile` and `reviewed`), startup terminalization for interrupted restores (no automatic replay), a legacy numbered-checkpoint fallback only before prior file-only side effects, and a **pending restore gate** that blocks other workspace/provider mutations until success, a safe failure, or explicit review.
> 
> **WebSocket** and **orchestration dispatch** enforce the same gate (git, terminals, imports, turns, etc.), with an interlock around restore and clearer **definitive vs ambiguous** dispatch rejection for clients. The UI persists pending restores across reload, disables composers and destructive actions globally, reconciles via event replay, and exposes **Review and unlock** when the working tree may be inconsistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75fb566442ca1cc7e13f6f5f3a6242d296fa21e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->