### PR TITLE
fix: sidebar thread title overlapping keybinds

### DIFF
--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -348,9 +348,8 @@ export function pruneProjectThreadListPagingForCollapsedProjects<
  * - A status/loader (or keyboard-jump) glyph occupies a ~2.25rem slot, and each
  *   fork/worktree/handoff meta chip adds width; the reserve grows only for the
  *   badges that are present.
- * - The wider reserve that clears the hover pin/archive actions is applied only
- *   on hover/focus (mirroring the project header row), so the title gives up that
- *   width exactly when those actions appear and not a moment sooner.
+ * - Hover pin/archive actions participate in the row's flex layout, so hover only
+ *   restores the standard right inset instead of reserving an absolute toolbar.
  *
  * Literal class strings are required so Tailwind's JIT scanner emits them.
  */
@@ -358,10 +357,10 @@ export function resolveThreadRowTrailingReserveClass(input: {
   metaChipCount: number;
   hasTrailingGlyph: boolean;
 }): string {
-  // Hover/focus reveals the pin/archive actions; the meta chips + glyph fade out
-  // at the same time, so the hover reserve is constant regardless of rest content.
+  // Hover/focus reveals inline pin/archive actions while the absolute resting
+  // metadata fades out, so only the row's standard right inset is needed.
   const hoverReserve =
-    "transition-[padding] duration-150 ease-out group-hover/thread-row:pr-[4.75rem] group-focus-within/thread-row:pr-[4.75rem]";
+    "transition-[padding] duration-150 ease-out group-hover/thread-row:pr-2 group-focus-within/thread-row:pr-2";
   const { metaChipCount, hasTrailingGlyph } = input;
   if (metaChipCount <= 0) {
     return cn(hasTrailingGlyph ? "pr-[1.75rem]" : "pr-2", hoverReserve);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -588,6 +588,11 @@ const THREAD_ROW_META_CHIP_HOVER_FADE_CLASS_NAME = cn(
   sidebarHoverRevealHideClassName("thread-row"),
 );
 
+// Jump hints are wider than the status glyph they replace. Add clearance only
+// after the row's text/content so leading icons and title alignment stay fixed.
+const THREAD_JUMP_HINT_TEXT_GAP_CLASS_NAME =
+  "mr-1 transition-[margin] duration-150 ease-out group-hover/thread-row:mr-0 group-focus-within/thread-row:mr-0";
+
 /** Fixed-width status column; fades on hover so pin/archive can overlay this slot. */
 function threadRowTimestampSlotClassName(
   isSubagentThread: boolean,
@@ -5085,7 +5090,6 @@ export default function Sidebar() {
     rightMetaChips: ThreadMetaChip[];
     threadStatus: ReturnType<typeof resolveThreadStatusForSidebar>;
     timestampToneClassName?: string;
-    hoverActions: ReactNode;
   }) {
     return (
       <div className="relative flex shrink-0 items-center justify-end gap-1">
@@ -5114,7 +5118,6 @@ export default function Sidebar() {
             <SidebarStatusTrailingGlyph status={input.threadStatus} />
           </span>
         ) : null}
-        {input.hoverActions}
       </div>
     );
   }
@@ -5323,7 +5326,14 @@ export default function Sidebar() {
                 terminalCount={terminalCount}
               />
             ) : null}
-            <div className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
+            <div
+              className={cn(
+                "flex min-w-0 flex-1 items-center gap-1.5 text-left group-hover/thread-row:flex-[0_1_auto] group-focus-within/thread-row:flex-[0_1_auto]",
+                threadJumpLabel &&
+                  !projectLabel &&
+                  THREAD_JUMP_HINT_TEXT_GAP_CLASS_NAME,
+              )}
+            >
               <span
                 className={cn(
                   "min-w-0 flex-1 truncate text-[length:var(--app-font-size-ui,12px)] leading-5",
@@ -5363,13 +5373,21 @@ export default function Sidebar() {
               // touching the worktree chip. It costs no space when the row is idle.
               <span
                 className={cn(
-                  "max-w-[40%] shrink-0 truncate text-right text-[length:var(--app-font-size-ui-meta,10px)] text-muted-foreground/38 transition-[margin] duration-150 ease-out",
-                  hasTrailingStatusGlyph && "mr-2",
+                  "max-w-[40%] shrink-0 truncate text-right text-[length:var(--app-font-size-ui-meta,10px)] text-muted-foreground/38 transition-[margin] duration-150 ease-out group-hover/thread-row:hidden group-focus-within/thread-row:hidden",
+                  threadJumpLabel
+                    ? THREAD_JUMP_HINT_TEXT_GAP_CLASS_NAME
+                    : hasTrailingStatusGlyph && "mr-2",
                 )}
               >
                 {projectLabel}
               </span>
             ) : null}
+            {renderThreadHoverActions({
+              threadId: thread.id,
+              toneClassName: "text-muted-foreground/42",
+              isPinned: true,
+              compact: isSubagentThread,
+            })}
             <div className="absolute top-1/2 right-1.5 flex -translate-y-1/2 items-center">
               {renderThreadRowTrailingCluster({
                 isSubagentThread,
@@ -5378,12 +5396,6 @@ export default function Sidebar() {
                 rightMetaChips,
                 threadStatus,
                 timestampToneClassName: "text-muted-foreground/38",
-                hoverActions: renderThreadHoverActions({
-                  threadId: thread.id,
-                  toneClassName: "text-muted-foreground/42",
-                  isPinned: true,
-                  compact: isSubagentThread,
-                }),
               })}
             </div>
           </div>
@@ -5584,7 +5596,7 @@ export default function Sidebar() {
             ) : null}
             <div
               className={cn(
-                "flex min-w-0 flex-1 items-center text-left",
+                "flex min-w-0 flex-1 items-center text-left group-hover/thread-row:flex-[0_1_auto] group-focus-within/thread-row:flex-[0_1_auto]",
                 isSubagentThread ? "gap-[5px]" : "gap-1.5",
               )}
             >
@@ -5621,7 +5633,12 @@ export default function Sidebar() {
                 </span>
               ) : null}
             </div>
-            <div className="ml-auto flex shrink-0 items-center gap-1.5 pr-1">
+            <div
+              className={cn(
+                "ml-auto flex shrink-0 items-center gap-1.5 pr-1 group-hover/thread-row:hidden group-focus-within/thread-row:hidden",
+                threadJumpLabel && THREAD_JUMP_HINT_TEXT_GAP_CLASS_NAME,
+              )}
+            >
               {canToggleSubagents ? (
                 <button
                   type="button"
@@ -5661,6 +5678,12 @@ export default function Sidebar() {
                 </Tooltip>
               ) : null}
             </div>
+            {renderThreadHoverActions({
+              threadId: thread.id,
+              toneClassName: secondaryMetaClass,
+              isPinned,
+              compact: isSubagentThread,
+            })}
             <div className={cn("absolute top-1/2 flex -translate-y-1/2 items-center", "right-1.5")}>
               {renderThreadRowTrailingCluster({
                 isSubagentThread,
@@ -5673,12 +5696,6 @@ export default function Sidebar() {
                     ? "text-foreground/38 dark:text-foreground/46"
                     : "text-muted-foreground/24"
                   : secondaryMetaClass,
-                hoverActions: renderThreadHoverActions({
-                  threadId: thread.id,
-                  toneClassName: secondaryMetaClass,
-                  isPinned,
-                  compact: isSubagentThread,
-                }),
               })}
             </div>
           </TooltipTrigger>

--- a/apps/web/src/components/SidebarRowHoverActions.tsx
+++ b/apps/web/src/components/SidebarRowHoverActions.tsx
@@ -1,5 +1,5 @@
 // FILE: SidebarRowHoverActions.tsx
-// Purpose: Absolutely positioned hover action strip on thread/chat rows.
+// Purpose: Inline hover action strip on thread/chat rows.
 // Layer: Sidebar UI primitive
 // Exports: SidebarRowHoverActions
 
@@ -17,8 +17,10 @@ export function SidebarRowHoverActions({
     <div
       data-testid={`thread-hover-actions-${threadId}`}
       className={cn(
-        "pointer-events-none absolute inset-y-0 right-0 my-auto inline-flex items-center",
-        "opacity-0 transition-opacity group-hover/thread-row:pointer-events-auto group-hover/thread-row:opacity-100 group-focus-within/thread-row:pointer-events-auto group-focus-within/thread-row:opacity-100",
+        "pointer-events-none inline-flex max-w-0 shrink-0 items-center overflow-hidden opacity-0",
+        "transition-[max-width,margin,opacity] duration-150 ease-out",
+        "group-hover/thread-row:ml-1 group-hover/thread-row:max-w-[5rem] group-hover/thread-row:pointer-events-auto group-hover/thread-row:opacity-100",
+        "group-focus-within/thread-row:ml-1 group-focus-within/thread-row:max-w-[5rem] group-focus-within/thread-row:pointer-events-auto group-focus-within/thread-row:opacity-100",
       )}
     >
       {children}


### PR DESCRIPTION
## What Changed

The keybind text was overlapping the thread title. 

### Before

<img width="812" height="346" alt="CleanShot 2026-07-13 at 04 28 54@2x" src="https://github.com/user-attachments/assets/f5185c15-296a-4f34-935f-70b7894de81b" />

### After

<img width="812" height="346" alt="CleanShot 2026-07-13 at 05 31 18@2x" src="https://github.com/user-attachments/assets/654dfa04-60aa-40e9-8ea9-9fc83cf1b5c2" />

## Why


## UI Changes

_Shown above_

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
