### PR TITLE
fix(opencode): discover Windows provider credentials

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.test.ts
@@ -7,16 +7,18 @@ import { Duration, Effect, Exit, Layer, Scope, Sink, Stream } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import { TestClock } from "effect/testing";
 import type { ChatAttachment } from "@synara/contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildOpenCodeServerProcessEnv,
+  KILO_CLI_SPEC,
   OpenCodeRuntime,
   OpenCodeRuntimeError,
   OpenCodeRuntimeLive,
   OPENCODE_LOCAL_SERVER_IDLE_TTL_MS,
   parseOpenCodeCliModelsOutput,
   parseOpenCodeCredentialProviderIDs,
+  resolveOpenCodeAuthFilePath,
   toOpenCodeFileParts,
 } from "./opencodeRuntime.ts";
 
@@ -728,5 +730,32 @@ describe("parseOpenCodeCredentialProviderIDs", () => {
 }`);
 
     expect(providerIDs).toEqual(["openai"]);
+  });
+});
+
+describe("resolveOpenCodeAuthFilePath", () => {
+  it("uses OpenCode's XDG data directory on every platform", () => {
+    vi.stubEnv("XDG_DATA_HOME", "");
+    try {
+      expect(resolveOpenCodeAuthFilePath({ home: "/home/developer" }).replaceAll("\\", "/")).toBe(
+        "/home/developer/.local/share/opencode/auth.json",
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("respects XDG_DATA_HOME and compatible CLI data directories", () => {
+    vi.stubEnv("XDG_DATA_HOME", "/custom/data");
+    try {
+      expect(
+        resolveOpenCodeAuthFilePath({ home: "/home/developer" }, KILO_CLI_SPEC).replaceAll(
+          "\\",
+          "/",
+        ),
+      ).toBe("/custom/data/kilo/auth.json");
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -455,12 +455,6 @@ function resolveOpenCodeDataDirectory(
   homeDirectory: string,
   dataDirectoryName = "opencode",
 ): string {
-  if (process.platform === "win32") {
-    const appDataDirectory =
-      trimToNull(process.env.APPDATA) ?? join(homeDirectory, "AppData", "Roaming");
-    return join(appDataDirectory, dataDirectoryName);
-  }
-
   const xdgDataHome =
     trimToNull(process.env.XDG_DATA_HOME) ?? join(homeDirectory, ".local", "share");
   return join(xdgDataHome, dataDirectoryName);


### PR DESCRIPTION
## What Changed

- Resolve OpenCode-compatible credential stores from the XDG data directory on Windows, matching OpenCode's own path behavior.
- Preserve explicit `XDG_DATA_HOME` overrides and compatible CLI data directory names such as Kilo.
- Add focused coverage for the default and overridden credential paths.

## Why

OpenCode stores credentials in `~/.local/share/opencode/auth.json` on Windows, but Synara looked under `%APPDATA%/opencode/auth.json`. Missing credential metadata caused model discovery to prefer only OpenCode-managed providers such as OpenCode Go and OpenCode Zen, filtering out authenticated providers such as OpenAI and OpenRouter.

## Validation

- `bun run test -- src/provider/opencodeRuntime.test.ts -t "resolveOpenCodeAuthFilePath|parseOpenCodeCredentialProviderIDs"` (4 passed)
- `bun run test -- src/provider/Layers/OpenCodeAdapter.test.ts` (49 passed)
- Live Windows discovery with OpenCode 1.17.18 returned 545 models across all 9 authenticated providers.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after screenshots are not applicable because this does not change UI
- [x] A video is not applicable because this does not change animation or interaction behavior
