### PR TITLE
fix: restore desktop window state

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -23,6 +23,7 @@ import {
   nativeImage,
   nativeTheme,
   protocol,
+  screen,
   session,
   shell,
   systemPreferences,
@@ -151,6 +152,11 @@ import {
 } from "./desktopUserDataProfile";
 import { isBrokenPipeError } from "./desktopProcessErrors";
 import {
+  readDesktopWindowState,
+  resolveVisibleWindowBounds,
+  writeDesktopWindowState,
+} from "./windowState";
+import {
   acknowledgeSynaraStorageSnapshot,
   readSynaraStorageSnapshot,
   resolveSynaraStorageSnapshotPath,
@@ -190,6 +196,7 @@ const NOTIFICATIONS_IS_SUPPORTED_CHANNEL = "desktop:notifications-is-supported";
 const NOTIFICATIONS_SHOW_CHANNEL = "desktop:notifications-show";
 const BASE_DIR = process.env.SYNARA_HOME?.trim() || Path.join(OS.homedir(), ".synara");
 const STATE_DIR = Path.join(BASE_DIR, "userdata");
+const DESKTOP_WINDOW_STATE_PATH = Path.join(STATE_DIR, "desktop-window-state.json");
 const DESKTOP_SCHEME = SYNARA_DESKTOP_SCHEME;
 const ROOT_DIR = Path.resolve(__dirname, "../../..");
 const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
@@ -3067,9 +3074,24 @@ function getTitleBarOptions(): BrowserWindowConstructorOptions {
 }
 
 function createWindow(): BrowserWindow {
+  const savedWindowState = readDesktopWindowState(DESKTOP_WINDOW_STATE_PATH);
+  const primaryDisplay = screen.getPrimaryDisplay();
+  const restoredBounds = savedWindowState
+    ? resolveVisibleWindowBounds({
+        savedBounds: savedWindowState.bounds,
+        displayWorkAreas: [
+          primaryDisplay.workArea,
+          ...screen
+            .getAllDisplays()
+            .filter((display) => display.id !== primaryDisplay.id)
+            .map((display) => display.workArea),
+        ],
+        minimumWidth: 840,
+        minimumHeight: 620,
+      })
+    : { width: 1100, height: 780 };
   const window = new BrowserWindow({
-    width: 1100,
-    height: 780,
+    ...restoredBounds,
     minWidth: 840,
     minHeight: 620,
     show: false,
@@ -3144,9 +3166,12 @@ function createWindow(): BrowserWindow {
     emitUpdateState();
   });
   window.once("ready-to-show", () => {
-    // Launch filling the screen work area; the 1100x780 size above stays as the
-    // restore bounds when the user toggles the window back out of maximized.
-    window.maximize();
+    // Preserve the original first-launch behavior, then respect the state saved
+    // by subsequent closes. Normal bounds are restored before maximizing so the
+    // native restore control returns to the user's last windowed size.
+    if (!savedWindowState || savedWindowState.isMaximized) {
+      window.maximize();
+    }
     window.show();
     emitDesktopWindowState(window);
   });
@@ -3155,6 +3180,17 @@ function createWindow(): BrowserWindow {
   window.on("unmaximize", () => emitDesktopWindowState(window));
   window.on("enter-full-screen", () => emitDesktopWindowState(window));
   window.on("leave-full-screen", () => emitDesktopWindowState(window));
+  window.on("close", () => {
+    try {
+      writeDesktopWindowState(DESKTOP_WINDOW_STATE_PATH, {
+        version: 1,
+        bounds: window.getNormalBounds(),
+        isMaximized: window.isMaximized(),
+      });
+    } catch (error) {
+      console.warn(`[desktop] Failed to persist window state: ${formatErrorMessage(error)}`);
+    }
+  });
 
   if (isDevelopment) {
     void window.loadURL(process.env.VITE_DEV_SERVER_URL as string);

--- a/apps/desktop/src/windowState.test.ts
+++ b/apps/desktop/src/windowState.test.ts
@@ -1,0 +1,92 @@
+import * as FS from "node:fs";
+import * as OS from "node:os";
+import * as Path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  parseDesktopWindowState,
+  readDesktopWindowState,
+  resolveVisibleWindowBounds,
+  writeDesktopWindowState,
+} from "./windowState";
+
+const workArea = { x: 0, y: 0, width: 1920, height: 1040 };
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    FS.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("desktop window state", () => {
+  it("parses a valid persisted state and rejects malformed bounds", () => {
+    expect(
+      parseDesktopWindowState({
+        version: 1,
+        bounds: { x: 120, y: 80, width: 1100, height: 780 },
+        isMaximized: false,
+      }),
+    ).toEqual({
+      version: 1,
+      bounds: { x: 120, y: 80, width: 1100, height: 780 },
+      isMaximized: false,
+    });
+    expect(
+      parseDesktopWindowState({
+        version: 1,
+        bounds: { x: 0, y: 0, width: -1, height: 780 },
+        isMaximized: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("round-trips state through the filesystem", () => {
+    const directory = FS.mkdtempSync(Path.join(OS.tmpdir(), "synara-window-state-"));
+    temporaryDirectories.push(directory);
+    const filePath = Path.join(directory, "nested", "window-state.json");
+    const state = {
+      version: 1,
+      bounds: { x: 40, y: 50, width: 1280, height: 800 },
+      isMaximized: true,
+    } as const;
+
+    writeDesktopWindowState(filePath, state);
+
+    expect(readDesktopWindowState(filePath)).toEqual(state);
+  });
+
+  it("keeps visible bounds unchanged", () => {
+    expect(
+      resolveVisibleWindowBounds({
+        savedBounds: { x: 100, y: 90, width: 1200, height: 800 },
+        displayWorkAreas: [workArea],
+        minimumWidth: 840,
+        minimumHeight: 620,
+      }),
+    ).toEqual({ x: 100, y: 90, width: 1200, height: 800 });
+  });
+
+  it("centers off-screen bounds on the primary display and clamps their size", () => {
+    expect(
+      resolveVisibleWindowBounds({
+        savedBounds: { x: 4000, y: 3000, width: 2400, height: 1600 },
+        displayWorkAreas: [workArea],
+        minimumWidth: 840,
+        minimumHeight: 620,
+      }),
+    ).toEqual({ x: 0, y: 0, width: 1920, height: 1040 });
+  });
+
+  it("restores a window onto the display where most of it was visible", () => {
+    expect(
+      resolveVisibleWindowBounds({
+        savedBounds: { x: 2100, y: 100, width: 1000, height: 700 },
+        displayWorkAreas: [workArea, { x: 1920, y: 0, width: 1920, height: 1040 }],
+        minimumWidth: 840,
+        minimumHeight: 620,
+      }),
+    ).toEqual({ x: 2100, y: 100, width: 1000, height: 700 });
+  });
+});

--- a/apps/desktop/src/windowState.ts
+++ b/apps/desktop/src/windowState.ts
@@ -94,14 +94,15 @@ export function resolveVisibleWindowBounds(input: {
   readonly minimumWidth: number;
   readonly minimumHeight: number;
 }): DesktopWindowBounds {
-  const { savedBounds, displayWorkAreas } = input;
-  if (displayWorkAreas.length === 0) {
+  const { savedBounds } = input;
+  const [firstWorkArea, ...remainingWorkAreas] = input.displayWorkAreas;
+  if (!firstWorkArea) {
     return savedBounds;
   }
 
-  let targetWorkArea = displayWorkAreas[0];
+  let targetWorkArea = firstWorkArea;
   let largestIntersection = intersectionArea(savedBounds, targetWorkArea);
-  for (const workArea of displayWorkAreas.slice(1)) {
+  for (const workArea of remainingWorkAreas) {
     const area = intersectionArea(savedBounds, workArea);
     if (area > largestIntersection) {
       targetWorkArea = workArea;

--- a/apps/desktop/src/windowState.ts
+++ b/apps/desktop/src/windowState.ts
@@ -1,0 +1,129 @@
+// FILE: windowState.ts
+// Purpose: Persists and safely restores the desktop window's normal bounds.
+// Layer: Desktop main process
+
+import * as FS from "node:fs";
+import * as Path from "node:path";
+
+export interface DesktopWindowBounds {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface PersistedDesktopWindowState {
+  readonly version: 1;
+  readonly bounds: DesktopWindowBounds;
+  readonly isMaximized: boolean;
+}
+
+function isFiniteInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value);
+}
+
+function isWindowBounds(value: unknown): value is DesktopWindowBounds {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    isFiniteInteger(candidate.x) &&
+    isFiniteInteger(candidate.y) &&
+    isFiniteInteger(candidate.width) &&
+    candidate.width > 0 &&
+    isFiniteInteger(candidate.height) &&
+    candidate.height > 0
+  );
+}
+
+export function parseDesktopWindowState(value: unknown): PersistedDesktopWindowState | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (
+    candidate.version !== 1 ||
+    !isWindowBounds(candidate.bounds) ||
+    typeof candidate.isMaximized !== "boolean"
+  ) {
+    return null;
+  }
+  return {
+    version: 1,
+    bounds: candidate.bounds,
+    isMaximized: candidate.isMaximized,
+  };
+}
+
+export function readDesktopWindowState(filePath: string): PersistedDesktopWindowState | null {
+  try {
+    return parseDesktopWindowState(JSON.parse(FS.readFileSync(filePath, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+export function writeDesktopWindowState(
+  filePath: string,
+  state: PersistedDesktopWindowState,
+): void {
+  FS.mkdirSync(Path.dirname(filePath), { recursive: true });
+  FS.writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+function intersectionArea(left: DesktopWindowBounds, right: DesktopWindowBounds): number {
+  const width = Math.max(
+    0,
+    Math.min(left.x + left.width, right.x + right.width) - Math.max(left.x, right.x),
+  );
+  const height = Math.max(
+    0,
+    Math.min(left.y + left.height, right.y + right.height) - Math.max(left.y, right.y),
+  );
+  return width * height;
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum);
+}
+
+export function resolveVisibleWindowBounds(input: {
+  readonly savedBounds: DesktopWindowBounds;
+  readonly displayWorkAreas: ReadonlyArray<DesktopWindowBounds>;
+  readonly minimumWidth: number;
+  readonly minimumHeight: number;
+}): DesktopWindowBounds {
+  const { savedBounds, displayWorkAreas } = input;
+  if (displayWorkAreas.length === 0) {
+    return savedBounds;
+  }
+
+  let targetWorkArea = displayWorkAreas[0];
+  let largestIntersection = intersectionArea(savedBounds, targetWorkArea);
+  for (const workArea of displayWorkAreas.slice(1)) {
+    const area = intersectionArea(savedBounds, workArea);
+    if (area > largestIntersection) {
+      targetWorkArea = workArea;
+      largestIntersection = area;
+    }
+  }
+
+  const width = Math.min(targetWorkArea.width, Math.max(input.minimumWidth, savedBounds.width));
+  const height = Math.min(targetWorkArea.height, Math.max(input.minimumHeight, savedBounds.height));
+  const centeredX = targetWorkArea.x + Math.round((targetWorkArea.width - width) / 2);
+  const centeredY = targetWorkArea.y + Math.round((targetWorkArea.height - height) / 2);
+
+  return {
+    x:
+      largestIntersection === 0
+        ? centeredX
+        : clamp(savedBounds.x, targetWorkArea.x, targetWorkArea.x + targetWorkArea.width - width),
+    y:
+      largestIntersection === 0
+        ? centeredY
+        : clamp(savedBounds.y, targetWorkArea.y, targetWorkArea.y + targetWorkArea.height - height),
+    width,
+    height,
+  };
+}


### PR DESCRIPTION
## What Changed

- Persist the desktop window normal bounds and maximized state when it closes.
- Restore saved bounds on launch while clamping stale or off-screen positions to the available displays.
- Preserve the existing maximized behavior on first launch.
- Add focused tests for state validation, file round-tripping, and single- and multi-display bounds restoration.

## Why

The desktop app currently discards the user’s windowed size and position and always launches maximized. Restoring the last usable normal bounds makes repeated desktop launches behave as expected without allowing a disconnected display to leave the window off-screen.

Fixes #344.

## Verification

- `bun run --cwd apps/desktop test -- src/windowState.test.ts` (5 tests passed)
- `bun run --cwd apps/desktop build` (passed; existing `original-fs` external dependency warning remains)
- `bunx oxfmt --check apps/desktop/src/main.ts apps/desktop/src/windowState.ts apps/desktop/src/windowState.test.ts` (passed)
- `bunx oxlint apps/desktop/src/main.ts apps/desktop/src/windowState.ts apps/desktop/src/windowState.test.ts` (0 warnings, 0 errors)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable because this does not change rendered UI
- [ ] I included a short video showing the resize, close, and reopen interaction