### PR TITLE
Collapse Cursor xAI/Grok model variants into base + reasoning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -594,3 +594,5 @@ jobs:
           git add apps/server/package.json apps/desktop/package.json apps/web/package.json packages/contracts/package.json bun.lock
           git commit -m "chore(release): prepare $RELEASE_TAG"
           git push origin HEAD:main
+
+# Keep workflow registered for fork Actions dispatch.

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -624,10 +624,11 @@ function cursorModelOptionsFromCliModelId(model: string | null | undefined): Cur
 
   const lower = trimmed.toLowerCase();
   const reasoningEffort = parseCursorCliReasoningEffort(lower);
+  const tokens = lower.split("-").filter((token) => token.length > 0);
   return {
     ...(reasoningEffort ? { reasoningEffort } : {}),
-    ...(lower.endsWith("-fast") ? { fastMode: true } : {}),
-    ...(lower.includes("-thinking") ? { thinking: true } : {}),
+    ...(tokens.includes("fast") ? { fastMode: true } : {}),
+    ...(tokens.includes("thinking") ? { thinking: true } : {}),
     ...(isCursorCliOneMillionContextModel(lower) ? { contextWindow: "1m" } : {}),
   };
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -520,7 +520,7 @@ import {
 import { useLocalStorage } from "~/hooks/useLocalStorage";
 import { useComposerSlashCommands } from "../hooks/useComposerSlashCommands";
 import { useFeatureFlags } from "../featureFlags";
-import { mergeCursorModelVariantsWithBaseControls } from "../cursorModelVariants";
+import { collapseCursorModelVariants } from "../cursorModelVariants";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import {
   canCreateThreadHandoff,
@@ -2055,7 +2055,7 @@ export default function ChatView({
     () =>
       showExpandedCursorModelVariants
         ? (cursorDynamicModelsQuery.data?.models ?? [])
-        : mergeCursorModelVariantsWithBaseControls(cursorDynamicModelsQuery.data?.models ?? []),
+        : collapseCursorModelVariants(cursorDynamicModelsQuery.data?.models ?? []),
     [cursorDynamicModelsQuery.data?.models, showExpandedCursorModelVariants],
   );
   const cursorModelDiscoveryEnabled =

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -8,6 +8,7 @@ import { resolveSelectableModel } from "@synara/shared/model";
 import * as Schema from "effect/Schema";
 import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { type ProviderPickerKind, PROVIDER_OPTIONS } from "../../session-logic";
+import { normalizeCursorModelVariantBaseId } from "../../cursorModelVariants";
 import { formatProviderModelOptionName } from "../../providerModelOptions";
 import { compareProvidersByOrder } from "../../providerOrdering";
 import {
@@ -148,17 +149,24 @@ function resolveSelectedModelLabel(input: {
     return exact.name;
   }
   if (input.provider === "cursor") {
-    const baseModel = stripParameterizedModelSuffix(input.model);
-    const baseMatch = input.options.find(
-      (option) => stripParameterizedModelSuffix(option.slug) === baseModel,
-    );
+    const selectedBase =
+      normalizeCursorModelVariantBaseId(input.model) ?? stripParameterizedModelSuffix(input.model);
+    const baseMatch = input.options.find((option) => {
+      const optionBase =
+        normalizeCursorModelVariantBaseId(option.slug) ??
+        stripParameterizedModelSuffix(option.slug);
+      return optionBase === selectedBase || option.slug === selectedBase;
+    });
     if (baseMatch) {
       return baseMatch.name;
     }
   }
   return formatProviderModelOptionName({
     provider: input.provider,
-    slug: input.model,
+    slug:
+      input.provider === "cursor"
+        ? (normalizeCursorModelVariantBaseId(input.model) ?? input.model)
+        : input.model,
   });
 }
 
@@ -350,17 +358,24 @@ export const ProviderModelMenuItems = memo(function ProviderModelMenuItems(
             favoriteSlugs: favoriteModelSlugSet,
           })
         : groupProviderModelOptions(filteredOptions);
+    const selectedModelValue =
+      activeProvider === provider
+        ? (resolveSelectableModel(provider, props.model, providerOptions) ??
+          (provider === "cursor"
+            ? (normalizeCursorModelVariantBaseId(props.model) ?? props.model)
+            : props.model))
+        : "";
 
     const content =
       groupedOptions.length > 0 ? (
         <MenuRadioGroup
-          value={activeProvider === provider ? props.model : ""}
+          value={selectedModelValue}
           onValueChange={(value) => handleModelChange(provider, value)}
         >
           <ProviderModelOptionGroupList
             groupedOptions={groupedOptions}
             provider={provider}
-            activeModel={props.model}
+            activeModel={selectedModelValue || props.model}
             isSearching={normalizedModelSearchQuery.length > 0}
             favoriteProvider={favoriteProvider}
             favoriteModelSlugSet={favoriteModelSlugSet}

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -39,6 +39,7 @@ import {
 import { useMemo } from "react";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { resolveAppModelSelection } from "./appSettings";
+import { canonicalizeCursorModelSelection } from "./cursorModelVariants";
 import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
@@ -1501,8 +1502,8 @@ function normalizeModelSelection(
   }
   const inferredClaudeAutoCompactWindow =
     provider === "claudeAgent" && /\[1m\]$/iu.test(rawModel) ? "1m" : undefined;
-  const model = normalizeModelSlug(rawModel, provider);
-  if (!model) {
+  const normalizedSlug = normalizeModelSlug(rawModel, provider);
+  if (!normalizedSlug) {
     return null;
   }
   const modelOptions = normalizeProviderModelOptions(
@@ -1534,7 +1535,14 @@ function normalizeModelSelection(
                   : provider === "pi"
                     ? modelOptions?.pi
                     : undefined;
-  return makeModelSelection(provider, model, options);
+  if (provider === "cursor") {
+    const canonical = canonicalizeCursorModelSelection({
+      model: normalizedSlug,
+      options,
+    });
+    return makeModelSelection(provider, canonical.model, canonical.options);
+  }
+  return makeModelSelection(provider, normalizedSlug, options);
 }
 
 // ── Sticky selection sanitization ─────────────────────────────────────

--- a/apps/web/src/cursorModelVariants.test.ts
+++ b/apps/web/src/cursorModelVariants.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  canonicalizeCursorModelSelection,
   collapseCursorModelVariants,
+  cursorModelOptionsFromVariantSlug,
   mergeCursorModelVariantsWithBaseControls,
   normalizeCursorModelVariantBaseId,
 } from "./cursorModelVariants";
@@ -16,6 +18,52 @@ describe("normalizeCursorModelVariantBaseId", () => {
       "claude-opus-4-6",
     );
     expect(normalizeCursorModelVariantBaseId("claude-5-sonnet-max-fast")).toBe("claude-sonnet-5");
+    expect(normalizeCursorModelVariantBaseId("grok-4-5-fast-high")).toBe("grok-4-5");
+    expect(normalizeCursorModelVariantBaseId("grok-4.5-high-fast")).toBe("grok-4.5");
+  });
+});
+
+describe("cursorModelOptionsFromVariantSlug", () => {
+  it("extracts reasoning and fast traits from Grok CLI variant ids", () => {
+    expect(cursorModelOptionsFromVariantSlug("grok-4-5-fast-high")).toEqual({
+      reasoningEffort: "high",
+      fastMode: true,
+    });
+    expect(cursorModelOptionsFromVariantSlug("grok-4.5-high-fast")).toEqual({
+      reasoningEffort: "high",
+      fastMode: true,
+    });
+  });
+});
+
+describe("canonicalizeCursorModelSelection", () => {
+  it("rewrites Grok Fast High variants onto a base model with selectors", () => {
+    expect(
+      canonicalizeCursorModelSelection({
+        model: "grok-4-5-fast-high",
+      }),
+    ).toEqual({
+      model: "grok-4-5",
+      options: {
+        reasoningEffort: "high",
+        fastMode: true,
+      },
+    });
+  });
+
+  it("keeps explicit options over slug-inferred traits", () => {
+    expect(
+      canonicalizeCursorModelSelection({
+        model: "grok-4-5-fast-high",
+        options: { reasoningEffort: "medium", fastMode: false },
+      }),
+    ).toEqual({
+      model: "grok-4-5",
+      options: {
+        reasoningEffort: "medium",
+        fastMode: false,
+      },
+    });
   });
 });
 
@@ -99,6 +147,51 @@ describe("collapseCursorModelVariants", () => {
           { value: "1m", label: "1M" },
         ],
         defaultContextWindow: "272k",
+      },
+    ]);
+  });
+
+  it("collapses Grok Fast High CLI variants like GPT and Claude", () => {
+    expect(
+      collapseCursorModelVariants([
+        {
+          slug: "grok-4-5-fast-high",
+          name: "Grok 4.5 Fast High",
+          upstreamProviderId: "xai",
+          upstreamProviderName: "xAI",
+          supportedReasoningEfforts: [{ value: "high", label: "High" }],
+          defaultReasoningEffort: "high",
+        },
+        {
+          slug: "grok-4-5-fast-medium",
+          name: "Grok 4.5 Fast Medium",
+          upstreamProviderId: "xai",
+          upstreamProviderName: "xAI",
+          supportedReasoningEfforts: [{ value: "medium", label: "Medium" }],
+          defaultReasoningEffort: "medium",
+        },
+        {
+          slug: "grok-4-5-low",
+          name: "Grok 4.5 Low",
+          upstreamProviderId: "xai",
+          upstreamProviderName: "xAI",
+          supportedReasoningEfforts: [{ value: "low", label: "Low" }],
+          defaultReasoningEffort: "low",
+        },
+      ]),
+    ).toEqual([
+      {
+        slug: "grok-4-5",
+        name: "Grok 4.5",
+        upstreamProviderId: "xai",
+        upstreamProviderName: "xAI",
+        supportedReasoningEfforts: [
+          { value: "high", label: "High", isDefault: true },
+          { value: "medium", label: "Medium" },
+          { value: "low", label: "Low" },
+        ],
+        defaultReasoningEffort: "high",
+        supportsFastMode: true,
       },
     ]);
   });

--- a/apps/web/src/cursorModelVariants.ts
+++ b/apps/web/src/cursorModelVariants.ts
@@ -1,4 +1,4 @@
-import type { ProviderModelDescriptor } from "@synara/contracts";
+import type { CursorModelOptions, ProviderModelDescriptor } from "@synara/contracts";
 
 function uniqueByValue<T extends { readonly value: string }>(values: ReadonlyArray<T>): T[] {
   const seen = new Set<string>();
@@ -54,6 +54,21 @@ function stripCursorParameterizedSuffix(value: string): string {
   return value.trim().replace(/\[[^\]]*\]$/u, "");
 }
 
+function cursorVariantSlugTokens(model: string): string[] {
+  return stripCursorParameterizedSuffix(model)
+    .toLowerCase()
+    .split("-")
+    .filter((token) => token.length > 0);
+}
+
+function cursorVariantHasFastMode(model: string): boolean {
+  return cursorVariantSlugTokens(model).includes("fast");
+}
+
+function cursorVariantHasThinking(model: string): boolean {
+  return cursorVariantSlugTokens(model).includes("thinking");
+}
+
 export function normalizeCursorModelVariantBaseId(model: string | null | undefined): string | null {
   const trimmed = model?.trim();
   if (!trimmed) {
@@ -84,9 +99,73 @@ export function normalizeCursorModelVariantBaseId(model: string | null | undefin
   return base;
 }
 
+/**
+ * Infers Cursor trait options encoded in flat CLI variant ids such as
+ * `grok-4-5-fast-high` so the composer can keep a base model + selectors.
+ */
+export function cursorModelOptionsFromVariantSlug(
+  model: string | null | undefined,
+): CursorModelOptions {
+  const trimmed = model?.trim();
+  if (!trimmed || trimmed.includes("[")) {
+    return {};
+  }
+
+  const reasoningEffort = parseCursorCliReasoningEffort(trimmed);
+  return {
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+    ...(cursorVariantHasFastMode(trimmed) ? { fastMode: true } : {}),
+    ...(cursorVariantHasThinking(trimmed) ? { thinking: true } : {}),
+  };
+}
+
+/**
+ * Rewrites a Cursor CLI trait variant onto its base slug, preserving effort /
+ * fast / thinking as model options (matching GPT and Claude composer UX).
+ */
+export function canonicalizeCursorModelSelection(input: {
+  model: string;
+  options?: CursorModelOptions | null | undefined;
+}): {
+  model: string;
+  options: CursorModelOptions | undefined;
+} {
+  const trimmedModel = input.model.trim();
+  const baseModel = normalizeCursorModelVariantBaseId(trimmedModel) ?? trimmedModel;
+  const inferredFromSlug = cursorModelOptionsFromVariantSlug(trimmedModel);
+  const explicit = input.options ?? undefined;
+
+  const reasoningEffort = explicit?.reasoningEffort ?? inferredFromSlug.reasoningEffort;
+  const fastMode =
+    explicit?.fastMode !== undefined
+      ? explicit.fastMode
+      : inferredFromSlug.fastMode === true
+        ? true
+        : undefined;
+  const thinking =
+    explicit?.thinking !== undefined
+      ? explicit.thinking
+      : inferredFromSlug.thinking === true
+        ? true
+        : undefined;
+  const contextWindow = explicit?.contextWindow;
+
+  const options: CursorModelOptions = {
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+    ...(fastMode !== undefined ? { fastMode } : {}),
+    ...(thinking !== undefined ? { thinking } : {}),
+    ...(contextWindow ? { contextWindow } : {}),
+  };
+
+  return {
+    model: baseModel,
+    options: Object.keys(options).length > 0 ? options : undefined,
+  };
+}
+
 function removeVariantNameSuffix(name: string): string {
   return name
-    .replace(/\s+Fast$/iu, "")
+    .replace(/\s+(?:None|Low|Medium|High|Extra High)$/iu, "")
     .replace(/\s+Thinking$/iu, "")
     .replace(/\s+Fast$/iu, "")
     .replace(/\s+(?:None|Low|Medium|High|Extra High)$/iu, "")
@@ -105,6 +184,9 @@ function defaultEffortForGroup(
     return efforts.includes("medium") ? "medium" : efforts[0];
   }
   if (baseSlug.includes("claude")) {
+    return efforts.includes("high") ? "high" : efforts[0];
+  }
+  if (baseSlug.includes("grok")) {
     return efforts.includes("high") ? "high" : efforts[0];
   }
   return efforts[0];
@@ -172,7 +254,7 @@ export function collapseCursorModelVariants(
   return Array.from(groups.entries()).map(([baseSlug, variants]) => {
     const preferredName =
       variants.find((variant) => variant.slug === baseSlug)?.name ??
-      variants.find((variant) => !variant.slug.endsWith("-fast"))?.name ??
+      variants.find((variant) => !cursorVariantHasFastMode(variant.slug))?.name ??
       variants[0]?.name ??
       baseSlug;
     const efforts = uniqueByValue(
@@ -225,10 +307,15 @@ export function collapseCursorModelVariants(
             ...(defaultEffort ? { defaultReasoningEffort: defaultEffort } : {}),
           }
         : {}),
-      ...(variants.some((variant) => variant.supportsFastMode === true)
+      ...(variants.some(
+        (variant) => variant.supportsFastMode === true || cursorVariantHasFastMode(variant.slug),
+      )
         ? { supportsFastMode: true as const }
         : {}),
-      ...(variants.some((variant) => variant.supportsThinkingToggle === true)
+      ...(variants.some(
+        (variant) =>
+          variant.supportsThinkingToggle === true || cursorVariantHasThinking(variant.slug),
+      )
         ? { supportsThinkingToggle: true as const }
         : {}),
       ...(contextWindowOptions.length > 0

--- a/apps/web/src/featureFlags.ts
+++ b/apps/web/src/featureFlags.ts
@@ -64,7 +64,8 @@ export const FEATURE_FLAGS: readonly FeatureFlag[] = [
     id: "show-expanded-cursor-model-variants",
     kind: "toggle",
     label: "Show Cursor model variants",
-    description: "Show every Cursor CLI model variant as a separate picker row.",
+    description:
+      "Show every Cursor CLI trait variant as its own picker row instead of collapsing to a base model with reasoning/fast selectors.",
     defaultEnabled: DEFAULT_FEATURE_FLAG_STATE["show-expanded-cursor-model-variants"],
   },
 ];

--- a/apps/web/src/hooks/useProviderModelCatalog.ts
+++ b/apps/web/src/hooks/useProviderModelCatalog.ts
@@ -14,7 +14,7 @@ import { useMemo } from "react";
 
 import { getAppModelOptions, getCustomModelsByProvider, useAppSettings } from "../appSettings";
 import { resolveRuntimeModelDescriptor } from "../components/chat/runtimeModelCapabilities";
-import { mergeCursorModelVariantsWithBaseControls } from "../cursorModelVariants";
+import { collapseCursorModelVariants } from "../cursorModelVariants";
 import { useFeatureFlags } from "../featureFlags";
 import {
   providerAgentsQueryOptions,
@@ -147,7 +147,7 @@ export function useProviderModelCatalog(input: {
     () =>
       showExpandedCursorModelVariants
         ? (cursorDynamicModelsQuery.data?.models ?? [])
-        : mergeCursorModelVariantsWithBaseControls(cursorDynamicModelsQuery.data?.models ?? []),
+        : collapseCursorModelVariants(cursorDynamicModelsQuery.data?.models ?? []),
     [cursorDynamicModelsQuery.data?.models, showExpandedCursorModelVariants],
   );
 


### PR DESCRIPTION
## Summary
- Default Cursor model picker now collapses CLI trait variants (including Grok 4.5 Fast/High) into a base model with separate reasoning/fast selectors, matching GPT and Claude.
- Persisted Cursor selections like `grok-4-5-fast-high` remap onto the base slug plus model options so the label no longer duplicates the reasoning dropdown.
- Expanded-variant feature flag still shows the raw CLI rows when explicitly enabled.

## Test plan
- [ ] Select Cursor → xAI Grok 4.5 family: model dropdown shows a base name without High/Medium/Low baked in
- [ ] Reasoning dropdown appears beside it and changes effort without renaming the model
- [ ] Fast mode still available when Cursor exposes Fast variants
- [ ] GPT/Claude Cursor models still behave the same as before
- [ ] Optional: enable "Show Cursor model variants" and confirm raw CLI rows return


Made with [Cursor](https://cursor.com)