### PR TITLE
feat(web): show Droid token multipliers

### DIFF
--- a/apps/server/src/provider/acp/DroidAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/DroidAcpSupport.test.ts
@@ -222,7 +222,11 @@ describe("discoverDroidAcpModels", () => {
         type: "select",
         currentValue: currentModel,
         options: [
-          { value: "model-a", name: "Model A" },
+          {
+            value: "model-a",
+            name: "Model A",
+            description: "0.4x Factory token rate",
+          },
           { value: "model-b", name: "Model B" },
         ],
       },
@@ -258,6 +262,7 @@ describe("discoverDroidAcpModels", () => {
     expect(result.models).toEqual([
       expect.objectContaining({
         slug: "model-a",
+        description: "0.4x Factory token rate",
         defaultReasoningEffort: "medium",
         supportedReasoningEfforts: [
           { value: "low", label: "Low" },
@@ -273,6 +278,7 @@ describe("discoverDroidAcpModels", () => {
         ],
       }),
     ]);
+    expect(result.models[1]).not.toHaveProperty("description");
     expect(currentModel).toBe("model-a");
   });
 });

--- a/apps/server/src/provider/acp/DroidAcpSupport.ts
+++ b/apps/server/src/provider/acp/DroidAcpSupport.ts
@@ -248,6 +248,7 @@ function droidModelDescriptor(
   return {
     slug: model.value,
     name: model.name,
+    ...(model.description ? { description: model.description } : {}),
     supportedReasoningEfforts: efforts.map((effort) => ({
       value: effort.value,
       label: effort.name,

--- a/apps/web/src/components/chat/ProviderModelOptionGroupList.tsx
+++ b/apps/web/src/components/chat/ProviderModelOptionGroupList.tsx
@@ -10,6 +10,7 @@ import { cn } from "~/lib/utils";
 import {
   resolveModelGroupDefaultOpen,
   shouldUseCollapsibleModelGroups,
+  providerModelCostMultiplierLabel,
   type ProviderModelOption,
   type ProviderModelOptionGroup,
 } from "../../providerModelOptions";
@@ -55,12 +56,16 @@ function ProviderModelRadioItem(
     onAfterSelection,
   } = props;
   const supportsFavorites = favoriteProvider !== null;
+  const costMultiplierLabel =
+    provider === "droid" ? providerModelCostMultiplierLabel(modelOption.description) : null;
+  const preserveChildLayout = supportsFavorites || costMultiplierLabel !== null;
 
   return (
     <MenuRadioItem
       key={`${provider}:${modelOption.slug}`}
       value={modelOption.slug}
-      preserveChildLayout={supportsFavorites}
+      preserveChildLayout={preserveChildLayout}
+      className={costMultiplierLabel ? "grid-cols-[minmax(0,1fr)_auto]" : undefined}
       trailing={
         supportsFavorites ? (
           <button
@@ -90,17 +95,25 @@ function ProviderModelRadioItem(
               <StarIcon aria-hidden="true" className="size-3" />
             )}
           </button>
+        ) : costMultiplierLabel && modelOption.description ? (
+          <span
+            title={modelOption.description}
+            className="shrink-0 text-[10px] font-medium tabular-nums text-muted-foreground/65"
+          >
+            <span aria-hidden="true">{costMultiplierLabel}</span>
+            <span className="sr-only">{modelOption.description}</span>
+          </span>
         ) : null
       }
       onClick={() => {
         onAfterSelection?.();
       }}
     >
-      {supportsFavorites ? (
+      {preserveChildLayout ? (
         <span
           className={cn(
             "block min-w-0 truncate",
-            COMPOSER_PICKER_MODEL_ROW_LABEL_INDENT_CLASS_NAME,
+            supportsFavorites && COMPOSER_PICKER_MODEL_ROW_LABEL_INDENT_CLASS_NAME,
           )}
         >
           {modelOption.name}

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -28,7 +28,14 @@ const MODEL_OPTIONS_BY_PROVIDER = {
     { slug: "grok-build-0.1", name: "Grok Build 0.1" },
     { slug: "grok-build", name: "Grok 4.3" },
   ],
-  droid: [{ slug: "claude-opus-4-8", name: "Claude Opus 4.8" }],
+  droid: [
+    {
+      slug: "gpt-5.6-luna",
+      name: "GPT-5.6 Luna",
+      description: "0.4x Factory token rate",
+    },
+    { slug: "custom:GPT-5.6-Luna-0", name: "Custom GPT-5.6 Luna" },
+  ],
   kilo: [
     {
       slug: "kilo/kilo-auto/free",
@@ -223,6 +230,28 @@ describe("ProviderModelPicker", () => {
         "claudeAgent",
         "claude-sonnet-4-6",
       );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows live Droid cost multipliers without adding one to BYOK models", async () => {
+    const mounted = await mountPicker({
+      provider: "droid",
+      model: "gpt-5.6-luna",
+      lockedProvider: "droid",
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      const rows = Array.from(document.querySelectorAll('[role="menuitemradio"]'));
+      const pricedRow = rows.find((row) => row.textContent?.includes("GPT-5.6 Luna"));
+      const byokRow = rows.find((row) => row.textContent?.includes("Custom GPT-5.6 Luna"));
+
+      expect(pricedRow?.textContent).toContain("0.4×");
+      expect(pricedRow?.querySelector('[title="0.4x Factory token rate"]')).not.toBeNull();
+      expect(byokRow?.textContent).not.toContain("×");
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -163,7 +163,13 @@ function resolveSelectedModelLabel(input: {
 }
 
 function buildModelSearchText(option: ProviderModelOption): string {
-  return [option.name, option.slug, option.upstreamProviderName, option.upstreamProviderId]
+  return [
+    option.name,
+    option.slug,
+    option.description,
+    option.upstreamProviderName,
+    option.upstreamProviderId,
+  ]
     .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
     .join(" ")
     .toLowerCase();

--- a/apps/web/src/providerModelOptions.test.ts
+++ b/apps/web/src/providerModelOptions.test.ts
@@ -10,6 +10,8 @@ import {
   formatProviderModelOptionName,
   groupProviderModelOptions,
   groupProviderModelOptionsWithFavorites,
+  mergeDynamicModelOptions,
+  providerModelCostMultiplierLabel,
   resolveModelGroupDefaultOpen,
   shouldUseCollapsibleModelGroups,
   type ProviderModelOption,
@@ -41,6 +43,44 @@ describe("formatProviderModelOptionName", () => {
         slug: "custom/internal-model",
       }),
     ).toBe("custom/internal-model");
+  });
+});
+
+describe("mergeDynamicModelOptions", () => {
+  it("preserves runtime descriptions without inventing them for custom models", () => {
+    const options = mergeDynamicModelOptions({
+      provider: "droid",
+      staticOptions: [{ slug: "custom:model", name: "Custom model", isCustom: true }],
+      dynamicModels: [
+        {
+          slug: "gpt-5.6-luna",
+          name: "GPT-5.6 Luna",
+          description: " 0.4x Factory token rate ",
+        },
+        { slug: "custom:model", name: "Custom model" },
+      ],
+    });
+
+    expect(options).toEqual([
+      {
+        slug: "gpt-5.6-luna",
+        name: "GPT-5.6 Luna",
+        description: "0.4x Factory token rate",
+      },
+      { slug: "custom:model", name: "Custom model" },
+    ]);
+  });
+});
+
+describe("providerModelCostMultiplierLabel", () => {
+  it("formats live provider multipliers without hardcoding their values", () => {
+    expect(providerModelCostMultiplierLabel("0.38x Factory token rate")).toBe("0.38×");
+    expect(providerModelCostMultiplierLabel("12x Factory token rate")).toBe("12×");
+  });
+
+  it("ignores descriptions that do not begin with a multiplier", () => {
+    expect(providerModelCostMultiplierLabel("Launch Pricing")).toBeNull();
+    expect(providerModelCostMultiplierLabel()).toBeNull();
   });
 });
 

--- a/apps/web/src/providerModelOptions.ts
+++ b/apps/web/src/providerModelOptions.ts
@@ -32,6 +32,7 @@ export type ProviderOptions = ProviderModelOptions[ProviderKind];
 export interface ProviderModelOption {
   slug: string;
   name: string;
+  description?: string;
   upstreamProviderId?: string;
   upstreamProviderName?: string;
 }
@@ -108,6 +109,7 @@ export function mergeDynamicModelOptions(input: {
   dynamicModels: ReadonlyArray<{
     slug: string;
     name?: string | null | undefined;
+    description?: string | null | undefined;
     upstreamProviderId?: string | null | undefined;
     upstreamProviderName?: string | null | undefined;
   }>;
@@ -146,6 +148,7 @@ export function mergeDynamicModelOptions(input: {
         rawName.toLowerCase() !== normalizedSlug.toLowerCase()
           ? rawName
           : displayNameFallback),
+      ...(dynamicModel.description?.trim() ? { description: dynamicModel.description.trim() } : {}),
       ...(dynamicModel.upstreamProviderId?.trim()
         ? { upstreamProviderId: dynamicModel.upstreamProviderId.trim() }
         : {}),
@@ -173,6 +176,12 @@ export function mergeDynamicModelOptions(input: {
       : normalizedDynamicOptions;
 
   return [...orderedDynamicOptions, ...missingStaticBuiltIns, ...customOnlyModels];
+}
+
+/** Returns a compact label for provider descriptions that begin with an `Nx` cost multiplier. */
+export function providerModelCostMultiplierLabel(description?: string): string | null {
+  const multiplier = description?.trim().match(/^(\d+(?:\.\d+)?)x(?:\s|$)/i)?.[1];
+  return multiplier ? `${multiplier}×` : null;
 }
 
 export function groupProviderModelOptions(

--- a/packages/contracts/src/providerDiscovery.test.ts
+++ b/packages/contracts/src/providerDiscovery.test.ts
@@ -1,0 +1,28 @@
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { ProviderListModelsResult } from "./providerDiscovery";
+
+const decodeProviderListModelsResult = Schema.decodeUnknownSync(ProviderListModelsResult);
+
+describe("ProviderListModelsResult", () => {
+  it("preserves optional runtime model descriptions", () => {
+    const result = decodeProviderListModelsResult({
+      models: [
+        {
+          slug: "gpt-5.6-luna",
+          name: "GPT-5.6 Luna",
+          description: "0.4x Factory token rate",
+        },
+        {
+          slug: "custom:GPT-5.6-Luna-0",
+          name: "GPT-5.6 Luna",
+        },
+      ],
+      source: "droid-acp",
+    });
+
+    expect(result.models[0]?.description).toBe("0.4x Factory token rate");
+    expect(result.models[1]?.description).toBeUndefined();
+  });
+});

--- a/packages/contracts/src/providerDiscovery.ts
+++ b/packages/contracts/src/providerDiscovery.ts
@@ -267,6 +267,7 @@ export type ProviderContextWindowDescriptor = typeof ProviderContextWindowDescri
 export const ProviderModelDescriptor = Schema.Struct({
   slug: TrimmedNonEmptyString,
   name: TrimmedNonEmptyString,
+  description: Schema.optional(TrimmedNonEmptyString),
   upstreamProviderId: Schema.optional(TrimmedNonEmptyString),
   upstreamProviderName: Schema.optional(TrimmedNonEmptyString),
   optionDescriptors: Schema.optional(Schema.Array(ProviderOptionDescriptor)),


### PR DESCRIPTION
## Summary

- preserve Droid model descriptions through provider discovery
- show the live Factory token multiplier as a compact badge in the Droid model picker
- keep BYOK models description-free when Droid does not provide pricing data

## Why

Droid already exposes dynamic descriptions such as `2x Factory token rate` and `0.38x Factory token rate` over ACP, but Synara dropped them while converting discovered models for the UI. This made relative model cost invisible at selection time.

The picker derives its badge from Droid's current description instead of hardcoding pricing, so future multiplier changes flow through automatically. The full description remains available to assistive technology and as a tooltip.

## Validation

- `bun fmt`
- `bun lint` (0 errors; existing warnings only)
- `bun typecheck`
- `bun run test` (all 10 package tasks passed)
- `bun run test:browser` (155 tests passed)
- `bun run build`
- packaged macOS app tested against Droid 0.170.0: Factory models showed live multipliers and custom BYOK models showed no badge

This targets `synara/droid` so it stays focused on the Droid integration introduced in #313, and is independent of #337.
