### PR TITLE
Fix file Undo preserving chat history

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
@@ -103,6 +103,7 @@ describe("CheckpointDiffQueryLive", () => {
           return true;
         }),
       restoreCheckpoint: () => Effect.succeed(true),
+      reverseCheckpointDiff: () => Effect.succeed(true),
       diffCheckpoints: ({ fromCheckpointRef, toCheckpointRef, cwd, ignoreWhitespace }) =>
         Effect.sync(() => {
           diffCheckpointsCalls.push({ fromCheckpointRef, toCheckpointRef, cwd, ignoreWhitespace });
@@ -199,6 +200,7 @@ describe("CheckpointDiffQueryLive", () => {
       copyCheckpointRef: () => Effect.succeed(true),
       hasCheckpointRef: () => Effect.die("unused"),
       restoreCheckpoint: () => Effect.succeed(true),
+      reverseCheckpointDiff: () => Effect.succeed(true),
       diffCheckpoints: ({ fromCheckpointRef, toCheckpointRef, cwd, ignoreWhitespace }) =>
         Effect.sync(() => {
           diffCheckpointsCalls.push({ fromCheckpointRef, toCheckpointRef, cwd, ignoreWhitespace });
@@ -268,6 +270,7 @@ describe("CheckpointDiffQueryLive", () => {
       copyCheckpointRef: () => Effect.succeed(true),
       hasCheckpointRef: () => Effect.succeed(true),
       restoreCheckpoint: () => Effect.succeed(true),
+      reverseCheckpointDiff: () => Effect.succeed(true),
       diffCheckpoints: () => Effect.succeed(""),
       deleteCheckpointRefs: () => Effect.void,
     };
@@ -331,6 +334,7 @@ describe("CheckpointDiffQueryLive", () => {
       copyCheckpointRef: () => Effect.succeed(true),
       hasCheckpointRef: () => Effect.succeed(true),
       restoreCheckpoint: () => Effect.succeed(true),
+      reverseCheckpointDiff: () => Effect.succeed(true),
       diffCheckpoints: () => Effect.succeed("diff patch"),
       deleteCheckpointRefs: () => Effect.void,
     };
@@ -395,6 +399,7 @@ describe("CheckpointDiffQueryLive", () => {
       copyCheckpointRef: () => Effect.succeed(true),
       hasCheckpointRef: () => Effect.succeed(true),
       restoreCheckpoint: () => Effect.succeed(true),
+      reverseCheckpointDiff: () => Effect.succeed(true),
       diffCheckpoints: () => Effect.succeed("diff patch"),
       deleteCheckpointRefs: () => Effect.void,
     };
@@ -460,6 +465,7 @@ describe("CheckpointDiffQueryLive", () => {
       copyCheckpointRef: () => Effect.succeed(true),
       hasCheckpointRef: () => Effect.succeed(true),
       restoreCheckpoint: () => Effect.succeed(true),
+      reverseCheckpointDiff: () => Effect.succeed(true),
       diffCheckpoints: ({ cwd }) =>
         Effect.sync(() => {
           diffCheckpointsCalls.push({ cwd });
@@ -529,6 +535,7 @@ describe("CheckpointDiffQueryLive", () => {
       copyCheckpointRef: () => Effect.succeed(true),
       hasCheckpointRef: () => Effect.succeed(true),
       restoreCheckpoint: () => Effect.succeed(true),
+      reverseCheckpointDiff: () => Effect.succeed(true),
       diffCheckpoints: () => Effect.succeed("diff patch"),
       deleteCheckpointRefs: () => Effect.void,
     };

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CheckpointStoreLive } from "./CheckpointStore.ts";
 import { CheckpointStore } from "../Services/CheckpointStore.ts";
 import { GitCore, type GitCoreShape } from "../../git/Services/GitCore.ts";
+import { GitCommandError } from "../../git/Errors.ts";
 import { CheckpointRef } from "@synara/contracts";
 
 async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
@@ -205,5 +206,69 @@ describe("CheckpointStoreLive", () => {
         expect(captureArgs(`update-ref ${missingRef} commit-oid`)).toHaveLength(1);
       }),
     );
+  });
+
+  it("restores the worktree patch when resetting the index fails during file undo", async () => {
+    const fromRef = CheckpointRef.makeUnsafe("refs/synara-checkpoints/thread/turn/start");
+    const toRef = CheckpointRef.makeUnsafe("refs/synara-checkpoints/thread/turn/end");
+    const commands: string[] = [];
+    const execute = vi.fn<GitCoreShape["execute"]>((input) => {
+      const args = input.args.join(" ");
+      commands.push(args);
+      if (args === `rev-parse --verify --quiet ${fromRef}^{commit}`) {
+        return Effect.succeed({ code: 0, stdout: "from-oid\n", stderr: "" });
+      }
+      if (args === `rev-parse --verify --quiet ${toRef}^{commit}`) {
+        return Effect.succeed({ code: 0, stdout: "to-oid\n", stderr: "" });
+      }
+      if (args.startsWith("diff --patch --binary --full-index")) {
+        return Effect.succeed({ code: 0, stdout: "turn patch", stderr: "" });
+      }
+      if (args === "diff --name-only --no-renames -z from-oid to-oid") {
+        return Effect.succeed({ code: 0, stdout: "src/file.ts\0", stderr: "" });
+      }
+      if (input.args[0] === "apply" && input.args[1] === "--reverse") {
+        return Effect.succeed({ code: 0, stdout: "", stderr: "" });
+      }
+      if (args === "reset --quiet from-oid -- src/file.ts") {
+        return Effect.fail(
+          new GitCommandError({
+            operation: input.operation,
+            command: args,
+            cwd: input.cwd,
+            detail: "reset failed",
+          }),
+        );
+      }
+      if (input.args[0] === "apply" && input.args[1] === "--whitespace=nowarn") {
+        return Effect.succeed({ code: 0, stdout: "", stderr: "" });
+      }
+      throw new Error(`Unexpected git args: ${args}`);
+    });
+    const layer = CheckpointStoreLive.pipe(
+      Layer.provide(Layer.succeed(GitCore, { execute } as unknown as GitCoreShape)),
+      Layer.provide(NodeServices.layer),
+    );
+    runtime = ManagedRuntime.make(layer);
+
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CheckpointStore;
+        return yield* store
+          .reverseCheckpointDiff({
+            cwd: "/repo",
+            fromCheckpointRef: fromRef,
+            toCheckpointRef: toRef,
+          })
+          .pipe(
+            Effect.map(() => "success" as const),
+            Effect.catch((error) => Effect.succeed(error._tag)),
+          );
+      }),
+    );
+
+    expect(result).toBe("GitCommandError");
+    expect(commands.filter((command) => command.startsWith("apply "))).toHaveLength(2);
+    expect(commands.at(-1)).toMatch(/^apply --whitespace=nowarn -- /);
   });
 });

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -363,6 +363,66 @@ const makeCheckpointStore = Effect.gen(function* () {
       return result.stdout;
     });
 
+  const reverseCheckpointDiff: CheckpointStoreShape["reverseCheckpointDiff"] = (input) =>
+    Effect.gen(function* () {
+      const operation = "CheckpointStore.reverseCheckpointDiff";
+      let fromCommitOid = yield* resolveCheckpointCommit(input.cwd, input.fromCheckpointRef);
+      const toCommitOid = yield* resolveCheckpointCommit(input.cwd, input.toCheckpointRef);
+
+      if (!fromCommitOid && input.fallbackFromToHead === true) {
+        fromCommitOid = yield* resolveHeadCommit(input.cwd);
+      }
+      if (!fromCommitOid || !toCommitOid) {
+        return false;
+      }
+
+      const diff = yield* git.execute({
+        operation,
+        cwd: input.cwd,
+        args: [
+          "diff",
+          "--patch",
+          "--binary",
+          "--full-index",
+          "--no-color",
+          "--no-ext-diff",
+          "--no-textconv",
+          fromCommitOid,
+          toCommitOid,
+        ],
+        maxOutputBytes: input.maxOutputBytes ?? CHECKPOINT_DIFF_MAX_OUTPUT_BYTES,
+      });
+      if (diff.stdout.length === 0) {
+        return true;
+      }
+
+      return yield* Effect.acquireUseRelease(
+        fs.makeTempDirectory({ prefix: "synara-checkpoint-undo-" }),
+        (tempDir) =>
+          Effect.gen(function* () {
+            const patchPath = path.join(tempDir, "turn.patch");
+            yield* fs.writeFileString(patchPath, diff.stdout);
+            yield* git.execute({
+              operation,
+              cwd: input.cwd,
+              args: ["apply", "--reverse", "--whitespace=nowarn", "--", patchPath],
+            });
+            return true;
+          }),
+        (tempDir) => fs.remove(tempDir, { recursive: true }),
+      ).pipe(
+        Effect.catchTag("PlatformError", (error) =>
+          Effect.fail(
+            new CheckpointInvariantError({
+              operation,
+              detail: "Failed to prepare the checkpoint patch for undo.",
+              cause: error,
+            }),
+          ),
+        ),
+      );
+    });
+
   const deleteCheckpointRefs: CheckpointStoreShape["deleteCheckpointRefs"] = (input) =>
     Effect.gen(function* () {
       const operation = "CheckpointStore.deleteCheckpointRefs";
@@ -387,6 +447,7 @@ const makeCheckpointStore = Effect.gen(function* () {
     hasCheckpointRef,
     restoreCheckpoint,
     diffCheckpoints,
+    reverseCheckpointDiff,
     deleteCheckpointRefs,
   } satisfies CheckpointStoreShape;
 });

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -366,12 +366,9 @@ const makeCheckpointStore = Effect.gen(function* () {
   const reverseCheckpointDiff: CheckpointStoreShape["reverseCheckpointDiff"] = (input) =>
     Effect.gen(function* () {
       const operation = "CheckpointStore.reverseCheckpointDiff";
-      let fromCommitOid = yield* resolveCheckpointCommit(input.cwd, input.fromCheckpointRef);
+      const fromCommitOid = yield* resolveCheckpointCommit(input.cwd, input.fromCheckpointRef);
       const toCommitOid = yield* resolveCheckpointCommit(input.cwd, input.toCheckpointRef);
 
-      if (!fromCommitOid && input.fallbackFromToHead === true) {
-        fromCommitOid = yield* resolveHeadCommit(input.cwd);
-      }
       if (!fromCommitOid || !toCommitOid) {
         return false;
       }

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -407,6 +407,13 @@ const makeCheckpointStore = Effect.gen(function* () {
               cwd: input.cwd,
               args: ["apply", "--reverse", "--whitespace=nowarn", "--", patchPath],
             });
+            if (input.affectedPaths.length > 0 && (yield* hasHeadCommit(input.cwd))) {
+              yield* git.execute({
+                operation,
+                cwd: input.cwd,
+                args: ["reset", "--quiet", "--", ...input.affectedPaths],
+              });
+            }
             return true;
           }),
         (tempDir) => fs.remove(tempDir, { recursive: true }),

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -413,11 +413,21 @@ const makeCheckpointStore = Effect.gen(function* () {
               args: ["apply", "--reverse", "--whitespace=nowarn", "--", patchPath],
             });
             if (affectedPaths.length > 0) {
-              yield* git.execute({
-                operation,
-                cwd: input.cwd,
-                args: ["reset", "--quiet", fromCommitOid, "--", ...affectedPaths],
-              });
+              const resetExit = yield* Effect.exit(
+                git.execute({
+                  operation,
+                  cwd: input.cwd,
+                  args: ["reset", "--quiet", fromCommitOid, "--", ...affectedPaths],
+                }),
+              );
+              if (Exit.isFailure(resetExit)) {
+                yield* git.execute({
+                  operation,
+                  cwd: input.cwd,
+                  args: ["apply", "--whitespace=nowarn", "--", patchPath],
+                });
+                return yield* Effect.failCause(resetExit.cause);
+              }
             }
             return true;
           }),

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -396,6 +396,14 @@ const makeCheckpointStore = Effect.gen(function* () {
         return true;
       }
 
+      const changedPaths = yield* git.execute({
+        operation,
+        cwd: input.cwd,
+        args: ["diff", "--name-only", "--no-renames", "-z", fromCommitOid, toCommitOid],
+        maxOutputBytes: input.maxOutputBytes ?? CHECKPOINT_DIFF_MAX_OUTPUT_BYTES,
+      });
+      const affectedPaths = changedPaths.stdout.split("\0").filter((entry) => entry.length > 0);
+
       return yield* Effect.acquireUseRelease(
         fs.makeTempDirectory({ prefix: "synara-checkpoint-undo-" }),
         (tempDir) =>
@@ -407,11 +415,11 @@ const makeCheckpointStore = Effect.gen(function* () {
               cwd: input.cwd,
               args: ["apply", "--reverse", "--whitespace=nowarn", "--", patchPath],
             });
-            if (input.affectedPaths.length > 0 && (yield* hasHeadCommit(input.cwd))) {
+            if (affectedPaths.length > 0) {
               yield* git.execute({
                 operation,
                 cwd: input.cwd,
-                args: ["reset", "--quiet", "--", ...input.affectedPaths],
+                args: ["reset", "--quiet", fromCommitOid, "--", ...affectedPaths],
               });
             }
             return true;

--- a/apps/server/src/checkpointing/Services/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Services/CheckpointStore.ts
@@ -50,6 +50,14 @@ export interface DiffCheckpointsInput {
   readonly maxOutputBytes?: number;
 }
 
+export interface ReverseCheckpointDiffInput {
+  readonly cwd: string;
+  readonly fromCheckpointRef: CheckpointRef;
+  readonly toCheckpointRef: CheckpointRef;
+  readonly fallbackFromToHead?: boolean;
+  readonly maxOutputBytes?: number;
+}
+
 export interface DeleteCheckpointRefsInput {
   readonly cwd: string;
   readonly checkpointRefs: ReadonlyArray<CheckpointRef>;
@@ -106,6 +114,13 @@ export interface CheckpointStoreShape {
   readonly diffCheckpoints: (
     input: DiffCheckpointsInput,
   ) => Effect.Effect<string, CheckpointStoreError>;
+
+  /**
+   * Reverse only the changes between two checkpoints onto the current workspace.
+   */
+  readonly reverseCheckpointDiff: (
+    input: ReverseCheckpointDiffInput,
+  ) => Effect.Effect<boolean, CheckpointStoreError>;
 
   /**
    * Delete the provided checkpoint refs.

--- a/apps/server/src/checkpointing/Services/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Services/CheckpointStore.ts
@@ -54,7 +54,6 @@ export interface ReverseCheckpointDiffInput {
   readonly cwd: string;
   readonly fromCheckpointRef: CheckpointRef;
   readonly toCheckpointRef: CheckpointRef;
-  readonly fallbackFromToHead?: boolean;
   readonly maxOutputBytes?: number;
 }
 

--- a/apps/server/src/checkpointing/Services/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Services/CheckpointStore.ts
@@ -54,6 +54,7 @@ export interface ReverseCheckpointDiffInput {
   readonly cwd: string;
   readonly fromCheckpointRef: CheckpointRef;
   readonly toCheckpointRef: CheckpointRef;
+  readonly affectedPaths: ReadonlyArray<string>;
   readonly fallbackFromToHead?: boolean;
   readonly maxOutputBytes?: number;
 }

--- a/apps/server/src/checkpointing/Services/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Services/CheckpointStore.ts
@@ -54,7 +54,6 @@ export interface ReverseCheckpointDiffInput {
   readonly cwd: string;
   readonly fromCheckpointRef: CheckpointRef;
   readonly toCheckpointRef: CheckpointRef;
-  readonly affectedPaths: ReadonlyArray<string>;
   readonly fallbackFromToHead?: boolean;
   readonly maxOutputBytes?: number;
 }

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1348,6 +1348,7 @@ describe("CheckpointReactor", () => {
       }),
     );
     fs.writeFileSync(path.join(harness.cwd, "one.txt"), "one\n", "utf8");
+    runGit(harness.cwd, ["add", "one.txt"]);
     await runtime!.runPromise(
       harness.checkpointStore.captureCheckpoint({
         cwd: harness.cwd,
@@ -1355,6 +1356,7 @@ describe("CheckpointReactor", () => {
       }),
     );
     fs.writeFileSync(path.join(harness.cwd, "two.txt"), "two\n", "utf8");
+    runGit(harness.cwd, ["add", "two.txt"]);
     await runtime!.runPromise(
       harness.checkpointStore.captureCheckpoint({
         cwd: harness.cwd,
@@ -1426,9 +1428,9 @@ describe("CheckpointReactor", () => {
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.checkpoint.revert",
-        commandId: CommandId.makeUnsafe("cmd-undo-files-turn-1"),
+        commandId: CommandId.makeUnsafe("cmd-undo-files-turn-2"),
         threadId,
-        turnCount: 1,
+        turnCount: 2,
         scope: "files",
         createdAt,
       }),
@@ -1438,16 +1440,16 @@ describe("CheckpointReactor", () => {
       (entry) => entry.id === threadId,
     );
     expect(afterFirstUndo?.activities).toEqual([]);
-    expect(afterFirstUndo?.checkpoints[0]?.files).toEqual([]);
-    expect(fs.existsSync(path.join(harness.cwd, "one.txt"))).toBe(false);
-    expect(fs.readFileSync(path.join(harness.cwd, "two.txt"), "utf8")).toBe("two\n");
+    expect(afterFirstUndo?.checkpoints[1]?.files).toEqual([]);
+    expect(fs.readFileSync(path.join(harness.cwd, "one.txt"), "utf8")).toBe("one\n");
+    expect(fs.existsSync(path.join(harness.cwd, "two.txt"))).toBe(false);
 
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.checkpoint.revert",
-        commandId: CommandId.makeUnsafe("cmd-undo-files-turn-2"),
+        commandId: CommandId.makeUnsafe("cmd-undo-files-turn-1"),
         threadId,
-        turnCount: 2,
+        turnCount: 1,
         scope: "files",
         createdAt,
       }),
@@ -1457,6 +1459,7 @@ describe("CheckpointReactor", () => {
     const readModel = await Effect.runPromise(harness.engine.getReadModel());
     const thread = readModel.threads.find((entry) => entry.id === threadId);
     expect(thread?.checkpoints.every((checkpoint) => checkpoint.files.length === 0)).toBe(true);
+    expect(thread?.latestTurn?.turnId).toBe(turnTwoId);
     expect(thread?.messages.map((message) => message.text)).toEqual([
       "Change two files",
       "Changed them",
@@ -1466,12 +1469,33 @@ describe("CheckpointReactor", () => {
     expect(fs.existsSync(path.join(harness.cwd, "two.txt"))).toBe(false);
     expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 1))).toBe(true);
     expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 2))).toBe(true);
+    expect(runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 1)]).trim()).toBe(
+      runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 2)]).trim(),
+    );
+    expect(runGit(harness.cwd, ["diff", "--cached", "--name-only"]).trim()).toBe("");
     const events = await Effect.runPromise(
       Stream.runCollect(harness.engine.readEvents(0)).pipe(
         Effect.map((chunk) => Array.from(chunk)),
       ),
     );
     expect(events.some((event) => event.type === "thread.reverted")).toBe(false);
+
+    fs.writeFileSync(path.join(harness.cwd, "later.txt"), "later\n", "utf8");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.makeUnsafe("cmd-full-revert-after-files-undo"),
+        threadId,
+        turnCount: 1,
+        scope: "thread",
+        createdAt,
+      }),
+    );
+    await harness.drain();
+    expect(fs.existsSync(path.join(harness.cwd, "one.txt"))).toBe(false);
+    expect(fs.existsSync(path.join(harness.cwd, "two.txt"))).toBe(false);
+    expect(fs.existsSync(path.join(harness.cwd, "later.txt"))).toBe(false);
+    expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(1);
   });
 
   it("keeps full thread revert behavior for explicit thread scope", async () => {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1638,6 +1638,57 @@ describe("CheckpointReactor", () => {
     expect(harness.provider.rollbackConversation).not.toHaveBeenCalled();
   });
 
+  it("does not undo files when the exact turn baseline is missing", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const turnId = asTurnId("turn-missing-baseline");
+
+    fs.writeFileSync(path.join(harness.cwd, "turn.txt"), "turn\n", "utf8");
+    await runtime!.runPromise(
+      harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+      }),
+    );
+    fs.writeFileSync(path.join(harness.cwd, "later.txt"), "later\n", "utf8");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.makeUnsafe("cmd-missing-baseline-diff"),
+        threadId,
+        turnId,
+        completedAt: createdAt,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+        status: "ready",
+        files: [{ path: "turn.txt", kind: "modified", additions: 1, deletions: 0 }],
+        checkpointTurnCount: 1,
+        createdAt,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.makeUnsafe("cmd-missing-baseline-undo"),
+        threadId,
+        turnCount: 1,
+        scope: "files",
+        createdAt,
+      }),
+    );
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.activities.some((activity) => activity.kind === "checkpoint.revert.failed"),
+    );
+    expect(thread.activities.some((activity) => activity.kind === "checkpoint.revert.failed")).toBe(
+      true,
+    );
+    expect(fs.readFileSync(path.join(harness.cwd, "turn.txt"), "utf8")).toBe("turn\n");
+    expect(fs.readFileSync(path.join(harness.cwd, "later.txt"), "utf8")).toBe("later\n");
+    expect(harness.provider.rollbackConversation).not.toHaveBeenCalled();
+  });
+
   it("keeps full thread revert behavior for explicit thread scope", async () => {
     const harness = await createHarness();
     const createdAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -357,6 +357,7 @@ describe("CheckpointReactor", () => {
     return {
       engine,
       provider,
+      checkpointStore,
       cwd,
       drain,
     };
@@ -1330,7 +1331,150 @@ describe("CheckpointReactor", () => {
     ).toBe(true);
   });
 
-  it("executes provider revert and emits thread.reverted for checkpoint revert requests", async () => {
+  it("undoes turn files without trimming chat or rolling back the Claude conversation", async () => {
+    const harness = await createHarness({
+      seedFilesystemCheckpoints: false,
+      providerName: "claudeAgent",
+    });
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const turnOneId = asTurnId("turn-files-1");
+    const turnTwoId = asTurnId("turn-files-2");
+
+    await runtime!.runPromise(
+      harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 0),
+      }),
+    );
+    fs.writeFileSync(path.join(harness.cwd, "one.txt"), "one\n", "utf8");
+    await runtime!.runPromise(
+      harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+      }),
+    );
+    fs.writeFileSync(path.join(harness.cwd, "two.txt"), "two\n", "utf8");
+    await runtime!.runPromise(
+      harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 2),
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.messages.import",
+        commandId: CommandId.makeUnsafe("cmd-import-files-undo-chat"),
+        threadId,
+        messages: [
+          {
+            messageId: MessageId.makeUnsafe("message-files-undo-user"),
+            role: "user",
+            text: "Change two files",
+            createdAt,
+            updatedAt: createdAt,
+          },
+          {
+            messageId: MessageId.makeUnsafe("message-files-undo-assistant"),
+            role: "assistant",
+            text: "Changed them",
+            createdAt,
+            updatedAt: createdAt,
+          },
+        ],
+        createdAt,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-files-undo"),
+        threadId,
+        session: {
+          threadId,
+          status: "ready",
+          providerName: "claudeAgent",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+    for (const [turnCount, turnId, filePath] of [
+      [1, turnOneId, "one.txt"],
+      [2, turnTwoId, "two.txt"],
+    ] as const) {
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.makeUnsafe(`cmd-files-undo-diff-${turnCount}`),
+          threadId,
+          turnId,
+          completedAt: createdAt,
+          checkpointRef: checkpointRefForThreadTurn(threadId, turnCount),
+          status: "ready",
+          files: [{ path: filePath, kind: "modified", additions: 1, deletions: 0 }],
+          checkpointTurnCount: turnCount,
+          createdAt,
+        }),
+      );
+    }
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.makeUnsafe("cmd-undo-files-turn-1"),
+        threadId,
+        turnCount: 1,
+        scope: "files",
+        createdAt,
+      }),
+    );
+    await harness.drain();
+    const afterFirstUndo = (await Effect.runPromise(harness.engine.getReadModel())).threads.find(
+      (entry) => entry.id === threadId,
+    );
+    expect(afterFirstUndo?.activities).toEqual([]);
+    expect(afterFirstUndo?.checkpoints[0]?.files).toEqual([]);
+    expect(fs.existsSync(path.join(harness.cwd, "one.txt"))).toBe(false);
+    expect(fs.readFileSync(path.join(harness.cwd, "two.txt"), "utf8")).toBe("two\n");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.makeUnsafe("cmd-undo-files-turn-2"),
+        threadId,
+        turnCount: 2,
+        scope: "files",
+        createdAt,
+      }),
+    );
+    await harness.drain();
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === threadId);
+    expect(thread?.checkpoints.every((checkpoint) => checkpoint.files.length === 0)).toBe(true);
+    expect(thread?.messages.map((message) => message.text)).toEqual([
+      "Change two files",
+      "Changed them",
+    ]);
+    expect(harness.provider.rollbackConversation).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(harness.cwd, "one.txt"))).toBe(false);
+    expect(fs.existsSync(path.join(harness.cwd, "two.txt"))).toBe(false);
+    expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 1))).toBe(true);
+    expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 2))).toBe(true);
+    const events = await Effect.runPromise(
+      Stream.runCollect(harness.engine.readEvents(0)).pipe(
+        Effect.map((chunk) => Array.from(chunk)),
+      ),
+    );
+    expect(events.some((event) => event.type === "thread.reverted")).toBe(false);
+  });
+
+  it("keeps full thread revert behavior for explicit thread scope", async () => {
     const harness = await createHarness();
     const createdAt = new Date().toISOString();
 
@@ -1387,6 +1531,7 @@ describe("CheckpointReactor", () => {
         commandId: CommandId.makeUnsafe("cmd-revert-request"),
         threadId: ThreadId.makeUnsafe("thread-1"),
         turnCount: 1,
+        scope: "thread",
         createdAt,
       }),
     );
@@ -1529,6 +1674,7 @@ describe("CheckpointReactor", () => {
         commandId: CommandId.makeUnsafe("cmd-revert-request-claude"),
         threadId: ThreadId.makeUnsafe("thread-1"),
         turnCount: 1,
+        scope: "thread",
         createdAt,
       }),
     );

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -187,14 +187,16 @@ function runGit(cwd: string, args: ReadonlyArray<string>) {
   });
 }
 
-function createGitRepository() {
+function createGitRepository(hasInitialCommit = true) {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "synara-checkpoint-handler-"));
   runGit(cwd, ["init", "--initial-branch=main"]);
   runGit(cwd, ["config", "user.email", "test@example.com"]);
   runGit(cwd, ["config", "user.name", "Test User"]);
-  fs.writeFileSync(path.join(cwd, "README.md"), "v1\n", "utf8");
-  runGit(cwd, ["add", "."]);
-  runGit(cwd, ["commit", "-m", "Initial"]);
+  if (hasInitialCommit) {
+    fs.writeFileSync(path.join(cwd, "README.md"), "v1\n", "utf8");
+    runGit(cwd, ["add", "."]);
+    runGit(cwd, ["commit", "-m", "Initial"]);
+  }
   return cwd;
 }
 
@@ -258,8 +260,9 @@ describe("CheckpointReactor", () => {
     readonly threadWorktreePath?: string | null;
     readonly providerSessionCwd?: string;
     readonly providerName?: ProviderKind;
+    readonly hasInitialCommit?: boolean;
   }) {
-    const cwd = createGitRepository();
+    const cwd = createGitRepository(options?.hasInitialCommit ?? true);
     tempDirs.push(cwd);
     const provider = createProviderServiceHarness(
       cwd,
@@ -1340,6 +1343,7 @@ describe("CheckpointReactor", () => {
     const threadId = ThreadId.makeUnsafe("thread-1");
     const turnOneId = asTurnId("turn-files-1");
     const turnTwoId = asTurnId("turn-files-2");
+    const placeholderTurnId = asTurnId("turn-files-placeholder");
 
     await runtime!.runPromise(
       harness.checkpointStore.captureCheckpoint({
@@ -1353,6 +1357,13 @@ describe("CheckpointReactor", () => {
       harness.checkpointStore.captureCheckpoint({
         cwd: harness.cwd,
         checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+      }),
+    );
+    await runtime!.runPromise(
+      harness.checkpointStore.copyCheckpointRef({
+        cwd: harness.cwd,
+        fromCheckpointRef: checkpointRefForThreadTurn(threadId, 1),
+        toCheckpointRef: checkpointRefForThreadTurnStart(threadId, turnTwoId),
       }),
     );
     fs.writeFileSync(path.join(harness.cwd, "two.txt"), "two\n", "utf8");
@@ -1424,6 +1435,20 @@ describe("CheckpointReactor", () => {
         }),
       );
     }
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.makeUnsafe("cmd-files-undo-live-placeholder"),
+        threadId,
+        turnId: placeholderTurnId,
+        completedAt: createdAt,
+        checkpointRef: CheckpointRef.makeUnsafe("provider-diff:files-undo-placeholder"),
+        status: "missing",
+        files: [{ path: "placeholder.txt", kind: "modified", additions: 1, deletions: 0 }],
+        checkpointTurnCount: 3,
+        createdAt,
+      }),
+    );
 
     await Effect.runPromise(
       harness.engine.dispatch({
@@ -1435,12 +1460,18 @@ describe("CheckpointReactor", () => {
         createdAt,
       }),
     );
-    await harness.drain();
+    await waitForThread(harness.engine, (entry) =>
+      entry.checkpoints.some(
+        (checkpoint) => checkpoint.checkpointTurnCount === 2 && checkpoint.files?.length === 0,
+      ),
+    );
     const afterFirstUndo = (await Effect.runPromise(harness.engine.getReadModel())).threads.find(
       (entry) => entry.id === threadId,
     );
     expect(afterFirstUndo?.activities).toEqual([]);
-    expect(afterFirstUndo?.checkpoints[1]?.files).toEqual([]);
+    expect(
+      afterFirstUndo?.checkpoints.find((checkpoint) => checkpoint.checkpointTurnCount === 2)?.files,
+    ).toEqual([]);
     expect(fs.readFileSync(path.join(harness.cwd, "one.txt"), "utf8")).toBe("one\n");
     expect(fs.existsSync(path.join(harness.cwd, "two.txt"))).toBe(false);
 
@@ -1454,12 +1485,20 @@ describe("CheckpointReactor", () => {
         createdAt,
       }),
     );
-    await harness.drain();
+    await waitForThread(harness.engine, (entry) =>
+      entry.checkpoints.some(
+        (checkpoint) => checkpoint.checkpointTurnCount === 1 && checkpoint.files?.length === 0,
+      ),
+    );
 
     const readModel = await Effect.runPromise(harness.engine.getReadModel());
     const thread = readModel.threads.find((entry) => entry.id === threadId);
-    expect(thread?.checkpoints.every((checkpoint) => checkpoint.files.length === 0)).toBe(true);
-    expect(thread?.latestTurn?.turnId).toBe(turnTwoId);
+    expect(
+      thread?.checkpoints
+        .filter((checkpoint) => !checkpoint.checkpointRef.startsWith("provider-diff:"))
+        .every((checkpoint) => checkpoint.files.length === 0),
+    ).toBe(true);
+    expect(thread?.latestTurn?.turnId).toBe(placeholderTurnId);
     expect(thread?.messages.map((message) => message.text)).toEqual([
       "Change two files",
       "Changed them",
@@ -1469,9 +1508,25 @@ describe("CheckpointReactor", () => {
     expect(fs.existsSync(path.join(harness.cwd, "two.txt"))).toBe(false);
     expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 1))).toBe(true);
     expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 2))).toBe(true);
-    expect(runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 1)]).trim()).toBe(
-      runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 2)]).trim(),
-    );
+    expect(
+      runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 1)]).trim(),
+    ).not.toBe(runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 2)]).trim());
+    expect(
+      runGit(harness.cwd, [
+        "diff",
+        "--name-only",
+        checkpointRefForThreadTurnStart(threadId, turnTwoId),
+        checkpointRefForThreadTurn(threadId, 2),
+      ]),
+    ).toBe("");
+    expect(
+      runGit(harness.cwd, [
+        "ls-tree",
+        "-r",
+        "--name-only",
+        checkpointRefForThreadTurnStart(threadId, turnTwoId),
+      ]),
+    ).toContain("one.txt");
     expect(runGit(harness.cwd, ["diff", "--cached", "--name-only"]).trim()).toBe("");
     const events = await Effect.runPromise(
       Stream.runCollect(harness.engine.readEvents(0)).pipe(
@@ -1491,11 +1546,88 @@ describe("CheckpointReactor", () => {
         createdAt,
       }),
     );
-    await harness.drain();
+    await waitForEvent(harness.engine, (event) => event.type === "thread.reverted");
     expect(fs.existsSync(path.join(harness.cwd, "one.txt"))).toBe(false);
     expect(fs.existsSync(path.join(harness.cwd, "two.txt"))).toBe(false);
     expect(fs.existsSync(path.join(harness.cwd, "later.txt"))).toBe(false);
     expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it("undoes staged renames without an active session or HEAD", async () => {
+    const harness = await createHarness({
+      hasSession: false,
+      hasInitialCommit: false,
+      seedFilesystemCheckpoints: false,
+    });
+    const createdAt = new Date().toISOString();
+    const threadId = ThreadId.makeUnsafe("thread-1");
+
+    await runtime!.runPromise(
+      harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 0),
+      }),
+    );
+    fs.writeFileSync(path.join(harness.cwd, "before.txt"), "before\n", "utf8");
+    runGit(harness.cwd, ["add", "before.txt"]);
+    await runtime!.runPromise(
+      harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+      }),
+    );
+    runGit(harness.cwd, ["mv", "before.txt", "after.txt"]);
+    await runtime!.runPromise(
+      harness.checkpointStore.captureCheckpoint({
+        cwd: harness.cwd,
+        checkpointRef: checkpointRefForThreadTurn(threadId, 2),
+      }),
+    );
+
+    for (const [turnCount, turnId, filePath] of [
+      [1, asTurnId("turn-unborn-add"), "before.txt"],
+      [2, asTurnId("turn-unborn-rename"), "after.txt"],
+    ] as const) {
+      await Effect.runPromise(
+        harness.engine.dispatch({
+          type: "thread.turn.diff.complete",
+          commandId: CommandId.makeUnsafe(`cmd-unborn-diff-${turnCount}`),
+          threadId,
+          turnId,
+          completedAt: createdAt,
+          checkpointRef: checkpointRefForThreadTurn(threadId, turnCount),
+          status: "ready",
+          files: [{ path: filePath, kind: "modified", additions: 1, deletions: 0 }],
+          checkpointTurnCount: turnCount,
+          createdAt,
+        }),
+      );
+    }
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.checkpoint.revert",
+        commandId: CommandId.makeUnsafe("cmd-unborn-undo-rename"),
+        threadId,
+        turnCount: 2,
+        scope: "files",
+        createdAt,
+      }),
+    );
+    await waitForThread(harness.engine, (entry) =>
+      entry.checkpoints.some(
+        (checkpoint) => checkpoint.checkpointTurnCount === 2 && checkpoint.files?.length === 0,
+      ),
+    );
+
+    expect(fs.existsSync(path.join(harness.cwd, "before.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(harness.cwd, "after.txt"))).toBe(false);
+    expect(runGit(harness.cwd, ["diff", "--cached", "--name-only"])).toBe("before.txt\n");
+    const thread = (await Effect.runPromise(harness.engine.getReadModel())).threads.find(
+      (entry) => entry.id === threadId,
+    );
+    expect(thread?.activities).toEqual([]);
+    expect(harness.provider.rollbackConversation).not.toHaveBeenCalled();
   });
 
   it("keeps full thread revert behavior for explicit thread scope", async () => {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1531,6 +1531,16 @@ describe("CheckpointReactor", () => {
         Effect.map((chunk) => Array.from(chunk)),
       ),
     );
+    const fileUndoEvent = events.find(
+      (event) =>
+        event.type === "thread.turn-diff-completed" &&
+        event.payload.turnId === turnOneId &&
+        event.payload.files.length === 0,
+    );
+    expect(fileUndoEvent?.type === "thread.turn-diff-completed").toBe(true);
+    if (fileUndoEvent?.type === "thread.turn-diff-completed") {
+      expect(fileUndoEvent.payload.preserveLatestTurn).toBe(true);
+    }
     expect(events.some((event) => event.type === "thread.reverted")).toBe(false);
 
     fs.writeFileSync(path.join(harness.cwd, "later.txt"), "later\n", "utf8");

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -1508,17 +1508,15 @@ describe("CheckpointReactor", () => {
     expect(fs.existsSync(path.join(harness.cwd, "two.txt"))).toBe(false);
     expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 1))).toBe(true);
     expect(gitRefExists(harness.cwd, checkpointRefForThreadTurn(threadId, 2))).toBe(true);
-    expect(
-      runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 1)]).trim(),
-    ).not.toBe(runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 2)]).trim());
+    expect(runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 1)]).trim()).toBe(
+      runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 2)]).trim(),
+    );
     expect(
       runGit(harness.cwd, [
-        "diff",
-        "--name-only",
+        "rev-parse",
         checkpointRefForThreadTurnStart(threadId, turnTwoId),
-        checkpointRefForThreadTurn(threadId, 2),
-      ]),
-    ).toBe("");
+      ]).trim(),
+    ).toBe(runGit(harness.cwd, ["rev-parse", checkpointRefForThreadTurn(threadId, 1)]).trim());
     expect(
       runGit(harness.cwd, [
         "ls-tree",
@@ -1526,7 +1524,7 @@ describe("CheckpointReactor", () => {
         "--name-only",
         checkpointRefForThreadTurnStart(threadId, turnTwoId),
       ]),
-    ).toContain("one.txt");
+    ).not.toContain("one.txt");
     expect(runGit(harness.cwd, ["diff", "--cached", "--name-only"]).trim()).toBe("");
     const events = await Effect.runPromise(
       Stream.runCollect(harness.engine.readEvents(0)).pipe(

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -902,6 +902,20 @@ const make = Effect.gen(function* () {
         }).pipe(Effect.catch(() => Effect.void));
         return;
       }
+      const latestUndoableTurnCount = thread.checkpoints.reduce(
+        (latest, checkpoint) =>
+          checkpoint.files.length > 0 ? Math.max(latest, checkpoint.checkpointTurnCount) : latest,
+        0,
+      );
+      if (targetCheckpoint.checkpointTurnCount !== latestUndoableTurnCount) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: "Undo newer file changes before undoing this turn.",
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
 
       const turnStartCheckpointRef =
         checkpointRefForThreadTurnStartInManagedFamily(
@@ -941,6 +955,7 @@ const make = Effect.gen(function* () {
         cwd: sessionRuntime.value.cwd,
         fromCheckpointRef,
         toCheckpointRef: targetCheckpoint.checkpointRef,
+        affectedPaths: targetCheckpoint.files.map((file) => file.path),
         fallbackFromToHead: event.payload.turnCount === 1 && !hasTurnStartCheckpoint,
       });
       if (!reversed) {
@@ -952,6 +967,23 @@ const make = Effect.gen(function* () {
         }).pipe(Effect.catch(() => Effect.void));
         return;
       }
+
+      yield* checkpointStore.captureCheckpoint({
+        cwd: sessionRuntime.value.cwd,
+        checkpointRef: targetCheckpoint.checkpointRef,
+      });
+      yield* Effect.forEach(
+        thread.checkpoints.filter(
+          (checkpoint) => checkpoint.checkpointTurnCount > targetCheckpoint.checkpointTurnCount,
+        ),
+        (checkpoint) =>
+          checkpointStore.copyCheckpointRef({
+            cwd: sessionRuntime.value.cwd,
+            fromCheckpointRef: targetCheckpoint.checkpointRef,
+            toCheckpointRef: checkpoint.checkpointRef,
+          }),
+        { discard: true },
+      );
 
       clearWorkspaceIndexCache(sessionRuntime.value.cwd);
       yield* orchestrationEngine.dispatch({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -21,6 +21,7 @@ import {
   checkpointRefForThreadTurnInManagedFamily,
   checkpointRefForThreadTurnLive,
   checkpointRefForThreadTurnStart,
+  checkpointRefForThreadTurnStartInManagedFamily,
   resolveThreadWorkspaceCwd,
 } from "../../checkpointing/Utils.ts";
 import { clearWorkspaceIndexCache } from "../../workspaceEntries.ts";
@@ -885,6 +886,89 @@ const make = Effect.gen(function* () {
         detail: `Checkpoint turn count ${event.payload.turnCount} exceeds current turn count ${currentTurnCount}.`,
         createdAt: now,
       }).pipe(Effect.catch(() => Effect.void));
+      return;
+    }
+
+    if (event.payload.scope === "files") {
+      const targetCheckpoint = thread.checkpoints.find(
+        (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
+      );
+      if (!targetCheckpoint || targetCheckpoint.files.length === 0) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: `File changes for turn ${event.payload.turnCount} are unavailable or already undone.`,
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+
+      const turnStartCheckpointRef =
+        checkpointRefForThreadTurnStartInManagedFamily(
+          targetCheckpoint.checkpointRef,
+          event.payload.threadId,
+          targetCheckpoint.turnId,
+        ) ?? checkpointRefForThreadTurnStart(event.payload.threadId, targetCheckpoint.turnId);
+      const hasTurnStartCheckpoint = yield* checkpointStore.hasCheckpointRef({
+        cwd: sessionRuntime.value.cwd,
+        checkpointRef: turnStartCheckpointRef,
+      });
+      const previousCheckpointRef =
+        event.payload.turnCount === 1
+          ? (checkpointRefForThreadTurnInManagedFamily(
+              targetCheckpoint.checkpointRef,
+              event.payload.threadId,
+              0,
+            ) ?? checkpointRefForThreadTurn(event.payload.threadId, 0))
+          : thread.checkpoints.find(
+              (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount - 1,
+            )?.checkpointRef;
+      const fromCheckpointRef = hasTurnStartCheckpoint
+        ? turnStartCheckpointRef
+        : previousCheckpointRef;
+
+      if (!fromCheckpointRef) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: `Starting checkpoint for turn ${event.payload.turnCount} is unavailable.`,
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+
+      const reversed = yield* checkpointStore.reverseCheckpointDiff({
+        cwd: sessionRuntime.value.cwd,
+        fromCheckpointRef,
+        toCheckpointRef: targetCheckpoint.checkpointRef,
+        fallbackFromToHead: event.payload.turnCount === 1 && !hasTurnStartCheckpoint,
+      });
+      if (!reversed) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: `Filesystem checkpoints for turn ${event.payload.turnCount} are unavailable.`,
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+
+      clearWorkspaceIndexCache(sessionRuntime.value.cwd);
+      yield* orchestrationEngine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: serverCommandId("checkpoint-files-undone"),
+        threadId: event.payload.threadId,
+        turnId: targetCheckpoint.turnId,
+        completedAt: targetCheckpoint.completedAt,
+        checkpointRef: targetCheckpoint.checkpointRef,
+        status: targetCheckpoint.status,
+        files: [],
+        ...(targetCheckpoint.assistantMessageId
+          ? { assistantMessageId: targetCheckpoint.assistantMessageId }
+          : {}),
+        checkpointTurnCount: targetCheckpoint.checkpointTurnCount,
+        createdAt: now,
+      });
       return;
     }
 

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -961,7 +961,6 @@ const make = Effect.gen(function* () {
         cwd: checkpointCwd,
         fromCheckpointRef,
         toCheckpointRef: targetCheckpoint.checkpointRef,
-        fallbackFromToHead: event.payload.turnCount === 1 && !hasTurnStartCheckpoint,
       });
       if (!reversed) {
         yield* appendRevertFailureActivity({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -877,7 +877,7 @@ const make = Effect.gen(function* () {
             threadId: event.payload.threadId,
             thread,
             project,
-            preferSessionRuntime: false,
+            preferSessionRuntime: true,
           })
         : undefined;
       if (!checkpointCwd) {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -22,6 +22,7 @@ import {
   checkpointRefForThreadTurnLive,
   checkpointRefForThreadTurnStart,
   checkpointRefForThreadTurnStartInManagedFamily,
+  isManagedCheckpointRefForThread,
   resolveThreadWorkspaceCwd,
 } from "../../checkpointing/Utils.ts";
 import { clearWorkspaceIndexCache } from "../../workspaceEntries.ts";
@@ -854,26 +855,6 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const sessionRuntime = yield* resolveSessionRuntimeForThread(event.payload.threadId);
-    if (Option.isNone(sessionRuntime)) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: "No active provider session with workspace cwd is bound to this thread.",
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
-    }
-    if (!isGitWorkspace(sessionRuntime.value.cwd)) {
-      yield* appendRevertFailureActivity({
-        threadId: event.payload.threadId,
-        turnCount: event.payload.turnCount,
-        detail: "Checkpoints are unavailable because this project is not a git repository.",
-        createdAt: now,
-      }).pipe(Effect.catch(() => Effect.void));
-      return;
-    }
-
     const currentTurnCount = thread.checkpoints.reduce(
       (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
       0,
@@ -890,10 +871,33 @@ const make = Effect.gen(function* () {
     }
 
     if (event.payload.scope === "files") {
+      const project = yield* getProjectShell(thread.projectId);
+      const checkpointCwd = project
+        ? yield* resolveCheckpointCwd({
+            threadId: event.payload.threadId,
+            thread,
+            project,
+            preferSessionRuntime: false,
+          })
+        : undefined;
+      if (!checkpointCwd) {
+        yield* appendRevertFailureActivity({
+          threadId: event.payload.threadId,
+          turnCount: event.payload.turnCount,
+          detail: "No git workspace is available for file Undo.",
+          createdAt: now,
+        }).pipe(Effect.catch(() => Effect.void));
+        return;
+      }
+
+      const isUndoableCheckpoint = (checkpoint: (typeof thread.checkpoints)[number]) =>
+        checkpoint.status === "ready" &&
+        checkpoint.files.length > 0 &&
+        isManagedCheckpointRefForThread(checkpoint.checkpointRef, event.payload.threadId);
       const targetCheckpoint = thread.checkpoints.find(
         (checkpoint) => checkpoint.checkpointTurnCount === event.payload.turnCount,
       );
-      if (!targetCheckpoint || targetCheckpoint.files.length === 0) {
+      if (!targetCheckpoint || !isUndoableCheckpoint(targetCheckpoint)) {
         yield* appendRevertFailureActivity({
           threadId: event.payload.threadId,
           turnCount: event.payload.turnCount,
@@ -904,7 +908,9 @@ const make = Effect.gen(function* () {
       }
       const latestUndoableTurnCount = thread.checkpoints.reduce(
         (latest, checkpoint) =>
-          checkpoint.files.length > 0 ? Math.max(latest, checkpoint.checkpointTurnCount) : latest,
+          isUndoableCheckpoint(checkpoint)
+            ? Math.max(latest, checkpoint.checkpointTurnCount)
+            : latest,
         0,
       );
       if (targetCheckpoint.checkpointTurnCount !== latestUndoableTurnCount) {
@@ -924,7 +930,7 @@ const make = Effect.gen(function* () {
           targetCheckpoint.turnId,
         ) ?? checkpointRefForThreadTurnStart(event.payload.threadId, targetCheckpoint.turnId);
       const hasTurnStartCheckpoint = yield* checkpointStore.hasCheckpointRef({
-        cwd: sessionRuntime.value.cwd,
+        cwd: checkpointCwd,
         checkpointRef: turnStartCheckpointRef,
       });
       const previousCheckpointRef =
@@ -952,10 +958,9 @@ const make = Effect.gen(function* () {
       }
 
       const reversed = yield* checkpointStore.reverseCheckpointDiff({
-        cwd: sessionRuntime.value.cwd,
+        cwd: checkpointCwd,
         fromCheckpointRef,
         toCheckpointRef: targetCheckpoint.checkpointRef,
-        affectedPaths: targetCheckpoint.files.map((file) => file.path),
         fallbackFromToHead: event.payload.turnCount === 1 && !hasTurnStartCheckpoint,
       });
       if (!reversed) {
@@ -969,23 +974,11 @@ const make = Effect.gen(function* () {
       }
 
       yield* checkpointStore.captureCheckpoint({
-        cwd: sessionRuntime.value.cwd,
+        cwd: checkpointCwd,
         checkpointRef: targetCheckpoint.checkpointRef,
       });
-      yield* Effect.forEach(
-        thread.checkpoints.filter(
-          (checkpoint) => checkpoint.checkpointTurnCount > targetCheckpoint.checkpointTurnCount,
-        ),
-        (checkpoint) =>
-          checkpointStore.copyCheckpointRef({
-            cwd: sessionRuntime.value.cwd,
-            fromCheckpointRef: targetCheckpoint.checkpointRef,
-            toCheckpointRef: checkpoint.checkpointRef,
-          }),
-        { discard: true },
-      );
 
-      clearWorkspaceIndexCache(sessionRuntime.value.cwd);
+      clearWorkspaceIndexCache(checkpointCwd);
       yield* orchestrationEngine.dispatch({
         type: "thread.turn.diff.complete",
         commandId: serverCommandId("checkpoint-files-undone"),
@@ -1001,6 +994,26 @@ const make = Effect.gen(function* () {
         checkpointTurnCount: targetCheckpoint.checkpointTurnCount,
         createdAt: now,
       });
+      return;
+    }
+
+    const sessionRuntime = yield* resolveSessionRuntimeForThread(event.payload.threadId);
+    if (Option.isNone(sessionRuntime)) {
+      yield* appendRevertFailureActivity({
+        threadId: event.payload.threadId,
+        turnCount: event.payload.turnCount,
+        detail: "No active provider session with workspace cwd is bound to this thread.",
+        createdAt: now,
+      }).pipe(Effect.catch(() => Effect.void));
+      return;
+    }
+    if (!isGitWorkspace(sessionRuntime.value.cwd)) {
+      yield* appendRevertFailureActivity({
+        threadId: event.payload.threadId,
+        turnCount: event.payload.turnCount,
+        detail: "Checkpoints are unavailable because this project is not a git repository.",
+        createdAt: now,
+      }).pipe(Effect.catch(() => Effect.void));
       return;
     }
 

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -977,6 +977,34 @@ const make = Effect.gen(function* () {
         cwd: checkpointCwd,
         checkpointRef: targetCheckpoint.checkpointRef,
       });
+      yield* Effect.forEach(
+        thread.checkpoints.filter(
+          (checkpoint) =>
+            checkpoint.checkpointTurnCount > targetCheckpoint.checkpointTurnCount &&
+            isManagedCheckpointRefForThread(checkpoint.checkpointRef, event.payload.threadId),
+        ),
+        (checkpoint) => {
+          const laterTurnStartCheckpointRef =
+            checkpointRefForThreadTurnStartInManagedFamily(
+              checkpoint.checkpointRef,
+              event.payload.threadId,
+              checkpoint.turnId,
+            ) ?? checkpointRefForThreadTurnStart(event.payload.threadId, checkpoint.turnId);
+          return Effect.all([
+            checkpointStore.copyCheckpointRef({
+              cwd: checkpointCwd,
+              fromCheckpointRef: targetCheckpoint.checkpointRef,
+              toCheckpointRef: checkpoint.checkpointRef,
+            }),
+            checkpointStore.copyCheckpointRef({
+              cwd: checkpointCwd,
+              fromCheckpointRef: targetCheckpoint.checkpointRef,
+              toCheckpointRef: laterTurnStartCheckpointRef,
+            }),
+          ]).pipe(Effect.asVoid);
+        },
+        { discard: true },
+      );
 
       clearWorkspaceIndexCache(checkpointCwd);
       yield* orchestrationEngine.dispatch({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -1020,6 +1020,7 @@ const make = Effect.gen(function* () {
           ? { assistantMessageId: targetCheckpoint.assistantMessageId }
           : {}),
         checkpointTurnCount: targetCheckpoint.checkpointTurnCount,
+        preserveLatestTurn: true,
         createdAt: now,
       });
       return;

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1084,7 +1084,9 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
           const nextRow = yield* withRefreshedThreadShellSummary({
             thread: {
               ...existingRow.value,
-              latestTurnId: event.payload.turnId,
+              latestTurnId: event.payload.preserveLatestTurn
+                ? existingRow.value.latestTurnId
+                : event.payload.turnId,
               updatedAt: event.occurredAt,
             },
             projectionThreadMessageRepository,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -227,6 +227,7 @@ describe("ProviderCommandReactor", () => {
       copyCheckpointRef: () => Effect.succeed(true),
       hasCheckpointRef: () => Effect.succeed(false),
       restoreCheckpoint,
+      reverseCheckpointDiff: () => Effect.succeed(true),
       diffCheckpoints: () => Effect.succeed(""),
       deleteCheckpointRefs: () => Effect.void,
       ...input?.checkpointStore,

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1347,6 +1347,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           turnCount: command.turnCount,
+          scope: command.scope ?? "thread",
           createdAt: command.createdAt,
         },
       };

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1615,6 +1615,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           files: command.files,
           assistantMessageId: command.assistantMessageId ?? null,
           completedAt: command.completedAt,
+          ...(command.preserveLatestTurn ? { preserveLatestTurn: true } : {}),
         },
       };
     }

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -372,7 +372,7 @@ describe("orchestration projector", () => {
     expect(thread?.session?.status).toBe("running");
   });
 
-  it("keeps latest turn running when an interim provider diff placeholder arrives", async () => {
+  it("keeps latest turn running for interim and explicitly preserving diff events", async () => {
     const createdAt = "2026-02-23T08:00:00.000Z";
     const startedAt = "2026-02-23T08:00:05.000Z";
     const placeholderAt = "2026-02-23T08:00:06.000Z";
@@ -460,6 +460,37 @@ describe("orchestration projector", () => {
 
     expect(afterPlaceholder.threads[0]?.checkpoints).toHaveLength(1);
     expect(afterPlaceholder.threads[0]?.latestTurn).toMatchObject({
+      turnId: "turn-1",
+      state: "running",
+      completedAt: null,
+    });
+
+    const afterPreservedDiff = await Effect.runPromise(
+      projectEvent(
+        afterPlaceholder,
+        makeEvent({
+          sequence: 4,
+          type: "thread.turn-diff-completed",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: placeholderAt,
+          commandId: "cmd-preserved-diff",
+          payload: {
+            threadId: "thread-1",
+            turnId: "turn-0",
+            checkpointTurnCount: 1,
+            checkpointRef: "refs/synara/checkpoints/thread-1/turn/0",
+            status: "ready",
+            files: [],
+            assistantMessageId: "assistant-0",
+            completedAt: placeholderAt,
+            preserveLatestTurn: true,
+          },
+        }),
+      ),
+    );
+
+    expect(afterPreservedDiff.threads[0]?.latestTurn).toMatchObject({
       turnId: "turn-1",
       state: "running",
       completedAt: null,

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -920,11 +920,18 @@ export function projectEvent(
           (thread.latestTurn?.turnId === payload.turnId
             ? thread.latestTurn.assistantMessageId
             : null);
-        const latestTurn =
-          isProviderDiffPlaceholderRef(payload.checkpointRef) &&
-          payload.status === "missing" &&
-          thread.latestTurn?.turnId === payload.turnId &&
-          thread.latestTurn.state === "running"
+        const previousLatestCheckpointTurnCount = thread.checkpoints.find(
+          (entry) => entry.turnId === thread.latestTurn?.turnId,
+        )?.checkpointTurnCount;
+        const preservesNewerLatestTurn =
+          previousLatestCheckpointTurnCount !== undefined &&
+          previousLatestCheckpointTurnCount > payload.checkpointTurnCount;
+        const latestTurn = preservesNewerLatestTurn
+          ? thread.latestTurn
+          : isProviderDiffPlaceholderRef(payload.checkpointRef) &&
+              payload.status === "missing" &&
+              thread.latestTurn?.turnId === payload.turnId &&
+              thread.latestTurn.state === "running"
             ? thread.latestTurn
             : {
                 turnId: payload.turnId,

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -924,8 +924,9 @@ export function projectEvent(
           (entry) => entry.turnId === thread.latestTurn?.turnId,
         )?.checkpointTurnCount;
         const preservesNewerLatestTurn =
-          previousLatestCheckpointTurnCount !== undefined &&
-          previousLatestCheckpointTurnCount > payload.checkpointTurnCount;
+          payload.preserveLatestTurn === true ||
+          (previousLatestCheckpointTurnCount !== undefined &&
+            previousLatestCheckpointTurnCount > payload.checkpointTurnCount);
         const latestTurn = preservesNewerLatestTurn
           ? thread.latestTurn
           : isProviderDiffPlaceholderRef(payload.checkpointRef) &&

--- a/apps/server/src/profileStatsArchive.test.ts
+++ b/apps/server/src/profileStatsArchive.test.ts
@@ -53,6 +53,7 @@ const checkpointStoreTestLayer = Layer.succeed(CheckpointStore, {
   copyCheckpointRef: () => Effect.die("unused checkpoint store test method"),
   hasCheckpointRef: () => Effect.die("unused checkpoint store test method"),
   restoreCheckpoint: () => Effect.die("unused checkpoint store test method"),
+  reverseCheckpointDiff: () => Effect.die("unused checkpoint store test method"),
   diffCheckpoints: () => Effect.die("unused checkpoint store test method"),
   deleteCheckpointRefs: (input) => deleteCheckpointRefsImpl(input),
 } satisfies CheckpointStoreShape);

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,4 +1,4 @@
-import { ThreadId, TurnId, type ModelSlug } from "@synara/contracts";
+import { CheckpointRef, EventId, ThreadId, TurnId, type ModelSlug } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -9,6 +9,7 @@ import {
   derivePromptHistoryFromMessages,
   failWorktreeSetupSnapshot,
   filterSidechatTranscriptMessages,
+  hasFileUndoSettled,
   isComposerCursorOnFirstLine,
   isComposerCursorOnLastLine,
   type LocalDispatchSnapshot,
@@ -42,6 +43,88 @@ import {
   shouldRenderTerminalWorkspace,
   worktreeSetupHasError,
 } from "./ChatView.logic";
+
+describe("file undo completion", () => {
+  const pending = {
+    threadId: ThreadId.makeUnsafe("thread-file-undo"),
+    turnCount: 2,
+    existingFailureActivityIds: [],
+  };
+  const summary = {
+    turnId: TurnId.makeUnsafe("turn-2"),
+    checkpointTurnCount: 2,
+    checkpointTurnCounts: [2],
+    checkpointRef: CheckpointRef.makeUnsafe("refs/synara/checkpoints/thread-file-undo/turn/2"),
+    status: "ready" as const,
+    completedAt: "2026-07-12T17:59:00.000Z",
+    files: [{ path: "src/file.ts", additions: 1, deletions: 0 }],
+  };
+
+  it("stays pending after command acceptance until the projected file diff settles", () => {
+    const baseThread = {
+      id: pending.threadId,
+      turnDiffSummaries: [summary],
+      activities: [],
+    };
+
+    expect(hasFileUndoSettled({ pending, thread: baseThread })).toBe(false);
+    expect(
+      hasFileUndoSettled({
+        pending,
+        thread: {
+          ...baseThread,
+          turnDiffSummaries: [{ ...summary, files: [] }],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("settles when the matching revert failure is projected", () => {
+    expect(
+      hasFileUndoSettled({
+        pending,
+        thread: {
+          id: pending.threadId,
+          turnDiffSummaries: [summary],
+          activities: [
+            {
+              id: EventId.makeUnsafe("activity-file-undo-failed"),
+              tone: "error",
+              kind: "checkpoint.revert.failed",
+              summary: "Checkpoint revert failed",
+              payload: { turnCount: 2, detail: "reset failed" },
+              turnId: null,
+              createdAt: "2026-07-12T18:00:01.000Z",
+            },
+          ],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores a matching failure activity that predates this undo request", () => {
+    expect(
+      hasFileUndoSettled({
+        pending: { ...pending, existingFailureActivityIds: ["activity-file-undo-failed"] },
+        thread: {
+          id: pending.threadId,
+          turnDiffSummaries: [summary],
+          activities: [
+            {
+              id: EventId.makeUnsafe("activity-file-undo-failed"),
+              tone: "error",
+              kind: "checkpoint.revert.failed",
+              summary: "Checkpoint revert failed",
+              payload: { turnCount: 2, detail: "old failure" },
+              turnId: null,
+              createdAt: "2026-07-12T17:00:00.000Z",
+            },
+          ],
+        },
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("composer menu selection", () => {
   const items = [{ id: "skill:check-code" }, { id: "skill:sanity-check" }] as const;

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -51,6 +51,41 @@ export const PROMPT_HISTORY_MAX_ENTRIES = 100;
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 export const DismissedProviderHealthBannersSchema = Schema.Array(Schema.String);
 
+export interface PendingFileUndo {
+  readonly threadId: ThreadIdType;
+  readonly turnCount: number;
+  readonly existingFailureActivityIds: readonly string[];
+}
+
+export function hasFileUndoSettled(input: {
+  readonly pending: PendingFileUndo;
+  readonly thread: Pick<Thread, "id" | "turnDiffSummaries" | "activities"> | null;
+}): boolean {
+  if (!input.thread || input.thread.id !== input.pending.threadId) {
+    return false;
+  }
+
+  const targetSummary = input.thread.turnDiffSummaries.find(
+    (summary) => summary.checkpointTurnCount === input.pending.turnCount,
+  );
+  if (targetSummary?.files.length === 0) {
+    return true;
+  }
+
+  return input.thread.activities.some((activity) => {
+    if (
+      activity.kind !== "checkpoint.revert.failed" ||
+      input.pending.existingFailureActivityIds.includes(activity.id) ||
+      typeof activity.payload !== "object" ||
+      activity.payload === null ||
+      !("turnCount" in activity.payload)
+    ) {
+      return false;
+    }
+    return activity.payload.turnCount === input.pending.turnCount;
+  });
+}
+
 const ALWAYS_ALLOW_RUNTIME_MODE: RuntimeMode = "full-access";
 
 /**

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3041,10 +3041,14 @@ export default function ChatView({
       });
     }
     return buildTurnDiffSummaryByAssistantMessageId({
-      turnDiffSummaries,
+      turnDiffSummaries: turnDiffSummaries.map((summary) => ({
+        ...summary,
+        checkpointTurnCount:
+          summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId],
+      })),
       messages: messagesForDiffAnchoring,
     });
-  }, [turnDiffSummaries, timelineMessages]);
+  }, [inferredCheckpointTurnCountByTurnId, turnDiffSummaries, timelineMessages]);
   const revertTurnCountByUserMessageId = useMemo(() => {
     const byUserMessageId = new Map<MessageId, number>();
     for (let index = 0; index < timelineEntries.length; index += 1) {
@@ -6255,12 +6259,53 @@ export default function ChatView({
           commandId: newCommandId(),
           threadId: activeThread.id,
           turnCount,
+          scope: "thread",
           createdAt: new Date().toISOString(),
         });
       } catch (err) {
         setThreadError(
           activeThread.id,
           err instanceof Error ? err.message : "Failed to revert thread state.",
+        );
+      }
+      setIsRevertingCheckpoint(false);
+    },
+    [activeThread, hasLiveTurn, isConnecting, isRevertingCheckpoint, isSendBusy, setThreadError],
+  );
+
+  const onUndoTurnFiles = useCallback(
+    async (turnCount: number) => {
+      const api = readNativeApi();
+      if (!api || !activeThread || isRevertingCheckpoint) return;
+
+      if (hasLiveTurn || isSendBusy || isConnecting) {
+        setThreadError(activeThread.id, "Interrupt the current turn before undoing file changes.");
+        return;
+      }
+      const confirmed = await api.dialogs.confirm(
+        [
+          `Undo file changes from turn ${turnCount}?`,
+          "Messages and provider conversation history will be kept.",
+          "This action cannot be undone.",
+        ].join("\n"),
+      );
+      if (!confirmed) return;
+
+      setIsRevertingCheckpoint(true);
+      setThreadError(activeThread.id, null);
+      try {
+        await api.orchestration.dispatchCommand({
+          type: "thread.checkpoint.revert",
+          commandId: newCommandId(),
+          threadId: activeThread.id,
+          turnCount,
+          scope: "files",
+          createdAt: new Date().toISOString(),
+        });
+      } catch (err) {
+        setThreadError(
+          activeThread.id,
+          err instanceof Error ? err.message : "Failed to undo file changes.",
         );
       }
       setIsRevertingCheckpoint(false);
@@ -10923,6 +10968,7 @@ export default function ChatView({
                     onOpenAutomation={onOpenAutomation}
                     revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
                     onRevertUserMessage={onRevertUserMessage}
+                    onUndoTurnFiles={onUndoTurnFiles}
                     onEditUserMessage={onEditUserMessage}
                     isRevertingCheckpoint={isRevertingCheckpoint}
                     onExpandTimelineImage={onExpandTimelineImage}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3045,9 +3045,6 @@ export default function ChatView({
         ...summary,
         checkpointTurnCount:
           summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId],
-        checkpointTurnCounts: [
-          summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId],
-        ].filter((turnCount): turnCount is number => typeof turnCount === "number"),
       })),
       messages: messagesForDiffAnchoring,
     });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3045,6 +3045,9 @@ export default function ChatView({
         ...summary,
         checkpointTurnCount:
           summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId],
+        checkpointTurnCounts: [
+          summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId],
+        ].filter((turnCount): turnCount is number => typeof turnCount === "number"),
       })),
       messages: messagesForDiffAnchoring,
     });
@@ -6274,9 +6277,9 @@ export default function ChatView({
   );
 
   const onUndoTurnFiles = useCallback(
-    async (turnCount: number) => {
+    async (turnCounts: readonly number[]) => {
       const api = readNativeApi();
-      if (!api || !activeThread || isRevertingCheckpoint) return;
+      if (!api || !activeThread || isRevertingCheckpoint || turnCounts.length === 0) return;
 
       if (hasLiveTurn || isSendBusy || isConnecting) {
         setThreadError(activeThread.id, "Interrupt the current turn before undoing file changes.");
@@ -6284,7 +6287,7 @@ export default function ChatView({
       }
       const confirmed = await api.dialogs.confirm(
         [
-          `Undo file changes from turn ${turnCount}?`,
+          "Undo the file changes shown in this card?",
           "Messages and provider conversation history will be kept.",
           "This action cannot be undone.",
         ].join("\n"),
@@ -6294,14 +6297,16 @@ export default function ChatView({
       setIsRevertingCheckpoint(true);
       setThreadError(activeThread.id, null);
       try {
-        await api.orchestration.dispatchCommand({
-          type: "thread.checkpoint.revert",
-          commandId: newCommandId(),
-          threadId: activeThread.id,
-          turnCount,
-          scope: "files",
-          createdAt: new Date().toISOString(),
-        });
+        for (const turnCount of [...new Set(turnCounts)].toSorted((left, right) => right - left)) {
+          await api.orchestration.dispatchCommand({
+            type: "thread.checkpoint.revert",
+            commandId: newCommandId(),
+            threadId: activeThread.id,
+            turnCount,
+            scope: "files",
+            createdAt: new Date().toISOString(),
+          });
+        }
       } catch (err) {
         setThreadError(
           activeThread.id,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -159,7 +159,9 @@ import {
   buildThreadBreadcrumbs,
   derivePromptHistoryFromMessages,
   enrichSubagentWorkEntries,
+  hasFileUndoSettled,
   promptStillMatchesActiveHistoryBrowse,
+  type PendingFileUndo,
   type PromptHistoryNavigationState,
   resolveActiveThreadTitle,
   resolveActiveTurnLiveDiffState,
@@ -1191,6 +1193,7 @@ export default function ChatView({
   const failedWorktreeSetupDispatchStartedAtRef = useRef<string | null>(null);
   const [isLocalConnecting, _setIsLocalConnecting] = useState(false);
   const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
+  const [pendingFileUndo, setPendingFileUndo] = useState<PendingFileUndo | null>(null);
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [respondingRequestIds, setRespondingRequestIds] = useState<ApprovalRequestId[]>([]);
   const [respondingUserInputRequestIds, setRespondingUserInputRequestIds] = useState<
@@ -1592,6 +1595,15 @@ export default function ChatView({
     [draftThread, fallbackDraftProject?.defaultModelSelection, localDraftError, threadId],
   );
   const activeThread = serverThread ?? localDraftThread;
+  useEffect(() => {
+    if (
+      pendingFileUndo &&
+      hasFileUndoSettled({ pending: pendingFileUndo, thread: activeThread ?? null })
+    ) {
+      setPendingFileUndo(null);
+      setIsRevertingCheckpoint(false);
+    }
+  }, [activeThread, pendingFileUndo]);
   const runtimeMode =
     composerDraft.runtimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   const interactionMode =
@@ -6294,22 +6306,32 @@ export default function ChatView({
 
       setIsRevertingCheckpoint(true);
       setThreadError(activeThread.id, null);
+      const turnCount = Math.max(...turnCounts);
+      const requestedAt = new Date().toISOString();
+      setPendingFileUndo({
+        threadId: activeThread.id,
+        turnCount,
+        existingFailureActivityIds: activeThread.activities
+          .filter((activity) => activity.kind === "checkpoint.revert.failed")
+          .map((activity) => activity.id),
+      });
       try {
         await api.orchestration.dispatchCommand({
           type: "thread.checkpoint.revert",
           commandId: newCommandId(),
           threadId: activeThread.id,
-          turnCount: Math.max(...turnCounts),
+          turnCount,
           scope: "files",
-          createdAt: new Date().toISOString(),
+          createdAt: requestedAt,
         });
       } catch (err) {
+        setPendingFileUndo(null);
+        setIsRevertingCheckpoint(false);
         setThreadError(
           activeThread.id,
           err instanceof Error ? err.message : "Failed to undo file changes.",
         );
       }
-      setIsRevertingCheckpoint(false);
     },
     [activeThread, hasLiveTurn, isConnecting, isRevertingCheckpoint, isSendBusy, setThreadError],
   );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -6284,7 +6284,8 @@ export default function ChatView({
       }
       const confirmed = await api.dialogs.confirm(
         [
-          "Undo the file changes shown in this card?",
+          "Undo the latest file changes shown in this card?",
+          "Earlier file changes will remain available to undo.",
           "Messages and provider conversation history will be kept.",
           "This action cannot be undone.",
         ].join("\n"),
@@ -6294,16 +6295,14 @@ export default function ChatView({
       setIsRevertingCheckpoint(true);
       setThreadError(activeThread.id, null);
       try {
-        for (const turnCount of [...new Set(turnCounts)].toSorted((left, right) => right - left)) {
-          await api.orchestration.dispatchCommand({
-            type: "thread.checkpoint.revert",
-            commandId: newCommandId(),
-            threadId: activeThread.id,
-            turnCount,
-            scope: "files",
-            createdAt: new Date().toISOString(),
-          });
-        }
+        await api.orchestration.dispatchCommand({
+          type: "thread.checkpoint.revert",
+          commandId: newCommandId(),
+          threadId: activeThread.id,
+          turnCount: Math.max(...turnCounts),
+          scope: "files",
+          createdAt: new Date().toISOString(),
+        });
       } catch (err) {
         setThreadError(
           activeThread.id,

--- a/apps/web/src/components/chat/ChatTranscriptPane.tsx
+++ b/apps/web/src/components/chat/ChatTranscriptPane.tsx
@@ -75,6 +75,7 @@ interface ChatTranscriptPaneProps {
   onOpenThread: (threadId: ThreadId) => void;
   onOpenAutomation?: ComponentProps<typeof MessagesTimeline>["onOpenAutomation"];
   onRevertUserMessage: (messageId: MessageId) => void;
+  onUndoTurnFiles?: ComponentProps<typeof MessagesTimeline>["onUndoTurnFiles"];
   onEditUserMessage?: (messageId: MessageId, text: string) => boolean | Promise<boolean>;
   onScrollToBottom: () => void;
   onToggleWorkGroup?: (groupId: string) => void;
@@ -131,6 +132,7 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
   onOpenThread,
   onOpenAutomation,
   onRevertUserMessage,
+  onUndoTurnFiles,
   onEditUserMessage,
   onScrollToBottom,
   onToggleWorkGroup,
@@ -214,6 +216,7 @@ export const ChatTranscriptPane = memo(function ChatTranscriptPane({
             {...(onOpenAutomation ? { onOpenAutomation } : {})}
             revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
             onRevertUserMessage={onRevertUserMessage}
+            {...(onUndoTurnFiles ? { onUndoTurnFiles } : {})}
             {...(onEditUserMessage ? { onEditUserMessage } : {})}
             isRevertingCheckpoint={isRevertingCheckpoint}
             onImageExpand={onExpandTimelineImage}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -500,6 +500,40 @@ describe("buildTurnDiffSummaryByAssistantMessageId", () => {
     expect(result.get(MessageId.makeUnsafe("a-final"))?.checkpointTurnCounts).toEqual([1, 2]);
   });
 
+  it("excludes no-change and placeholder mini-turns from merged Undo targets", () => {
+    const result = buildTurnDiffSummaryByAssistantMessageId({
+      turnDiffSummaries: [
+        makeSummary({ turnId: "turn-files", checkpointTurnCount: 1 }),
+        makeSummary({ turnId: "turn-no-files", checkpointTurnCount: 2, files: [] }),
+        makeSummary({
+          turnId: "turn-placeholder",
+          checkpointTurnCount: 3,
+          checkpointRef: CheckpointRef.makeUnsafe("provider-diff:event-3"),
+        }),
+      ],
+      messages: [
+        { id: MessageId.makeUnsafe("u-1"), role: "user", turnId: null },
+        {
+          id: MessageId.makeUnsafe("a-files"),
+          role: "assistant",
+          turnId: TurnId.makeUnsafe("turn-files"),
+        },
+        {
+          id: MessageId.makeUnsafe("a-no-files"),
+          role: "assistant",
+          turnId: TurnId.makeUnsafe("turn-no-files"),
+        },
+        {
+          id: MessageId.makeUnsafe("a-placeholder"),
+          role: "assistant",
+          turnId: TurnId.makeUnsafe("turn-placeholder"),
+        },
+      ],
+    });
+
+    expect(result.get(MessageId.makeUnsafe("a-placeholder"))?.checkpointTurnCounts).toEqual([]);
+  });
+
   it("keeps separate cards for response segments split by user messages", () => {
     const result = buildTurnDiffSummaryByAssistantMessageId({
       turnDiffSummaries: [makeSummary({ turnId: "turn-1" }), makeSummary({ turnId: "turn-2" })],

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -510,6 +510,12 @@ describe("buildTurnDiffSummaryByAssistantMessageId", () => {
           checkpointTurnCount: 3,
           checkpointRef: CheckpointRef.makeUnsafe("provider-diff:event-3"),
         }),
+        makeSummary({
+          turnId: "turn-missing",
+          checkpointTurnCount: 4,
+          status: "missing",
+          checkpointRef: CheckpointRef.makeUnsafe("checkpoint-turn-missing"),
+        }),
       ],
       messages: [
         { id: MessageId.makeUnsafe("u-1"), role: "user", turnId: null },
@@ -528,10 +534,16 @@ describe("buildTurnDiffSummaryByAssistantMessageId", () => {
           role: "assistant",
           turnId: TurnId.makeUnsafe("turn-placeholder"),
         },
+        {
+          id: MessageId.makeUnsafe("a-missing"),
+          role: "assistant",
+          turnId: TurnId.makeUnsafe("turn-missing"),
+        },
       ],
     });
 
-    expect(result.get(MessageId.makeUnsafe("a-placeholder"))?.checkpointTurnCounts).toEqual([]);
+    expect(result.has(MessageId.makeUnsafe("a-placeholder"))).toBe(false);
+    expect(result.get(MessageId.makeUnsafe("a-missing"))?.checkpointTurnCounts).toEqual([]);
   });
 
   it("keeps separate cards for response segments split by user messages", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -500,6 +500,38 @@ describe("buildTurnDiffSummaryByAssistantMessageId", () => {
     expect(result.get(MessageId.makeUnsafe("a-final"))?.checkpointTurnCounts).toEqual([1, 2]);
   });
 
+  it("preserves Undo metadata when an empty placeholder follows file changes", () => {
+    const result = buildTurnDiffSummaryByAssistantMessageId({
+      turnDiffSummaries: [
+        makeSummary({ turnId: "turn-files", checkpointTurnCount: 1 }),
+        makeSummary({
+          turnId: "turn-empty-placeholder",
+          status: "missing",
+          checkpointRef: CheckpointRef.makeUnsafe("provider-diff:event-empty"),
+          files: [],
+        }),
+      ],
+      messages: [
+        { id: MessageId.makeUnsafe("u-1"), role: "user", turnId: null },
+        {
+          id: MessageId.makeUnsafe("a-files"),
+          role: "assistant",
+          turnId: TurnId.makeUnsafe("turn-files"),
+        },
+        {
+          id: MessageId.makeUnsafe("a-empty-placeholder"),
+          role: "assistant",
+          turnId: TurnId.makeUnsafe("turn-empty-placeholder"),
+        },
+      ],
+    });
+
+    const summary = result.get(MessageId.makeUnsafe("a-empty-placeholder"));
+    expect(summary?.checkpointTurnCounts).toEqual([1]);
+    expect(summary?.status).toBe("ready");
+    expect(summary?.checkpointRef).toBe(CheckpointRef.makeUnsafe("checkpoint-turn-files"));
+  });
+
   it("excludes no-change and placeholder mini-turns from merged Undo targets", () => {
     const result = buildTurnDiffSummaryByAssistantMessageId({
       turnDiffSummaries: [

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -469,10 +469,12 @@ describe("buildTurnDiffSummaryByAssistantMessageId", () => {
       turnDiffSummaries: [
         makeSummary({
           turnId: "turn-files",
+          checkpointTurnCount: 1,
           files: [{ path: "a.ts", additions: 1, deletions: 0 }],
         }),
         makeSummary({
           turnId: "turn-final",
+          checkpointTurnCount: 2,
           files: [{ path: "b.ts", additions: 0, deletions: 1 }],
         }),
       ],
@@ -495,6 +497,7 @@ describe("buildTurnDiffSummaryByAssistantMessageId", () => {
       "a.ts",
       "b.ts",
     ]);
+    expect(result.get(MessageId.makeUnsafe("a-final"))?.checkpointTurnCounts).toEqual([1, 2]);
   });
 
   it("keeps separate cards for response segments split by user messages", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -225,27 +225,42 @@ function mergeTurnDiffSummaries(
   existing: TurnDiffSummary | undefined,
   next: TurnDiffSummary,
 ): TurnDiffSummary {
-  if (!existing) return next;
+  const checkpointTurnCountsFor = (summary: TurnDiffSummary): number[] => {
+    if (
+      summary.files.length === 0 ||
+      summary.checkpointRef === undefined ||
+      summary.checkpointRef.startsWith("provider-diff:")
+    ) {
+      return [];
+    }
+    return (
+      summary.checkpointTurnCounts ??
+      (summary.checkpointTurnCount === undefined ? [] : [summary.checkpointTurnCount])
+    );
+  };
+  if (!existing) {
+    const checkpointTurnCounts = checkpointTurnCountsFor(next);
+    return { ...next, checkpointTurnCounts };
+  }
 
   const filesByPath = new Map(existing.files.map((file) => [file.path, file]));
   for (const file of next.files) {
     filesByPath.set(file.path, file);
   }
   const checkpointTurnCounts = new Set([
-    ...(existing.checkpointTurnCounts ??
-      (existing.checkpointTurnCount === undefined ? [] : [existing.checkpointTurnCount])),
-    ...(next.checkpointTurnCounts ??
-      (next.checkpointTurnCount === undefined ? [] : [next.checkpointTurnCount])),
+    ...checkpointTurnCountsFor(existing),
+    ...checkpointTurnCountsFor(next),
   ]);
+  const allDisplayedFilesUndoable = [existing, next].every(
+    (summary) => summary.files.length === 0 || checkpointTurnCountsFor(summary).length > 0,
+  );
 
   return {
     ...next,
     files: [...filesByPath.values()],
-    ...(checkpointTurnCounts.size === 0
-      ? {}
-      : {
-          checkpointTurnCounts: [...checkpointTurnCounts].toSorted((left, right) => left - right),
-        }),
+    checkpointTurnCounts: allDisplayedFilesUndoable
+      ? [...checkpointTurnCounts].toSorted((left, right) => left - right)
+      : [],
   };
 }
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -228,6 +228,8 @@ function mergeTurnDiffSummaries(
   const checkpointTurnCountsFor = (summary: TurnDiffSummary): number[] => {
     if (
       summary.files.length === 0 ||
+      summary.status === "missing" ||
+      summary.status === "error" ||
       summary.checkpointRef === undefined ||
       summary.checkpointRef.startsWith("provider-diff:")
     ) {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -253,6 +253,12 @@ function mergeTurnDiffSummaries(
     ...checkpointTurnCountsFor(existing),
     ...checkpointTurnCountsFor(next),
   ]);
+  const undoMetadata =
+    checkpointTurnCountsFor(next).length > 0
+      ? next
+      : checkpointTurnCountsFor(existing).length > 0
+        ? existing
+        : next;
   const allDisplayedFilesUndoable = [existing, next].every(
     (summary) => summary.files.length === 0 || checkpointTurnCountsFor(summary).length > 0,
   );
@@ -260,6 +266,9 @@ function mergeTurnDiffSummaries(
   return {
     ...next,
     files: [...filesByPath.values()],
+    checkpointRef: undoMetadata.checkpointRef,
+    status: undoMetadata.status,
+    checkpointTurnCount: undoMetadata.checkpointTurnCount,
     checkpointTurnCounts: allDisplayedFilesUndoable
       ? [...checkpointTurnCounts].toSorted((left, right) => left - right)
       : [],

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -231,10 +231,21 @@ function mergeTurnDiffSummaries(
   for (const file of next.files) {
     filesByPath.set(file.path, file);
   }
+  const checkpointTurnCounts = new Set([
+    ...(existing.checkpointTurnCounts ??
+      (existing.checkpointTurnCount === undefined ? [] : [existing.checkpointTurnCount])),
+    ...(next.checkpointTurnCounts ??
+      (next.checkpointTurnCount === undefined ? [] : [next.checkpointTurnCount])),
+  ]);
 
   return {
     ...next,
     files: [...filesByPath.values()],
+    ...(checkpointTurnCounts.size === 0
+      ? {}
+      : {
+          checkpointTurnCounts: [...checkpointTurnCounts].toSorted((left, right) => left - right),
+        }),
   };
 }
 

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -3,7 +3,7 @@
 // Layer: Web chat component tests
 // Depends on: renderToStaticMarkup and a mocked LegendList.
 
-import { MessageId, TurnId } from "@synara/contracts";
+import { CheckpointRef, MessageId, TurnId } from "@synara/contracts";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { formatShortTimestamp } from "../../timestampFormat";
@@ -2640,6 +2640,9 @@ describe("MessagesTimeline", () => {
               {
                 turnId: TurnId.makeUnsafe("turn-diff-1"),
                 checkpointTurnCount: 1,
+                checkpointTurnCounts: [1],
+                checkpointRef: CheckpointRef.makeUnsafe("refs/synara/checkpoints/thread/turn/1"),
+                status: "ready",
                 completedAt: "2026-03-17T19:12:30.000Z",
                 assistantMessageId,
                 files: [

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -2639,6 +2639,7 @@ describe("MessagesTimeline", () => {
               assistantMessageId,
               {
                 turnId: TurnId.makeUnsafe("turn-diff-1"),
+                checkpointTurnCount: 1,
                 completedAt: "2026-03-17T19:12:30.000Z",
                 assistantMessageId,
                 files: [
@@ -2654,6 +2655,7 @@ describe("MessagesTimeline", () => {
         onOpenTurnDiff={() => {}}
         revertTurnCountByUserMessageId={new Map()}
         onRevertUserMessage={() => {}}
+        onUndoTurnFiles={() => {}}
         isRevertingCheckpoint={false}
         onImageExpand={() => {}}
         markdownCwd={undefined}
@@ -2664,6 +2666,7 @@ describe("MessagesTimeline", () => {
     );
 
     expect(markup).toContain("Edited 1 file");
+    expect(markup).toContain("Undo");
     expect(markup).toContain("Review");
     expect(markup).toContain('aria-expanded="true"');
     expect(markup).toContain("font-system-ui truncate font-normal");

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -407,6 +407,7 @@ interface MessagesTimelineProps {
   onOpenAutomation?: (automationId: string) => void;
   revertTurnCountByUserMessageId: Map<MessageId, number>;
   onRevertUserMessage: (messageId: MessageId) => void;
+  onUndoTurnFiles?: (turnCount: number) => void;
   onEditUserMessage?: (messageId: MessageId, text: string) => boolean | Promise<boolean>;
   activeTurnId?: TurnId | null;
   isRevertingCheckpoint: boolean;
@@ -463,6 +464,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   onOpenAutomation,
   revertTurnCountByUserMessageId,
   onRevertUserMessage,
+  onUndoTurnFiles,
   onEditUserMessage,
   activeTurnId,
   isRevertingCheckpoint,
@@ -810,19 +812,6 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     });
     return editTarget.editable ? (editTarget.messageId as MessageId) : null;
   }, [activeTurnId, rows]);
-  const userMessageIdByAssistantMessageId = useMemo(() => {
-    const map = new Map<MessageId, MessageId>();
-    let lastUserMessageId: MessageId | null = null;
-    for (const row of rows) {
-      if (row.kind !== "message") continue;
-      if (row.message.role === "user") {
-        lastUserMessageId = row.message.id;
-      } else if (row.message.role === "assistant" && lastUserMessageId) {
-        map.set(row.message.id, lastUserMessageId);
-      }
-    }
-    return map;
-  }, [rows]);
   const previousRowCountRef = useRef(rows.length);
   useEffect(() => {
     const previousRowCount = previousRowCountRef.current;
@@ -1591,12 +1580,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   const fileChangesExpanded =
                     expandedFileChangesByTurnId[turnSummary.turnId] ?? true;
                   const fileListExpanded = expandedFileListByTurnId[turnSummary.turnId] ?? false;
-                  const correspondingUserMessageId = userMessageIdByAssistantMessageId.get(
-                    row.message.id,
-                  );
+                  const checkpointTurnCount = turnSummary.checkpointTurnCount;
                   const canUndo =
-                    correspondingUserMessageId != null &&
-                    revertTurnCountByUserMessageId.has(correspondingUserMessageId);
+                    typeof checkpointTurnCount === "number" && onUndoTurnFiles !== undefined;
                   const totalAdditions = checkpointFiles.reduce(
                     (sum, file) => sum + (file.additions ?? 0),
                     0,
@@ -1687,7 +1673,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                               type="button"
                               className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
                               style={{ fontSize: chatTypographyStyle.fontSize }}
-                              onClick={() => onRevertUserMessage(correspondingUserMessageId)}
+                              onClick={() => onUndoTurnFiles(checkpointTurnCount)}
                             >
                               Undo
                               <Undo2Icon className="size-3" />

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1584,7 +1584,13 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                   const checkpointTurnCounts =
                     turnSummary.checkpointTurnCounts ??
                     (checkpointTurnCount === undefined ? [] : [checkpointTurnCount]);
-                  const canUndo = checkpointTurnCounts.length > 0 && onUndoTurnFiles !== undefined;
+                  const canUndo =
+                    turnSummary.status !== "missing" &&
+                    turnSummary.status !== "error" &&
+                    turnSummary.checkpointRef !== undefined &&
+                    !turnSummary.checkpointRef.startsWith("provider-diff:") &&
+                    checkpointTurnCounts.length > 0 &&
+                    onUndoTurnFiles !== undefined;
                   const totalAdditions = checkpointFiles.reduce(
                     (sum, file) => sum + (file.additions ?? 0),
                     0,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -407,7 +407,7 @@ interface MessagesTimelineProps {
   onOpenAutomation?: (automationId: string) => void;
   revertTurnCountByUserMessageId: Map<MessageId, number>;
   onRevertUserMessage: (messageId: MessageId) => void;
-  onUndoTurnFiles?: (turnCount: number) => void;
+  onUndoTurnFiles?: (turnCounts: readonly number[]) => void;
   onEditUserMessage?: (messageId: MessageId, text: string) => boolean | Promise<boolean>;
   activeTurnId?: TurnId | null;
   isRevertingCheckpoint: boolean;
@@ -1581,8 +1581,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     expandedFileChangesByTurnId[turnSummary.turnId] ?? true;
                   const fileListExpanded = expandedFileListByTurnId[turnSummary.turnId] ?? false;
                   const checkpointTurnCount = turnSummary.checkpointTurnCount;
-                  const canUndo =
-                    typeof checkpointTurnCount === "number" && onUndoTurnFiles !== undefined;
+                  const checkpointTurnCounts =
+                    turnSummary.checkpointTurnCounts ??
+                    (checkpointTurnCount === undefined ? [] : [checkpointTurnCount]);
+                  const canUndo = checkpointTurnCounts.length > 0 && onUndoTurnFiles !== undefined;
                   const totalAdditions = checkpointFiles.reduce(
                     (sum, file) => sum + (file.additions ?? 0),
                     0,
@@ -1673,7 +1675,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                               type="button"
                               className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
                               style={{ fontSize: chatTypographyStyle.fontSize }}
-                              onClick={() => onUndoTurnFiles(checkpointTurnCount)}
+                              onClick={() => onUndoTurnFiles(checkpointTurnCounts)}
                             >
                               Undo
                               <Undo2Icon className="size-3" />

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -139,6 +139,7 @@ export interface TurnDiffSummary {
   checkpointRef?: CheckpointRef | undefined;
   assistantMessageId?: MessageId | undefined;
   checkpointTurnCount?: number | undefined;
+  checkpointTurnCounts?: number[] | undefined;
 }
 
 // Ephemeral client-side progress of the "New worktree" first-send setup

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1145,6 +1145,7 @@ const ThreadCheckpointRevertCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   turnCount: NonNegativeInt,
+  scope: Schema.optional(Schema.Literals(["thread", "files"])),
   createdAt: IsoDateTime,
 });
 
@@ -1636,6 +1637,9 @@ const ThreadUserInputResponseRequestedPayload = Schema.Struct({
 export const ThreadCheckpointRevertRequestedPayload = Schema.Struct({
   threadId: ThreadId,
   turnCount: NonNegativeInt,
+  scope: Schema.optional(Schema.Literals(["thread", "files"])).pipe(
+    Schema.withDecodingDefault(() => "thread"),
+  ),
   createdAt: IsoDateTime,
 });
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -1306,6 +1306,7 @@ const ThreadTurnDiffCompleteCommand = Schema.Struct({
   files: Schema.Array(OrchestrationCheckpointFile),
   assistantMessageId: Schema.optional(MessageId),
   checkpointTurnCount: NonNegativeInt,
+  preserveLatestTurn: Schema.optional(Schema.Boolean),
   createdAt: IsoDateTime,
 });
 
@@ -1701,6 +1702,7 @@ export const ThreadTurnDiffCompletedPayload = Schema.Struct({
   files: Schema.Array(OrchestrationCheckpointFile),
   assistantMessageId: Schema.NullOr(MessageId),
   completedAt: IsoDateTime,
+  preserveLatestTurn: Schema.optional(Schema.Boolean),
 });
 
 export const ThreadActivityAppendedPayload = Schema.Struct({


### PR DESCRIPTION
## Summary

- make the file/diff card Undo reverse only that turn's checkpoint diff
- preserve transcript messages and provider conversation state
- keep explicit full-message/thread revert behavior unchanged
- keep sequential file undos from restoring already-undone changes

## Root cause

The file-change card and the user-message revert action both dispatched the same full checkpoint revert. That path restores the whole workspace checkpoint, rolls back provider turns, and emits `thread.reverted`, which intentionally trims newer transcript messages.

## Verification

- `bun run --cwd apps/server test src/orchestration/Layers/CheckpointReactor.test.ts`
- `bun run --cwd apps/web test src/components/chat/MessagesTimeline.test.tsx`
- `bun fmt`
- `bun lint` (0 errors; existing warnings only)
- `bun typecheck`
- `git diff --check`

Fixes #285

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git worktree/index manipulation and orchestration revert paths; mistakes could corrupt workspace state or confuse revert vs file-undo behavior, though scope is explicit and covered by integration tests.
> 
> **Overview**
> **File-change card Undo** no longer triggers a full thread checkpoint revert. It dispatches `thread.checkpoint.revert` with **`scope: "files"`**, which reverses only that turn’s git diff onto the workspace while **keeping messages and provider conversation** intact.
> 
> The server adds **`CheckpointStore.reverseCheckpointDiff`** (reverse-apply patch, index reset, re-apply on reset failure) and **`CheckpointReactor`** handling for file scope: sequential undo of the latest undoable turn, baseline ref resolution, checkpoint ref realignment after undo, and a **`thread.turn.diff.complete`** with empty files plus **`preserveLatestTurn`**. Full **`scope: "thread"`** revert (user-message revert path) still restores checkpoints, rolls back the provider, and emits **`thread.reverted`**.
> 
> Contracts and projection honor optional **`scope`** on revert and **`preserveLatestTurn`** on turn-diff events so **`latestTurn`** does not jump backward after file undo. The web UI wires the diff card **Undo** to file scope, tracks pending undo via **`hasFileUndoSettled`**, and merges **`checkpointTurnCounts`** so multi-segment answers undo the right turns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4149caf1cffdce4d17aa9dddf46c35a4efe09a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->