### PR TITLE
Fix scoped React Doctor findings

### DIFF
--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -8,7 +8,6 @@
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useStore } from "zustand";
 import {
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
@@ -507,8 +506,8 @@ export function BrowserPanel({
 }: BrowserPanelProps) {
   const api = readNativeApi();
   const isLiveRuntime = runtimeMode === "live";
-  const threadBrowserState = useStore(useBrowserStateStore, selectThreadBrowserState(threadId));
-  const recentHistory = useStore(useBrowserStateStore, selectThreadBrowserHistory(threadId));
+  const threadBrowserState = useBrowserStateStore(selectThreadBrowserState(threadId));
+  const recentHistory = useBrowserStateStore(selectThreadBrowserHistory(threadId));
   const upsertThreadState = useBrowserStateStore((store) => store.upsertThreadState);
   const addComposerDraftImage = useComposerDraftStore((store) => store.addImage);
   const composerDraftImageCount = useComposerDraftStore(

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -658,7 +658,7 @@ export default function GitActionsControl({
       isDefaultBranchOverride,
       progressToastId,
       filePaths,
-    }: RunGitActionWithToastInput) => {
+    }: RunGitActionWithToastInput) {
       const actionStatus = statusOverride ?? gitStatusForActions;
       const actionBranch = actionStatus?.branch ?? null;
       const actionIsDefaultBranch =
@@ -939,13 +939,7 @@ export default function GitActionsControl({
       featureBranch: true,
       skipDefaultBranchPrompt: true,
     });
-  }, [
-    allSelected,
-    isCommitDialogOpen,
-    dialogCommitMessage,
-    runGitActionWithToast,
-    selectedFiles,
-  ]);
+  }, [allSelected, isCommitDialogOpen, dialogCommitMessage, runGitActionWithToast, selectedFiles]);
 
   const openCreateBranchDialog = useCallback(() => {
     setCreateBranchName(suggestedCreateBranchName);

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -12,7 +12,7 @@ import type {
   ThreadId,
 } from "@synara/contracts";
 import { useIsMutating, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronDownIcon,
   CloudSyncIcon,
@@ -646,8 +646,8 @@ export default function GitActionsControl({
     void promise.catch(() => undefined);
   }, [pullMutation, threadToastData]);
 
-  const runGitActionWithToast = useEffectEvent(
-    async ({
+  const runGitActionWithToast = useCallback(
+    async function runGitActionWithToast({
       action,
       commitMessage,
       forcePushOnlyProgress = false,
@@ -880,6 +880,15 @@ export default function GitActionsControl({
         });
       }
     },
+    [
+      defaultBranchName,
+      gitStatusForActions,
+      hasOriginRemote,
+      isDefaultBranch,
+      persistThreadPr,
+      runImmediateGitActionMutation,
+      threadToastData,
+    ],
   );
 
   const continuePendingDefaultBranchAction = useCallback(() => {
@@ -896,7 +905,7 @@ export default function GitActionsControl({
       ...(requiresFeatureBranchForDefaultBranchAction(action) ? { featureBranch: true } : {}),
       skipDefaultBranchPrompt: true,
     });
-  }, [pendingDefaultBranchAction]);
+  }, [pendingDefaultBranchAction, runGitActionWithToast]);
 
   const checkoutFeatureBranchAndContinuePendingAction = useCallback(() => {
     if (!pendingDefaultBranchAction) return;
@@ -912,7 +921,7 @@ export default function GitActionsControl({
       featureBranch: true,
       skipDefaultBranchPrompt: true,
     });
-  }, [pendingDefaultBranchAction]);
+  }, [pendingDefaultBranchAction, runGitActionWithToast]);
 
   const runDialogActionOnNewBranch = useCallback(() => {
     if (!isCommitDialogOpen) return;
@@ -930,7 +939,13 @@ export default function GitActionsControl({
       featureBranch: true,
       skipDefaultBranchPrompt: true,
     });
-  }, [allSelected, isCommitDialogOpen, dialogCommitMessage, selectedFiles]);
+  }, [
+    allSelected,
+    isCommitDialogOpen,
+    dialogCommitMessage,
+    runGitActionWithToast,
+    selectedFiles,
+  ]);
 
   const openCreateBranchDialog = useCallback(() => {
     setCreateBranchName(suggestedCreateBranchName);
@@ -962,7 +977,14 @@ export default function GitActionsControl({
     if (quickAction.action) {
       void runGitActionWithToast({ action: quickAction.action });
     }
-  }, [openCreateBranchDialog, openExistingPr, quickAction, runSyncWithRemote, threadToastData]);
+  }, [
+    openCreateBranchDialog,
+    openExistingPr,
+    quickAction,
+    runGitActionWithToast,
+    runSyncWithRemote,
+    threadToastData,
+  ]);
 
   const openCommitDialog = useCallback(() => {
     setExcludedFiles(new Set());
@@ -1099,7 +1121,7 @@ export default function GitActionsControl({
       }
       openCommitDialog();
     },
-    [openCommitDialog, openExistingPr],
+    [openCommitDialog, openExistingPr, runGitActionWithToast],
   );
 
   const gitPickerMenuItems = useMemo<GitPickerMenuItem[]>(() => {
@@ -1227,6 +1249,7 @@ export default function GitActionsControl({
     allSelected,
     dialogCommitMessage,
     isCommitDialogOpen,
+    runGitActionWithToast,
     selectedFiles,
     setDialogCommitMessage,
     setIsCommitDialogOpen,

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -4,7 +4,7 @@
 // is rendered detached, floating just above the composer (not fused into the
 // composer surface), so it reuses the composer surface chrome to stay in-tint.
 import { type ApprovalRequestId } from "@synara/contracts";
-import { memo, useEffect, useEffectEvent, useRef } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import { type PendingUserInput } from "../../session-logic";
 import {
   derivePendingUserInputProgress,
@@ -98,19 +98,22 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
     };
   }, [activeQuestion?.id, isResponding]);
 
-  const handleOptionSelection = useEffectEvent((questionId: string, optionLabel: string) => {
-    const nextDraftAnswer = onToggleOption(questionId, optionLabel);
-    if (activeQuestion?.multiSelect) {
-      return;
-    }
-    if (autoAdvanceTimerRef.current !== null) {
-      window.clearTimeout(autoAdvanceTimerRef.current);
-    }
-    autoAdvanceTimerRef.current = window.setTimeout(() => {
-      autoAdvanceTimerRef.current = null;
-      onAdvanceRef.current(nextDraftAnswer ? { [questionId]: nextDraftAnswer } : undefined);
-    }, 200);
-  });
+  const handleOptionSelection = useCallback(
+    (questionId: string, optionLabel: string) => {
+      const nextDraftAnswer = onToggleOption(questionId, optionLabel);
+      if (activeQuestion?.multiSelect) {
+        return;
+      }
+      if (autoAdvanceTimerRef.current !== null) {
+        window.clearTimeout(autoAdvanceTimerRef.current);
+      }
+      autoAdvanceTimerRef.current = window.setTimeout(() => {
+        autoAdvanceTimerRef.current = null;
+        onAdvanceRef.current(nextDraftAnswer ? { [questionId]: nextDraftAnswer } : undefined);
+      }, 200);
+    },
+    [activeQuestion?.multiSelect, onToggleOption],
+  );
 
   // Keyboard shortcut: digits toggle options for multi-select prompts and preserve
   // the current auto-advance behavior for single-select questions.
@@ -141,7 +144,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [activeQuestion, isResponding]);
+  }, [activeQuestion, handleOptionSelection, isResponding]);
 
   if (!activeQuestion) {
     return null;

--- a/apps/web/src/hooks/useTemporaryThreadLifecycle.ts
+++ b/apps/web/src/hooks/useTemporaryThreadLifecycle.ts
@@ -24,8 +24,7 @@ export function useTemporaryThreadLifecycle(activeThreadId: ThreadId | null): vo
   const clearTemporaryThread = useTemporaryThreadStore((store) => store.clearTemporaryThread);
   const initialDraftIsTemporary = useComposerDraftStore(
     (store) =>
-      activeThreadId !== null &&
-      store.draftThreadsByThreadId[activeThreadId]?.isTemporary === true,
+      activeThreadId !== null && store.draftThreadsByThreadId[activeThreadId]?.isTemporary === true,
   );
   const previousThreadStateRef = useRef<{
     threadId: ThreadId | null;

--- a/apps/web/src/hooks/useTemporaryThreadLifecycle.ts
+++ b/apps/web/src/hooks/useTemporaryThreadLifecycle.ts
@@ -22,10 +22,11 @@ export function useTemporaryThreadLifecycle(activeThreadId: ThreadId | null): vo
   const removeThreadFromSplitViews = useSplitViewStore((store) => store.removeThreadFromSplitViews);
   const temporaryThreadIds = useTemporaryThreadStore((store) => store.temporaryThreadIds);
   const clearTemporaryThread = useTemporaryThreadStore((store) => store.clearTemporaryThread);
-  const initialDraftThread =
-    activeThreadId !== null
-      ? useComposerDraftStore.getState().draftThreadsByThreadId[activeThreadId]
-      : undefined;
+  const initialDraftIsTemporary = useComposerDraftStore(
+    (store) =>
+      activeThreadId !== null &&
+      store.draftThreadsByThreadId[activeThreadId]?.isTemporary === true,
+  );
   const previousThreadStateRef = useRef<{
     threadId: ThreadId | null;
     wasTemporary: boolean;
@@ -33,7 +34,7 @@ export function useTemporaryThreadLifecycle(activeThreadId: ThreadId | null): vo
     threadId: activeThreadId,
     wasTemporary:
       (activeThreadId ? temporaryThreadIds[activeThreadId] === true : false) ||
-      initialDraftThread?.isTemporary === true,
+      initialDraftIsTemporary,
   });
   const disposingThreadIdsRef = useRef<Set<ThreadId>>(new Set());
 


### PR DESCRIPTION
## Summary

Runs React Doctor v0.7.6 against `@synara/web`, triages the three top error families, and stacks two verified fix commits on this central draft PR.

### Fixed

- **Rules of Hooks — 9/9 true positives, high confidence**
  - replaces `useEffectEvent` calls from user handlers in Git actions and pending-input choices with dependency-safe callbacks
  - covers default-branch confirmation, quick/menu/commit actions, toast follow-up CTAs, mouse choice selection, and keyboard selection
- **Hook-as-value / Compiler compatibility — 3/3 true positives, high confidence**
  - calls the bound browser Zustand store directly instead of passing a hook as a normal value
  - replaces a render-time `.getState()` read with a narrow boolean selector while preserving the initial temporary-draft snapshot

### Triaged without code changes

- **Missing cleanup — 2/2 false positives, high confidence**
  - `ChatView` disconnects its `ResizeObserver` through the callback-ref null/replacement lifecycle
  - `EditorWorkspaceView` removes the exact pointer listeners, cancels RAF, restores body state, and also tears down on unmount

### Deliberately out of scope

The broad baseline contains 1,560 findings, including 519 redundant-memoization warnings across 147 files. React Doctor itself marks that work as migration-scale. This PR avoids mass churn and limits changes to the top high-confidence families. No suppressions or Doctor configuration changes were added.

## Commits

1. `f6940783d` — fix React event callback usage
2. `aa5862a4b` — fix React Compiler store access

## Validation

- React Doctor v0.7.6: serial, changed-lines scan against `main` — **no issues**
- Vitest with one worker — **97 tests passed** across Git action logic, browser logic, and temporary-thread lifecycle
- `git diff --check` — clean

Full workspace `fmt`, `lint`, and `typecheck` were not run because repository instructions require explicit user authorization for those heavyweight checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized React hook and store-subscription fixes with no auth, data-model, or API changes; behavior is intended to match prior flows with clearer hook dependencies.
> 
> **Overview**
> Addresses targeted **React Doctor** hook/Compiler issues in `@synara/web` without broad refactors.
> 
> **Rules of Hooks / event callbacks:** `useEffectEvent` is removed from user-driven paths in `GitActionsControl` and `ComposerPendingUserInputPanel`. Shared handlers (`runGitActionWithToast`, option selection) are **`useCallback`** with explicit dependency arrays, and callers that invoke them update their own `useCallback` deps so git quick/menu/commit flows and pending-input mouse/keyboard selection stay dependency-safe.
> 
> **Zustand / Compiler:** `BrowserPanel` subscribes via **`useBrowserStateStore(selector)`** instead of `useStore(useBrowserStateStore, selector)`. `useTemporaryThreadLifecycle` replaces a render-time **`getState()`** draft read with a narrow selector for `isTemporary`, keeping the initial “was temporary” snapshot for cleanup logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c001ecc06ca39c646f648d267c77a48f1937300. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->