### PR TITLE
fix(server): handle empty ACP config responses

### DIFF
--- a/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it } from "vitest";
 import { Effect } from "effect";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
-import { assistantItemId, decodeSetSessionConfigOptionResponse } from "./AcpSessionRuntime.ts";
+import {
+  assistantItemId,
+  decodeSetSessionConfigOptionResponse,
+  sessionConfigOptionsFromSetup,
+} from "./AcpSessionRuntime.ts";
 
 describe("assistantItemId", () => {
   // Format contract only — distinct runtimeInstanceId wiring is covered by
@@ -62,5 +66,25 @@ describe("decodeSetSessionConfigOptionResponse", () => {
     if (error._tag === "AcpTransportError") {
       expect(error.detail).toContain("invalid session/set_config_option response");
     }
+  });
+});
+
+describe("sessionConfigOptionsFromSetup", () => {
+  const replayedConfigOptions = [
+    {
+      id: "model",
+      name: "Model",
+      type: "select",
+      currentValue: "gpt-5.6-luna",
+      options: [{ value: "gpt-5.6-luna", name: "GPT-5.6 Luna" }],
+    },
+  ] satisfies ReadonlyArray<EffectAcpSchema.SessionConfigOption>;
+
+  it("preserves config retained from replay when setup omits configOptions", () => {
+    expect(sessionConfigOptionsFromSetup({}, replayedConfigOptions)).toBe(replayedConfigOptions);
+  });
+
+  it("uses an explicit setup inventory instead of replayed config", () => {
+    expect(sessionConfigOptionsFromSetup({ configOptions: [] }, replayedConfigOptions)).toEqual([]);
   });
 });

--- a/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
@@ -59,6 +59,8 @@ describe("decodeSetSessionConfigOptionResponse", () => {
       ).pipe(Effect.flip),
     );
     expect(error._tag).toBe("AcpTransportError");
-    expect(error.detail).toContain("invalid session/set_config_option response");
+    if (error._tag === "AcpTransportError") {
+      expect(error.detail).toContain("invalid session/set_config_option response");
+    }
   });
 });

--- a/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { assistantItemId } from "./AcpSessionRuntime.ts";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import { applySessionConfigOptionValue, assistantItemId } from "./AcpSessionRuntime.ts";
 
 describe("assistantItemId", () => {
   // Format contract only — distinct runtimeInstanceId wiring is covered by
@@ -12,5 +14,47 @@ describe("assistantItemId", () => {
     expect(a).not.toBe(b);
     expect(a).toBe("assistant:session-1:aaaa1111:segment:0");
     expect(b).toBe("assistant:session-1:bbbb2222:segment:0");
+  });
+});
+
+describe("applySessionConfigOptionValue", () => {
+  it("updates the requested option while retaining the rest of the inventory", () => {
+    const configOptions = [
+      {
+        id: "model",
+        name: "Model",
+        type: "select",
+        currentValue: "gpt-5.5",
+        options: [
+          { value: "gpt-5.5", name: "GPT-5.5" },
+          { value: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
+        ],
+      },
+      {
+        id: "thinking",
+        name: "Thinking",
+        type: "boolean",
+        currentValue: false,
+      },
+    ] satisfies ReadonlyArray<EffectAcpSchema.SessionConfigOption>;
+
+    expect(applySessionConfigOptionValue(configOptions, "model", "gpt-5.6-luna")).toEqual([
+      { ...configOptions[0], currentValue: "gpt-5.6-luna" },
+      configOptions[1],
+    ]);
+    expect(configOptions[0]?.currentValue).toBe("gpt-5.5");
+  });
+
+  it("does not apply a value with the wrong option type", () => {
+    const configOptions = [
+      {
+        id: "thinking",
+        name: "Thinking",
+        type: "boolean",
+        currentValue: false,
+      },
+    ] satisfies ReadonlyArray<EffectAcpSchema.SessionConfigOption>;
+
+    expect(applySessionConfigOptionValue(configOptions, "thinking", "true")).toEqual(configOptions);
   });
 });

--- a/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 
+import { Effect } from "effect";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
-import { applySessionConfigOptionValue, assistantItemId } from "./AcpSessionRuntime.ts";
+import { assistantItemId, decodeSetSessionConfigOptionResponse } from "./AcpSessionRuntime.ts";
 
 describe("assistantItemId", () => {
   // Format contract only — distinct runtimeInstanceId wiring is covered by
@@ -17,44 +18,47 @@ describe("assistantItemId", () => {
   });
 });
 
-describe("applySessionConfigOptionValue", () => {
-  it("updates the requested option while retaining the rest of the inventory", () => {
-    const configOptions = [
-      {
-        id: "model",
-        name: "Model",
-        type: "select",
-        currentValue: "gpt-5.5",
-        options: [
-          { value: "gpt-5.5", name: "GPT-5.5" },
-          { value: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
-        ],
-      },
-      {
-        id: "thinking",
-        name: "Thinking",
-        type: "boolean",
-        currentValue: false,
-      },
-    ] satisfies ReadonlyArray<EffectAcpSchema.SessionConfigOption>;
+describe("decodeSetSessionConfigOptionResponse", () => {
+  const configOptions = [
+    {
+      id: "model",
+      name: "Model",
+      type: "select",
+      currentValue: "gpt-5.6-luna",
+      options: [{ value: "gpt-5.6-luna", name: "GPT-5.6 Luna" }],
+    },
+  ] satisfies ReadonlyArray<EffectAcpSchema.SessionConfigOption>;
 
-    expect(applySessionConfigOptionValue(configOptions, "model", "gpt-5.6-luna")).toEqual([
-      { ...configOptions[0], currentValue: "gpt-5.6-luna" },
-      configOptions[1],
-    ]);
-    expect(configOptions[0]?.currentValue).toBe("gpt-5.5");
+  it("uses the matching config update for an empty response", () => {
+    const decoded = Effect.runSync(
+      decodeSetSessionConfigOptionResponse({}, Effect.succeed(configOptions)),
+    );
+    expect(decoded).toEqual({ configOptions });
   });
 
-  it("does not apply a value with the wrong option type", () => {
-    const configOptions = [
-      {
-        id: "thinking",
-        name: "Thinking",
-        type: "boolean",
-        currentValue: false,
-      },
-    ] satisfies ReadonlyArray<EffectAcpSchema.SessionConfigOption>;
+  it("strictly decodes a non-empty response without awaiting an update", () => {
+    let awaitedUpdate = false;
+    const decoded = Effect.runSync(
+      decodeSetSessionConfigOptionResponse(
+        { configOptions },
+        Effect.sync(() => {
+          awaitedUpdate = true;
+          return [];
+        }),
+      ),
+    );
+    expect(decoded).toEqual({ configOptions });
+    expect(awaitedUpdate).toBe(false);
+  });
 
-    expect(applySessionConfigOptionValue(configOptions, "thinking", "true")).toEqual(configOptions);
+  it("rejects an invalid non-empty response", async () => {
+    const error = await Effect.runPromise(
+      decodeSetSessionConfigOptionResponse(
+        { unexpected: true },
+        Effect.succeed(configOptions),
+      ).pipe(Effect.flip),
+    );
+    expect(error._tag).toBe("AcpTransportError");
+    expect(error.detail).toContain("invalid session/set_config_option response");
   });
 });

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -655,7 +655,9 @@ const makeAcpSessionRuntime = (
       }
 
       yield* Ref.set(modeStateRef, parseSessionModeState(sessionSetupResult));
-      yield* Ref.set(configOptionsRef, sessionConfigOptionsFromSetup(sessionSetupResult));
+      yield* Ref.update(configOptionsRef, (current) =>
+        sessionConfigOptionsFromSetup(sessionSetupResult, current),
+      );
       // Fresh sessions accept session/update while session/new is in flight, and
       // those events are already in the queue; resetting the merge/segment state
       // they created would orphan their continuations (new segment ids, unmerged
@@ -820,14 +822,15 @@ const makeAcpSessionRuntime = (
     } satisfies AcpSessionRuntimeShape;
   });
 
-function sessionConfigOptionsFromSetup(
+export function sessionConfigOptionsFromSetup(
   response:
     | {
         readonly configOptions?: ReadonlyArray<EffectAcpSchema.SessionConfigOption> | null;
       }
     | undefined,
+  fallback: ReadonlyArray<EffectAcpSchema.SessionConfigOption> = [],
 ): ReadonlyArray<EffectAcpSchema.SessionConfigOption> {
-  return response?.configOptions ?? [];
+  return response?.configOptions ?? fallback;
 }
 
 // Flattens grouped ACP select options so semantic configuration lookup stays provider-agnostic.

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -13,6 +13,7 @@ import {
   Layer,
   Queue,
   Ref,
+  Schema,
   Scope,
   ServiceMap,
   Stream,
@@ -20,7 +21,7 @@ import {
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as EffectAcpClient from "effect-acp/client";
 import * as EffectAcpErrors from "effect-acp/errors";
-import type * as EffectAcpSchema from "effect-acp/schema";
+import * as EffectAcpSchema from "effect-acp/schema";
 import type * as EffectAcpProtocol from "effect-acp/protocol";
 
 import {
@@ -300,12 +301,18 @@ const makeAcpSessionRuntime = (
           update.sessionUpdate === "available_commands_update"
             ? Ref.set(availableCommandsRef, update.availableCommands)
             : Effect.void;
+        const rememberConfigOptions =
+          update.sessionUpdate === "config_option_update"
+            ? Ref.set(configOptionsRef, update.configOptions)
+            : Effect.void;
+        const rememberBoundedState = rememberCommands.pipe(Effect.andThen(rememberConfigOptions));
         if (!acceptingSessionUpdates) {
-          // Command inventory is bounded state, not transcript replay; retain
-          // it even while historical session updates are being suppressed.
-          return rememberCommands;
+          // Command and configuration inventories are bounded state, not
+          // transcript replay; retain them even while historical session
+          // updates are being suppressed.
+          return rememberBoundedState;
         }
-        return rememberCommands.pipe(
+        return rememberBoundedState.pipe(
           Effect.andThen(
             handleSessionUpdate({
               offer: offerSessionEvent,
@@ -402,6 +409,31 @@ const makeAcpSessionRuntime = (
         | EffectAcpSchema.ResumeSessionResponse,
     ): Effect.Effect<void> => Ref.set(configOptionsRef, sessionConfigOptionsFromSetup(response));
 
+    const waitForConfigOptionUpdate = (
+      configId: string,
+      value: string | boolean,
+      attemptsRemaining = 25,
+    ): Effect.Effect<ReadonlyArray<EffectAcpSchema.SessionConfigOption>> =>
+      Ref.get(configOptionsRef).pipe(
+        Effect.flatMap((configOptions) => {
+          const updated = findSessionConfigOption(configOptions, configId);
+          if (updated && configOptionCurrentValueMatches(updated, value)) {
+            return Effect.succeed(configOptions);
+          }
+          if (attemptsRemaining > 0) {
+            return Effect.sleep("10 millis").pipe(
+              Effect.andThen(waitForConfigOptionUpdate(configId, value, attemptsRemaining - 1)),
+            );
+          }
+          // Some agents return an empty success response without publishing a
+          // config update. Preserve discovery progress with the requested
+          // value while retaining the last known option inventory.
+          return Ref.updateAndGet(configOptionsRef, (current) =>
+            applySessionConfigOptionValue(current, configId, value),
+          );
+        }),
+      );
+
     const updateCurrentModeId = (modeId: string): Effect.Effect<void> =>
       Ref.update(modeStateRef, (current) =>
         current ? { ...current, currentModeId: modeId } : current,
@@ -438,8 +470,34 @@ const makeAcpSessionRuntime = (
               return runLoggedRequest(
                 "session/set_config_option",
                 requestPayload,
-                acp.agent.setSessionConfigOption(requestPayload),
-              ).pipe(Effect.tap((response) => updateConfigOptions(response)));
+                acp.raw.request("session/set_config_option", requestPayload),
+              ).pipe(
+                Effect.flatMap((response) => {
+                  if (isEmptyRecord(response)) {
+                    return waitForConfigOptionUpdate(configId, value).pipe(
+                      Effect.map(
+                        (configOptions) =>
+                          ({
+                            configOptions,
+                          }) satisfies EffectAcpSchema.SetSessionConfigOptionResponse,
+                      ),
+                    );
+                  }
+                  return Schema.decodeUnknownEffect(EffectAcpSchema.SetSessionConfigOptionResponse)(
+                    response,
+                  ).pipe(
+                    Effect.mapError(
+                      (cause) =>
+                        new EffectAcpErrors.AcpTransportError({
+                          detail:
+                            "ACP agent returned an invalid session/set_config_option response",
+                          cause,
+                        }),
+                    ),
+                    Effect.tap((decoded) => updateConfigOptions(decoded)),
+                  );
+                }),
+              );
             }),
           ),
         ),
@@ -757,6 +815,31 @@ function configOptionCurrentValueMatches(
     return false;
   }
   return currentValue.trim() === String(value).trim();
+}
+
+export function applySessionConfigOptionValue(
+  configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption>,
+  configId: string,
+  value: string | boolean,
+): ReadonlyArray<EffectAcpSchema.SessionConfigOption> {
+  return configOptions.map((configOption) => {
+    if (configOption.id !== configId) {
+      return configOption;
+    }
+    if (configOption.type === "boolean") {
+      return typeof value === "boolean" ? { ...configOption, currentValue: value } : configOption;
+    }
+    return typeof value === "string" ? { ...configOption, currentValue: value } : configOption;
+  });
+}
+
+function isEmptyRecord(value: unknown): value is Record<string, never> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
+  );
 }
 
 const handleSessionUpdate = ({

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -11,6 +11,7 @@ import {
   Effect,
   Exit,
   Layer,
+  Option,
   Queue,
   Ref,
   Schema,
@@ -35,6 +36,14 @@ import {
   type AcpSessionModeState,
   type AcpToolCallState,
 } from "./AcpRuntimeModel.ts";
+
+const CONFIG_OPTION_UPDATE_TIMEOUT = "5 seconds";
+
+type ConfigOptionUpdateWaiter = {
+  readonly configId: string;
+  readonly value: string | boolean;
+  readonly deferred: Deferred.Deferred<ReadonlyArray<EffectAcpSchema.SessionConfigOption>>;
+};
 
 export interface AcpSpawnInput {
   readonly command: string;
@@ -198,6 +207,9 @@ const makeAcpSessionRuntime = (
     // server restarts or session resumes (segment index resets to 0 each time).
     const runtimeInstanceId = randomUUID().slice(0, 8);
     const configOptionsRef = yield* Ref.make(sessionConfigOptionsFromSetup(undefined));
+    const configOptionUpdateWaitersRef = yield* Ref.make<ReadonlyArray<ConfigOptionUpdateWaiter>>(
+      [],
+    );
     const startStateRef = yield* Ref.make<AcpStartState>({ _tag: "NotStarted" });
     // session/load can replay a large history before the consumer attaches; drop
     // those notifications so they never accumulate in the unbounded queue. For
@@ -294,6 +306,29 @@ const makeAcpSessionRuntime = (
     // driven by the callback path, not this queue.)
     yield* Stream.runDrain(acp.raw.notifications).pipe(Effect.forkIn(runtimeScope));
 
+    const resolveConfigOptionUpdateWaiters = (
+      configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption>,
+    ): Effect.Effect<void> =>
+      Ref.modify(configOptionUpdateWaitersRef, (waiters) => {
+        const resolved: ConfigOptionUpdateWaiter[] = [];
+        const pending: ConfigOptionUpdateWaiter[] = [];
+        for (const waiter of waiters) {
+          const configOption = findSessionConfigOption(configOptions, waiter.configId);
+          if (configOption && configOptionCurrentValueMatches(configOption, waiter.value)) {
+            resolved.push(waiter);
+          } else {
+            pending.push(waiter);
+          }
+        }
+        return [resolved, pending] as const;
+      }).pipe(
+        Effect.flatMap((waiters) =>
+          Effect.forEach(waiters, (waiter) => Deferred.succeed(waiter.deferred, configOptions), {
+            discard: true,
+          }),
+        ),
+      );
+
     yield* acp.handleSessionUpdate((notification) =>
       Effect.suspend(() => {
         const update = notification.update;
@@ -303,7 +338,9 @@ const makeAcpSessionRuntime = (
             : Effect.void;
         const rememberConfigOptions =
           update.sessionUpdate === "config_option_update"
-            ? Ref.set(configOptionsRef, update.configOptions)
+            ? Ref.set(configOptionsRef, update.configOptions).pipe(
+                Effect.andThen(resolveConfigOptionUpdateWaiters(update.configOptions)),
+              )
             : Effect.void;
         const rememberBoundedState = rememberCommands.pipe(Effect.andThen(rememberConfigOptions));
         if (!acceptingSessionUpdates) {
@@ -412,27 +449,43 @@ const makeAcpSessionRuntime = (
     const waitForConfigOptionUpdate = (
       configId: string,
       value: string | boolean,
-      attemptsRemaining = 25,
-    ): Effect.Effect<ReadonlyArray<EffectAcpSchema.SessionConfigOption>> =>
-      Ref.get(configOptionsRef).pipe(
-        Effect.flatMap((configOptions) => {
-          const updated = findSessionConfigOption(configOptions, configId);
-          if (updated && configOptionCurrentValueMatches(updated, value)) {
-            return Effect.succeed(configOptions);
-          }
-          if (attemptsRemaining > 0) {
-            return Effect.sleep("10 millis").pipe(
-              Effect.andThen(waitForConfigOptionUpdate(configId, value, attemptsRemaining - 1)),
-            );
-          }
-          // Some agents return an empty success response without publishing a
-          // config update. Preserve discovery progress with the requested
-          // value while retaining the last known option inventory.
-          return Ref.updateAndGet(configOptionsRef, (current) =>
-            applySessionConfigOptionValue(current, configId, value),
-          );
-        }),
-      );
+    ): Effect.Effect<
+      ReadonlyArray<EffectAcpSchema.SessionConfigOption>,
+      EffectAcpErrors.AcpError
+    > =>
+      Effect.gen(function* () {
+        const deferred = yield* Deferred.make<ReadonlyArray<EffectAcpSchema.SessionConfigOption>>();
+        const waiter: ConfigOptionUpdateWaiter = { configId, value, deferred };
+        yield* Ref.update(configOptionUpdateWaitersRef, (waiters) => [...waiters, waiter]);
+
+        // The notification may have arrived before the empty response was
+        // observed and this waiter was registered. Recheck the retained state
+        // after registration so both event orderings are race-safe.
+        const current = yield* Ref.get(configOptionsRef);
+        const currentOption = findSessionConfigOption(current, configId);
+        if (currentOption && configOptionCurrentValueMatches(currentOption, value)) {
+          yield* Deferred.succeed(deferred, current);
+        }
+
+        const result = yield* Deferred.await(deferred).pipe(
+          Effect.timeoutOption(CONFIG_OPTION_UPDATE_TIMEOUT),
+          Effect.ensuring(
+            Ref.update(configOptionUpdateWaitersRef, (waiters) =>
+              waiters.filter((candidate) => candidate !== waiter),
+            ),
+          ),
+        );
+        if (Option.isNone(result)) {
+          return yield* new EffectAcpErrors.AcpTransportError({
+            detail:
+              "ACP agent returned an empty session/set_config_option response without a matching config_option_update notification",
+            cause: new Error(
+              `Timed out waiting for config option ${JSON.stringify(configId)} to become ${JSON.stringify(value)}`,
+            ),
+          });
+        }
+        return result.value;
+      });
 
     const updateCurrentModeId = (modeId: string): Effect.Effect<void> =>
       Ref.update(modeStateRef, (current) =>
@@ -470,34 +523,17 @@ const makeAcpSessionRuntime = (
               return runLoggedRequest(
                 "session/set_config_option",
                 requestPayload,
-                acp.raw.request("session/set_config_option", requestPayload),
-              ).pipe(
-                Effect.flatMap((response) => {
-                  if (isEmptyRecord(response)) {
-                    return waitForConfigOptionUpdate(configId, value).pipe(
-                      Effect.map(
-                        (configOptions) =>
-                          ({
-                            configOptions,
-                          }) satisfies EffectAcpSchema.SetSessionConfigOptionResponse,
+                acp.raw
+                  .request("session/set_config_option", requestPayload)
+                  .pipe(
+                    Effect.flatMap((response) =>
+                      decodeSetSessionConfigOptionResponse(
+                        response,
+                        waitForConfigOptionUpdate(configId, value),
                       ),
-                    );
-                  }
-                  return Schema.decodeUnknownEffect(EffectAcpSchema.SetSessionConfigOptionResponse)(
-                    response,
-                  ).pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new EffectAcpErrors.AcpTransportError({
-                          detail:
-                            "ACP agent returned an invalid session/set_config_option response",
-                          cause,
-                        }),
                     ),
-                    Effect.tap((decoded) => updateConfigOptions(decoded)),
-                  );
-                }),
-              );
+                  ),
+              ).pipe(Effect.tap((response) => updateConfigOptions(response)));
             }),
           ),
         ),
@@ -817,20 +853,25 @@ function configOptionCurrentValueMatches(
   return currentValue.trim() === String(value).trim();
 }
 
-export function applySessionConfigOptionValue(
-  configOptions: ReadonlyArray<EffectAcpSchema.SessionConfigOption>,
-  configId: string,
-  value: string | boolean,
-): ReadonlyArray<EffectAcpSchema.SessionConfigOption> {
-  return configOptions.map((configOption) => {
-    if (configOption.id !== configId) {
-      return configOption;
-    }
-    if (configOption.type === "boolean") {
-      return typeof value === "boolean" ? { ...configOption, currentValue: value } : configOption;
-    }
-    return typeof value === "string" ? { ...configOption, currentValue: value } : configOption;
-  });
+export function decodeSetSessionConfigOptionResponse(
+  response: unknown,
+  configUpdate: Effect.Effect<
+    ReadonlyArray<EffectAcpSchema.SessionConfigOption>,
+    EffectAcpErrors.AcpError
+  >,
+): Effect.Effect<EffectAcpSchema.SetSessionConfigOptionResponse, EffectAcpErrors.AcpError> {
+  if (isEmptyRecord(response)) {
+    return configUpdate.pipe(Effect.map((configOptions) => ({ configOptions })));
+  }
+  return Schema.decodeUnknownEffect(EffectAcpSchema.SetSessionConfigOptionResponse)(response).pipe(
+    Effect.mapError(
+      (cause) =>
+        new EffectAcpErrors.AcpTransportError({
+          detail: "ACP agent returned an invalid session/set_config_option response",
+          cause,
+        }),
+    ),
+  );
 }
 
 function isEmptyRecord(value: unknown): value is Record<string, never> {


### PR DESCRIPTION
## Summary

- tolerate agents such as Droid that return an empty `session/set_config_option` result and publish the updated configuration through `config_option_update`
- retain configuration updates even while transcript replay events are suppressed
- preserve strict schema validation for non-empty responses and keep a bounded fallback for agents that omit both response data and a notification

## Reproduction

Droid 0.170.0 and 0.164.0 return `result: {}` from `session/set_config_option`. The typed `effect-acp` client rejects that response because `configOptions` is missing, so turns fail before prompting and runtime model discovery falls back to Synara’s built-in list. Droid then sends the full configuration in a separate `config_option_update` notification.

## Verification

- `bun fmt`
- `bun lint` — 0 errors (existing repository warnings remain)
- `bun typecheck`
- `bun run test` — 1,724 passed, 6 skipped
- `bun run build`
- live ACP discovery against Droid 0.170.0 returned 42 models, including GPT-5.6 and custom BYOK entries
- manually verified in the packaged macOS app: GPT-5.6 Luna appeared in the picker and completed a real prompt successfully

Targets #313 because the affected Droid runtime model-discovery path is introduced there.