### PR TITLE
feat(canvas): add AI canvas workspace

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@effect/language-service": "catalog:",
     "@effect/vitest": "catalog:",
+    "@synara/excalidraw-mcp": "workspace:*",
     "@synara/contracts": "workspace:*",
     "@synara/shared": "workspace:*",
     "@synara/web": "workspace:*",

--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -164,6 +164,16 @@ const buildCmd = Command.make(
         })`bun tsdown`,
       );
 
+      const canvasMcpDist = path.join(repoRoot, "packages/excalidraw-mcp/dist");
+      const canvasMcpEntry = path.join(canvasMcpDist, "main.mjs");
+      if (!(yield* fs.exists(canvasMcpEntry))) {
+        return yield* new CliError({
+          message: `Missing Canvas MCP build at ${canvasMcpEntry}. Build workspace dependencies first.`,
+        });
+      }
+      yield* fs.copy(canvasMcpDist, path.join(serverDir, "dist/excalidraw-mcp"));
+      yield* Effect.log("[cli] Bundled Canvas MCP into dist/excalidraw-mcp");
+
       const webDist = path.join(repoRoot, "apps/web/dist");
       const clientTarget = path.join(serverDir, "dist/client");
 
@@ -201,7 +211,11 @@ const publishCmd = Command.make(
       const backupPath = `${packageJsonPath}.bak`;
 
       // Assert build assets exist
-      for (const relPath of ["dist/index.mjs", "dist/client/index.html"]) {
+      for (const relPath of [
+        "dist/index.mjs",
+        "dist/client/index.html",
+        "dist/excalidraw-mcp/main.mjs",
+      ]) {
         const abs = path.join(serverDir, relPath);
         if (!(yield* fs.exists(abs))) {
           return yield* new CliError({

--- a/apps/server/src/canvasAgentContext.test.ts
+++ b/apps/server/src/canvasAgentContext.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { wrapCanvasAgentContext } from "./canvasAgentContext";
+
+describe("wrapCanvasAgentContext", () => {
+  it("injects bounded drawing rules without scene or capability data", () => {
+    const result = wrapCanvasAgentContext({ threadId: "drawing-1", messageText: "画 TCP/IP 图" });
+    expect(result).toContain('drawing_id="drawing-1"');
+    expect(result).toContain("ask exactly one focused clarification question");
+    expect(result).toContain("Call read_me before your first drawing operation");
+    expect(result).toContain("画 TCP/IP 图");
+    expect(result).not.toContain("BRIDGE_TOKEN");
+  });
+});

--- a/apps/server/src/canvasAgentContext.ts
+++ b/apps/server/src/canvasAgentContext.ts
@@ -1,0 +1,14 @@
+const CANVAS_CONTEXT_VERSION = 1;
+
+export function wrapCanvasAgentContext(input: {
+  readonly threadId: string;
+  readonly messageText: string;
+}): string {
+  return `<canvas_context version="${CANVAS_CONTEXT_VERSION}" drawing_id="${input.threadId}">
+You are collaborating on the current editable Excalidraw Drawing. Call read_me before your first drawing operation in this conversation, then call read_scene before modifying an existing scene. If a choice changes factual structure, ask exactly one focused clarification question before drawing; choose sensible defaults for visual-only choices. Use create_view for scene changes, preserve unrelated elements and stable ids, and summarize the completed change briefly. Do not access or select another Drawing.
+</canvas_context>
+
+<latest_user_message>
+${input.messageText}
+</latest_user_message>`;
+}

--- a/apps/server/src/canvasBridge.test.ts
+++ b/apps/server/src/canvasBridge.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { EMPTY_CANVAS_SCENE } from "@synara/shared/excalidrawScene";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  authorizeCanvasBridgeCapability,
+  issueCanvasBridgeCapability,
+  resetCanvasBridgeCapabilitiesForTest,
+  revokeCanvasBridgeCapability,
+  startCanvasBridgeServer,
+} from "./canvasBridge";
+import { createCanvasDrawing } from "./canvasDrawingFiles";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+beforeEach(resetCanvasBridgeCapabilitiesForTest);
+
+describe("canvas bridge capabilities", () => {
+  it("binds a high-entropy token to one drawing", () => {
+    const grant = issueCanvasBridgeCapability({ cwd: "/project", threadId: "drawing-1" });
+    expect(grant.token.length).toBeGreaterThan(32);
+    expect(authorizeCanvasBridgeCapability(grant.token, "drawing-1")).toEqual({
+      cwd: "/project",
+      threadId: "drawing-1",
+    });
+    expect(authorizeCanvasBridgeCapability(grant.token, "drawing-2")).toBeNull();
+  });
+
+  it("rejects a revoked capability", () => {
+    const grant = issueCanvasBridgeCapability({ cwd: "/project", threadId: "drawing-1" });
+    revokeCanvasBridgeCapability(grant.token);
+    expect(authorizeCanvasBridgeCapability(grant.token, "drawing-1")).toBeNull();
+  });
+
+  it("serves capability-scoped drawings on an independent loopback listener", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "synara-canvas-bridge-"));
+    roots.push(cwd);
+    const snapshot = await createCanvasDrawing({ cwd, threadId: "drawing-loopback" });
+    const grant = issueCanvasBridgeCapability({ cwd, threadId: "drawing-loopback" });
+    const server = await startCanvasBridgeServer();
+    try {
+      const response = await fetch(`${server.baseUrl}/internal/canvas/read`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${grant.token}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ threadId: "drawing-loopback" }),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        revision: snapshot.revision,
+        scene: EMPTY_CANVAS_SCENE,
+      });
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/apps/server/src/canvasBridge.ts
+++ b/apps/server/src/canvasBridge.ts
@@ -1,0 +1,195 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { createServer } from "node:http";
+
+import type { CanvasDrawingRef } from "@synara/contracts";
+import { MAX_CANVAS_SCENE_BYTES } from "@synara/shared/excalidrawScene";
+
+import {
+  CanvasDrawingConflictError,
+  readCanvasDrawing,
+  saveCanvasDrawing,
+} from "./canvasDrawingFiles";
+
+const CAPABILITY_TTL_MS = 12 * 60 * 60 * 1_000;
+const MAX_CAPABILITIES = 256;
+const MAX_BRIDGE_REQUEST_BYTES = MAX_CANVAS_SCENE_BYTES + 64 * 1024;
+
+interface CanvasBridgeGrant extends CanvasDrawingRef {
+  expiresAt: number;
+}
+
+const grants = new Map<string, CanvasBridgeGrant>();
+
+function tokenKey(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function pruneExpired(now = Date.now()): void {
+  for (const [token, grant] of grants) {
+    if (grant.expiresAt <= now) grants.delete(token);
+  }
+  while (grants.size >= MAX_CAPABILITIES) {
+    const oldest = grants.keys().next().value;
+    if (oldest === undefined) break;
+    grants.delete(oldest);
+  }
+}
+
+export function issueCanvasBridgeCapability(
+  input: CanvasDrawingRef,
+): { readonly token: string; readonly expiresAt: number } {
+  pruneExpired();
+  const token = randomBytes(32).toString("base64url");
+  const expiresAt = Date.now() + CAPABILITY_TTL_MS;
+  grants.set(tokenKey(token), { ...input, expiresAt });
+  return { token, expiresAt };
+}
+
+export function revokeCanvasBridgeCapability(token: string): void {
+  grants.delete(tokenKey(token));
+}
+
+export function authorizeCanvasBridgeCapability(
+  token: string,
+  threadId: string,
+): CanvasDrawingRef | null {
+  const now = Date.now();
+  pruneExpired(now);
+  const grant = grants.get(tokenKey(token));
+  if (!grant) return null;
+  const left = Buffer.from(grant.threadId);
+  const right = Buffer.from(threadId);
+  if (left.byteLength !== right.byteLength || !timingSafeEqual(left, right)) return null;
+  grant.expiresAt = now + CAPABILITY_TTL_MS;
+  return { cwd: grant.cwd, threadId: grant.threadId };
+}
+
+export function resetCanvasBridgeCapabilitiesForTest(): void {
+  grants.clear();
+}
+
+function isLoopbackAddress(address: string | undefined): boolean {
+  return address === "127.0.0.1" || address === "::1" || address === "::ffff:127.0.0.1";
+}
+
+async function readJsonBody(request: import("node:http").IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let byteLength = 0;
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    byteLength += buffer.byteLength;
+    if (byteLength > MAX_BRIDGE_REQUEST_BYTES) {
+      throw new RangeError("Canvas bridge request is too large.");
+    }
+    chunks.push(buffer);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function sendJson(
+  response: import("node:http").ServerResponse,
+  status: number,
+  value: unknown,
+): void {
+  response.writeHead(status, { "content-type": "application/json; charset=utf-8" });
+  response.end(JSON.stringify(value));
+}
+
+export interface CanvasBridgeServer {
+  readonly baseUrl: string;
+  readonly close: () => Promise<void>;
+}
+
+export function startCanvasBridgeServer(): Promise<CanvasBridgeServer> {
+  return new Promise((resolve, reject) => {
+    const server = createServer(async (request, response) => {
+      if (!isLoopbackAddress(request.socket.remoteAddress)) {
+        response.writeHead(403).end("Forbidden");
+        return;
+      }
+      if (request.method !== "POST") {
+        response.writeHead(405).end("Method Not Allowed");
+        return;
+      }
+
+      try {
+        const payload = await readJsonBody(request);
+        if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+          response.writeHead(400).end("Bad Request");
+          return;
+        }
+        const record = payload as Record<string, unknown>;
+        const threadId = typeof record.threadId === "string" ? record.threadId : "";
+        const authorization = request.headers.authorization ?? "";
+        const token = authorization.startsWith("Bearer ") ? authorization.slice(7) : "";
+        const drawing = authorizeCanvasBridgeCapability(token, threadId);
+        if (!drawing) {
+          response.writeHead(403).end("Forbidden");
+          return;
+        }
+
+        if (request.url === "/internal/canvas/read") {
+          sendJson(response, 200, await readCanvasDrawing(drawing));
+          return;
+        }
+        if (request.url === "/internal/canvas/save") {
+          if (typeof record.expectedRevision !== "string" || !record.scene) {
+            response.writeHead(400).end("Bad Request");
+            return;
+          }
+          sendJson(
+            response,
+            200,
+            await saveCanvasDrawing({
+              ...drawing,
+              expectedRevision: record.expectedRevision,
+              scene: record.scene as never,
+            }),
+          );
+          return;
+        }
+        response.writeHead(404).end("Not Found");
+      } catch (error) {
+        if (response.headersSent) {
+          response.end();
+          return;
+        }
+        const status =
+          error instanceof CanvasDrawingConflictError
+            ? 409
+            : error instanceof RangeError
+              ? 413
+              : error instanceof SyntaxError
+                ? 400
+                : 500;
+        response.writeHead(status).end(
+          error instanceof CanvasDrawingConflictError
+            ? error.message
+            : status === 413
+              ? "Payload Too Large"
+              : status === 400
+                ? "Bad Request"
+                : "Canvas bridge request failed",
+        );
+      }
+    });
+
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("Canvas bridge did not receive a TCP address."));
+        return;
+      }
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        close: () =>
+          new Promise<void>((closeResolve, closeReject) => {
+            server.close((error) => (error ? closeReject(error) : closeResolve()));
+          }),
+      });
+    });
+  });
+}

--- a/apps/server/src/canvasDrawingFiles.test.ts
+++ b/apps/server/src/canvasDrawingFiles.test.ts
@@ -1,0 +1,162 @@
+import { access, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  EMPTY_CANVAS_SCENE,
+  InvalidCanvasSceneError,
+  MAX_CANVAS_SCENE_BYTES,
+} from "@synara/shared/excalidrawScene";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  CanvasDrawingConflictError,
+  CanvasDrawingPathError,
+  createCanvasDrawing,
+  deleteCanvasDrawing,
+  readCanvasDrawing,
+  restoreTrashedCanvasDrawing,
+  saveCanvasDrawing,
+  trashCanvasDrawing,
+} from "./canvasDrawingFiles";
+
+const roots: string[] = [];
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "synara-canvas-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("canvasDrawingFiles", () => {
+  it("creates, saves, reads, and moves a drawing to trash", async () => {
+    const cwd = await workspace();
+    const created = await createCanvasDrawing({ cwd, threadId: "drawing-1" });
+    expect(created.scene).toEqual(EMPTY_CANVAS_SCENE);
+
+    const scene = {
+      ...EMPTY_CANVAS_SCENE,
+      elements: [{ id: "layer-1", type: "rectangle" }],
+    };
+    const saved = await saveCanvasDrawing({
+      cwd,
+      threadId: "drawing-1",
+      scene,
+      expectedRevision: created.revision,
+    });
+    expect(saved.revision).not.toBe(created.revision);
+    expect((await readCanvasDrawing({ cwd, threadId: "drawing-1" })).scene).toEqual(scene);
+
+    expect(await deleteCanvasDrawing({ cwd, threadId: "drawing-1" })).toEqual({ deleted: true });
+    await expect(readCanvasDrawing({ cwd, threadId: "drawing-1" })).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("rejects stale revisions without overwriting the valid file", async () => {
+    const cwd = await workspace();
+    const created = await createCanvasDrawing({ cwd, threadId: "drawing-2" });
+    await expect(
+      saveCanvasDrawing({
+        cwd,
+        threadId: "drawing-2",
+        scene: { ...EMPTY_CANVAS_SCENE, elements: [{ id: "new" }] },
+        expectedRevision: "stale",
+      }),
+    ).rejects.toBeInstanceOf(CanvasDrawingConflictError);
+    expect((await readCanvasDrawing({ cwd, threadId: "drawing-2" })).revision).toBe(
+      created.revision,
+    );
+  });
+
+  it("serializes concurrent saves so only one writer can consume a revision", async () => {
+    const cwd = await workspace();
+    const created = await createCanvasDrawing({ cwd, threadId: "drawing-concurrent" });
+    const results = await Promise.allSettled(
+      ["first", "second"].map((id) =>
+        saveCanvasDrawing({
+          cwd,
+          threadId: "drawing-concurrent",
+          scene: { ...EMPTY_CANVAS_SCENE, elements: [{ id }] },
+          expectedRevision: created.revision,
+        }),
+      ),
+    );
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejected = results.find((result) => result.status === "rejected");
+    expect(rejected).toMatchObject({ reason: expect.any(CanvasDrawingConflictError) });
+    expect((await readCanvasDrawing({ cwd, threadId: "drawing-concurrent" })).scene.elements)
+      .toHaveLength(1);
+  });
+
+  it("rejects unsafe ids and a symlinked drawings directory", async () => {
+    const cwd = await workspace();
+    await expect(createCanvasDrawing({ cwd, threadId: "../escape" })).rejects.toBeInstanceOf(
+      CanvasDrawingPathError,
+    );
+
+    const outside = await workspace();
+    await mkdir(outside, { recursive: true });
+    await symlink(outside, path.join(cwd, "drawings"));
+    await expect(createCanvasDrawing({ cwd, threadId: "drawing-3" })).rejects.toBeInstanceOf(
+      CanvasDrawingPathError,
+    );
+  });
+
+  it("rejects a symlinked trash ancestor before creating outside directories", async () => {
+    const cwd = await workspace();
+    const outside = await workspace();
+    await createCanvasDrawing({ cwd, threadId: "drawing-trash-symlink" });
+    await symlink(outside, path.join(cwd, ".synara"));
+
+    await expect(
+      trashCanvasDrawing({ cwd, threadId: "drawing-trash-symlink" }),
+    ).rejects.toBeInstanceOf(CanvasDrawingPathError);
+    await expect(access(path.join(outside, "trash"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects oversized drawing files before parsing their contents", async () => {
+    const cwd = await workspace();
+    const created = await createCanvasDrawing({ cwd, threadId: "drawing-too-large" });
+    await writeFile(path.join(cwd, created.relativePath), Buffer.alloc(MAX_CANVAS_SCENE_BYTES + 1));
+
+    await expect(
+      readCanvasDrawing({ cwd, threadId: "drawing-too-large" }),
+    ).rejects.toBeInstanceOf(InvalidCanvasSceneError);
+  });
+
+  it("keeps the previous JSON when a save payload is invalid", async () => {
+    const cwd = await workspace();
+    const created = await createCanvasDrawing({ cwd, threadId: "drawing-4" });
+    const filePath = path.join(cwd, created.relativePath);
+    const before = await readFile(filePath, "utf8");
+
+    await expect(
+      saveCanvasDrawing({
+        cwd,
+        threadId: "drawing-4",
+        scene: { elements: "not-an-array" } as never,
+        expectedRevision: created.revision,
+      }),
+    ).rejects.toThrow();
+    expect(await readFile(filePath, "utf8")).toBe(before);
+  });
+
+  it("can compensate a trashed drawing when its thread deletion fails", async () => {
+    const cwd = await workspace();
+    await createCanvasDrawing({ cwd, threadId: "drawing-5" });
+    const trashed = await trashCanvasDrawing({ cwd, threadId: "drawing-5" });
+    await expect(readCanvasDrawing({ cwd, threadId: "drawing-5" })).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await restoreTrashedCanvasDrawing(trashed);
+    expect((await readCanvasDrawing({ cwd, threadId: "drawing-5" })).scene).toEqual(
+      EMPTY_CANVAS_SCENE,
+    );
+  });
+});

--- a/apps/server/src/canvasDrawingFiles.ts
+++ b/apps/server/src/canvasDrawingFiles.ts
@@ -1,0 +1,247 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  lstat,
+  mkdir,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+
+import type {
+  CanvasDrawingDeleteResult,
+  CanvasDrawingRef,
+  CanvasDrawingSaveInput,
+  CanvasDrawingSnapshot,
+} from "@synara/contracts";
+import {
+  EMPTY_CANVAS_SCENE,
+  InvalidCanvasSceneError,
+  MAX_CANVAS_SCENE_BYTES,
+  parseCanvasScene,
+  serializeCanvasScene,
+} from "@synara/shared/excalidrawScene";
+
+const SAFE_CANVAS_THREAD_ID = /^[A-Za-z0-9._:-]+$/;
+const drawingMutationTails = new Map<string, Promise<void>>();
+
+type CanvasDrawingFileSaveInput = CanvasDrawingSaveInput & CanvasDrawingRef;
+
+export class CanvasDrawingPathError extends Error {
+  readonly name = "CanvasDrawingPathError";
+}
+
+export class CanvasDrawingConflictError extends Error {
+  readonly name = "CanvasDrawingConflictError";
+  constructor(
+    readonly expectedRevision: string,
+    readonly actualRevision: string,
+  ) {
+    super("Canvas revision conflict: the drawing changed since it was loaded. Reload before saving again.");
+  }
+}
+
+function revisionOf(contents: string): string {
+  return createHash("sha256").update(contents).digest("hex");
+}
+
+async function withDrawingMutation<A>(
+  input: CanvasDrawingRef,
+  operation: () => Promise<A>,
+): Promise<A> {
+  const key = `${input.cwd}\0${input.threadId}`;
+  const previous = drawingMutationTails.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const tail = previous.then(() => gate);
+  drawingMutationTails.set(key, tail);
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (drawingMutationTails.get(key) === tail) {
+      drawingMutationTails.delete(key);
+    }
+  }
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
+}
+
+async function safeDirectory(cwd: string, segments: readonly string[]): Promise<{
+  readonly root: string;
+  readonly directory: string;
+}> {
+  const root = await realpath(cwd);
+  let directory = root;
+  for (const segment of segments) {
+    if (!segment || segment === "." || segment === ".." || segment.includes(path.sep)) {
+      throw new CanvasDrawingPathError("Canvas directory contains an unsafe path segment.");
+    }
+    const candidate = path.join(directory, segment);
+    let stat = await lstat(candidate).catch((cause: NodeJS.ErrnoException) => {
+      if (cause.code === "ENOENT") return null;
+      throw cause;
+    });
+    if (!stat) {
+      await mkdir(candidate);
+      stat = await lstat(candidate);
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new CanvasDrawingPathError("Canvas directories cannot contain symbolic links.");
+    }
+    directory = await realpath(candidate);
+    if (!isWithin(root, directory)) {
+      throw new CanvasDrawingPathError("Canvas directory resolves outside the project.");
+    }
+  }
+  return { root, directory };
+}
+
+function assertSafeThreadId(threadId: string): void {
+  if (!SAFE_CANVAS_THREAD_ID.test(threadId)) {
+    throw new CanvasDrawingPathError("Drawing identity cannot be used as a safe file name.");
+  }
+}
+
+async function drawingPath(input: CanvasDrawingRef): Promise<{
+  readonly root: string;
+  readonly filePath: string;
+  readonly relativePath: string;
+  readonly size: number | null;
+}> {
+  assertSafeThreadId(input.threadId);
+  const { root, directory } = await safeDirectory(input.cwd, ["drawings"]);
+  const fileName = `${input.threadId}.excalidraw`;
+  const filePath = path.join(directory, fileName);
+  if (!isWithin(root, filePath)) {
+    throw new CanvasDrawingPathError("Drawing path resolves outside the project.");
+  }
+  const stat = await lstat(filePath).catch((cause: NodeJS.ErrnoException) => {
+    if (cause.code === "ENOENT") return null;
+    throw cause;
+  });
+  if (stat?.isSymbolicLink()) {
+    throw new CanvasDrawingPathError("Drawing files cannot be symbolic links.");
+  }
+  return { root, filePath, relativePath: path.relative(root, filePath), size: stat?.size ?? null };
+}
+
+async function atomicWrite(filePath: string, contents: string): Promise<void> {
+  const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(tempPath, contents, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    await rename(tempPath, filePath);
+  } finally {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+  }
+}
+
+async function snapshotFromFile(input: CanvasDrawingRef): Promise<CanvasDrawingSnapshot> {
+  const resolved = await drawingPath(input);
+  if (resolved.size !== null && resolved.size > MAX_CANVAS_SCENE_BYTES) {
+    throw new InvalidCanvasSceneError(
+      `Canvas scene exceeds the ${MAX_CANVAS_SCENE_BYTES} byte limit.`,
+    );
+  }
+  const contents = await readFile(resolved.filePath, "utf8");
+  return {
+    relativePath: resolved.relativePath,
+    scene: parseCanvasScene(contents),
+    revision: revisionOf(contents),
+  };
+}
+
+export async function createCanvasDrawing(
+  input: CanvasDrawingRef,
+): Promise<CanvasDrawingSnapshot> {
+  return withDrawingMutation(input, async () => {
+    const resolved = await drawingPath(input);
+    try {
+      return await snapshotFromFile(input);
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException | null)?.code !== "ENOENT") throw cause;
+    }
+    await atomicWrite(resolved.filePath, serializeCanvasScene(EMPTY_CANVAS_SCENE));
+    return snapshotFromFile(input);
+  });
+}
+
+export function readCanvasDrawing(input: CanvasDrawingRef): Promise<CanvasDrawingSnapshot> {
+  return snapshotFromFile(input);
+}
+
+export async function saveCanvasDrawing(
+  input: CanvasDrawingFileSaveInput,
+): Promise<CanvasDrawingSnapshot> {
+  return withDrawingMutation(input, async () => {
+    const resolved = await drawingPath(input);
+    if (resolved.size !== null && resolved.size > MAX_CANVAS_SCENE_BYTES) {
+      throw new InvalidCanvasSceneError(
+        `Canvas scene exceeds the ${MAX_CANVAS_SCENE_BYTES} byte limit.`,
+      );
+    }
+    const current = await readFile(resolved.filePath, "utf8");
+    const currentRevision = revisionOf(current);
+    if (currentRevision !== input.expectedRevision) {
+      throw new CanvasDrawingConflictError(input.expectedRevision, currentRevision);
+    }
+    const contents = serializeCanvasScene(input.scene);
+    if (contents === current) return snapshotFromFile(input);
+    await atomicWrite(resolved.filePath, contents);
+    return snapshotFromFile(input);
+  });
+}
+
+export async function deleteCanvasDrawing(
+  input: CanvasDrawingRef,
+): Promise<CanvasDrawingDeleteResult> {
+  const trashed = await trashCanvasDrawing(input);
+  return { deleted: trashed !== null };
+}
+
+export interface TrashedCanvasDrawing {
+  readonly originalPath: string;
+  readonly trashPath: string;
+}
+
+export async function trashCanvasDrawing(
+  input: CanvasDrawingRef,
+): Promise<TrashedCanvasDrawing | null> {
+  return withDrawingMutation(input, async () => {
+    const resolved = await drawingPath(input);
+    const stat = await lstat(resolved.filePath).catch((cause: NodeJS.ErrnoException) => {
+      if (cause.code === "ENOENT") return null;
+      throw cause;
+    });
+    if (!stat) return null;
+    if (stat.isSymbolicLink()) {
+      throw new CanvasDrawingPathError("Drawing files cannot be symbolic links.");
+    }
+    const { directory: trashDirectory } = await safeDirectory(input.cwd, [
+      ".synara",
+      "trash",
+      "drawings",
+    ]);
+    const trashPath = path.join(
+      trashDirectory,
+      `${input.threadId}.${new Date().toISOString().replaceAll(":", "-")}.excalidraw`,
+    );
+    await rename(resolved.filePath, trashPath);
+    return { originalPath: resolved.filePath, trashPath };
+  });
+}
+
+export async function restoreTrashedCanvasDrawing(
+  trashed: TrashedCanvasDrawing | null,
+): Promise<void> {
+  if (!trashed) return;
+  await rename(trashed.trashPath, trashed.originalPath);
+}

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -645,6 +645,7 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
           yield* projectionThreadRepository.upsert({
             threadId: event.payload.threadId,
             projectId: event.payload.projectId,
+            surface: event.payload.surface,
             title: event.payload.title,
             modelSelection: event.payload.modelSelection,
             runtimeMode: event.payload.runtimeMode,

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -573,6 +573,7 @@ function toProjectedThreadShell(input: {
   return {
     id: threadRow.threadId,
     projectId: threadRow.projectId,
+    surface: threadRow.surface,
     title: threadRow.title,
     modelSelection: threadRow.modelSelection,
     runtimeMode: threadRow.runtimeMode,
@@ -614,6 +615,7 @@ function toProjectedThreadShellFromStoredSummary(input: {
   return {
     id: threadRow.threadId,
     projectId: threadRow.projectId,
+    surface: threadRow.surface,
     title: threadRow.title,
     modelSelection: threadRow.modelSelection,
     runtimeMode: threadRow.runtimeMode,
@@ -660,6 +662,7 @@ function toProjectedThread(input: {
   return {
     id: threadRow.threadId,
     projectId: threadRow.projectId,
+    surface: threadRow.surface,
     title: threadRow.title,
     modelSelection: threadRow.modelSelection,
     runtimeMode: threadRow.runtimeMode,
@@ -763,6 +766,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          surface,
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",
@@ -808,6 +812,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          surface,
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",
@@ -1151,6 +1156,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          surface,
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",
@@ -1198,6 +1204,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          surface,
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -513,6 +513,49 @@ describe("ProviderCommandReactor", () => {
     );
   }
 
+  it("creates the backing canvas file as soon as a canvas thread is created", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    const workspaceRoot = path.join(path.dirname(harness.stateDir), "canvas-project");
+    const threadId = ThreadId.makeUnsafe("thread-canvas");
+    fs.mkdirSync(workspaceRoot, { recursive: true });
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.makeUnsafe("cmd-project-create-canvas"),
+        projectId: asProjectId("project-canvas"),
+        title: "Canvas Project",
+        workspaceRoot,
+        defaultModelSelection: { provider: "grok", model: "grok-4" },
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.makeUnsafe("cmd-thread-create-canvas"),
+        threadId,
+        projectId: asProjectId("project-canvas"),
+        surface: "canvas",
+        title: "Canvas Thread",
+        modelSelection: { provider: "grok", model: "grok-4" },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "full-access",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+      }),
+    );
+
+    const drawingPath = path.join(workspaceRoot, "drawings", `${threadId}.excalidraw`);
+    await waitFor(() => fs.existsSync(drawingPath));
+    expect(JSON.parse(fs.readFileSync(drawingPath, "utf8"))).toMatchObject({
+      type: "excalidraw",
+      elements: [],
+    });
+  });
+
   it("bootstraps sidechat context when the provider cannot fork natively", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -2,6 +2,9 @@
 // Purpose: Routes orchestration intents into provider sessions and maintains replay-safe context.
 // Layer: Orchestration provider reactor
 
+import { createRequire } from "node:module";
+import path from "node:path";
+
 import {
   type ChatAttachment,
   CommandId,
@@ -45,6 +48,13 @@ import {
   resolveThreadWorkspaceCwd,
 } from "../../checkpointing/Utils.ts";
 import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts";
+import { wrapCanvasAgentContext } from "../../canvasAgentContext.ts";
+import {
+  issueCanvasBridgeCapability,
+  revokeCanvasBridgeCapability,
+  startCanvasBridgeServer,
+} from "../../canvasBridge.ts";
+import { createCanvasDrawing } from "../../canvasDrawingFiles.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import { ProviderAdapterRequestError, ProviderServiceError } from "../../provider/Errors.ts";
 import { buildInlineSkillInstructions } from "../../provider/skillPromptInjection.ts";
@@ -285,6 +295,10 @@ const make = Effect.gen(function* () {
   const git = yield* GitCore;
   const textGeneration = yield* TextGeneration;
   const serverSettings = yield* ServerSettingsService;
+  const canvasBridgeServer = yield* Effect.acquireRelease(
+    Effect.tryPromise(() => startCanvasBridgeServer()),
+    (server) => Effect.promise(() => server.close()).pipe(Effect.catch(() => Effect.void)),
+  );
   const handledTurnStartKeys = yield* Cache.make<string, true>({
     capacity: HANDLED_TURN_START_KEY_MAX,
     timeToLive: HANDLED_TURN_START_KEY_TTL,
@@ -299,6 +313,13 @@ const make = Effect.gen(function* () {
     );
 
   const threadProviderOptions = new Map<string, ProviderStartOptions>();
+  const canvasBridgeTokens = new Map<string, string>();
+  const revokeCanvasBridgeForThread = (threadId: string) => {
+    const token = canvasBridgeTokens.get(threadId);
+    if (!token) return;
+    revokeCanvasBridgeCapability(token);
+    canvasBridgeTokens.delete(threadId);
+  };
   // The selection last applied to each live session. Keep this separate from
   // projected thread metadata so an option changed mid-turn is still compared
   // against the old subprocess configuration before the next turn starts.
@@ -514,6 +535,35 @@ const make = Effect.gen(function* () {
 
   const resolveThread = Effect.fnUntraced(function* (threadId: ThreadId) {
     return Option.getOrUndefined(yield* projectionSnapshotQuery.getThreadDetailById(threadId));
+  });
+
+  const initializeCanvasDrawingForThread = Effect.fnUntraced(function* (input: {
+    readonly threadId: ThreadId;
+    readonly projectId: ProjectId;
+  }) {
+    const project = Option.getOrUndefined(
+      yield* projectionSnapshotQuery.getProjectShellById(input.projectId),
+    );
+    if (!project) {
+      yield* Effect.logWarning("provider command reactor could not initialize canvas drawing", {
+        threadId: input.threadId,
+        projectId: input.projectId,
+        reason: "project missing from projection",
+      });
+      return;
+    }
+    yield* Effect.tryPromise(() =>
+      createCanvasDrawing({ cwd: project.workspaceRoot, threadId: input.threadId })
+    ).pipe(
+      Effect.catch((error) =>
+        Effect.logWarning("provider command reactor failed to initialize canvas drawing", {
+          threadId: input.threadId,
+          projectId: input.projectId,
+          workspaceRoot: project.workspaceRoot,
+          cause: error instanceof Error ? error.message : String(error),
+        }),
+      ),
+    );
   });
 
   // Recovers the parent thread when older/local-only subagent rows are missing parentThreadId metadata.
@@ -830,8 +880,34 @@ const make = Effect.gen(function* () {
     const startProviderSession = (input?: {
       readonly resumeCursor?: unknown;
       readonly provider?: ProviderKind;
-    }) =>
-      providerService.startSession(threadId, {
+    }) => {
+      const canvas =
+        thread.surface === "canvas" && preferredProvider === "grok" && effectiveCwd
+          ? (() => {
+              const previousToken = canvasBridgeTokens.get(threadId);
+              if (previousToken) revokeCanvasBridgeForThread(threadId);
+              const grant = issueCanvasBridgeCapability({ cwd: effectiveCwd, threadId });
+              canvasBridgeTokens.set(threadId, grant.token);
+              const mcpEntryPath = process.versions.bun
+                ? path.join(
+                    path.dirname(
+                      createRequire(import.meta.url).resolve(
+                        "@synara/excalidraw-mcp/package.json",
+                      ),
+                    ),
+                    "src/main.ts",
+                  )
+                : path.join(import.meta.dirname, "excalidraw-mcp/main.mjs");
+              return {
+                bridgeUrl: canvasBridgeServer.baseUrl,
+                bridgeToken: grant.token,
+                threadId,
+                mcpCommand: process.execPath,
+                mcpArgs: [mcpEntryPath],
+              } as const;
+            })()
+          : undefined;
+      const start = providerService.startSession(threadId, {
         threadId,
         ...(preferredProvider ? { provider: preferredProvider } : {}),
         ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
@@ -840,8 +916,15 @@ const make = Effect.gen(function* () {
           ? { providerOptions: options.providerOptions }
           : {}),
         ...(input?.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
+        ...(canvas ? { canvas } : {}),
         runtimeMode: desiredRuntimeMode,
       });
+      return canvas
+        ? start.pipe(
+            Effect.onError(() => Effect.sync(() => revokeCanvasBridgeForThread(threadId))),
+          )
+        : start;
+    };
 
     const bindSessionToThread = (session: ProviderSession) =>
       setThreadSession({
@@ -1041,9 +1124,13 @@ const make = Effect.gen(function* () {
     if (input.modelSelection !== undefined) {
       threadSessionModelSelections.set(input.threadId, input.modelSelection);
     }
+    const userMessageWithSurfaceContext =
+      thread.surface === "canvas"
+        ? wrapCanvasAgentContext({ threadId: thread.id, messageText: input.messageText })
+        : input.messageText;
     const boundaryMessageText = thread.sidechatSourceThreadId
-      ? wrapSidechatInput(input.messageText)
-      : input.messageText;
+      ? wrapSidechatInput(userMessageWithSurfaceContext)
+      : userMessageWithSurfaceContext;
     const shouldBootstrapHandoff =
       thread.handoff?.bootstrapStatus === "pending" &&
       !hasNativeAssistantMessagesBefore(thread, input.messageId);
@@ -2279,6 +2366,7 @@ const make = Effect.gen(function* () {
     pendingQueuedDispatchThreads.delete(thread.id);
     clearPendingContextBootstraps(thread.id);
     suppressContextBootstrapOnNextStartThreadIds.add(thread.id);
+    revokeCanvasBridgeForThread(thread.id);
 
     const now = event.payload.createdAt;
     const providerThreadId =
@@ -2357,6 +2445,12 @@ const make = Effect.gen(function* () {
         }
         case "thread.created":
           threadSessionModelSelections.set(event.payload.threadId, event.payload.modelSelection);
+          if (event.payload.surface === "canvas") {
+            yield* initializeCanvasDrawingForThread({
+              threadId: event.payload.threadId,
+              projectId: event.payload.projectId,
+            });
+          }
           return;
         case "thread.meta-updated": {
           const thread = yield* resolveThread(event.payload.threadId);

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -436,6 +436,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           projectId: command.projectId,
+          surface: command.surface,
           title: command.title,
           modelSelection: command.modelSelection,
           runtimeMode: command.runtimeMode,

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -75,6 +75,7 @@ describe("orchestration projector", () => {
       {
         id: "thread-1",
         projectId: "project-1",
+        surface: "chat",
         title: "demo",
         modelSelection: {
           provider: "codex",

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -350,6 +350,7 @@ export function projectEvent(
           {
             id: payload.threadId,
             projectId: payload.projectId,
+            surface: payload.surface,
             title: payload.title,
             modelSelection: payload.modelSelection,
             runtimeMode: payload.runtimeMode,

--- a/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionRepositories.test.ts
@@ -80,6 +80,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
       yield* threads.upsert({
         threadId: ThreadId.makeUnsafe("thread-null-options"),
         projectId: ProjectId.makeUnsafe("project-null-options"),
+        surface: "canvas",
         title: "Null options thread",
         modelSelection: {
           provider: "claudeAgent",
@@ -136,6 +137,7 @@ projectionRepositoriesLayer("Projection repositories", (it) => {
         provider: "claudeAgent",
         model: "claude-opus-4-6",
       });
+      assert.strictEqual(Option.getOrNull(persisted)?.surface, "canvas");
     }),
   );
 

--- a/apps/server/src/persistence/Layers/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreads.ts
@@ -50,6 +50,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
         INSERT INTO projection_threads (
           thread_id,
           project_id,
+          surface,
           title,
           model_selection_json,
           runtime_mode,
@@ -86,6 +87,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
         VALUES (
           ${row.threadId},
           ${row.projectId},
+          ${row.surface},
           ${row.title},
           ${JSON.stringify(row.modelSelection)},
           ${row.runtimeMode},
@@ -122,6 +124,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
         ON CONFLICT (thread_id)
         DO UPDATE SET
           project_id = excluded.project_id,
+          surface = excluded.surface,
           title = excluded.title,
           model_selection_json = excluded.model_selection_json,
           runtime_mode = excluded.runtime_mode,
@@ -165,6 +168,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          surface,
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",
@@ -210,6 +214,7 @@ const makeProjectionThreadRepository = Effect.gen(function* () {
         SELECT
           thread_id AS "threadId",
           project_id AS "projectId",
+          surface,
           title,
           model_selection_json AS "modelSelection",
           runtime_mode AS "runtimeMode",

--- a/apps/server/src/persistence/Migrations.test.ts
+++ b/apps/server/src/persistence/Migrations.test.ts
@@ -54,6 +54,7 @@ layer("reconcileMigrationLineage", (it) => {
       const afterColumns = yield* projectionThreadsColumnNames(sql);
       assert.include(afterColumns, "env_mode");
       assert.include(afterColumns, "archived_at");
+      assert.include(afterColumns, "surface");
 
       // The tracker now mirrors the Synara lineage exactly; foreign rows are gone.
       const rows = yield* trackerRows(sql);

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -69,6 +69,7 @@ import Migration0050 from "./Migrations/050_ProfileStatsArchive.ts";
 import Migration0051 from "./Migrations/051_ProfileStatsDeletedTokensModel.ts";
 import Migration0052 from "./Migrations/052_ProjectionThreadUserMessageSummaryIndex.ts";
 import Migration0053 from "./Migrations/053_BackfillThreadActivitySequence.ts";
+import Migration0054 from "./Migrations/054_ProjectionThreadsSurface.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -134,6 +135,7 @@ export const migrationEntries = [
   [51, "ProfileStatsDeletedTokensModel", Migration0051],
   [52, "ProjectionThreadUserMessageSummaryIndex", Migration0052],
   [53, "BackfillThreadActivitySequence", Migration0053],
+  [54, "ProjectionThreadsSurface", Migration0054],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/054_ProjectionThreadsSurface.ts
+++ b/apps/server/src/persistence/Migrations/054_ProjectionThreadsSurface.ts
@@ -1,0 +1,18 @@
+/** Adds the immutable chat/canvas surface discriminator to projected threads. */
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { columnExists } from "./schemaHelpers.ts";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  if (yield* columnExists(sql, "projection_threads", "surface")) {
+    return;
+  }
+
+  yield* sql`
+    ALTER TABLE projection_threads
+    ADD COLUMN surface TEXT NOT NULL DEFAULT 'chat'
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreads.ts
@@ -18,6 +18,7 @@ import {
   ProjectId,
   ProviderInteractionMode,
   RuntimeMode,
+  ThreadSurface,
   ThreadEnvironmentMode,
   ThreadId,
   TurnId,
@@ -30,6 +31,7 @@ import type { ProjectionRepositoryError } from "../Errors.ts";
 export const ProjectionThread = Schema.Struct({
   threadId: ThreadId,
   projectId: ProjectId,
+  surface: ThreadSurface,
   title: Schema.String,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -80,7 +80,7 @@ import {
   type AcpToolCallState,
   parsePermissionRequest,
 } from "../acp/AcpRuntimeModel.ts";
-import { makeAcpNativeLoggers } from "../acp/AcpNativeLogging.ts";
+import { makeAcpNativeLoggers, redactAcpLogPayload } from "../acp/AcpNativeLogging.ts";
 import {
   forkAcpTurnIdleWatchdog,
   resolveAcpTurnIdleTimeoutMs,
@@ -166,6 +166,7 @@ const collectStreamAsString = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.
   );
 
 function summarizeGrokAcpLogPayload(payload: unknown): unknown {
+  payload = redactAcpLogPayload(payload);
   const text =
     typeof payload === "string"
       ? payload
@@ -1108,6 +1109,22 @@ export function makeGrokAdapter(
             grokSettings: effectiveGrokSettings,
             childProcessSpawner,
             cwd,
+            ...(input.canvas
+              ? {
+                  mcpServers: [
+                    {
+                      name: "synara-excalidraw",
+                      command: input.canvas.mcpCommand,
+                      args: input.canvas.mcpArgs,
+                      env: [
+                        { name: "SYNARA_CANVAS_BRIDGE_URL", value: input.canvas.bridgeUrl },
+                        { name: "SYNARA_CANVAS_BRIDGE_TOKEN", value: input.canvas.bridgeToken },
+                        { name: "SYNARA_CANVAS_THREAD_ID", value: input.canvas.threadId },
+                      ],
+                    },
+                  ],
+                }
+              : {}),
             ...(resumeSessionId ? { resumeSessionId } : {}),
             clientInfo: { name: "Synara", version: "0.0.0" },
             ...acpRuntimeLoggers,

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -20,6 +20,40 @@ const mockAgentPath = path.join(__dirname, "../../../scripts/acp-mock-agent.ts")
 const bunExe = "bun";
 
 describe("AcpSessionRuntime", () => {
+  it.effect("passes configured MCP servers to new sessions", () => {
+    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    const mcpServers = [
+      {
+        name: "synara-excalidraw",
+        command: "node",
+        args: ["mcp.mjs"],
+        env: [{ name: "TOKEN", value: "secret" }],
+      },
+    ];
+    return Effect.gen(function* () {
+      const runtime = yield* AcpSessionRuntime;
+      yield* runtime.start();
+      expect(
+        requestEvents.find(
+          (event) => event.method === "session/new" && event.status === "started",
+        )?.payload,
+      ).toMatchObject({ mcpServers });
+    }).pipe(
+      Effect.provide(
+        AcpSessionRuntime.layer({
+          spawn: { command: bunExe, args: [mockAgentPath] },
+          cwd: process.cwd(),
+          mcpServers,
+          clientInfo: { name: "synara-test", version: "0.0.0" },
+          authMethodId: "test",
+          requestLogger: (event) => Effect.sync(() => requestEvents.push(event)),
+        }),
+      ),
+      Effect.scoped,
+      Effect.provide(NodeServices.layer),
+    );
+  });
+
   it.effect("merges custom initialize client capabilities into the ACP handshake", () => {
     const requestEvents: Array<AcpSessionRequestLogEvent> = [];
     return Effect.gen(function* () {
@@ -63,11 +97,25 @@ describe("AcpSessionRuntime", () => {
     );
   });
 
-  it.effect("loads a resumed session and still prompts normally", () =>
-    Effect.gen(function* () {
+  it.effect("loads a resumed session with configured MCP servers and still prompts", () => {
+    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    const mcpServers = [
+      {
+        name: "synara-excalidraw",
+        command: "node",
+        args: ["mcp.mjs"],
+        env: [{ name: "TOKEN", value: "secret" }],
+      },
+    ];
+    return Effect.gen(function* () {
       const runtime = yield* AcpSessionRuntime;
       const started = yield* runtime.start();
       expect(started.sessionId).toBe("mock-session-1");
+      expect(
+        requestEvents.find(
+          (event) => event.method === "session/load" && event.status === "started",
+        )?.payload,
+      ).toMatchObject({ mcpServers });
 
       // Resumed sessions drop session/update until a consumer attaches, so the
       // events stream must be taken before prompting (mirrors the adapters,
@@ -98,14 +146,16 @@ describe("AcpSessionRuntime", () => {
           },
           cwd: process.cwd(),
           resumeSessionId: "mock-session-1",
+          mcpServers,
           clientInfo: { name: "synara-test", version: "0.0.0" },
           authMethodId: "test",
+          requestLogger: (event) => Effect.sync(() => requestEvents.push(event)),
         }),
       ),
       Effect.scoped,
       Effect.provide(NodeServices.layer),
-    ),
-  );
+    );
+  });
 
   it.effect("prefers session/resume when the agent advertises it", () => {
     const requestEvents: Array<AcpSessionRequestLogEvent> = [];

--- a/apps/server/src/provider/acp/AcpNativeLogging.test.ts
+++ b/apps/server/src/provider/acp/AcpNativeLogging.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { redactAcpLogPayload } from "./AcpNativeLogging";
+
+describe("redactAcpLogPayload", () => {
+  it("removes Canvas bridge capabilities from nested ACP session payloads", () => {
+    expect(
+      redactAcpLogPayload({
+        mcpServers: [
+          {
+            name: "synara-excalidraw",
+            env: [
+              { name: "SYNARA_CANVAS_BRIDGE_TOKEN", value: "bridge-secret" },
+              { name: "SYNARA_CANVAS_THREAD_ID", value: "drawing-1" },
+            ],
+          },
+        ],
+        authorization: "Bearer bridge-secret",
+      }),
+    ).toEqual({
+      mcpServers: [
+        {
+          name: "synara-excalidraw",
+          env: [
+            { name: "SYNARA_CANVAS_BRIDGE_TOKEN", value: "[REDACTED]" },
+            { name: "SYNARA_CANVAS_THREAD_ID", value: "drawing-1" },
+          ],
+        },
+      ],
+      authorization: "[REDACTED]",
+    });
+  });
+
+  it("distinguishes repeated references from actual cycles", () => {
+    const shared = { name: "ordinary", value: "visible" };
+    const cyclic: { self?: unknown } = {};
+    cyclic.self = cyclic;
+
+    expect(redactAcpLogPayload({ first: shared, second: shared, cyclic })).toEqual({
+      first: shared,
+      second: shared,
+      cyclic: { self: "[Circular]" },
+    });
+  });
+});

--- a/apps/server/src/provider/acp/AcpNativeLogging.ts
+++ b/apps/server/src/provider/acp/AcpNativeLogging.ts
@@ -5,6 +5,31 @@ import type * as EffectAcpProtocol from "effect-acp/protocol";
 import type { EventNdjsonLogger } from "../Layers/EventNdjsonLogger.ts";
 import type { AcpSessionRequestLogEvent, AcpSessionRuntimeOptions } from "./AcpSessionRuntime.ts";
 
+const SENSITIVE_LOG_FIELD = /(?:token|secret|password|authorization|api[-_]?key)/i;
+
+export function redactAcpLogPayload(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) return value.map((entry) => redactAcpLogPayload(entry, seen));
+
+    const record = value as Record<string, unknown>;
+    const sensitiveEnvEntry =
+      typeof record.name === "string" && SENSITIVE_LOG_FIELD.test(record.name);
+    return Object.fromEntries(
+      Object.entries(record).map(([key, entry]) => [
+        key,
+        SENSITIVE_LOG_FIELD.test(key) || (sensitiveEnvEntry && key === "value")
+          ? "[REDACTED]"
+          : redactAcpLogPayload(entry, seen),
+      ]),
+    );
+  } finally {
+    seen.delete(value);
+  }
+}
+
 function writeNativeAcpLog(input: {
   readonly nativeEventLogger: EventNdjsonLogger | undefined;
   readonly provider: ProviderKind;
@@ -24,7 +49,7 @@ function writeNativeAcpLog(input: {
           provider: input.provider,
           createdAt: observedAt,
           threadId: input.threadId,
-          payload: input.payload,
+          payload: redactAcpLogPayload(input.payload),
         },
       },
       input.threadId,

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -55,6 +55,7 @@ export interface AcpSpawnInput {
 export interface AcpSessionRuntimeOptions {
   readonly spawn: AcpSpawnInput;
   readonly cwd: string;
+  readonly mcpServers?: ReadonlyArray<EffectAcpSchema.McpServer>;
   readonly resumeSessionId?: string;
   readonly clientCapabilities?: EffectAcpSchema.InitializeRequest["clientCapabilities"];
   readonly clientInfo: {
@@ -587,7 +588,7 @@ const makeAcpSessionRuntime = (
         const resumePayload = {
           sessionId: options.resumeSessionId,
           cwd: options.cwd,
-          mcpServers: [],
+          mcpServers: options.mcpServers ?? [],
         } satisfies EffectAcpSchema.ResumeSessionRequest;
         const supportsResume =
           initializeResult.agentCapabilities?.sessionCapabilities?.resume != null;
@@ -610,7 +611,7 @@ const makeAcpSessionRuntime = (
                 const loadPayload = {
                   sessionId: options.resumeSessionId,
                   cwd: options.cwd,
-                  mcpServers: [],
+                  mcpServers: options.mcpServers ?? [],
                 } satisfies EffectAcpSchema.LoadSessionRequest;
                 return runLoggedRequest(
                   "session/load",
@@ -634,7 +635,7 @@ const makeAcpSessionRuntime = (
           acceptingSessionUpdates = true;
           const createPayload = {
             cwd: options.cwd,
-            mcpServers: [],
+            mcpServers: options.mcpServers ?? [],
           } satisfies EffectAcpSchema.NewSessionRequest;
           const created = yield* runLoggedRequest(
             "session/new",
@@ -651,7 +652,7 @@ const makeAcpSessionRuntime = (
         acceptingSessionUpdates = true;
         const createPayload = {
           cwd: options.cwd,
-          mcpServers: [],
+          mcpServers: options.mcpServers ?? [],
         } satisfies EffectAcpSchema.NewSessionRequest;
         const created = yield* runLoggedRequest(
           "session/new",

--- a/apps/server/src/wsRpc.ts
+++ b/apps/server/src/wsRpc.ts
@@ -24,6 +24,13 @@ import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 
 import { AutomationService } from "./automation/Services/AutomationService";
 import { authErrorResponse, makeEffectAuthRequest } from "./auth/http";
+import {
+  createCanvasDrawing,
+  readCanvasDrawing,
+  restoreTrashedCanvasDrawing,
+  saveCanvasDrawing,
+  trashCanvasDrawing,
+} from "./canvasDrawingFiles";
 import { ServerAuth } from "./auth/Services/ServerAuth";
 import { SessionCredentialService } from "./auth/Services/SessionCredentialService";
 import { CheckpointDiffQuery } from "./checkpointing/Services/CheckpointDiffQuery";
@@ -612,6 +619,25 @@ export const makeWsRpcLayer = () =>
       const rpcEffect = <A, E, R>(effect: Effect.Effect<A, E, R>, fallbackMessage: string) =>
         effect.pipe(Effect.mapError((cause) => toWsRpcError(cause, fallbackMessage)));
 
+      const resolveCanvasDrawingInput = <A extends { readonly threadId: ThreadId }>(input: A) =>
+        Effect.gen(function* () {
+          const thread = Option.getOrUndefined(
+            yield* projectionReadModelQuery.getThreadShellById(input.threadId),
+          );
+          if (!thread || thread.surface !== "canvas") {
+            return yield* Effect.fail(
+              new Error("Canvas drawing access requires an active Canvas thread."),
+            );
+          }
+          const project = Option.getOrUndefined(
+            yield* projectionReadModelQuery.getProjectShellById(thread.projectId),
+          );
+          if (!project) {
+            return yield* Effect.fail(new Error("The Canvas thread project is unavailable."));
+          }
+          return { ...input, cwd: project.workspaceRoot };
+        });
+
       return WsRpcGroup.of({
         [ORCHESTRATION_WS_METHODS.dispatchCommand]: (command) =>
           rpcEffect(
@@ -751,6 +777,56 @@ export const makeWsRpcLayer = () =>
           ),
         [WS_METHODS.projectsWriteFile]: (input) =>
           rpcEffect(workspaceFileSystem.writeFile(input), "Failed to write workspace file"),
+        [WS_METHODS.canvasCreateDrawing]: (input) =>
+          rpcEffect(
+            resolveCanvasDrawingInput(input).pipe(
+              Effect.flatMap((resolved) => Effect.tryPromise(() => createCanvasDrawing(resolved))),
+            ),
+            "Failed to create canvas drawing",
+          ),
+        [WS_METHODS.canvasReadDrawing]: (input) =>
+          rpcEffect(
+            resolveCanvasDrawingInput(input).pipe(
+              Effect.flatMap((resolved) => Effect.tryPromise(() => readCanvasDrawing(resolved))),
+            ),
+            "Failed to read canvas drawing",
+          ),
+        [WS_METHODS.canvasSaveDrawing]: (input) =>
+          rpcEffect(
+            resolveCanvasDrawingInput(input).pipe(
+              Effect.flatMap((resolved) => Effect.tryPromise(() => saveCanvasDrawing(resolved))),
+            ),
+            "Failed to save canvas drawing",
+          ),
+        [WS_METHODS.canvasDeleteDrawing]: (input) =>
+          rpcEffect(
+            resolveCanvasDrawingInput(input).pipe(
+              Effect.flatMap((resolved) =>
+                Effect.gen(function* () {
+                  const trashed = yield* Effect.tryPromise(() => trashCanvasDrawing(resolved));
+                  yield* runtimeStartup
+                    .enqueueCommand(
+                      orchestrationEngine.dispatch({
+                        type: "thread.delete",
+                        commandId: CommandId.makeUnsafe(
+                          `server:canvas-delete:${crypto.randomUUID()}`,
+                        ),
+                        threadId: resolved.threadId,
+                      }),
+                    )
+                    .pipe(
+                      Effect.onError(() =>
+                        Effect.tryPromise(() => restoreTrashedCanvasDrawing(trashed)).pipe(
+                          Effect.catch(() => Effect.void),
+                        ),
+                      ),
+                    );
+                  return { deleted: trashed !== null };
+                }),
+              ),
+            ),
+            "Failed to delete canvas drawing",
+          ),
         [WS_METHODS.projectsRunDevServer]: (input) =>
           rpcEffect(devServerManager.run(input), "Failed to start dev server"),
         [WS_METHODS.projectsStopDevServer]: (input) =>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@excalidraw/excalidraw": "^0.18.0",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@formkit/auto-animate": "^0.9.0",

--- a/apps/web/src/components/CanvasWorkspaceView.browser.tsx
+++ b/apps/web/src/components/CanvasWorkspaceView.browser.tsx
@@ -1,0 +1,172 @@
+import "../index.css";
+
+import {
+  type CanvasDrawingSnapshot,
+  type NativeApi,
+  ProjectId,
+  ThreadId,
+} from "@synara/contracts";
+import { EMPTY_CANVAS_SCENE } from "@synara/shared/excalidrawScene";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { page } from "vitest/browser";
+import { render } from "vitest-browser-react";
+
+import { resetWsNativeApiForTest } from "../wsNativeApi";
+import { useStore } from "../store";
+import { CanvasWorkspaceView } from "./CanvasWorkspaceView";
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-router")>(
+    "@tanstack/react-router",
+  );
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(async () => undefined),
+  };
+});
+
+const PROJECT_ID = ProjectId.makeUnsafe("project-canvas-browser");
+const THREAD_ID = ThreadId.makeUnsafe("thread-canvas-browser");
+const NOW_ISO = "2026-07-14T00:00:00.000Z";
+
+function makeSnapshot(): CanvasDrawingSnapshot {
+  return {
+    relativePath: "drawings/thread-canvas-browser.excalidraw",
+    scene: EMPTY_CANVAS_SCENE,
+    revision: "revision-1",
+  };
+}
+
+describe("CanvasWorkspaceView", () => {
+  let previousNativeApi: NativeApi | undefined;
+
+  beforeEach(() => {
+    previousNativeApi = window.nativeApi;
+    resetWsNativeApiForTest();
+    localStorage.clear();
+    document.body.innerHTML = "";
+    useStore.setState({
+      projects: [
+        {
+          id: PROJECT_ID,
+          kind: "local",
+          name: "Canvas Project",
+          remoteName: "Canvas Project",
+          folderName: "canvas-project",
+          localName: null,
+          cwd: "/repo/canvas-project",
+          defaultModelSelection: { provider: "grok", model: "grok-4" },
+          expanded: true,
+          scripts: [],
+          createdAt: NOW_ISO,
+          updatedAt: NOW_ISO,
+        },
+      ],
+      threads: [
+        {
+          id: THREAD_ID,
+          codexThreadId: null,
+          projectId: PROJECT_ID,
+          surface: "canvas",
+          title: "Canvas Thread",
+          modelSelection: { provider: "grok", model: "grok-4" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          session: null,
+          messages: [],
+          proposedPlans: [],
+          error: null,
+          createdAt: NOW_ISO,
+          updatedAt: NOW_ISO,
+          latestTurn: null,
+          turnDiffSummaries: [],
+          activities: [],
+          branch: null,
+          worktreePath: null,
+        },
+      ],
+      threadIds: [THREAD_ID],
+      threadShellById: {
+        [THREAD_ID]: {
+          id: THREAD_ID,
+          codexThreadId: null,
+          projectId: PROJECT_ID,
+          surface: "canvas",
+          title: "Canvas Thread",
+          modelSelection: { provider: "grok", model: "grok-4" },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          error: null,
+          createdAt: NOW_ISO,
+          updatedAt: NOW_ISO,
+          latestUserMessageAt: null,
+          hasPendingApprovals: false,
+          hasPendingUserInput: false,
+          hasActionableProposedPlan: false,
+          branch: null,
+          worktreePath: null,
+        },
+      },
+      sidebarThreadSummaryById: {},
+      threadsHydrated: true,
+    });
+
+    const snapshot = makeSnapshot();
+    Object.defineProperty(window, "nativeApi", {
+      configurable: true,
+      value: {
+        canvas: {
+          readDrawing: vi.fn(async () => snapshot),
+          saveDrawing: vi.fn(async () => snapshot),
+          deleteDrawing: vi.fn(async () => ({ deleted: true })),
+          createDrawing: vi.fn(async () => snapshot),
+        },
+        orchestration: {
+          dispatchCommand: vi.fn(async () => ({ sequence: 1 })),
+        },
+      } satisfies Partial<NativeApi>,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "nativeApi", {
+      configurable: true,
+      value: previousNativeApi,
+    });
+    resetWsNativeApiForTest();
+    document.body.innerHTML = "";
+  });
+
+  it("renders the canvas shell and toggles the persistent chat pane", async () => {
+    const screen = await render(
+      <div style={{ width: "1440px", height: "900px" }}>
+        <CanvasWorkspaceView
+          threadId={THREAD_ID}
+          projectId={PROJECT_ID}
+          projectName="Canvas Project"
+          chatPanel={<div>Persistent Chat</div>}
+        />
+      </div>,
+    );
+
+    try {
+      await expect.element(page.getByText("Canvas Project")).toBeInTheDocument();
+      await expect.element(
+        page.getByRole("button", { name: "Canvas Thread" }),
+      ).toBeInTheDocument();
+      await expect.element(
+        page.getByRole("main").getByText("Canvas Thread"),
+      ).toBeInTheDocument();
+      await expect.element(page.getByText("Persistent Chat")).toBeInTheDocument();
+      await expect.element(page.getByText("Saved locally")).toBeInTheDocument();
+
+      await page.getByRole("button", { name: "Hide chat panel" }).click();
+      await expect.element(page.getByText("Persistent Chat")).not.toBeVisible();
+
+      await page.getByRole("button", { name: "Show chat panel" }).click();
+      await expect.element(page.getByText("Persistent Chat")).toBeVisible();
+    } finally {
+      await screen.unmount();
+    }
+  });
+});

--- a/apps/web/src/components/CanvasWorkspaceView.tsx
+++ b/apps/web/src/components/CanvasWorkspaceView.tsx
@@ -1,0 +1,444 @@
+// FILE: CanvasWorkspaceView.tsx
+// Purpose: Editor-style Excalidraw workspace with project drawings and a persistent AI chat.
+// Layer: Chat route presentation
+
+import type {
+  CanvasDrawingSnapshot,
+  CanvasScene,
+  ProjectId,
+  ThreadId,
+  TurnId,
+} from "@synara/contracts";
+import {
+  convertToExcalidrawElements,
+  Excalidraw,
+  FONT_FAMILY,
+  serializeAsJSON,
+} from "@excalidraw/excalidraw";
+import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types";
+import "@excalidraw/excalidraw/index.css";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { FiMessageSquare, FiPlus, FiTrash2 } from "react-icons/fi";
+
+import { useHandleNewCanvasDrawing } from "~/hooks/useHandleNewCanvasDrawing";
+import { useTheme } from "~/hooks/useTheme";
+import { canvasAgentMutationTurnId, isCanvasAgentEditing } from "~/lib/canvasAgentState";
+import { cn } from "~/lib/utils";
+import { readNativeApi } from "~/nativeApi";
+import { createThreadSelector, createThreadShellsSelector } from "~/storeSelectors";
+import { useStore } from "~/store";
+import { ResizableChatPane, useResizableChatPane } from "./ResizableChatPane";
+import { toastManager } from "./ui/toast";
+
+type SaveState = "loading" | "saved" | "saving" | "conflict" | "error";
+type PendingSceneChange =
+  | { readonly kind: "serialized"; readonly scene: CanvasScene }
+  | {
+      readonly kind: "excalidraw";
+      readonly elements: readonly unknown[];
+      readonly appState: unknown;
+      readonly files: unknown;
+    };
+
+const AUTOSAVE_DELAY_MS = 500;
+
+function toCanvasScene(elements: readonly unknown[], appState: unknown, files: unknown): CanvasScene {
+  return JSON.parse(
+    serializeAsJSON(elements as never, appState as never, files as never, "database"),
+  ) as CanvasScene;
+}
+
+function canonicalizeAgentElements(scene: CanvasScene): { scene: CanvasScene; changed: boolean } {
+  const canonical: Array<Record<string, unknown>> = [];
+  const shorthand: Array<Record<string, unknown>> = [];
+  for (const element of scene.elements) {
+    if (element.label !== undefined || element.version === undefined) {
+      shorthand.push(element);
+    } else {
+      canonical.push(element);
+    }
+  }
+  if (shorthand.length === 0) return { scene, changed: false };
+
+  const converted = convertToExcalidrawElements(
+    shorthand.map((element) =>
+      element.label
+        ? {
+            ...element,
+            label: { textAlign: "center", verticalAlign: "middle", ...element.label },
+          }
+        : element,
+    ) as never,
+    { regenerateIds: false },
+  ).map((element) =>
+    element.type === "text" ? { ...element, fontFamily: FONT_FAMILY.Excalifont } : element,
+  );
+
+  return {
+    scene: { ...scene, elements: [...canonical, ...(converted as never)] },
+    changed: true,
+  };
+}
+
+function saveStateLabel(state: SaveState): string {
+  switch (state) {
+    case "loading":
+      return "Loading";
+    case "saving":
+      return "Saving…";
+    case "conflict":
+      return "Reload required";
+    case "error":
+      return "Save failed";
+    case "saved":
+      return "Saved locally";
+  }
+}
+
+export function CanvasWorkspaceView(props: {
+  threadId: ThreadId;
+  projectId: ProjectId;
+  projectName: string;
+  chatPanel: ReactNode;
+}) {
+  const navigate = useNavigate();
+  const { resolvedTheme } = useTheme();
+  const { handleNewCanvasDrawing } = useHandleNewCanvasDrawing();
+  const chatPane = useResizableChatPane({ storageKey: "synara.canvas.chatPane" });
+  const thread = useStore(
+    useMemo(() => createThreadSelector(props.threadId), [props.threadId]),
+  );
+  const threadShells = useStore(useMemo(() => createThreadShellsSelector(), []));
+  const drawings = useMemo(
+    () =>
+      threadShells
+        .filter(
+          (candidate) =>
+            candidate.projectId === props.projectId &&
+            candidate.surface === "canvas" &&
+            !candidate.archivedAt,
+        )
+        .toSorted((left, right) =>
+          (right.updatedAt ?? right.createdAt).localeCompare(left.updatedAt ?? left.createdAt),
+        ),
+    [props.projectId, threadShells],
+  );
+  const agentEditing = isCanvasAgentEditing({
+    latestTurn: thread?.latestTurn ?? null,
+    activities: thread?.activities ?? [],
+  });
+  const mutationTurnId = canvasAgentMutationTurnId({
+    latestTurn: thread?.latestTurn ?? null,
+    activities: thread?.activities ?? [],
+  });
+
+  const excalidrawApiRef = useRef<ExcalidrawImperativeAPI | null>(null);
+  const revisionRef = useRef<string | null>(null);
+  const pendingSceneRef = useRef<PendingSceneChange | null>(null);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saveChainRef = useRef<Promise<void>>(Promise.resolve());
+  const applyingRemoteSceneRef = useRef(false);
+  const conflictRef = useRef(false);
+  const lastReloadedMutationTurnIdRef = useRef<TurnId | null>(
+    thread?.latestTurn?.state === "running" ? null : mutationTurnId,
+  );
+  const [initialScene, setInitialScene] = useState<CanvasScene | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>("loading");
+
+  const applySnapshot = useCallback(
+    (snapshot: CanvasDrawingSnapshot) => {
+      revisionRef.current = snapshot.revision;
+      pendingSceneRef.current = null;
+      conflictRef.current = false;
+      applyingRemoteSceneRef.current = true;
+      setInitialScene(snapshot.scene);
+      const api = excalidrawApiRef.current;
+      if (api) {
+        api.updateScene({
+          elements: snapshot.scene.elements as never,
+          appState: snapshot.scene.appState as never,
+        });
+        if (snapshot.scene.files) {
+          api.addFiles(Object.values(snapshot.scene.files) as never);
+        }
+      }
+      requestAnimationFrame(() => {
+        applyingRemoteSceneRef.current = false;
+      });
+      setSaveState("saved");
+    },
+    [],
+  );
+
+  const reloadDrawing = useCallback(async () => {
+    const api = readNativeApi();
+    if (!api) return;
+    setSaveState("loading");
+    try {
+      let snapshot = await api.canvas.readDrawing({ threadId: props.threadId });
+      const canonicalized = canonicalizeAgentElements(snapshot.scene);
+      if (canonicalized.changed) {
+        snapshot = await api.canvas.saveDrawing({
+          threadId: props.threadId,
+          scene: canonicalized.scene,
+          expectedRevision: snapshot.revision,
+        });
+      }
+      applySnapshot(snapshot);
+    } catch (error) {
+      setSaveState("error");
+      toastManager.add({
+        type: "error",
+        title: "Unable to load drawing",
+        description: error instanceof Error ? error.message : "The drawing could not be loaded.",
+      });
+    }
+  }, [applySnapshot, props.threadId]);
+
+  useEffect(() => {
+    void reloadDrawing();
+  }, [reloadDrawing]);
+
+  const flushPendingSave = useCallback(() => {
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    if (!pendingSceneRef.current || conflictRef.current) {
+      return;
+    }
+
+    saveChainRef.current = saveChainRef.current.then(async () => {
+      const api = readNativeApi();
+      const pendingScene = pendingSceneRef.current;
+      const expectedRevision = revisionRef.current;
+      if (!api || !pendingScene || !expectedRevision) return;
+      pendingSceneRef.current = null;
+      setSaveState("saving");
+      let scene: CanvasScene | null = null;
+      try {
+        scene =
+          pendingScene.kind === "serialized"
+            ? pendingScene.scene
+            : toCanvasScene(pendingScene.elements, pendingScene.appState, pendingScene.files);
+        const snapshot = await api.canvas.saveDrawing({
+          threadId: props.threadId,
+          scene,
+          expectedRevision,
+        });
+        revisionRef.current = snapshot.revision;
+        setSaveState("saved");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const conflicted = /revision|conflict/i.test(message);
+        pendingSceneRef.current ??= scene ? { kind: "serialized", scene } : pendingScene;
+        conflictRef.current = conflicted;
+        setSaveState(conflicted ? "conflict" : "error");
+      }
+
+    });
+  }, [props.threadId]);
+
+  const handleSceneChange = useCallback(
+    (elements: readonly unknown[], appState: unknown, files: unknown) => {
+      if (applyingRemoteSceneRef.current || agentEditing || conflictRef.current) {
+        return;
+      }
+      pendingSceneRef.current = { kind: "excalidraw", elements, appState, files };
+      setSaveState("saving");
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(flushPendingSave, AUTOSAVE_DELAY_MS);
+    },
+    [agentEditing, flushPendingSave],
+  );
+
+  useEffect(() => {
+    if (agentEditing) {
+      flushPendingSave();
+    }
+  }, [agentEditing, flushPendingSave]);
+
+  useEffect(() => {
+    const currentState = thread?.latestTurn?.state ?? null;
+    if (
+      mutationTurnId &&
+      currentState !== "running" &&
+      lastReloadedMutationTurnIdRef.current !== mutationTurnId
+    ) {
+      lastReloadedMutationTurnIdRef.current = mutationTurnId;
+      void (async () => {
+        flushPendingSave();
+        await saveChainRef.current;
+        if (!pendingSceneRef.current && !conflictRef.current) {
+          await reloadDrawing();
+        }
+      })();
+    }
+  }, [flushPendingSave, mutationTurnId, reloadDrawing, thread?.latestTurn?.state]);
+
+  useEffect(
+    () => () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      flushPendingSave();
+    },
+    [flushPendingSave],
+  );
+
+  const handleDelete = useCallback(async () => {
+    if (!window.confirm(`Delete “${thread?.title ?? "this drawing"}”?`)) return;
+    const api = readNativeApi();
+    if (!api) return;
+    const nextDrawing = drawings.find((drawing) => drawing.id !== props.threadId) ?? null;
+    try {
+      await api.canvas.deleteDrawing({ threadId: props.threadId });
+      if (nextDrawing) {
+        await navigate({
+          to: "/$threadId",
+          params: { threadId: nextDrawing.id },
+          search: (previous) => ({ ...previous, view: "canvas" }),
+        });
+      } else {
+        await navigate({ to: "/" });
+      }
+    } catch (error) {
+      toastManager.add({
+        type: "error",
+        title: "Unable to delete drawing",
+        description: error instanceof Error ? error.message : "The drawing could not be deleted.",
+      });
+    }
+  }, [drawings, navigate, props.threadId, thread?.title]);
+
+  return (
+    <div className="flex h-full min-h-0 w-full overflow-hidden" data-testid="canvas-workspace">
+      <aside className="flex w-56 shrink-0 flex-col border-r border-border/65 bg-[var(--color-background-surface)]">
+        <div className="flex h-11 shrink-0 items-center gap-2 border-b border-border/65 px-3">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[11px] text-muted-foreground">Project</div>
+            <div className="truncate text-[12px] font-medium">{props.projectName}</div>
+          </div>
+          <button
+            type="button"
+            className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="New AI drawing"
+            aria-label="New AI drawing"
+            onClick={() => void handleNewCanvasDrawing(props.projectId)}
+          >
+            <FiPlus className="size-4" />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
+          <div className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/65">
+            Drawings
+          </div>
+          {drawings.map((drawing) => {
+            const active = drawing.id === props.threadId;
+            return (
+              <button
+                key={drawing.id}
+                type="button"
+                className={cn(
+                  "flex h-8 w-full items-center rounded-md px-2 text-left text-[12px] transition-colors",
+                  active ? "bg-muted font-medium text-foreground" : "text-foreground/75 hover:bg-muted/65",
+                )}
+                onClick={() =>
+                  void navigate({
+                    to: "/$threadId",
+                    params: { threadId: drawing.id },
+                    search: (previous) => ({ ...previous, view: "canvas" }),
+                  })
+                }
+              >
+                <span className="truncate">{drawing.title}</span>
+              </button>
+            );
+          })}
+        </div>
+      </aside>
+
+      <main className="flex min-w-0 flex-1 flex-col bg-background">
+        <header className="flex h-11 shrink-0 items-center gap-3 border-b border-border/65 px-3">
+          <div className="min-w-0 flex-1 truncate text-[13px] font-medium">
+            {thread?.title ?? "Drawing"}
+          </div>
+          {agentEditing ? (
+            <span className="rounded-full bg-amber-500/12 px-2 py-1 text-[10px] font-medium text-amber-700 dark:text-amber-300">
+              AI is editing · pan and zoom only
+            </span>
+          ) : null}
+          {saveState === "conflict" ? (
+            <button
+              type="button"
+              className="rounded-md border border-border px-2 py-1 text-[11px] hover:bg-muted"
+              onClick={() => void reloadDrawing()}
+            >
+              Reload scene
+            </button>
+          ) : null}
+          {saveState === "error" ? (
+            <button
+              type="button"
+              className="rounded-md border border-border px-2 py-1 text-[11px] hover:bg-muted"
+              onClick={flushPendingSave}
+            >
+              Retry save
+            </button>
+          ) : null}
+          <span className="text-[10px] text-muted-foreground">{saveStateLabel(saveState)}</span>
+          <button
+            type="button"
+            className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-pressed={chatPane.visible}
+            title={chatPane.visible ? "Hide chat panel" : "Show chat panel"}
+            aria-label={chatPane.visible ? "Hide chat panel" : "Show chat panel"}
+            onClick={chatPane.toggleVisible}
+          >
+            <FiMessageSquare className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+            title="Delete drawing"
+            aria-label="Delete drawing"
+            onClick={() => void handleDelete()}
+          >
+            <FiTrash2 className="size-3.5" />
+          </button>
+        </header>
+        <div className="relative min-h-0 flex-1" data-testid="excalidraw-canvas">
+          {initialScene ? (
+            <Excalidraw
+              initialData={initialScene as never}
+              excalidrawAPI={(api) => {
+                excalidrawApiRef.current = api;
+              }}
+              onChange={handleSceneChange as never}
+              viewModeEnabled={agentEditing}
+              theme={resolvedTheme === "dark" ? "dark" : "light"}
+              UIOptions={{ canvasActions: { loadScene: false } }}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Loading drawing…
+            </div>
+          )}
+        </div>
+      </main>
+
+      <ResizableChatPane
+        controller={chatPane}
+        className="min-w-[20rem] max-w-[37.5rem] flex-col border-l border-border/65 bg-background"
+      >
+        {props.chatPanel}
+      </ResizableChatPane>
+    </div>
+  );
+}

--- a/apps/web/src/components/EditorWorkspaceView.tsx
+++ b/apps/web/src/components/EditorWorkspaceView.tsx
@@ -6,14 +6,9 @@
 import type { ProjectId } from "@synara/contracts";
 import type { FileDiffMetadata } from "@pierre/diffs/react";
 import {
-  type CSSProperties,
-  type KeyboardEvent as ReactKeyboardEvent,
-  type PointerEvent as ReactPointerEvent,
   type ReactNode,
   useCallback,
-  useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 
@@ -61,6 +56,7 @@ import {
 } from "./chat/workspaceExplorer";
 import { ProjectMenuPicker, type ProjectMenuPickerOption } from "./ProjectMenuPicker";
 import { WorkspaceFilePreview } from "./WorkspaceFilePreview";
+import { ResizableChatPane, useResizableChatPane } from "./ResizableChatPane";
 
 type EditorCenterMode = "file" | "diff";
 type EditorActivityBarItem = EditorCenterMode | "search";
@@ -71,7 +67,6 @@ const EDITOR_CHAT_PANE_VISIBLE_STORAGE_KEY = "synara.editor.chatPaneVisible";
 const EDITOR_CHAT_PANE_DEFAULT_WIDTH = 384;
 const EDITOR_CHAT_PANE_MIN_WIDTH = 320;
 const EDITOR_CHAT_PANE_MAX_WIDTH = 600;
-const EDITOR_CHAT_PANE_KEYBOARD_STEP = 24;
 
 interface EditorWorkspaceViewProps {
   workspaceRoot: string | null;
@@ -98,44 +93,6 @@ interface EditorWorkspaceViewProps {
   onSelectProject?: (projectId: ProjectId) => void;
 }
 
-function clampEditorChatPaneWidth(width: number): number {
-  return Math.min(
-    EDITOR_CHAT_PANE_MAX_WIDTH,
-    Math.max(EDITOR_CHAT_PANE_MIN_WIDTH, Math.round(width)),
-  );
-}
-
-function readStoredEditorChatPaneWidth(): number {
-  if (typeof window === "undefined") {
-    return EDITOR_CHAT_PANE_DEFAULT_WIDTH;
-  }
-
-  try {
-    const rawValue = window.localStorage.getItem(EDITOR_CHAT_PANE_STORAGE_KEY);
-    const parsed = rawValue === null ? Number.NaN : Number.parseFloat(rawValue);
-    return Number.isFinite(parsed)
-      ? clampEditorChatPaneWidth(parsed)
-      : EDITOR_CHAT_PANE_DEFAULT_WIDTH;
-  } catch {
-    return EDITOR_CHAT_PANE_DEFAULT_WIDTH;
-  }
-}
-
-function storeEditorChatPaneWidth(width: number): void {
-  if (typeof window === "undefined") {
-    return;
-  }
-
-  try {
-    window.localStorage.setItem(
-      EDITOR_CHAT_PANE_STORAGE_KEY,
-      String(clampEditorChatPaneWidth(width)),
-    );
-  } catch {
-    // Best-effort preference persistence only.
-  }
-}
-
 function readStoredEditorVisibility(key: string): boolean {
   if (typeof window === "undefined") {
     return true;
@@ -156,18 +113,6 @@ function storeEditorVisibility(key: string, visible: boolean): void {
   } catch {
     // Best-effort preference persistence only.
   }
-}
-
-interface EditorChatPaneResizeState {
-  pointerId: number;
-  startX: number;
-  startWidth: number;
-  pendingWidth: number;
-  rafId: number | null;
-  restoreBodyCursor: string;
-  restoreBodyUserSelect: string;
-  onPointerMove: (event: PointerEvent) => void;
-  onPointerEnd: (event: PointerEvent) => void;
 }
 
 function DiffFileRow(props: {
@@ -368,17 +313,20 @@ export function EditorWorkspaceView(props: EditorWorkspaceViewProps) {
   // global sidebar is collapsed, so it has to clear the macOS traffic lights the
   // same way every other chat-surface header does.
   const trafficLightGutterClassName = useDesktopTopBarTrafficLightGutterClassName();
-  const [chatPaneWidth, setChatPaneWidth] = useState(readStoredEditorChatPaneWidth);
-  const chatPaneResizeStateRef = useRef<EditorChatPaneResizeState | null>(null);
+  const chatPane = useResizableChatPane({
+    storageKey: "synara.editor.chatPane",
+    widthStorageKey: EDITOR_CHAT_PANE_STORAGE_KEY,
+    visibilityStorageKey: EDITOR_CHAT_PANE_VISIBLE_STORAGE_KEY,
+    defaultWidth: EDITOR_CHAT_PANE_DEFAULT_WIDTH,
+    minWidth: EDITOR_CHAT_PANE_MIN_WIDTH,
+    maxWidth: EDITOR_CHAT_PANE_MAX_WIDTH,
+  });
   // Both side surfaces can be hidden so the main content takes the full width:
   // re-clicking the active activity-bar item collapses the sidebar (VS Code
   // style), and the header chat toggle hides the chat pane (kept mounted so
   // the chat runtime survives).
   const [sidebarVisible, setSidebarVisible] = useState(() =>
     readStoredEditorVisibility(EDITOR_SIDEBAR_VISIBLE_STORAGE_KEY),
-  );
-  const [chatPaneVisible, setChatPaneVisible] = useState(() =>
-    readStoredEditorVisibility(EDITOR_CHAT_PANE_VISIBLE_STORAGE_KEY),
   );
   // The search pane replaces the explorer/diff sidebar without touching the
   // center mode, so picking a result simply opens it in the file preview. The
@@ -411,126 +359,6 @@ export function EditorWorkspaceView(props: EditorWorkspaceViewProps) {
     },
     [centerMode, onCenterModeChange, searchPaneActive, sidebarVisible],
   );
-  const toggleChatPaneVisible = useCallback(() => {
-    setChatPaneVisible((previous) => {
-      const next = !previous;
-      storeEditorVisibility(EDITOR_CHAT_PANE_VISIBLE_STORAGE_KEY, next);
-      return next;
-    });
-  }, []);
-
-  const stopChatPaneResize = useCallback(() => {
-    const resizeState = chatPaneResizeStateRef.current;
-    if (!resizeState || typeof window === "undefined") {
-      return;
-    }
-
-    if (resizeState.rafId !== null) {
-      window.cancelAnimationFrame(resizeState.rafId);
-      resizeState.rafId = null;
-    }
-
-    window.removeEventListener("pointermove", resizeState.onPointerMove);
-    window.removeEventListener("pointerup", resizeState.onPointerEnd);
-    window.removeEventListener("pointercancel", resizeState.onPointerEnd);
-    document.body.style.cursor = resizeState.restoreBodyCursor;
-    document.body.style.userSelect = resizeState.restoreBodyUserSelect;
-    setChatPaneWidth(resizeState.pendingWidth);
-    storeEditorChatPaneWidth(resizeState.pendingWidth);
-    chatPaneResizeStateRef.current = null;
-  }, []);
-
-  useEffect(() => stopChatPaneResize, [stopChatPaneResize]);
-
-  const handleChatPaneResizePointerDown = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      if (event.button !== 0 || typeof window === "undefined") {
-        return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-      stopChatPaneResize();
-
-      const resizeState: EditorChatPaneResizeState = {
-        pointerId: event.pointerId,
-        startX: event.clientX,
-        startWidth: chatPaneWidth,
-        pendingWidth: chatPaneWidth,
-        rafId: null,
-        restoreBodyCursor: document.body.style.cursor,
-        restoreBodyUserSelect: document.body.style.userSelect,
-        onPointerMove: () => undefined,
-        onPointerEnd: () => undefined,
-      };
-
-      resizeState.onPointerMove = (moveEvent) => {
-        if (moveEvent.pointerId !== resizeState.pointerId) {
-          return;
-        }
-
-        resizeState.pendingWidth = clampEditorChatPaneWidth(
-          resizeState.startWidth + resizeState.startX - moveEvent.clientX,
-        );
-
-        if (resizeState.rafId !== null) {
-          return;
-        }
-
-        resizeState.rafId = window.requestAnimationFrame(() => {
-          resizeState.rafId = null;
-          setChatPaneWidth(resizeState.pendingWidth);
-        });
-      };
-
-      resizeState.onPointerEnd = (endEvent) => {
-        if (endEvent.pointerId !== resizeState.pointerId) {
-          return;
-        }
-        stopChatPaneResize();
-      };
-
-      chatPaneResizeStateRef.current = resizeState;
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-      window.addEventListener("pointermove", resizeState.onPointerMove);
-      window.addEventListener("pointerup", resizeState.onPointerEnd);
-      window.addEventListener("pointercancel", resizeState.onPointerEnd);
-    },
-    [chatPaneWidth, stopChatPaneResize],
-  );
-
-  const handleChatPaneResizeDoubleClick = useCallback(() => {
-    setChatPaneWidth(EDITOR_CHAT_PANE_DEFAULT_WIDTH);
-    storeEditorChatPaneWidth(EDITOR_CHAT_PANE_DEFAULT_WIDTH);
-  }, []);
-
-  const handleChatPaneResizeKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLDivElement>) => {
-      let nextWidth: number | null = null;
-
-      if (event.key === "ArrowLeft") {
-        nextWidth = chatPaneWidth + EDITOR_CHAT_PANE_KEYBOARD_STEP;
-      } else if (event.key === "ArrowRight") {
-        nextWidth = chatPaneWidth - EDITOR_CHAT_PANE_KEYBOARD_STEP;
-      } else if (event.key === "Home") {
-        nextWidth = EDITOR_CHAT_PANE_MIN_WIDTH;
-      } else if (event.key === "End") {
-        nextWidth = EDITOR_CHAT_PANE_MAX_WIDTH;
-      }
-
-      if (nextWidth === null) {
-        return;
-      }
-
-      event.preventDefault();
-      const clampedWidth = clampEditorChatPaneWidth(nextWidth);
-      setChatPaneWidth(clampedWidth);
-      storeEditorChatPaneWidth(clampedWidth);
-    },
-    [chatPaneWidth],
-  );
-
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col bg-[var(--color-background-root)] text-foreground">
       <div
@@ -574,13 +402,15 @@ export function EditorWorkspaceView(props: EditorWorkspaceViewProps) {
         <ChatHeaderButton
           type="button"
           tone="outline"
-          aria-pressed={chatPaneVisible}
-          title={chatPaneVisible ? "Hide chat panel" : "Show chat panel"}
+          aria-pressed={chatPane.visible}
+          title={chatPane.visible ? "Hide chat panel" : "Show chat panel"}
           className="gap-1.5"
-          onClick={toggleChatPaneVisible}
+          onClick={chatPane.toggleVisible}
         >
           <PanelRightCloseIcon className="size-3.5" />
-          <span className="sr-only">{chatPaneVisible ? "Hide chat panel" : "Show chat panel"}</span>
+          <span className="sr-only">
+            {chatPane.visible ? "Hide chat panel" : "Show chat panel"}
+          </span>
         </ChatHeaderButton>
         <ChatHeaderButton
           type="button"
@@ -650,47 +480,7 @@ export function EditorWorkspaceView(props: EditorWorkspaceViewProps) {
               </div>
             ) : null}
           </main>
-          <div
-            role="separator"
-            aria-label="Resize chat panel"
-            aria-orientation="vertical"
-            aria-valuemin={EDITOR_CHAT_PANE_MIN_WIDTH}
-            aria-valuemax={EDITOR_CHAT_PANE_MAX_WIDTH}
-            aria-valuenow={chatPaneWidth}
-            tabIndex={0}
-            title="Drag to resize chat panel"
-            className={cn(
-              "group relative z-10 w-0 shrink-0 cursor-col-resize outline-none",
-              chatPaneVisible ? "hidden lg:block" : "hidden",
-            )}
-            onPointerDown={handleChatPaneResizePointerDown}
-            onDoubleClick={handleChatPaneResizeDoubleClick}
-            onKeyDown={handleChatPaneResizeKeyDown}
-          >
-            <span
-              className="absolute inset-y-0 left-[-3px] w-1.5 cursor-col-resize bg-transparent transition-colors group-hover:bg-[var(--color-background-button-secondary-hover)] group-focus-visible:bg-[var(--color-background-button-secondary-hover)]"
-              aria-hidden="true"
-            />
-            <span
-              className="pointer-events-none absolute inset-y-0 left-0 w-px bg-[var(--app-surface-divider)] transition-colors group-hover:bg-[var(--color-text-accent)] group-focus-visible:bg-[var(--color-text-accent)]"
-              aria-hidden="true"
-            />
-          </div>
-          {/* Hidden (not unmounted) so the chat runtime and composer focus
-              state survive toggling the pane. */}
-          <aside
-            className={cn(
-              "min-h-[18rem] w-full shrink-0 bg-[var(--color-background-surface)] lg:h-full lg:w-[var(--editor-chat-pane-width)]",
-              chatPaneVisible ? "flex" : "hidden",
-            )}
-            style={
-              {
-                "--editor-chat-pane-width": `${chatPaneWidth}px`,
-              } as CSSProperties
-            }
-          >
-            {props.chatPanel}
-          </aside>
+          <ResizableChatPane controller={chatPane}>{props.chatPanel}</ResizableChatPane>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/ResizableChatPane.tsx
+++ b/apps/web/src/components/ResizableChatPane.tsx
@@ -1,0 +1,234 @@
+import {
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { cn } from "~/lib/utils";
+
+interface ResizeState {
+  pointerId: number;
+  startX: number;
+  startWidth: number;
+  pendingWidth: number;
+  rafId: number | null;
+  restoreBodyCursor: string;
+  restoreBodyUserSelect: string;
+  onPointerMove: (event: PointerEvent) => void;
+  onPointerEnd: (event: PointerEvent) => void;
+}
+
+export interface ResizableChatPaneController {
+  readonly visible: boolean;
+  readonly toggleVisible: () => void;
+  readonly width: number;
+  readonly minWidth: number;
+  readonly maxWidth: number;
+  readonly resetWidth: () => void;
+  readonly onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  readonly onKeyDown: (event: ReactKeyboardEvent<HTMLDivElement>) => void;
+}
+
+function readStoredNumber(key: string, fallback: number): number {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const value = Number.parseFloat(window.localStorage.getItem(key) ?? "");
+    return Number.isFinite(value) ? value : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function readStoredVisibility(key: string): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    return window.localStorage.getItem(key) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+function storePreference(key: string, value: number | boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, String(value));
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
+export function useResizableChatPane(input: {
+  readonly storageKey: string;
+  readonly widthStorageKey?: string;
+  readonly visibilityStorageKey?: string;
+  readonly defaultWidth?: number;
+  readonly minWidth?: number;
+  readonly maxWidth?: number;
+  readonly keyboardStep?: number;
+}): ResizableChatPaneController {
+  const defaultWidth = input.defaultWidth ?? 384;
+  const minWidth = input.minWidth ?? 320;
+  const maxWidth = input.maxWidth ?? 600;
+  const keyboardStep = input.keyboardStep ?? 24;
+  const widthStorageKey = input.widthStorageKey ?? `${input.storageKey}.width`;
+  const visibilityStorageKey = input.visibilityStorageKey ?? `${input.storageKey}.visible`;
+  const clampWidth = useCallback(
+    (width: number) => Math.min(maxWidth, Math.max(minWidth, Math.round(width))),
+    [maxWidth, minWidth],
+  );
+  const [width, setWidth] = useState(() =>
+    clampWidth(readStoredNumber(widthStorageKey, defaultWidth)),
+  );
+  const [visible, setVisible] = useState(() => readStoredVisibility(visibilityStorageKey));
+  const resizeStateRef = useRef<ResizeState | null>(null);
+
+  const stopResize = useCallback(() => {
+    const state = resizeStateRef.current;
+    if (!state || typeof window === "undefined") return;
+    if (state.rafId !== null) window.cancelAnimationFrame(state.rafId);
+    window.removeEventListener("pointermove", state.onPointerMove);
+    window.removeEventListener("pointerup", state.onPointerEnd);
+    window.removeEventListener("pointercancel", state.onPointerEnd);
+    document.body.style.cursor = state.restoreBodyCursor;
+    document.body.style.userSelect = state.restoreBodyUserSelect;
+    setWidth(state.pendingWidth);
+    storePreference(widthStorageKey, state.pendingWidth);
+    resizeStateRef.current = null;
+  }, [widthStorageKey]);
+
+  useEffect(() => stopResize, [stopResize]);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0 || typeof window === "undefined") return;
+      event.preventDefault();
+      event.stopPropagation();
+      stopResize();
+
+      const state: ResizeState = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startWidth: width,
+        pendingWidth: width,
+        rafId: null,
+        restoreBodyCursor: document.body.style.cursor,
+        restoreBodyUserSelect: document.body.style.userSelect,
+        onPointerMove: () => undefined,
+        onPointerEnd: () => undefined,
+      };
+      state.onPointerMove = (moveEvent) => {
+        if (moveEvent.pointerId !== state.pointerId) return;
+        state.pendingWidth = clampWidth(state.startWidth + state.startX - moveEvent.clientX);
+        if (state.rafId !== null) return;
+        state.rafId = window.requestAnimationFrame(() => {
+          state.rafId = null;
+          setWidth(state.pendingWidth);
+        });
+      };
+      state.onPointerEnd = (endEvent) => {
+        if (endEvent.pointerId === state.pointerId) stopResize();
+      };
+      resizeStateRef.current = state;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      window.addEventListener("pointermove", state.onPointerMove);
+      window.addEventListener("pointerup", state.onPointerEnd);
+      window.addEventListener("pointercancel", state.onPointerEnd);
+    },
+    [clampWidth, stopResize, width],
+  );
+
+  const onKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      const nextWidth =
+        event.key === "ArrowLeft"
+          ? width + keyboardStep
+          : event.key === "ArrowRight"
+            ? width - keyboardStep
+            : event.key === "Home"
+              ? minWidth
+              : event.key === "End"
+                ? maxWidth
+                : null;
+      if (nextWidth === null) return;
+      event.preventDefault();
+      const clamped = clampWidth(nextWidth);
+      setWidth(clamped);
+      storePreference(widthStorageKey, clamped);
+    },
+    [clampWidth, keyboardStep, maxWidth, minWidth, width, widthStorageKey],
+  );
+
+  return {
+    visible,
+    toggleVisible: () =>
+      setVisible((previous) => {
+        const next = !previous;
+        storePreference(visibilityStorageKey, next);
+        return next;
+      }),
+    width,
+    minWidth,
+    maxWidth,
+    resetWidth: () => {
+      const clamped = clampWidth(defaultWidth);
+      setWidth(clamped);
+      storePreference(widthStorageKey, clamped);
+    },
+    onPointerDown,
+    onKeyDown,
+  };
+}
+
+export function ResizableChatPane(props: {
+  readonly controller: ResizableChatPaneController;
+  readonly children: ReactNode;
+  readonly className?: string;
+}) {
+  const pane = props.controller;
+  return (
+    <>
+      <div
+        role="separator"
+        aria-label="Resize chat panel"
+        aria-orientation="vertical"
+        aria-valuemin={pane.minWidth}
+        aria-valuemax={pane.maxWidth}
+        aria-valuenow={pane.width}
+        tabIndex={pane.visible ? 0 : -1}
+        title="Drag to resize chat panel"
+        className={cn(
+          "group relative z-10 w-0 shrink-0 cursor-col-resize outline-none",
+          pane.visible ? "hidden lg:block" : "hidden",
+        )}
+        onPointerDown={pane.onPointerDown}
+        onDoubleClick={pane.resetWidth}
+        onKeyDown={pane.onKeyDown}
+      >
+        <span
+          className="absolute inset-y-0 left-[-3px] w-1.5 cursor-col-resize bg-transparent transition-colors group-hover:bg-[var(--color-background-button-secondary-hover)] group-focus-visible:bg-[var(--color-background-button-secondary-hover)]"
+          aria-hidden="true"
+        />
+        <span
+          className="pointer-events-none absolute inset-y-0 left-0 w-px bg-[var(--app-surface-divider)] transition-colors group-hover:bg-[var(--color-text-accent)] group-focus-visible:bg-[var(--color-text-accent)]"
+          aria-hidden="true"
+        />
+      </div>
+      <aside
+        className={cn(
+          "min-h-[18rem] w-full shrink-0 bg-[var(--color-background-surface)] lg:h-full lg:w-[var(--resizable-chat-pane-width)]",
+          pane.visible ? "flex" : "hidden",
+          props.className,
+        )}
+        style={{ "--resizable-chat-pane-width": `${pane.width}px` } as CSSProperties}
+      >
+        {props.children}
+      </aside>
+    </>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -198,6 +198,7 @@ import {
   type SidebarSearchPaletteMode,
 } from "./SidebarSearchPalette";
 import { useHandleNewChat } from "../hooks/useHandleNewChat";
+import { useHandleNewCanvasDrawing } from "../hooks/useHandleNewCanvasDrawing";
 import { useHandleNewStudioChat } from "../hooks/useHandleNewStudioChat";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { useThreadHandoff } from "../hooks/useThreadHandoff";
@@ -1445,6 +1446,7 @@ export default function Sidebar() {
   const studioSectionVisible = appSettings.showStudioSection;
   const workspaceSectionVisible = appSettings.showWorkspaceSection;
   const { handleNewThread } = useHandleNewThread();
+  const { handleNewCanvasDrawing } = useHandleNewCanvasDrawing();
   const { handleNewChat } = useHandleNewChat();
   const { handleNewStudioChat } = useHandleNewStudioChat();
   const { createThreadHandoff } = useThreadHandoff();
@@ -3023,11 +3025,15 @@ export default function Sidebar() {
       const deletedPaneInActiveSplit = activeSplitView
         ? resolveSplitViewPaneIdForThread(activeSplitView, threadId)
         : null;
-      await api.orchestration.dispatchCommand({
-        type: "thread.delete",
-        commandId: newCommandId(),
-        threadId,
-      });
+      if (thread.surface === "canvas") {
+        await api.canvas.deleteDrawing({ threadId });
+      } else {
+        await api.orchestration.dispatchCommand({
+          type: "thread.delete",
+          commandId: newCommandId(),
+          threadId,
+        });
+      }
       if (opts.reconcileDeletedThread ?? true) {
         void reconcileDeletedThreadFromClient({
           threadId,
@@ -5855,6 +5861,18 @@ export default function Sidebar() {
               <PinStatusIcon pinned={isProjectPinned} className="size-3.5" />
             </button>
             <SidebarSectionToolbar placement="overlay" revealOnHover>
+              <SidebarIconButton
+                icon={PencilIcon}
+                label={`Create new drawing in ${project.name}`}
+                tooltip="New AI drawing"
+                tooltipSide="top"
+                data-testid="new-canvas-drawing-button"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void handleNewCanvasDrawing(project.id);
+                }}
+              />
               <SidebarIconButton
                 icon={TerminalIcon}
                 label={`Create new terminal thread in ${project.name}`}

--- a/apps/web/src/diffRouteSearch.test.ts
+++ b/apps/web/src/diffRouteSearch.test.ts
@@ -102,4 +102,13 @@ describe("parseDiffRouteSearch", () => {
       splitViewId: "split-1",
     });
   });
+
+  it("recognizes the canvas workspace without accepting editor-only file state", () => {
+    expect(
+      parseDiffRouteSearch({
+        view: "canvas",
+        editorFilePath: "src/app.ts",
+      }),
+    ).toEqual({ view: "canvas" });
+  });
 });

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -8,7 +8,7 @@ export type ChatRightPanel = "browser" | "diff";
 
 export interface DiffRouteSearch {
   splitViewId?: string | undefined;
-  view?: "editor" | undefined;
+  view?: "editor" | "canvas" | undefined;
   editorFilePath?: string | undefined;
   panel?: ChatRightPanel | undefined;
   diff?: "1" | undefined;
@@ -44,8 +44,8 @@ export function stripDiffSearchParams<T extends Record<string, unknown>>(
 export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRouteSearch {
   const splitViewId = normalizeSearchString(search.splitViewId);
   const viewRaw = normalizeSearchString(search.view);
-  const view = viewRaw === "editor" ? "editor" : undefined;
-  const editorFilePath = view ? normalizeSearchString(search.editorFilePath) : undefined;
+  const view = viewRaw === "editor" || viewRaw === "canvas" ? viewRaw : undefined;
+  const editorFilePath = view === "editor" ? normalizeSearchString(search.editorFilePath) : undefined;
   const panelRaw = normalizeSearchString(search.panel);
   const panel: ChatRightPanel | undefined =
     panelRaw === "browser" ? "browser" : panelRaw === "diff" ? "diff" : undefined;

--- a/apps/web/src/hooks/useHandleNewCanvasDrawing.ts
+++ b/apps/web/src/hooks/useHandleNewCanvasDrawing.ts
@@ -1,0 +1,107 @@
+// FILE: useHandleNewCanvasDrawing.ts
+// Purpose: Creates a durable Canvas thread and its project-local Excalidraw scene as one UI action.
+// Layer: Web orchestration hook
+
+import type { ProjectId, ThreadId } from "@synara/contracts";
+import { getDefaultModel } from "@synara/shared/model";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
+
+import { toastManager } from "../components/ui/toast";
+import { newCommandId, newThreadId } from "../lib/utils";
+import { readNativeApi } from "../nativeApi";
+import { useStore } from "../store";
+import { getThreadsFromState } from "../threadDerivation";
+
+const DRAWING_PROJECTION_CATCH_UP_ATTEMPTS = 8;
+const DRAWING_PROJECTION_CATCH_UP_DELAY_MS = 50;
+
+function waitForProjectionCatchUp(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, DRAWING_PROJECTION_CATCH_UP_DELAY_MS));
+}
+
+export function useHandleNewCanvasDrawing() {
+  const navigate = useNavigate();
+
+  const handleNewCanvasDrawing = useCallback(
+    async (projectId: ProjectId): Promise<ThreadId | null> => {
+      const api = readNativeApi();
+      const state = useStore.getState();
+      const project = state.projects.find((candidate) => candidate.id === projectId);
+      if (!api || !project) {
+        toastManager.add({
+          type: "error",
+          title: "Unable to create drawing",
+          description: "The project is not available yet.",
+        });
+        return null;
+      }
+
+      const siblingCount = getThreadsFromState(state).filter(
+        (thread) => thread.projectId === projectId && thread.surface === "canvas",
+      ).length;
+      const threadId = newThreadId();
+      const title = siblingCount === 0 ? "Untitled drawing" : `Untitled drawing ${siblingCount + 1}`;
+      let threadCreated = false;
+      let drawingCreated = false;
+
+      try {
+        await api.orchestration.dispatchCommand({
+          type: "thread.create",
+          commandId: newCommandId(),
+          threadId,
+          projectId,
+          surface: "canvas",
+          title,
+          modelSelection: { provider: "grok", model: getDefaultModel("grok") },
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          envMode: "local",
+          branch: null,
+          worktreePath: null,
+          createdAt: new Date().toISOString(),
+        });
+        threadCreated = true;
+        for (let attempt = 0; attempt < DRAWING_PROJECTION_CATCH_UP_ATTEMPTS; attempt += 1) {
+          try {
+            await api.canvas.createDrawing({ threadId });
+            drawingCreated = true;
+            break;
+          } catch (error) {
+            if (attempt === DRAWING_PROJECTION_CATCH_UP_ATTEMPTS - 1) throw error;
+            await waitForProjectionCatchUp();
+          }
+        }
+        await navigate({
+          to: "/$threadId",
+          params: { threadId },
+          search: (previous) => ({ ...previous, view: "canvas" }),
+        });
+        return threadId;
+      } catch (error) {
+        if (drawingCreated) {
+          await api.canvas
+            .deleteDrawing({ threadId })
+            .catch(() => undefined);
+        } else if (threadCreated) {
+          await api.orchestration
+            .dispatchCommand({
+              type: "thread.delete",
+              commandId: newCommandId(),
+              threadId,
+            })
+            .catch(() => undefined);
+        }
+        toastManager.add({
+          type: "error",
+          title: "Unable to create drawing",
+          description: error instanceof Error ? error.message : "The drawing could not be created.",
+        });
+        return null;
+      }
+    },
+    [navigate],
+  );
+
+  return { handleNewCanvasDrawing };
+}

--- a/apps/web/src/lib/canvasAgentState.test.ts
+++ b/apps/web/src/lib/canvasAgentState.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { EventId, TurnId } from "@synara/contracts";
+
+import { canvasAgentMutationTurnId, isCanvasAgentEditing } from "./canvasAgentState";
+
+const turnId = TurnId.makeUnsafe("turn-1");
+
+describe("isCanvasAgentEditing", () => {
+  it("locks only while the running turn has entered create_view", () => {
+    const activity = {
+      id: EventId.makeUnsafe("event-1"),
+      tone: "tool" as const,
+      kind: "tool.call.started",
+      summary: "Running create_view",
+      payload: { toolName: "create_view" },
+      turnId,
+      createdAt: "2026-07-14T00:00:00.000Z",
+    };
+
+    expect(
+      isCanvasAgentEditing({
+        latestTurn: {
+          turnId,
+          state: "running",
+          requestedAt: "2026-07-14T00:00:00.000Z",
+          startedAt: "2026-07-14T00:00:00.000Z",
+          completedAt: null,
+          assistantMessageId: null,
+        },
+        activities: [activity],
+      }),
+    ).toBe(true);
+    expect(
+      isCanvasAgentEditing({
+        latestTurn: {
+          turnId,
+          state: "completed",
+          requestedAt: "2026-07-14T00:00:00.000Z",
+          startedAt: "2026-07-14T00:00:00.000Z",
+          completedAt: "2026-07-14T00:00:01.000Z",
+          assistantMessageId: null,
+        },
+        activities: [activity],
+      }),
+    ).toBe(false);
+    expect(
+      canvasAgentMutationTurnId({
+        latestTurn: {
+          turnId,
+          state: "completed",
+          requestedAt: "2026-07-14T00:00:00.000Z",
+          startedAt: "2026-07-14T00:00:00.000Z",
+          completedAt: "2026-07-14T00:00:01.000Z",
+          assistantMessageId: null,
+        },
+        activities: [activity],
+      }),
+    ).toBe(turnId);
+  });
+
+  it("keeps the canvas editable while the agent is only researching", () => {
+    expect(
+      isCanvasAgentEditing({
+        latestTurn: {
+          turnId,
+          state: "running",
+          requestedAt: "2026-07-14T00:00:00.000Z",
+          startedAt: "2026-07-14T00:00:00.000Z",
+          completedAt: null,
+          assistantMessageId: null,
+        },
+        activities: [],
+      }),
+    ).toBe(false);
+    expect(
+      canvasAgentMutationTurnId({
+        latestTurn: {
+          turnId,
+          state: "completed",
+          requestedAt: "2026-07-14T00:00:00.000Z",
+          startedAt: "2026-07-14T00:00:00.000Z",
+          completedAt: "2026-07-14T00:00:01.000Z",
+          assistantMessageId: null,
+        },
+        activities: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores create_view text in another tool's output", () => {
+    expect(
+      canvasAgentMutationTurnId({
+        latestTurn: {
+          turnId,
+          state: "completed",
+          requestedAt: "2026-07-14T00:00:00.000Z",
+          startedAt: "2026-07-14T00:00:00.000Z",
+          completedAt: "2026-07-14T00:00:01.000Z",
+          assistantMessageId: null,
+        },
+        activities: [
+          {
+            id: EventId.makeUnsafe("event-read-me"),
+            tone: "tool",
+            kind: "tool.completed",
+            summary: "read_me",
+            payload: {
+              title: "read_me",
+              data: { rawOutput: "Always call create_view after read_scene." },
+            },
+            turnId,
+            createdAt: "2026-07-14T00:00:00.000Z",
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("still detects a canvas mutation when only the activity summary names create_view", () => {
+    expect(
+      canvasAgentMutationTurnId({
+        latestTurn: {
+          turnId,
+          state: "completed",
+          requestedAt: "2026-07-14T00:00:00.000Z",
+          startedAt: "2026-07-14T00:00:00.000Z",
+          completedAt: "2026-07-14T00:00:01.000Z",
+          assistantMessageId: null,
+        },
+        activities: [
+          {
+            id: EventId.makeUnsafe("event-summary-only"),
+            tone: "tool",
+            kind: "tool.started",
+            summary: "create_view started",
+            payload: {
+              title: "MCP tool call",
+              data: { detail: "drawing update in progress" },
+            },
+            turnId,
+            createdAt: "2026-07-14T00:00:00.000Z",
+          },
+        ],
+      }),
+    ).toBe(turnId);
+  });
+});

--- a/apps/web/src/lib/canvasAgentState.ts
+++ b/apps/web/src/lib/canvasAgentState.ts
@@ -1,0 +1,54 @@
+// FILE: canvasAgentState.ts
+// Purpose: Derives the Canvas single-writer lock from the current agent turn's tool activity.
+// Layer: Web domain utility
+
+import type {
+  OrchestrationLatestTurn,
+  OrchestrationThreadActivity,
+  TurnId,
+} from "@synara/contracts";
+
+const CANVAS_MUTATION_TOOL_NAMES = ["create_view", "canvas_create_view"];
+
+function activityMentionsCanvasMutation(activity: OrchestrationThreadActivity): boolean {
+  const payload = activity.payload as Record<string, unknown>;
+  const data =
+    payload.data && typeof payload.data === "object" && !Array.isArray(payload.data)
+      ? (payload.data as Record<string, unknown>)
+      : null;
+  const structuredNames = [
+    activity.summary,
+    payload.toolName,
+    payload.title,
+    payload.name,
+    data?.toolName,
+    data?.title,
+    data?.name,
+  ].filter((value): value is string => typeof value === "string");
+  return structuredNames.some((name) => {
+    const normalized = name.toLowerCase();
+    return CANVAS_MUTATION_TOOL_NAMES.some((toolName) => normalized.includes(toolName));
+  });
+}
+
+export function canvasAgentMutationTurnId(input: {
+  latestTurn: OrchestrationLatestTurn | null;
+  activities: readonly OrchestrationThreadActivity[];
+}): TurnId | null {
+  const turnId = input.latestTurn?.turnId ?? null;
+  if (!turnId) return null;
+  return input.activities.some(
+    (activity) => activity.turnId === turnId && activityMentionsCanvasMutation(activity),
+  )
+    ? turnId
+    : null;
+}
+
+export function isCanvasAgentEditing(input: {
+  latestTurn: OrchestrationLatestTurn | null;
+  activities: readonly OrchestrationThreadActivity[];
+}): boolean {
+  return (
+    input.latestTurn?.state === "running" && canvasAgentMutationTurnId(input) !== null
+  );
+}

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -127,6 +127,7 @@ import {
   createAllThreadsSelector,
   createProjectSelector,
   createSidebarThreadSummariesSelector,
+  createThreadSelector,
   createThreadExistsSelector,
   createThreadProjectIdSelector,
   createThreadWorkspaceMetadataSelector,
@@ -165,6 +166,11 @@ const BrowserPanel = lazy(() => import("../components/BrowserPanel"));
 const EditorWorkspaceView = lazy(() =>
   import("../components/EditorWorkspaceView").then((module) => ({
     default: module.EditorWorkspaceView,
+  })),
+);
+const CanvasWorkspaceView = lazy(() =>
+  import("../components/CanvasWorkspaceView").then((module) => ({
+    default: module.CanvasWorkspaceView,
   })),
 );
 const DockTerminalPane = lazy(() => import("../components/chat/DockTerminalPane"));
@@ -1413,6 +1419,14 @@ const DOCK_EMBEDDED_PANEL_STATE: SplitViewPanePanelState = {
   lastOpenPanel: "browser",
 };
 
+const CANVAS_CHAT_PANEL_STATE: SplitViewPanePanelState = {
+  panel: null,
+  diffTurnId: null,
+  diffFilePath: null,
+  hasOpenedPanel: false,
+  lastOpenPanel: "browser",
+};
+
 function stripEditorViewSearchParams<T extends Record<string, unknown>>(
   params: T,
 ): Omit<T, "view" | "editorFilePath"> {
@@ -1450,6 +1464,9 @@ function SingleChatSurface(props: {
   const updatePane = useRightDockStore((store) => store.updatePane);
   const activeProject = useStore(
     useMemo(() => createProjectSelector(props.projectId), [props.projectId]),
+  );
+  const activeThread = useStore(
+    useMemo(() => createThreadSelector(props.threadId), [props.threadId]),
   );
   const threadWorkspaceMetadata = useStore(
     useMemo(() => createThreadWorkspaceMetadataSelector(props.threadId), [props.threadId]),
@@ -2179,6 +2196,41 @@ function SingleChatSurface(props: {
     }),
     [editorCenterMode, editorDiffPanelState.diffFilePath, editorDiffPanelState.diffTurnId],
   );
+
+  if (activeThread?.surface === "canvas" && activeProject && props.projectId) {
+    return (
+      <div className={cn(CHAT_MAIN_VIEWPORT_SHELL_CLASS_NAME, CHAT_MAIN_CONTENT_SURFACE_CLASS_NAME)}>
+        <Suspense fallback={<ChatMountSkeleton />}>
+          <CanvasWorkspaceView
+            key={props.threadId}
+            threadId={props.threadId}
+            projectId={props.projectId}
+            projectName={activeProject.name}
+            chatPanel={
+              <SidebarInset
+                className="min-h-0 min-w-0 overflow-hidden overscroll-y-none text-foreground"
+                surfaceClassName={CHAT_BACKGROUND_CLASS_NAME}
+              >
+                <DeferredChatView
+                  threadId={props.threadId}
+                  paneScopeId={`canvas:${props.threadId}`}
+                  deferMount={false}
+                  surfaceMode="split"
+                  presentationMode="editor"
+                  isFocusedPane
+                  panelState={CANVAS_CHAT_PANEL_STATE}
+                  onToggleDiff={noop}
+                  onToggleBrowser={noop}
+                  onOpenBrowserUrl={noop}
+                  onOpenTurnDiff={noop}
+                />
+              </SidebarInset>
+            }
+          />
+        </Suspense>
+      </div>
+    );
+  }
 
   if (props.search.view === "editor") {
     return (

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -364,6 +364,7 @@ function threadShellsEqual(left: ThreadShell | undefined, right: ThreadShell): b
     left.id === right.id &&
     left.codexThreadId === right.codexThreadId &&
     left.projectId === right.projectId &&
+    (left.surface ?? "chat") === (right.surface ?? "chat") &&
     left.title === right.title &&
     left.modelSelection === right.modelSelection &&
     left.runtimeMode === right.runtimeMode &&
@@ -412,6 +413,7 @@ function toThreadShell(thread: Thread): ThreadShell {
     id: thread.id,
     codexThreadId: thread.codexThreadId,
     projectId: thread.projectId,
+    surface: thread.surface ?? "chat",
     title: thread.title,
     modelSelection: thread.modelSelection,
     runtimeMode: thread.runtimeMode,
@@ -1694,6 +1696,7 @@ function normalizeThreadFromReadModel(
   if (
     previous &&
     previous.projectId === incoming.projectId &&
+    (previous.surface ?? "chat") === incoming.surface &&
     previous.title === incoming.title &&
     previous.modelSelection === modelSelection &&
     previous.runtimeMode === incoming.runtimeMode &&
@@ -1741,6 +1744,7 @@ function normalizeThreadFromReadModel(
     id: incoming.id,
     codexThreadId: null,
     projectId: incoming.projectId,
+    surface: incoming.surface,
     title: incoming.title,
     modelSelection,
     runtimeMode: incoming.runtimeMode,
@@ -1840,6 +1844,7 @@ function normalizeThreadShellSnapshot(
     id: incoming.id,
     codexThreadId: previous?.codexThreadId ?? null,
     projectId: incoming.projectId,
+    surface: incoming.surface,
     title: incoming.title,
     modelSelection,
     runtimeMode: incoming.runtimeMode,
@@ -2139,6 +2144,7 @@ function sidebarThreadSummariesEqual(
     left !== undefined &&
     left.id === right.id &&
     left.projectId === right.projectId &&
+    (left.surface ?? "chat") === (right.surface ?? "chat") &&
     left.title === right.title &&
     left.modelSelection === right.modelSelection &&
     left.interactionMode === right.interactionMode &&
@@ -2181,6 +2187,7 @@ function buildSidebarThreadSummary(
   const nextSummary: SidebarThreadSummary = {
     id: thread.id,
     projectId: thread.projectId,
+    surface: thread.surface ?? "chat",
     title: thread.title,
     modelSelection: thread.modelSelection,
     interactionMode: thread.interactionMode,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -27,6 +27,7 @@ import type {
   ProviderInteractionMode,
   ProjectKind,
   RuntimeMode,
+  ThreadSurface,
   ThreadEnvironmentMode,
 } from "@synara/contracts";
 
@@ -202,6 +203,7 @@ export interface Thread extends ThreadWorkspaceState {
   id: ThreadId;
   codexThreadId: string | null;
   projectId: ProjectId;
+  surface?: ThreadSurface;
   title: string;
   modelSelection: ModelSelection;
   runtimeMode: RuntimeMode;
@@ -240,6 +242,7 @@ export interface ThreadShell extends ThreadWorkspaceState {
   id: ThreadId;
   codexThreadId: string | null;
   projectId: ProjectId;
+  surface?: ThreadSurface;
   title: string;
   modelSelection: ModelSelection;
   runtimeMode: RuntimeMode;
@@ -279,6 +282,7 @@ export interface ThreadTurnState {
 export interface SidebarThreadSummary {
   id: ThreadId;
   projectId: ProjectId;
+  surface?: ThreadSurface;
   title: string;
   modelSelection: ModelSelection;
   interactionMode: ProviderInteractionMode;

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -528,6 +528,26 @@ describe("wsNativeApi", () => {
     });
   });
 
+  it("forwards Canvas operations using only the server-resolved drawing identity", async () => {
+    requestMock.mockResolvedValue({});
+    const { createWsNativeApi } = await import("./wsNativeApi");
+    const api = createWsNativeApi();
+    const threadId = ThreadId.makeUnsafe("drawing-1");
+    const scene = { elements: [], appState: {}, files: {} };
+
+    await api.canvas.createDrawing({ threadId });
+    await api.canvas.readDrawing({ threadId });
+    await api.canvas.saveDrawing({ threadId, scene, expectedRevision: "revision-1" });
+    await api.canvas.deleteDrawing({ threadId });
+
+    expect(requestMock.mock.calls.slice(-4)).toEqual([
+      [WS_METHODS.canvasCreateDrawing, { threadId }],
+      [WS_METHODS.canvasReadDrawing, { threadId }],
+      [WS_METHODS.canvasSaveDrawing, { threadId, scene, expectedRevision: "revision-1" }],
+      [WS_METHODS.canvasDeleteDrawing, { threadId }],
+    ]);
+  });
+
   it("forwards workspace file reads to the websocket project method", async () => {
     requestMock.mockResolvedValue({
       relativePath: "src/app.ts",

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -504,6 +504,12 @@ export function createWsNativeApi(): NativeApi {
         };
       },
     },
+    canvas: {
+      createDrawing: (input) => transport.request(WS_METHODS.canvasCreateDrawing, input),
+      readDrawing: (input) => transport.request(WS_METHODS.canvasReadDrawing, input),
+      saveDrawing: (input) => transport.request(WS_METHODS.canvasSaveDrawing, input),
+      deleteDrawing: (input) => transport.request(WS_METHODS.canvasDeleteDrawing, input),
+    },
     filesystem: {
       browse: (input) => transport.request(WS_METHODS.filesystemBrowse, input),
     },

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/desktop": {
       "name": "@synara/desktop",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "effect": "catalog:",
         "electron": "40.6.0",
@@ -43,7 +43,7 @@
     },
     "apps/server": {
       "name": "@synara/cli",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "bin": {
         "synara": "./dist/index.mjs",
       },
@@ -57,6 +57,7 @@
         "@effect/sql-sqlite-bun": "catalog:",
         "@opencode-ai/sdk": "^1.15.13",
         "@pierre/diffs": "^1.1.0-beta.16",
+        "@synara/excalidraw-mcp": "workspace:*",
         "@xterm/headless": "^6.0.0",
         "effect": "catalog:",
         "node-pty": "^1.1.0",
@@ -81,13 +82,14 @@
     },
     "apps/web": {
       "name": "@synara/web",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@excalidraw/excalidraw": "^0.18.0",
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@formkit/auto-animate": "^0.9.0",
@@ -152,7 +154,7 @@
     },
     "packages/contracts": {
       "name": "@synara/contracts",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -174,6 +176,23 @@
         "@effect/openapi-generator": "catalog:",
         "@effect/platform-node": "catalog:",
         "@effect/vitest": "catalog:",
+        "tsdown": "catalog:",
+        "typescript": "catalog:",
+        "vitest": "catalog:",
+      },
+    },
+    "packages/excalidraw-mcp": {
+      "name": "@synara/excalidraw-mcp",
+      "version": "0.3.2-synara.1",
+      "bin": {
+        "synara-excalidraw-mcp": "./dist/main.mjs",
+      },
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.25.2",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/node": "catalog:",
         "tsdown": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
@@ -232,6 +251,8 @@
     "vitest": "^4.0.0",
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.207", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.207", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.207", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.207", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.207", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.207", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.207", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.207", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.207" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-y0PkQRmQBi96MHiN5Xzfq+GaddxCZCqI/cXEQBLYBLXGa4i1nDSlulQqkMBj2RorrrSGQJ6Wdw+uhu6OfHNPzA=="],
 
     "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.207", "", { "os": "darwin", "cpu": "arm64" }, "sha512-08xSo1FDx8h0aLhL5tvcRxa2SMmcUV3aDWeZiEJVTclyiDAs61BgTjAxCg+SZcu1CndjJO8cfO0yM5dhamxz3g=="],
@@ -406,7 +427,19 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@6.0.2", "", {}, "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="],
+
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
+
+    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.0.3", "", { "dependencies": { "@chevrotain/gast": "11.0.3", "@chevrotain/types": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ=="],
+
+    "@chevrotain/gast": ["@chevrotain/gast@11.0.3", "", { "dependencies": { "@chevrotain/types": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q=="],
+
+    "@chevrotain/regexp-to-ast": ["@chevrotain/regexp-to-ast@11.0.3", "", {}, "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
+    "@chevrotain/utils": ["@chevrotain/utils@11.0.3", "", {}, "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="],
 
     "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
 
@@ -520,6 +553,16 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
+    "@excalidraw/excalidraw": ["@excalidraw/excalidraw@0.18.1", "", { "dependencies": { "@braintree/sanitize-url": "6.0.2", "@excalidraw/laser-pointer": "1.3.1", "@excalidraw/mermaid-to-excalidraw": "2.2.2", "@excalidraw/random-username": "1.1.0", "@radix-ui/react-popover": "1.1.6", "@radix-ui/react-tabs": "1.0.2", "browser-fs-access": "0.29.1", "canvas-roundrect-polyfill": "0.0.1", "clsx": "1.1.1", "cross-env": "7.0.3", "es6-promise-pool": "2.5.0", "fractional-indexing": "3.2.0", "fuzzy": "0.1.3", "image-blob-reduce": "3.0.1", "jotai": "2.11.0", "jotai-scope": "0.7.2", "lodash.debounce": "4.0.8", "lodash.throttle": "4.1.1", "nanoid": "3.3.3", "open-color": "1.9.1", "pako": "2.0.3", "perfect-freehand": "1.2.0", "pica": "7.1.1", "png-chunk-text": "1.0.0", "png-chunks-encode": "1.0.0", "png-chunks-extract": "1.0.0", "points-on-curve": "1.0.1", "pwacompat": "2.0.17", "roughjs": "4.6.4", "sass": "1.51.0", "tunnel-rat": "0.1.2" }, "peerDependencies": { "react": "^17.0.2 || ^18.2.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.2.0 || ^19.0.0" } }, "sha512-6i5Gt7IDTOH//qa0Z315Ly5iVRhjWpu2whrlQFqkuwrkKUWgRsMk0P5qdE7bpyDpai7jeLeWYkyj1eVAfni1lw=="],
+
+    "@excalidraw/laser-pointer": ["@excalidraw/laser-pointer@1.3.1", "", {}, "sha512-psA1z1N2qeAfsORdXc9JmD2y4CmDwmuMRxnNdJHZexIcPwaNEyIpNcelw+QkL9rz9tosaN9krXuKaRqYpRAR6g=="],
+
+    "@excalidraw/markdown-to-text": ["@excalidraw/markdown-to-text@0.1.2", "", {}, "sha512-1nDXBNAojfi3oSFwJswKREkFm5wrSjqay81QlyRv2pkITG/XYB5v+oChENVBQLcxQwX4IUATWvXM5BcaNhPiIg=="],
+
+    "@excalidraw/mermaid-to-excalidraw": ["@excalidraw/mermaid-to-excalidraw@2.2.2", "", { "dependencies": { "@excalidraw/markdown-to-text": "0.1.2", "@mermaid-js/parser": "^0.6.3", "mermaid": "^11.12.1", "nanoid": "4.0.2" } }, "sha512-5VKQq5CdRocC82vOIUpQ5ufJOVV9FpBTdHGA+ULqazeIVV+cr299877omQCibsdS3Bpitz2fsnTwnIXEmLVDSg=="],
+
+    "@excalidraw/random-username": ["@excalidraw/random-username@1.1.0", "", {}, "sha512-nULYsQxkWHnbmHvcs+efMkJ4/9TtvNyFeLyHdeGxW0zHs6P+jYVqcRff9A6Vq9w9JXeDRnRh2VKvTtS19GW2qA=="],
+
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
     "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
@@ -551,6 +594,10 @@
     "@hapi/topo": ["@hapi/topo@6.0.2", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -692,9 +739,11 @@
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA=="],
 
+    "@mermaid-js/parser": ["@mermaid-js/parser@0.6.3", "", { "dependencies": { "langium": "3.3.1" } }, "sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA=="],
+
     "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.25.2", "", { "dependencies": { "@hono/node-server": "^1.19.7", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "jose": "^6.1.1", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
@@ -870,39 +919,59 @@
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
-    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+    "@radix-ui/primitive": ["@radix-ui/primitive@1.1.1", "", {}, "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="],
+
+    "@radix-ui/react-arrow": ["@radix-ui/react-arrow@1.1.2", "", { "dependencies": { "@radix-ui/react-primitive": "2.0.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg=="],
+
+    "@radix-ui/react-collection": ["@radix-ui/react-collection@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0", "@radix-ui/react-context": "1.0.0", "@radix-ui/react-primitive": "1.0.1", "@radix-ui/react-slot": "1.0.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g=="],
 
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
 
-    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+    "@radix-ui/react-context": ["@radix-ui/react-context@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q=="],
 
     "@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw=="],
 
-    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+    "@radix-ui/react-direction": ["@radix-ui/react-direction@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ=="],
 
-    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
+    "@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.5", "", { "dependencies": { "@radix-ui/primitive": "1.1.1", "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-use-callback-ref": "1.1.0", "@radix-ui/react-use-escape-keydown": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg=="],
 
-    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+    "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg=="],
+
+    "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-use-callback-ref": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA=="],
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
 
-    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
+    "@radix-ui/react-popover": ["@radix-ui/react-popover@1.1.6", "", { "dependencies": { "@radix-ui/primitive": "1.1.1", "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-context": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.5", "@radix-ui/react-focus-guards": "1.1.1", "@radix-ui/react-focus-scope": "1.1.2", "@radix-ui/react-id": "1.1.0", "@radix-ui/react-popper": "1.2.2", "@radix-ui/react-portal": "1.1.4", "@radix-ui/react-presence": "1.1.2", "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-slot": "1.1.2", "@radix-ui/react-use-controllable-state": "1.1.0", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-NQouW0x4/GnkFJ/pRqsIS3rM/k97VzKnVb2jB7Gq7VEGPy5g7uNV1ykySFt7eWSp3i2uSGFwaJcvIRJBAHmmFg=="],
 
-    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+    "@radix-ui/react-popper": ["@radix-ui/react-popper@1.2.2", "", { "dependencies": { "@floating-ui/react-dom": "^2.0.0", "@radix-ui/react-arrow": "1.1.2", "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-context": "1.1.1", "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-use-callback-ref": "1.1.0", "@radix-ui/react-use-layout-effect": "1.1.0", "@radix-ui/react-use-rect": "1.1.0", "@radix-ui/react-use-size": "1.1.0", "@radix-ui/rect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA=="],
+
+    "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.4", "", { "dependencies": { "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA=="],
+
+    "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg=="],
 
     "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg=="],
 
-    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+    "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.0.2", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/primitive": "1.0.0", "@radix-ui/react-collection": "1.0.1", "@radix-ui/react-compose-refs": "1.0.0", "@radix-ui/react-context": "1.0.0", "@radix-ui/react-direction": "1.0.0", "@radix-ui/react-id": "1.0.0", "@radix-ui/react-primitive": "1.0.1", "@radix-ui/react-use-callback-ref": "1.0.0", "@radix-ui/react-use-controllable-state": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-HLK+CqD/8pN6GfJm3U+cqpqhSKYAWiOJDe+A+8MfxBnOue39QEeMa43csUn2CXCHQT0/mewh1LrrG4tfkM9DMA=="],
 
-    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+    "@radix-ui/react-slot": ["@radix-ui/react-slot@1.1.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ=="],
 
-    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
+    "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.0.2", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/primitive": "1.0.0", "@radix-ui/react-context": "1.0.0", "@radix-ui/react-direction": "1.0.0", "@radix-ui/react-id": "1.0.0", "@radix-ui/react-presence": "1.0.0", "@radix-ui/react-primitive": "1.0.1", "@radix-ui/react-roving-focus": "1.0.2", "@radix-ui/react-use-controllable-state": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-gOUwh+HbjCuL0UCo8kZ+kdUEG8QtpdO4sMQduJ34ZEz0r4922g9REOBM+vIsfwtGxSug4Yb1msJMJYN2Bk8TpQ=="],
+
+    "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw=="],
+
+    "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.1.0", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw=="],
 
     "@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
 
-    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+    "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.0", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.0", "", { "dependencies": { "@radix-ui/rect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ=="],
+
+    "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.0", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw=="],
+
+    "@radix-ui/rect": ["@radix-ui/rect@1.1.0", "", {}, "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.3", "", { "os": "android", "cpu": "arm64" }, "sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ=="],
 
@@ -1054,6 +1123,8 @@
 
     "@synara/desktop": ["@synara/desktop@workspace:apps/desktop"],
 
+    "@synara/excalidraw-mcp": ["@synara/excalidraw-mcp@workspace:packages/excalidraw-mcp"],
+
     "@synara/marketing": ["@synara/marketing@workspace:apps/marketing"],
 
     "@synara/scripts": ["@synara/scripts@workspace:scripts"],
@@ -1154,6 +1225,68 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -1161,6 +1294,8 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -1192,6 +1327,8 @@
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
@@ -1201,6 +1338,8 @@
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
@@ -1334,6 +1473,8 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "browser-fs-access": ["browser-fs-access@0.29.1", "", {}, "sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw=="],
+
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
@@ -1362,6 +1503,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001779", "", {}, "sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA=="],
 
+    "canvas-roundrect-polyfill": ["canvas-roundrect-polyfill@0.0.1", "", {}, "sha512-yWq+R3U3jE+coOeEb3a3GgE2j/0MMiDKM/QpLb6h9ihf5fGY9UXtvK9o4vNqjWXoZz7/3EaSVU3IX53TvFFUOw=="],
+
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
@@ -1375,6 +1518,10 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "chevrotain": ["chevrotain@11.0.3", "", { "dependencies": { "@chevrotain/cst-dts-gen": "11.0.3", "@chevrotain/gast": "11.0.3", "@chevrotain/regexp-to-ast": "11.0.3", "@chevrotain/types": "11.0.3", "@chevrotain/utils": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw=="],
+
+    "chevrotain-allstar": ["chevrotain-allstar@0.3.1", "", { "dependencies": { "lodash-es": "^4.17.21" }, "peerDependencies": { "chevrotain": "^11.0.0" } }, "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -1428,7 +1575,13 @@
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
+
+    "crc-32": ["crc-32@0.3.0", "", {}, "sha512-kucVIjOmMc1f0tv53BJ/5WIX+MGLcKuoBhnGqQrgKJNqLByb/sVMWfW/Aw6hw0jgcqjJ2pi9E5y32zOIpaUlsA=="],
+
+    "cross-env": ["cross-env@7.0.3", "", { "dependencies": { "cross-spawn": "^7.0.1" }, "bin": { "cross-env": "src/bin/cross-env.js", "cross-env-shell": "src/bin/cross-env-shell.js" } }, "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -1446,7 +1599,81 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -1473,6 +1700,8 @@
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -1503,6 +1732,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -1560,7 +1791,11 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
+
     "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
+
+    "es6-promise-pool": ["es6-promise-pool@2.5.0", "", {}, "sha512-VHErXfzR/6r/+yyzPKeBvO0lgjfC5cbDCQWjWwMZWSb6YU39TGIl51OUmCfWCq4ylMdJSB8zkz2vIuIeIxXApA=="],
 
     "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
@@ -1596,7 +1831,7 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
-    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -1652,6 +1887,8 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
+    "fractional-indexing": ["fractional-indexing@3.2.0", "", {}, "sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ=="],
+
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
@@ -1659,6 +1896,8 @@
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "fuzzy": ["fuzzy@0.1.3", "", {}, "sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w=="],
 
     "fuzzysort": ["fuzzysort@3.1.0", "", {}, "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ=="],
 
@@ -1698,6 +1937,8 @@
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
+    "glur": ["glur@1.1.2", "", {}, "sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA=="],
+
     "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
@@ -1711,6 +1952,8 @@
     "graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 
     "h3": ["h3@1.15.6", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-oi15ESLW5LRthZ+qPCi5GNasY/gvynSKUQxgiovrY63bPAtG59wtM+LSrlcwvOHAXzGrXVLnI97brbkdPF9WoQ=="],
+
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -1784,7 +2027,13 @@
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
+    "image-blob-reduce": ["image-blob-reduce@3.0.1", "", { "dependencies": { "pica": "^7.1.0" } }, "sha512-/VmmWgIryG/wcn4TVrV7cC4mlfUC/oyiKIfSg5eVM3Ten/c1c34RJhMYKCWTnoSMHSqXLt3tsrBR4Q2HInvN+Q=="],
+
+    "immutable": ["immutable@4.3.9", "", {}, "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
     "import-without-cache": ["import-without-cache@0.2.5", "", {}, "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A=="],
 
@@ -1793,6 +2042,8 @@
     "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "ioredis": ["ioredis@5.10.0", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA=="],
 
@@ -1858,6 +2109,10 @@
 
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
+    "jotai": ["jotai@2.11.0", "", { "peerDependencies": { "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@types/react", "react"] }, "sha512-zKfoBBD1uDw3rljwHkt0fWuja1B76R7CjznuBO+mSX6jpsO1EBeWNRKpeaQho9yPI/pvCv4recGfgOXGxwPZvQ=="],
+
+    "jotai-scope": ["jotai-scope@0.7.2", "", { "peerDependencies": { "jotai": ">=2.9.2", "react": ">=17.0.0" } }, "sha512-Gwed97f3dDObrO43++2lRcgOqw4O2sdr4JCjP/7eHK1oPACDJ7xKHGScpJX9XaflU+KBHXF+VhwECnzcaQiShg=="],
+
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -1894,11 +2149,17 @@
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "koffi": ["koffi@2.16.2", "", {}, "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA=="],
 
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
+
+    "langium": ["langium@3.3.1", "", { "dependencies": { "chevrotain": "~11.0.3", "chevrotain-allstar": "~0.3.0", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.0.8" } }, "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "lazy-val": ["lazy-val@1.0.5", "", {}, "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="],
 
@@ -1934,6 +2195,10 @@
 
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
+    "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
+
     "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
 
     "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
@@ -1941,6 +2206,8 @@
     "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
 
     "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
+
+    "lodash.throttle": ["lodash.throttle@4.1.1", "", {}, "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ=="],
 
     "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
 
@@ -2009,6 +2276,8 @@
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -2100,13 +2369,15 @@
 
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
 
+    "multimath": ["multimath@2.0.0", "", { "dependencies": { "glur": "^1.1.2", "object-assign": "^4.1.1" } }, "sha512-toRx66cAMJ+Ccz7pMIg38xSIrtnbozk0dchXezwQDMgQmbGpfxjtv68H+L00iFL8hxDaVjrmwAFSb3I6bg8Q2g=="],
+
     "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.3", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -2166,6 +2437,8 @@
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
+    "open-color": ["open-color@1.9.1", "", {}, "sha512-vCseG/EQ6/RcvxhUcGJiHViOgrtz4x0XbZepXvKik66TMGkvbmjeJrKFyBEx6daG5rNyyd14zYXhz0hZVwQFOw=="],
+
     "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
     "opentype.js": ["opentype.js@0.8.0", "", { "dependencies": { "tiny-inflate": "^1.0.2" }, "bin": { "ot": "./bin/ot" } }, "sha512-FQHR4oGP+a0m/f6yHoRpBOIbn/5ZWxKd4D/djHVJu8+KpBTYrJda0b7mLcgDEMWXE9xBCJm+qb0yv6FcvPjukg=="],
@@ -2194,6 +2467,8 @@
 
     "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
+    "pako": ["pako@2.0.3", "", {}, "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
@@ -2214,6 +2489,8 @@
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -2228,6 +2505,10 @@
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
+    "perfect-freehand": ["perfect-freehand@1.2.0", "", {}, "sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw=="],
+
+    "pica": ["pica@7.1.1", "", { "dependencies": { "glur": "^1.1.2", "inherits": "^2.0.3", "multimath": "^2.0.0", "object-assign": "^4.1.1", "webworkify": "^1.5.0" } }, "sha512-WY73tMvNzXWEld2LicT9Y260L43isrZ85tPuqRyvtkljSDLmnNFQmZICt4xUJMVulmcc6L9O7jbBrtx3DOz/YQ=="],
+
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -2240,7 +2521,17 @@
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
+    "png-chunk-text": ["png-chunk-text@1.0.0", "", {}, "sha512-DEROKU3SkkLGWNMzru3xPVgxyd48UGuMSZvioErCure6yhOc/pRH2ZV+SEn7nmaf7WNf3NdIpH+UTrRdKyq9Lw=="],
+
+    "png-chunks-encode": ["png-chunks-encode@1.0.0", "", { "dependencies": { "crc-32": "^0.3.0", "sliced": "^1.0.1" } }, "sha512-J1jcHgbQRsIIgx5wxW9UmCymV3wwn4qCCJl6KYgEU/yHCh/L2Mwq/nMOkRPtmV79TLxRZj5w3tH69pvygFkDqA=="],
+
+    "png-chunks-extract": ["png-chunks-extract@1.0.0", "", { "dependencies": { "crc-32": "^0.3.0" } }, "sha512-ZiVwF5EJ0DNZyzAqld8BP1qyJBaGOFaq9zl579qfbkcmOwWLLO4I9L8i2O4j3HkI6/35i0nKG2n+dZplxiT89Q=="],
+
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
+    "points-on-curve": ["points-on-curve@1.0.1", "", {}, "sha512-3nmX4/LIiyuwGLwuUrfhTlDeQFlAhi7lyK/zcRNGhalwapDWgAGR82bUpmn2mA03vII3fvNCG8jAONzKXwpxAg=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
@@ -2275,6 +2566,8 @@
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
     "pure-rand": ["pure-rand@8.1.0", "", {}, "sha512-53B3MB8wetRdD6JZ4W/0gDKaOvKwuXrEmV1auQc0hASWge8rieKV4PCCVNVbJ+i24miiubb4c/B+dg8Ho0ikYw=="],
+
+    "pwacompat": ["pwacompat@2.0.17", "", {}, "sha512-6Du7IZdIy7cHiv7AhtDy4X2QRM8IAD5DII69mt5qWibC2d15ZU8DmBG1WdZKekG11cChSu4zkSUGPF9sweOl6w=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
@@ -2378,9 +2671,13 @@
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rolldown": ["rolldown@1.0.0-rc.3", "", { "dependencies": { "@oxc-project/types": "=0.112.0", "@rolldown/pluginutils": "1.0.0-rc.3" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.3", "@rolldown/binding-darwin-arm64": "1.0.0-rc.3", "@rolldown/binding-darwin-x64": "1.0.0-rc.3", "@rolldown/binding-freebsd-x64": "1.0.0-rc.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.3", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.3", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.3", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.3", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.3", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.3", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.3", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.3", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.3" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw=="],
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.22.5", "", { "dependencies": { "@babel/generator": "8.0.0-rc.2", "@babel/helper-validator-identifier": "8.0.0-rc.2", "@babel/parser": "8.0.0-rc.2", "@babel/types": "8.0.0-rc.2", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.6", "obug": "^2.1.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20250601.1", "rolldown": "^1.0.0-rc.3", "typescript": "^5.0.0 || ^6.0.0-beta", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-M/HXfM4cboo+jONx9Z0X+CUf3B5tCi7ni+kR5fUW50Fp9AlZk0oVLesibGWgCXDKFp5lpgQ9yhKoImUFjl3VZw=="],
+
+    "roughjs": ["roughjs@4.6.4", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-s6EZ0BntezkFYMf/9mGn7M8XGIoaav9QQBCnJROWB3brUWQ683Q2LbRD/hq0Z3bAJ/9NVpU/5LpiTWvQMyLDhw=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -2388,11 +2685,15 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "sass": ["sass@1.51.0", "", { "dependencies": { "chokidar": ">=3.0.0 <4.0.0", "immutable": "^4.0.0", "source-map-js": ">=0.6.2 <2.0.0" }, "bin": { "sass": "sass.js" } }, "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA=="],
 
     "sax": ["sax@1.5.0", "", {}, "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA=="],
 
@@ -2439,6 +2740,8 @@
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "sliced": ["sliced@1.0.1", "", {}, "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA=="],
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
@@ -2489,6 +2792,8 @@
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "sumchecker": ["sumchecker@3.0.1", "", { "dependencies": { "debug": "^4.1.0" } }, "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg=="],
 
@@ -2554,6 +2859,8 @@
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
+
     "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
 
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
@@ -2565,6 +2872,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "tunnel-rat": ["tunnel-rat@0.1.2", "", { "dependencies": { "zustand": "^4.3.2" } }, "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ=="],
 
     "turbo": ["turbo@2.8.17", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.17", "turbo-darwin-arm64": "2.8.17", "turbo-linux-64": "2.8.17", "turbo-linux-arm64": "2.8.17", "turbo-windows-64": "2.8.17", "turbo-windows-arm64": "2.8.17" }, "bin": { "turbo": "bin/turbo" } }, "sha512-YwPsNSqU2f/RXU/+Kcb7cPkPZARxom4+me7LKEdN5jsvy2tpfze3zDZ4EiGrJnvOm9Avu9rK0aaYsP7qZ3iz7A=="],
 
@@ -2716,6 +3025,8 @@
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
+    "webworkify": ["webworkify@1.5.0", "", {}, "sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
@@ -2765,6 +3076,8 @@
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@anthropic-ai/claude-agent-sdk/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
@@ -2834,6 +3147,14 @@
 
     "@base-ui/utils/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
+    "@chevrotain/cst-dts-gen/@chevrotain/types": ["@chevrotain/types@11.0.3", "", {}, "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="],
+
+    "@chevrotain/cst-dts-gen/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
+
+    "@chevrotain/gast/@chevrotain/types": ["@chevrotain/types@11.0.3", "", {}, "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="],
+
+    "@chevrotain/gast/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
+
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -2864,19 +3185,111 @@
 
     "@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@excalidraw/excalidraw/clsx": ["clsx@1.1.1", "", {}, "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="],
+
+    "@excalidraw/mermaid-to-excalidraw/nanoid": ["nanoid@4.0.2", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="],
+
     "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
+    "@radix-ui/react-arrow/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.2", "", { "dependencies": { "@radix-ui/react-slot": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w=="],
+
+    "@radix-ui/react-collection/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-context": ["@radix-ui/react-context@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-primitive": ["@radix-ui/react-primitive@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-slot": "1.0.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA=="],
+
+    "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw=="],
+
+    "@radix-ui/react-dialog/@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-context": ["@radix-ui/react-context@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-dismissable-layer": ["@radix-ui/react-dismissable-layer@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-escape-keydown": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.9", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.5", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ=="],
+
     "@radix-ui/react-dialog/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
-    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+    "@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@radix-ui/react-focus-scope/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+    "@radix-ui/react-dialog/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
 
-    "@radix-ui/react-portal/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
+    "@radix-ui/react-direction/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw=="],
+
+    "@radix-ui/react-dismissable-layer/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.2", "", { "dependencies": { "@radix-ui/react-slot": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w=="],
+
+    "@radix-ui/react-focus-scope/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw=="],
+
+    "@radix-ui/react-focus-scope/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.2", "", { "dependencies": { "@radix-ui/react-slot": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-id": ["@radix-ui/react-id@1.1.0", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.2", "", { "dependencies": { "@radix-ui/react-slot": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w=="],
+
+    "@radix-ui/react-popper/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw=="],
+
+    "@radix-ui/react-popper/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.2", "", { "dependencies": { "@radix-ui/react-slot": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w=="],
+
+    "@radix-ui/react-popper/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w=="],
+
+    "@radix-ui/react-portal/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.2", "", { "dependencies": { "@radix-ui/react-slot": "1.1.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w=="],
+
+    "@radix-ui/react-portal/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w=="],
+
+    "@radix-ui/react-presence/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw=="],
+
+    "@radix-ui/react-presence/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w=="],
 
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
+
+    "@radix-ui/react-roving-focus/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/primitive": ["@radix-ui/primitive@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" } }, "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-context": ["@radix-ui/react-context@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-id": ["@radix-ui/react-id@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-use-layout-effect": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-primitive": ["@radix-ui/react-primitive@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-slot": "1.0.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-use-callback-ref": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg=="],
+
+    "@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw=="],
+
+    "@radix-ui/react-tabs/@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@radix-ui/react-tabs/@radix-ui/primitive": ["@radix-ui/primitive@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" } }, "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-context": ["@radix-ui/react-context@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-id": ["@radix-ui/react-id@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-use-layout-effect": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-presence": ["@radix-ui/react-presence@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0", "@radix-ui/react-use-layout-effect": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-primitive": ["@radix-ui/react-primitive@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-slot": "1.0.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0", "react-dom": "^16.8 || ^17.0 || ^18.0" } }, "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-use-callback-ref": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg=="],
+
+    "@radix-ui/react-use-size/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w=="],
 
     "@rolldown/plugin-babel/rolldown": ["rolldown@1.0.0-rc.9", "", { "dependencies": { "@oxc-project/types": "=0.115.0", "@rolldown/pluginutils": "1.0.0-rc.9" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-x64": "1.0.0-rc.9", "@rolldown/binding-freebsd-x64": "1.0.0-rc.9", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q=="],
 
@@ -2924,6 +3337,10 @@
 
     "astro/shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
+    "chevrotain/@chevrotain/types": ["@chevrotain/types@11.0.3", "", {}, "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="],
+
+    "chevrotain/lodash-es": ["lodash-es@4.17.21", "", {}, "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="],
+
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
@@ -2933,6 +3350,16 @@
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
+
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
 
     "degenerator/ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
 
@@ -2966,9 +3393,19 @@
 
     "hosted-git-info/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
+    "langium/vscode-uri": ["vscode-uri@3.0.8", "", {}, "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="],
+
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "mermaid/@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "mermaid/@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "mermaid/roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -2984,6 +3421,10 @@
 
     "path-scurry/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
+    "points-on-path/points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -2998,9 +3439,15 @@
 
     "rolldown-plugin-dts/@babel/types": ["@babel/types@8.0.0-rc.2", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.2", "@babel/helper-validator-identifier": "^8.0.0-rc.2" } }, "sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw=="],
 
+    "roughjs/points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "sass/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+
+    "shadcn/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "shadcn/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
@@ -3017,6 +3464,8 @@
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "tunnel-rat/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
     "unrun/rolldown": ["rolldown@1.0.0-rc.9", "", { "dependencies": { "@oxc-project/types": "=0.115.0", "@rolldown/pluginutils": "1.0.0-rc.9" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-x64": "1.0.0-rc.9", "@rolldown/binding-freebsd-x64": "1.0.0-rc.9", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q=="],
 
@@ -3037,6 +3486,8 @@
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "@anthropic-ai/claude-agent-sdk/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "@astrojs/markdown-remark/shiki/@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
 
@@ -3164,6 +3615,28 @@
 
     "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "@radix-ui/react-dialog/@radix-ui/react-dismissable-layer/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-dismissable-layer/@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.1", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g=="],
+
+    "@radix-ui/react-dialog/@radix-ui/react-focus-scope/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
+
+    "@radix-ui/react-popover/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.0", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ=="],
+
+    "@radix-ui/react-roving-focus/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-id/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-presence/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-presence/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.0.1", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-compose-refs": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw=="],
+
+    "@radix-ui/react-tabs/@radix-ui/react-use-controllable-state/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg=="],
+
     "@rolldown/plugin-babel/rolldown/@oxc-project/types": ["@oxc-project/types@0.115.0", "", {}, "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="],
 
     "@rolldown/plugin-babel/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.9", "", { "os": "android", "cpu": "arm64" }, "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg=="],
@@ -3195,6 +3668,8 @@
     "@rolldown/plugin-babel/rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.9", "", {}, "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw=="],
 
     "@synara/scripts/@anthropic-ai/claude-agent-sdk/@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
+
+    "@synara/scripts/@anthropic-ai/claude-agent-sdk/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.31.1", "", { "os": "android", "cpu": "arm64" }, "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg=="],
 
@@ -3244,13 +3719,29 @@
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
     "enquirer/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "mermaid/roughjs/points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
     "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "rolldown-plugin-dts/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.2", "", {}, "sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ=="],
+
+    "sass/chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "sass/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "shadcn/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "shadcn/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "shadcn/open/wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
@@ -3356,11 +3847,17 @@
 
     "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA=="],
+
+    "@synara/scripts/@anthropic-ai/claude-agent-sdk/@modelcontextprotocol/sdk/express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
     "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "ast-kit/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.2", "", {}, "sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ=="],
 
     "cli-highlight/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "sass/chokidar/readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "@babel/plugin-transform-modules-commonjs/@babel/helper-module-transforms/@babel/helper-module-imports/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 

--- a/docs/plans/2026-07-14-001-feat-ai-canvas-workspace-plan.md
+++ b/docs/plans/2026-07-14-001-feat-ai-canvas-workspace-plan.md
@@ -1,0 +1,593 @@
+---
+title: AI Canvas Workspace - Plan
+type: feat
+date: 2026-07-14
+topic: ai-canvas-workspace
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+depth: deep
+deepened: 2026-07-14
+---
+
+# AI Canvas Workspace - Plan
+
+## Goal Capsule
+
+- **Objective:** 在 Synara 中增加以 Excalidraw 为核心的 Canvas workspace，让用户可以与 Grok agent 长期协作，将自然语言、代码研究或文档研究结果转化为可继续编辑的结构化图。
+- **Product authority:** 本文记录 2026-07-14 与产品所有者确认的产品行为、首版范围和验收标准；后续规划可以决定实现细节，但不能改写这些产品决策。
+- **Open blockers:** 无。稳定 Drawing 身份、数据库关系、MCP 进程边界和文件监听策略留给实现规划确定。
+- **Execution profile:** 跨 contracts、SQLite projection、server workspace/runtime、Grok ACP、MCP 子进程与 React/Excalidraw UI 的 Deep 实施；按依赖顺序完成 schema → 文件/runtime → provider → UI → 端到端恢复。
+- **Tail ownership:** 实施者负责本地 fork 归档、迁移兼容、聚焦测试、真实浏览器验收、PR 与 CI；任何未完成的外部阻塞必须在交付说明中明确列出。
+- **Stop conditions:** 只有在创建/重开 Drawing、人工保存、AI 工具写入、Grok session 恢复、中断/失败解锁及 TCP/IP 基准路径均有可观察证据后才可交付。
+
+---
+
+## Product Contract
+
+### Summary
+
+Synara 将增加一个新的顶层 Canvas workspace，并继续使用现有 Project 表示用户选择的本地目录。每个 Project 可以同时拥有编码对话和多张 Drawing；每张 Drawing 对应一个可持久化的 `.excalidraw` 文件，以及一个固定、长期、仅存于本机数据库的 Grok ACP 对话。用户在中间的原生 Excalidraw 画布查看和编辑结构化图，并在右侧持续与 AI 协作。
+
+### Problem Frame
+
+现有 Synara 的核心交互以 agent 对话和代码编辑为中心，无法把 agent 对代码、文档或一般概念的理解直接沉淀为可反复修改的视觉资产。Mermaid 适合快速表达关系，但成图风格较朴素、自由布局能力有限；HTML 输出信息密度往往过高，也不是理想的可编辑图形源文件。用户需要的是一种 canvas-first 的工作方式：AI 负责研究、组织和绘制，用户可以继续手工调整，并在同一个长期上下文里要求 AI 迭代。
+
+### Key Decisions
+
+- **Canvas 是 Synara 内的新 workspace。** 它不是独立应用，也不创建另一套 Project 体系；同一个本地 Project 可以同时承载代码工作与绘图工作。
+- **Drawing 是一等实体。** 一个 Project 可包含多张 Drawing，每张 Drawing 拥有稳定身份、一个 `.excalidraw` 内容文件和一个固定的长期对话。
+- **结构化图是首要输出。** 首版产物必须能在 Excalidraw 中逐元素选择、移动、编辑和继续生成；生成式位图只作为后续补充能力。
+- **原生画布归 Synara 所有。** 主界面直接嵌入 `@excalidraw/excalidraw`，不把 MCP App iframe 当成产品主画布。
+- **基于 fork 集成 MCP。** 本地 fork `excalidraw/excalidraw-mcp`，复用它的元素格式、场景创建、恢复、删除、checkpoint 和流式更新思路，并将输出桥接到 Synara Drawing runtime；不从零重写一个 MCP。
+- **首版只承诺 Grok ACP。** 现有 provider 架构继续保留，但 Canvas 的 MCP 注入、会话恢复和绘图调用先在 Grok ACP 路径打通，再推广到其他 provider。
+- **AI 与人工编辑串行。** AI 绘图时用户可以查看、缩放、平移和中断，但不能同时修改元素，以避免冲突和损坏。
+- **语义歧义先澄清。** 当不同选择会改变图的事实结构时，AI 先问一个聚焦问题；布局、配色等非结构性选择由 AI 使用合理默认值。
+
+### Actors
+
+- A1. 用户：创建、打开、编辑 Drawing，并通过长期对话要求 AI 研究、绘制和修改。
+- A2. Grok ACP agent：理解请求、在必要时澄清、研究可用上下文，并通过绘图工具读取或修改当前场景。
+- A3. Drawing runtime：维护画布状态、串行化编辑、执行 MCP 场景变更、持久化文件，并在失败时保持可恢复状态。
+- A4. Synara orchestration：维护 Project、Drawing、Thread 及 provider session 的本地关系和生命周期。
+
+### Requirements
+
+**Workspace and navigation**
+
+- R1. Synara 必须提供独立于 Chat 和 Editor 的顶层 Canvas workspace，并保持其属于同一个产品外壳和导航体系。
+- R2. Canvas workspace 必须使用三栏协作布局：左侧 Project/Drawing 导航、中间主画布、右侧固定长期对话。
+- R3. 现有 Project 必须继续代表用户选择的本地目录，并能同时包含现有编码线程和任意数量的 Drawing。
+- R4. 用户必须能够在 Project 内创建、命名、打开、切换和删除 Drawing，并能从左侧导航识别当前 Drawing。
+- R5. 打开 Drawing 时，中间区域必须显示原生 Excalidraw 画布；右侧对话可以调整宽度或隐藏，但不能因隐藏而销毁会话状态。
+
+**Drawing identity and persistence**
+
+- R6. 每张 Drawing 必须拥有稳定身份，不能只依赖易变化的显示名称来关联文件和对话。
+- R7. 每张 Drawing 的结构化内容必须持久化为其 Project 目录内的 `.excalidraw` 文件，并以该文件作为场景内容的事实来源。
+- R8. 每张 Drawing 必须固定关联一个长期 Thread；后续打开、编辑和 AI 请求都继续使用该 Thread，而不是自动新建短会话。
+- R9. Drawing 与 Thread 的关系、对话消息和 provider session 元数据必须沿用 Synara 的本机数据库持久化方式，不在 Project 内创建对话 sidecar 文件。
+- R10. 重启 Synara 或重新打开 Project 后，系统必须恢复 Drawing 内容及其原有长期对话，并让用户从上次上下文继续工作。
+- R11. 用户或 AI 产生的有效场景变更必须可靠保存；写入失败不能静默丢失已确认的画布状态。
+
+**AI collaboration behavior**
+
+- R12. 用户必须能用自然语言要求 AI 新建任意结构化图，或基于当前场景进行局部修改、重排、补充和删除。
+- R13. Agent 在执行修改前必须能够读取当前 Drawing 的结构和必要上下文，避免把每次请求当作空白画布重新生成。
+- R14. 当请求存在会改变事实结构的歧义时，AI 必须先提出一个聚焦澄清问题；当差异只涉及视觉风格时，AI 应直接采用合理默认值。
+- R15. AI 进入场景写入阶段后，Drawing runtime 必须暂时锁定人工元素编辑，同时保留查看、缩放、平移和中断能力。
+- R16. AI 修改必须作为边界清晰的场景操作应用；完成后解锁编辑，失败或中断后也必须解锁，并保留最近一次有效场景。
+- R17. AI 的局部修改必须尽量保留未被请求影响的元素、用户手工调整和稳定元素身份，不能无理由整图重建。
+- R18. 对话必须清楚显示 AI 正在研究、等待澄清、绘图、完成、失败或已中断的状态，让用户能够判断当前是否可编辑。
+
+**Integration and quality**
+
+- R19. 首版必须通过 Grok 的 ACP runtime 向 agent 提供 Drawing MCP 工具，并支持新会话、恢复会话和重新连接后的持续使用。
+- R20. MCP 适配必须建立在本地 fork 的 `excalidraw-mcp` 上，并保留可追踪的上游来源，以便后续选择性同步上游改进。
+- R21. Synara 必须拥有主画布和持久化生命周期；MCP 层负责向 agent 暴露场景能力，不能以嵌入式 MCP App 替代 Canvas workspace。
+- R22. 首版生成的图必须由可编辑的 Excalidraw 元素构成，并能表达层级、容器、连线、标签和方向等常见架构关系。
+- R23. AI 绘图结果必须优先保证语义正确、层次清晰和可读性，再优化装饰性风格。
+
+### Key Flows
+
+- F1. 创建并首次绘图
+  - **Trigger:** A1 在某个 Project 中创建 Drawing 并输入绘图请求。
+  - **Actors:** A1, A2, A3, A4
+  - **Steps:** 系统创建稳定 Drawing 身份、`.excalidraw` 文件和固定 Thread；A2 判断是否需要澄清；A3 锁定编辑并应用 MCP 场景操作；有效结果保存后解锁。
+  - **Outcome:** 用户看到一张可编辑的结构化图，并能在同一对话中继续迭代。
+  - **Covers:** R3-R9, R12-R16, R19-R23
+
+- F2. 继续已有 Drawing
+  - **Trigger:** A1 重新打开曾经编辑过的 Drawing。
+  - **Actors:** A1, A2, A3, A4
+  - **Steps:** 系统加载 `.excalidraw` 场景和关联 Thread；A2 可读取当前结构与对话上下文；新的修改只影响请求涉及的部分。
+  - **Outcome:** 文件、对话和 AI 上下文连续，用户无需重新解释整张图。
+  - **Covers:** R6-R13, R17
+
+- F3. 人工编辑后交给 AI 修改
+  - **Trigger:** A1 手工移动、改写或新增元素后提出后续请求。
+  - **Actors:** A1, A2, A3
+  - **Steps:** A3 保存人工修改；A2 读取最新场景；A3 串行应用 AI 的局部场景操作，并保护无关元素。
+  - **Outcome:** 人工与 AI 的修改在同一份结构化源文件上累积。
+  - **Covers:** R11-R13, R15-R17
+
+- F4. 绘图失败或被中断
+  - **Trigger:** A1 中断绘图，或 MCP、provider、持久化过程失败。
+  - **Actors:** A1, A2, A3, A4
+  - **Steps:** 当前操作停止；A3 丢弃或回退未完成的无效变更；恢复最近一次有效场景；解除人工编辑锁；对话展示结果和可恢复状态。
+  - **Outcome:** Drawing 不损坏，用户可以继续手工编辑或再次请求 AI。
+  - **Covers:** R11, R15, R16, R18, R19
+
+### Workspace Relationship
+
+```mermaid
+flowchart TB
+  P["Existing Project / local directory"]
+  CT["Coding threads"]
+  D1["Drawing A"]
+  D2["Drawing B"]
+  F1["A.excalidraw source file"]
+  T1["One long-lived local Thread"]
+  C1["Native Excalidraw canvas"]
+  G["Grok ACP agent"]
+  M["Forked excalidraw-mcp bridge"]
+
+  P --> CT
+  P --> D1
+  P --> D2
+  D1 --> F1
+  D1 --> T1
+  F1 --> C1
+  T1 --> G
+  G --> M
+  M --> C1
+  C1 --> F1
+```
+
+### Acceptance Examples
+
+- AE1. TCP/IP 分层架构图
+  - **Covers:** R12, R14, R22, R23
+  - **Given:** 用户在空白 Drawing 中输入“绘制 TCP/IP 协议栈架构图，看到正确的分层架构展示”。
+  - **When:** 采用四层还是五层会改变图的结构。
+  - **Then:** AI 先用一个问题确认分层模型，再绘制方向一致、层次清晰、协议归属正确、元素可单独编辑的架构图。
+
+- AE2. 基于人工修改继续绘图
+  - **Covers:** R13, R15-R17
+  - **Given:** 用户已经移动一个层级并手工改写标签。
+  - **When:** 用户要求 AI 只补充各层的数据单元和示例协议。
+  - **Then:** AI 读取最新场景，只补充请求内容，并保留用户的布局调整和无关元素。
+
+- AE3. 重启后继续长期对话
+  - **Covers:** R6-R10, R19
+  - **Given:** Drawing 已经历多轮人工和 AI 修改。
+  - **When:** 用户重启 Synara 并再次打开该 Drawing。
+  - **Then:** 系统恢复相同 `.excalidraw` 内容及相同 Thread，用户可以引用之前讨论过的概念继续修改。
+
+- AE4. 中断未完成的 AI 绘图
+  - **Covers:** R11, R15, R16, R18
+  - **Given:** AI 正在流式修改一个已有场景。
+  - **When:** 用户中断操作或 MCP 进程异常退出。
+  - **Then:** 系统停止本次操作、恢复最近一次有效场景、解除编辑锁，并在对话中显示可理解的失败或中断状态。
+
+### Success Criteria
+
+- 基准请求可以产出语义正确的 TCP/IP 分层图，而不是只有视觉上类似分层的错误内容。
+- AI 生成的主要节点、连线、标签和容器均可在 Excalidraw 中独立选择和编辑。
+- 用户能够在同一 Project 内自然切换编码线程与多张 Drawing，不需要管理两套目录或项目概念。
+- 任意 Drawing 在应用重启后仍能恢复文件、固定对话和继续协作所需的上下文。
+- 正常完成、用户中断、agent 失败和保存失败都不会留下损坏的 `.excalidraw` 文件或永久编辑锁。
+- AI 对已有图的局部修改不会无理由覆盖用户调整或重建整张图。
+
+### Scope Boundaries
+
+**Deferred for later**
+
+- 面向代码仓库的专用研究流程，例如自动扫描项目后生成依赖图或架构图。
+- 面向文档集合的专用研究流程，例如概念抽取、引文追踪和知识图谱生成。
+- ChatGPT 风格的生成式位图与结构化 Excalidraw 场景混合创作。
+- 动画时间线、镜头编排、视频渲染和自媒体导出。
+- Grok 之外的 Codex、Claude、Cursor、Gemini 等 provider 的正式 Canvas 支持。
+- 实时多人协作，以及 AI 写入期间的无锁并发人工编辑。
+
+**Outside this product's identity**
+
+- 用 Mermaid 或 HTML 文档作为 Canvas workspace 的主要可编辑源格式。
+- 将 `excalidraw-mcp` 自带 MCP App iframe 直接包装成 Synara 的完整绘图产品。
+- 为 Canvas 再创建一套与现有 Synara Project、Thread 和 orchestration 平行的应用或数据库。
+
+### Dependencies / Assumptions
+
+- `@excalidraw/excalidraw` 的嵌入式 React API 能支持场景读取、更新、保存及必要的编辑状态控制。
+- Grok CLI 的 ACP 实现允许 Synara 在创建和恢复 session 时注入 MCP server 配置。
+- 本地 fork 的 `excalidraw-mcp` 许可证和元素模型允许在 Synara 内修改、分发和持续维护。
+- Synara 现有本地 SQLite orchestration 可以扩展 Drawing 与 Thread 的关系，而不改变“对话只存本机”的产品承诺。
+- Project 目录在绘图期间可写；只读目录、外部文件冲突和跨设备同步的具体策略由实现规划定义。
+
+### Sources / Research
+
+- `apps/web/src/components/EditorWorkspaceView.tsx`：现有左侧工作区、中间内容和右侧对话布局可作为 Canvas workspace 的交互基础。
+- `apps/web/src/routes/_chat.$threadId.tsx`：现有 thread、workspace root 与 editor workspace 的组合入口。
+- `apps/web/src/routes/_chat.tsx`：现有顶层 chat/editor view 切换行为。
+- `packages/contracts/src/orchestration.ts`：现有 Project、Thread 和 workspace root 的契约入口。
+- `apps/server/src/provider/acp/AcpSessionRuntime.ts`：共享 ACP session 创建与恢复路径目前传入空 `mcpServers`，是首版注入绘图 MCP 的关键接点。
+- `apps/server/src/provider/Layers/GrokAdapter.ts`：Grok 通过 ACP 运行，是首版 provider 集成入口。
+- [excalidraw/excalidraw-mcp](https://github.com/excalidraw/excalidraw-mcp)：上游 MCP Apps 实现与本地 fork 来源。
+- [excalidraw-mcp server implementation](https://github.com/excalidraw/excalidraw-mcp/blob/main/src/server.ts)：现有模型工具、场景创建与 MCP App 资源实现的参考入口。
+
+---
+
+## Planning Contract
+
+### Plan Summary
+
+实现采用“Drawing 是专用 Thread，而不是平行聚合”的模型：现有 Thread 增加向后兼容的 `surface` 字段；`surface=canvas` 时，thread ID 同时是 Drawing 的稳定身份，标题仍是可变显示名，场景文件固定为 Project 下 `drawings/<thread-id>.excalidraw`。Synara server 负责受限路径、验证和原子文件生命周期；本地 fork 的 MCP 通过 Grok ACP 以 stdio 启动，只能读写当前 Drawing；web 端嵌入原生 Excalidraw，并复用现有 ChatView 作为同一 Thread 的永久右栏。
+
+### Key Technical Decisions
+
+#### KTD1 — Drawing 复用 Thread 聚合，以 `surface` 区分行为
+
+- 在 `thread.create`、`thread.created`、完整/壳层 read model 与 SQLite projection 中增加默认值为 `chat` 的 `surface: "chat" | "canvas"`。
+- `surface=canvas` 的 Thread 即 Drawing；不新增 Drawing 表、Drawing 事件流或第二套对话外键。
+- 依据：R6、R8-R10 明确要求稳定身份和固定长期对话；复用 Thread 让消息、session、模型选择、恢复、删除和本机数据库承诺继续沿用已验证路径。
+- 放弃独立 Drawing 聚合，因为它会引入跨聚合一致性、双重生命周期和“文件存在但 Thread 丢失”的更多失败组合。
+
+#### KTD2 — 文件名由稳定 ID 派生，显示名不参与路径
+
+- 每张图固定使用 `drawings/<thread-id>.excalidraw`；创建时建立目录和空场景，重命名只更新 Thread title。
+- 文件路径由 server 根据 Project workspace root 与 Thread ID计算，客户端和 agent 都不能提交任意绝对路径。
+- 依据：R6-R7、R11；避免标题中的路径字符、重名和 rename 后 MCP/session 仍指向旧文件。
+
+#### KTD3 — Synara server 是唯一文件生命周期边界，所有提交采用验证后的原子替换
+
+- 增加 Canvas Drawing RPC：创建、读取、保存、删除。保存先校验大小上限与 Excalidraw JSON 基本结构，再写临时文件并原子 rename；只有成功后响应新版本标识。
+- 创建流程先写空场景再创建 Thread；Thread 创建失败时删除新文件。删除流程先把文件原子移动到 Project 内 `.synara/trash/drawings/`，再删除 Thread；数据库删除失败时把文件移回。
+- 浏览器保存使用场景 revision/内容 hash 做乐观并发保护。MCP 不直接打开 Drawing 文件；server 为每个运行中的 Canvas session 签发短期、限定 threadId 的 loopback capability，forked MCP 通过内部 bridge 调用同一个 CanvasDrawingService。MCP 提交后 UI 重新读取 server 事实源，避免浏览器缓存覆盖 agent 的新版本。
+- 依据：R7、R11、R16 与项目“失败时行为可预测”的优先级。
+
+#### KTD4 — fork 上游 MCP，但把 MCP App UI 替换为单 Drawing 文件适配器
+
+- 将上游 `excalidraw/excalidraw-mcp` v0.3.2、commit `157aa23ceb1976008aadc89eb05e3444060f09d6` 的服务端相关实现、MIT LICENSE 与来源说明 vendoring 为 workspace package。
+- 保留上游 `read_me`、场景读取、`create_view` 的元素 shorthand/restore/delete/checkpoint 思路；去掉产品主路径中的 MCP App iframe/resource UI。
+- stdio 子进程从受控环境变量获得唯一内部 bridge URL、threadId 与短期 capability；工具参数不能切换 Drawing，子进程也不获得文件绝对路径。场景变更在内存完成、完整验证后经 CanvasDrawingService 一次性原子提交，失败不留下半成品。
+- 这满足 R20-R21 的“基于 fork，不从零重写”，同时让 Synara 原生 Canvas 继续拥有 UI 和持久化生命周期。
+
+#### KTD5 — MCP 配置是可恢复的 Grok session 输入，不是一次性新会话参数
+
+- `AcpSessionRuntimeOptions` 接收 `mcpServers`，并在 `session/new`、`session/resume`、`session/load` 及 fallback 新建路径传入同一配置。
+- ProviderCommandReactor 根据 projected Thread surface 和 Project workspace root 生成受控 Canvas 配置，并合并到持久化的 Grok provider start options；server 派生字段优先，客户端不能覆盖 Drawing 路径。
+- Grok adapter 将 Drawing 配置解析为本地 fork 的 stdio command；非 Canvas Thread 与其他 provider 保持原行为。
+- 依据：R19；ACP 的恢复能力不会自动重放工具配置，因此重新附加同一 MCP server 是继续旧 session 的必要条件。
+
+#### KTD6 — 人工与 AI 通过明确的单写者状态机串行
+
+- UI 的编辑锁来源是当前 Thread 的 provider turn/tool 活动：研究和澄清阶段可编辑；进入 Canvas 写工具后锁定元素编辑，但保留 pan/zoom 与中断。
+- AI 工具完成、失败、turn abort、runtime error 或 session exit 都必须触发重新读取事实源并释放锁；保存失败时保留浏览器内未提交场景并显示可重试错误。
+- 首版以完整工具调用为原子更新粒度，不承诺 token 级或元素级动画流式渲染；这不改变 R18 要求的清晰状态展示。
+
+#### KTD7 — Canvas 是现有 thread route 的第三种 workspace surface
+
+- `view` 路由状态增加 `canvas`；`_chat.$threadId.tsx` 对 Canvas Thread 渲染 `CanvasWorkspaceView`，沿用 Editor workspace 的可调整/隐藏右侧 ChatView 和主 shell 规则。
+- 左栏只展示当前 Project 的 Canvas Threads，并提供创建、切换、重命名、删除；普通 Chat/Editor 路径不展示 Canvas Threads 为普通编码对话。
+- Excalidraw 组件延迟加载，避免增加普通聊天首屏 bundle 和初始化成本。
+
+#### KTD8 — 每个 Canvas turn 都获得明确、版本化的绘图行为上下文
+
+- ProviderCommandReactor 在 Canvas Thread 的用户消息前注入紧凑的 `<canvas_context>`：当前 Drawing 身份、工具使用边界、先读取现有 scene、只在事实结构歧义时问一个问题、局部修改保留无关元素与稳定 ID、完成后用简短对话说明结果。
+- MCP `read_me` 返回同一份版本化行为规则和 scene/tool contract，避免 Grok session 压缩或恢复后只记得工具名却忘记协作约束。
+- prompt/context 逻辑集中在 server 共享模块并有 snapshot/behavior tests；不依赖用户每轮重复说明，也不把场景全文塞入 prompt。
+- 依据：R13-R18、AE1-AE2；工具可达性不等于 agent 会可靠选择正确动作，必须同时提供 action parity 与 context parity。
+
+### Assumptions
+
+- A-S1. `surface` 是实现规划中的兼容字段；历史事件、历史数据库行和非 Canvas 新线程都解码为 `chat`。
+- A-S2. V1 删除采用可恢复的本地 trash move，而不是立即永久删除 `.excalidraw` 文件；UI 仍表现为 Drawing 已删除。trash 清理策略不在本次范围。
+- A-S3. V1 只处理 Synara 内 web 与 MCP bridge 的写入并发；用户在外部编辑器修改同一文件时以 revision conflict 提示重新加载，不做三方 merge。
+- A-S4. V1 的 AI 进度以对话/turn/tool-call 状态和工具完成后的场景刷新表达，不加入逐 token 的画布动画。
+- A-S5. 上游 scene conversion 在 Bun/Node 的 headless MCP 进程中可运行；若 `@excalidraw/excalidraw` 的浏览器依赖阻止 headless import，实施时仅把上游纯转换/restore 逻辑提取到 fork 内，保持工具协议和许可证来源不变。
+
+### High-Level Technical Design
+
+以下图用于验证边界与顺序，不规定具体函数签名。
+
+```mermaid
+flowchart LR
+  UI["CanvasWorkspaceView\nNative Excalidraw"]
+  CHAT["Existing ChatView\nlong-lived Thread"]
+  RPC["NativeApi / WebSocket RPC"]
+  ORCH["Orchestration\nThread surface=canvas"]
+  FILE["CanvasDrawingService\nvalidate + atomic write"]
+  DB["SQLite events + projections"]
+  SCENE["Project/drawings/<thread-id>.excalidraw"]
+  GROK["Grok ACP runtime"]
+  BRIDGE["Loopback capability bridge\nthread-scoped + short-lived"]
+  MCP["Local forked excalidraw-mcp\nscoped stdio process"]
+
+  UI <--> RPC
+  CHAT <--> RPC
+  RPC <--> ORCH
+  ORCH <--> DB
+  RPC <--> FILE
+  FILE <--> SCENE
+  ORCH --> GROK
+  GROK <--> MCP
+  MCP <--> BRIDGE
+  BRIDGE <--> FILE
+  MCP -. "tool status" .-> ORCH
+```
+
+#### Create and first draw sequence
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant Web as Canvas UI
+  participant Server as CanvasDrawingService
+  participant Orch as Orchestration
+  participant Grok as Grok ACP
+  participant MCP as Drawing MCP
+  participant Bridge as Canvas bridge
+  participant File as .excalidraw
+
+  User->>Web: Create Drawing
+  Web->>Server: create(projectId, title)
+  Server->>File: atomic empty scene
+  Server->>Orch: thread.create(surface=canvas, provider=grok)
+  Orch-->>Web: projected Canvas Thread
+  User->>Grok: drawing request
+  Grok-->>User: one clarification if semantic structure is ambiguous
+  User->>Grok: answer
+  Grok->>MCP: read_scene / create_view
+  MCP->>Bridge: scoped read/save(threadId, revision)
+  Bridge->>Server: validate capability + delegate
+  Server->>File: validate + atomic scene commit
+  MCP-->>Orch: tool completed
+  Orch-->>Web: unlock + refetch
+  Web->>Server: read latest scene/version
+  Server-->>Web: editable elements
+```
+
+#### Save, conflict, failure, and restart lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> Loading
+  Loading --> Editable: valid file loaded
+  Editable --> Saving: user scene changed
+  Saving --> Editable: atomic commit + new revision
+  Saving --> UnsavedError: validation / IO failure
+  UnsavedError --> Saving: retry
+  UnsavedError --> Loading: explicit reload
+  Editable --> AgentResearch: turn starts
+  AgentResearch --> Editable: clarification / no drawing tool
+  AgentResearch --> AgentWriting: canvas tool starts
+  AgentWriting --> Loading: tool succeeds, aborts, or fails
+  Loading --> Editable: last valid file reloaded
+  Loading --> RecoverableError: missing / invalid file
+  RecoverableError --> Loading: restore or retry
+```
+
+### Sequencing and Dependency Graph
+
+```mermaid
+flowchart LR
+  U1["U1 Thread surface contract + projection"] --> U2["U2 Drawing file lifecycle RPC"]
+  U2 --> U3["U3 Forked MCP package"]
+  U1 --> U4["U4 Grok ACP MCP injection"]
+  U3 --> U4
+  U1 --> U5["U5 Canvas route + workspace shell"]
+  U2 --> U6["U6 Excalidraw scene runtime"]
+  U5 --> U6
+  U4 --> U7["U7 AI lock/recovery integration"]
+  U6 --> U7
+  U7 --> U8["U8 End-to-end benchmark + packaging"]
+```
+
+### System-Wide Impact
+
+- **Contracts/events:** `thread.create` 与 `thread.created` 增加兼容字段；所有 shell/detail snapshot 和 WS 增量事件携带 surface。事件 schema 默认值保证旧日志可重放。
+- **SQLite:** projection_threads 增列并 default/backfill 为 `chat`；repository 的 SELECT/UPSERT 同步更新。迁移是 additive，不改写事件日志。
+- **Workspace filesystem:** 新 drawing RPC 只接受 projectId/threadId 和场景内容；server 解析实际路径、拒绝 path traversal/symlink escape、限制场景大小，并复用 `atomicWrite.ts` 模式。MCP 使用 thread-scoped loopback capability bridge 调用同一 service，不直接接触路径。
+- **Provider lifecycle:** Canvas 工具配置必须贯穿新建、恢复、重连和 provider fallback；普通 Grok chat 不启动 Drawing MCP。session 终止事件是 UI 解锁的兜底。
+- **Agent context and parity:** Grok 每轮获得版本化 Canvas context，并获得当前 Drawing 的 `read_me`、`read_scene`、`create_view` 与 checkpoint 能力；用户能做的核心场景读取/修改，agent 也能经同一保存服务完成。删除 Drawing 和切换 Project 仍是人工边界。
+- **Web state/cache:** scene query key 包含 project/thread/revision；manual autosave 采用单 flight/coalescing，切换 Drawing 前等待或显式报告未保存状态。工具完成事件只 invalidate 当前 Drawing。
+- **Performance:** Excalidraw 与其 CSS lazy-loaded；普通 Chat 不付出 bundle/初始化成本。大场景 onChange 去抖、相同内容不重复保存；文件大小上限防止 RPC 和 JSON parse 无界增长。
+- **Privacy/security:** 对话仍只在 SQLite；结构化图按用户要求写入 Project。MCP 子进程只获短期 thread-scoped capability；bridge 仅 loopback、每次校验 thread/surface/session、终止 session 即撤销，日志不得记录 token、完整场景或对话正文。
+- **Packaging:** 本地 MCP workspace package 必须进入 server/desktop 构建产物，并用运行时可解析路径启动；LICENSE 和 UPSTREAM 元数据随包分发。
+
+### Risks and Mitigations
+
+| Risk | Impact | Mitigation / evidence required |
+| --- | --- | --- |
+| Excalidraw scene API 或 restore 逻辑依赖浏览器全局 | MCP 无法 headless 运行 | 先用 fork package 单测验证 Node/Bun import；必要时只提取上游纯转换代码，保持协议与来源 |
+| UI autosave 与 MCP bridge 并发提交互相覆盖 | 丢失人工或 AI 修改 | revision/hash 乐观锁、AI 写入期锁、tool 完成后强制 refetch、冲突不自动覆盖 |
+| loopback MCP capability 泄露或复用 | 其他本机进程越权改图 | 高熵短期 token、仅 loopback、绑定 thread/session、constant-time 校验、session exit 撤销、日志脱敏 |
+| MCP 配置仅在 session/new 注入 | 重启后 agent 看不到工具 | 对 new/resume/load/fallback 全路径做请求参数测试，并验证持久 provider options |
+| Thread 创建与文件创建跨存储边界 | 残留文件或无文件 Thread | 明确补偿顺序；创建失败删文件，删除 DB 失败恢复 trash 文件；启动加载提供可恢复错误 |
+| `.excalidraw` 场景过大导致 UI/RPC 卡顿 | 性能和稳定性下降 | 大小/元素数边界、去抖保存、lazy load、聚焦性能测试；V1 不做无限场景保证 |
+| fork 与上游漂移 | 后续更新困难 | 固定 upstream commit、保留 LICENSE/UPSTREAM、将 Synara 适配集中在小模块并覆盖 tool contract tests |
+| Tool status 形状随 provider 变化 | 锁可能无法释放 | 锁以 thread/turn terminal events 兜底，不只依赖单个 Grok tool 名；所有异常路径覆盖测试 |
+| 删除语义造成意外数据丢失 | 用户资产不可恢复 | V1 move-to-trash，RPC/DB 失败补偿；不做自动永久清理 |
+
+### Resolved During Planning
+
+- Drawing 身份：复用 Thread ID，不采用 title 或另建随机文件 ID。
+- 文件位置：Project 内稳定 `drawings/<thread-id>.excalidraw`。
+- 删除策略：UI 删除 + 本地可恢复 trash move。
+- MCP 边界：本地 fork 的单 Drawing stdio server，通过 Synara loopback capability bridge 保存；不嵌入 MCP App，不开放任意路径或直接文件访问。
+- 更新粒度：完整 tool-call 原子提交；V1 不承诺逐元素动画流。
+- 首版 provider：只有 Grok 自动注入 Drawing MCP，其他 provider 路径保持兼容但不宣称支持。
+
+### Deferred to Implementation Validation
+
+- 上游 `convertToExcalidrawElements`/restore 的最小 headless 依赖集合，通过 U3 的 executable spike 决定具体提取边界。
+- desktop 打包后 MCP entry 的最终解析方式，通过 U8 的 packaged-path smoke test 固化；不得回退为开发机绝对路径。
+
+---
+
+## Implementation Units
+
+### U1 — Thread surface contract, event projection, and migration
+
+- **Goal:** 让 Canvas Drawing 在现有 orchestration 中成为可查询、可恢复、向后兼容的专用 Thread。
+- **Requirements:** R3, R6, R8-R10, R19；F1, F2；AE3。
+- **Files:**
+  - Modify `packages/contracts/src/orchestration.ts`, `packages/contracts/src/orchestration.test.ts`
+  - Modify `apps/server/src/orchestration/Schemas.ts`, `apps/server/src/orchestration/decider.ts`, `apps/server/src/orchestration/projector.ts`
+  - Modify `apps/server/src/persistence/Services/ProjectionThreads.ts`, `apps/server/src/persistence/Layers/ProjectionThreads.ts`
+  - Create `apps/server/src/persistence/Migrations/054_ProjectionThreadsSurface.ts`
+  - Modify `apps/server/src/persistence/Migrations.ts`, `apps/server/src/persistence/Migrations.test.ts`, `apps/server/src/persistence/Layers/ProjectionRepositories.test.ts`
+- **Approach:** 增加 schema default 为 `chat` 的 surface 字段；事件创建后不可通过 meta update 改 surface，防止同一 Thread 在 chat/canvas 间漂移。projection migration additive + default/backfill；snapshot 和 WS shell delta 自动携带字段。
+- **Test scenarios:** 历史 `thread.created` 无 surface 时解码为 chat；新 canvas command/projector/projection round-trip 保留 canvas；旧数据库迁移后现有行为 chat；删除与重放不改变 surface。
+- **Verification:** contracts 与 server 聚焦测试通过；读取 shell/detail snapshot 可观察到 canvas surface，历史 fixtures 无回归。
+
+### U2 — Drawing file lifecycle and RPC boundary
+
+- **Goal:** 提供受限、可补偿、原子且带版本冲突检测的 Drawing 文件事实源。
+- **Requirements:** R4, R6-R7, R10-R11, R16；F1-F4；AE3-AE4。
+- **Files:**
+  - Create `packages/shared/src/excalidrawScene.ts`; modify `packages/shared/package.json`; create `packages/shared/src/excalidrawScene.test.ts`
+  - Create `apps/server/src/canvas/Services/CanvasDrawingService.ts`, `apps/server/src/canvas/Layers/CanvasDrawingService.ts`, `apps/server/src/canvas/Layers/CanvasDrawingService.test.ts`, `apps/server/src/canvas/runtimeLayer.ts`
+  - Create `apps/server/src/canvas/canvasBridge.ts`, `apps/server/src/canvas/canvasBridge.test.ts`; modify `apps/server/src/http.ts` to mount the loopback-only internal route
+  - Modify `apps/server/src/atomicWrite.ts` and its tests if rename/cleanup primitives need generalization
+  - Modify `packages/contracts/src/ipc.ts`, `packages/contracts/src/ws.ts`, `apps/server/src/wsRpc.ts`, `apps/web/src/wsNativeApi.ts`
+- **Approach:** shared 子路径只放纯 scene schema/normalization/hash 逻辑；server service 解析 project/thread、校验 canvas surface、限制路径与 payload、执行 atomic save 和 trash compensation。RPC 返回 scene + revision，并要求 save 携带 expected revision。内部 bridge 签发/撤销 session-scoped capability，并只把已鉴权请求委托给同一 service。
+- **Test scenarios:** 创建空 scene；read/save/reload；过大或 malformed JSON 拒绝；path/symlink escape 拒绝；stale revision 返回 conflict 且文件未变；原子 write 失败保留旧文件；delete/DB failure compensation 恢复文件；无 token/错误 thread/已撤销 token/非 loopback 请求均拒绝且不泄露场景。
+- **Verification:** 临时 Project 上每次成功写入都是完整可解析 JSON，失败注入后原文件 byte-for-byte 保持，RPC error 可被客户端区分重试/冲突/无权限。
+
+### U3 — Local forked Excalidraw MCP workspace package
+
+- **Goal:** 基于可追踪上游实现提供只作用于当前 Drawing 的 headless MCP 工具。
+- **Requirements:** R12-R13, R17, R20-R23；F1-F3；AE1-AE2。
+- **Files:**
+  - Create `packages/excalidraw-mcp/package.json`, `packages/excalidraw-mcp/LICENSE`, `packages/excalidraw-mcp/UPSTREAM.md`
+  - Create/adapt `packages/excalidraw-mcp/src/server.ts`, `src/scene.ts`, `src/checkpoint-store.ts`, `src/cli.ts`
+  - Create `packages/excalidraw-mcp/src/server.test.ts`, `src/scene.test.ts`
+  - Modify root `bun.lock`
+- **Approach:** 从固定上游 commit 引入服务端工具和转换思路，删除 MCP App iframe/resource 依赖；进程只从环境读取 scoped bridge endpoint/token/threadId。`create_view` 经 bridge 加载最新 scene，将 shorthand/restore/delete 应用于现有元素，保留未涉及 ID，携带 expected revision 提交；checkpoint 用于工具调用内恢复。
+- **Test scenarios:** MCP initialize/listTools；read_me/read_scene；空 scene 创建 TCP/IP 层级元素；局部 patch 保留无关元素/ID；delete pseudo-elements；malformed tool input 无写入；bridge/提交失败后旧 scene 仍有效；工具参数无法选择其他 Drawing；token 不出现在错误与日志。
+- **Verification:** 使用 MCP client fixture 调用工具后生成的文件可由 shared scene schema 与 Excalidraw restore 读取，元素包含容器、标签、连线并保持稳定 ID；UPSTREAM/LICENSE 可追踪。
+
+### U4 — Grok ACP MCP injection across session lifecycle
+
+- **Goal:** 新建、恢复和重连的 Canvas Thread 都向 Grok 暴露同一个受限 Drawing MCP。
+- **Requirements:** R8-R10, R13, R18-R20；F1-F2, F4；AE3-AE4。
+- **Files:**
+  - Modify `packages/contracts/src/provider.ts`（或实际 `ProviderStartOptions` 所在 schema）及对应测试
+  - Modify `apps/server/src/provider/acp/AcpSessionRuntime.ts`, `apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts`
+  - Modify `apps/server/src/provider/Layers/GrokAdapter.ts`, `apps/server/src/provider/Layers/GrokAdapter.test.ts`
+  - Create `apps/server/src/canvas/canvasAgentContext.ts` and tests
+  - Modify `apps/server/src/orchestration/Layers/ProviderCommandReactor.ts` and tests
+  - Modify `apps/server/package.json` so packaged server can resolve the MCP package
+- **Approach:** 添加 server-owned canvas runtime option；从 projected canvas Thread + Project root 派生短期 bridge capability 与 MCP config，持久化可重建 session 所需的非秘密元数据，所有 ACP open paths 使用等价 mcpServers。每个 Canvas turn 注入版本化 `<canvas_context>`，MCP `read_me` 复用同一行为规则。仅 Grok canvas path 构造本地 fork command；chat Thread、非 Grok provider 不注入。
+- **Test scenarios:** session/new、resume、load、resume-fallback-new 都携带等价 MCP server；重连签发新 token 并撤销旧 token；Canvas restart 恢复后可 list/read tools；每轮 prompt 包含 bounded canvas context 且不包含 scene 全文/token；普通 Grok chat mcpServers 为空；客户端伪造路径被 server 派生值覆盖；MCP 启动失败转为可理解 runtime error 并终止 turn。
+- **Verification:** JSON-RPC request capture 能证明每条 lifecycle path 的 mcpServers 等价；重新创建 adapter 后旧 provider binding 仍能读取同一 Drawing。
+
+### U5 — Canvas route and three-column workspace shell
+
+- **Goal:** 在现有产品外壳中提供 Project/Drawing 左栏、Canvas 中栏、固定长期 Chat 右栏。
+- **Requirements:** R1-R5, R8；F1-F2。
+- **Files:**
+  - Modify `apps/web/src/diffRouteSearch.ts`, `apps/web/src/diffRouteSearch.test.ts`
+  - Modify `apps/web/src/routes/_chat.$threadId.tsx`, `apps/web/src/routes/_chat.tsx`
+  - Create `apps/web/src/components/canvas/CanvasWorkspaceView.tsx`, `CanvasDrawingSidebar.tsx`, `CanvasWorkspaceView.test.tsx`
+  - Modify `apps/web/src/components/Sidebar.tsx` and related logic/tests only where top-level Canvas entry and filtering require it
+- **Approach:** 增加 `view=canvas` route；lazy-load Canvas workspace。复用 EditorWorkspaceView 的 resize/隐藏 Chat 结构与 shared disclosure motion，右栏始终以当前 Drawing threadId 渲染 ChatView 并保持 mounted。左栏从 store selector 过滤 surface=canvas threads，提供 CRUD 与 active state；chat 列表排除 canvas threads。
+- **Test scenarios:** Canvas route parse/round-trip；同 Project 多 Drawing 创建/切换；Chat/Editor 与 Canvas 互不混列；隐藏/恢复右栏不卸载长期对话；重命名不改变文件 identity；删除导航到下一个 Drawing 或空状态；键盘和 aria label 可操作。
+- **Verification:** component tests 观察到三栏和正确 threadId；route reload 后仍打开相同 Drawing；普通聊天首屏不 eager import Excalidraw chunk。
+
+### U6 — Native Excalidraw scene runtime and manual persistence
+
+- **Goal:** 加载、编辑、自动保存并可靠恢复结构化 Excalidraw scene。
+- **Requirements:** R5, R7, R10-R11, R22-R23；F1-F3；AE2-AE3。
+- **Files:**
+  - Modify `apps/web/package.json`, root `bun.lock`
+  - Create `apps/web/src/components/canvas/ExcalidrawCanvas.tsx`, `useCanvasScene.ts`, `canvasSceneState.ts`
+  - Create `apps/web/src/components/canvas/useCanvasScene.test.tsx`, `ExcalidrawCanvas.browser.test.tsx`
+  - Create/modify `apps/web/src/lib/canvasReactQuery.ts` and tests
+- **Approach:** lazy import `@excalidraw/excalidraw` 与 CSS；initialData 从 drawing RPC 获取。onChange 进行内容等价检查和 trailing debounce，单 flight 保存并合并后续变更；successful save 更新 revision。切换/卸载前 flush，冲突或 IO failure 保留本地 dirty scene 并提供 retry/reload，不静默覆盖。
+- **Test scenarios:** 首次空 scene；手工新增/移动/改标签后 debounce save；连续编辑 coalesce；切换前 flush；保存失败保持 dirty + retry；revision conflict 不覆盖远端；无变化不写；大 scene 限制；reload 恢复人工布局和元素 ID。
+- **Verification:** browser component test 可逐元素选择/移动/编辑并在重挂载后恢复；网络/RPC 失败注入显示状态且数据不丢。
+
+### U7 — AI writing lock, refresh, interruption, and state copy
+
+- **Goal:** 将 Grok turn/tool 生命周期映射为用户可理解、不会永久锁死的 Canvas 协作状态。
+- **Requirements:** R12-R18；F1-F4；AE1-AE2, AE4。
+- **Files:**
+  - Create `apps/web/src/components/canvas/canvasAgentState.ts`, `canvasAgentState.test.ts`
+  - Modify `apps/web/src/components/canvas/ExcalidrawCanvas.tsx`, `CanvasWorkspaceView.tsx`
+  - Modify existing provider activity/tool-call mapping only if current events cannot distinguish Canvas write tool
+  - Add focused route/component integration tests near affected files
+- **Approach:** 从 projected latest turn、tool activity/raw input 和 terminal runtime events 推导 `idle/researching/clarifying/writing/reloading/error/interrupted`。只在 drawing write tool active 时关闭元素 mutation；Excalidraw view mode 配置仍允许 scroll/pan/zoom。success/abort/error/exit 统一 invalidate + reload，再在 finally 语义下 unlock；用户中断沿用现有 Thread interrupt command。
+- **Test scenarios:** research 不锁；create_view active 锁编辑但可 pan/zoom；tool success 刷新后解锁；abort/runtime error/session exit 均解锁并恢复最后有效 scene；保存失败与 agent failure 文案可区分；用户 interrupt 只终止当前 turn，不更换 Thread。
+- **Verification:** 状态机单测覆盖全部 terminal edges；浏览器测试中断模拟后仍可手工移动元素，文件保持上次有效 JSON。
+
+### U8 — End-to-end benchmark, packaging, and operational evidence
+
+- **Goal:** 证明核心 TCP/IP 场景、长期恢复和桌面分发路径真实可用。
+- **Requirements:** R1-R23；F1-F4；AE1-AE4。
+- **Files:**
+  - Create `apps/web/src/components/canvas/CanvasWorkspaceView.browser.test.tsx` 或现有 browser suite 的等价测试
+  - Add server integration fixture/test covering orchestration + file service + fake Grok ACP/MCP process
+  - Modify `apps/server/scripts/cli.ts`, desktop packaging inputs, or package build config only as MCP entry inclusion requires
+  - Update `packages/excalidraw-mcp/UPSTREAM.md` with verified build/run instructions
+- **Approach:** 用 deterministic fake Grok ACP/MCP 覆盖 CI 行为，再以本机 Grok 做非阻塞真实 smoke。基准先返回“四层还是五层”的单一澄清，再生成可编辑四/五层图；重启 server 并恢复同 Thread/tool config。验证 packaged build 可解析 MCP entry，不依赖源码绝对路径。
+- **Test scenarios:** AE1 完整 clarify→answer→draw；人工编辑后局部补充且保留 ID；server restart 后同 thread/session/scene；write failure 与 interrupt 恢复；MCP binary missing 显示错误；desktop build/runtime resolve smoke。
+- **Verification:** 自动化断言正确层次、协议归属、元素/箭头可编辑和长期 Thread identity；真实浏览器截图/交互证据显示三栏、正确图层和失败恢复；构建产物内可找到并启动 stdio MCP。
+
+---
+
+## Verification Contract
+
+### Automated checks
+
+- `bun run --cwd packages/contracts test -- orchestration.test.ts`
+- `bun run --cwd packages/shared test -- excalidrawScene.test.ts`
+- `bun run --cwd packages/excalidraw-mcp test`
+- `bun run --cwd apps/server test -- <changed canvas/provider/orchestration test files>`
+- `bun run --cwd apps/web test -- <changed canvas/route/store test files>`
+- `bun run --cwd apps/web test:browser -- <canvas browser test files>`
+- `bun run build --filter=@synara/excalidraw-mcp --filter=@synara/cli --filter=@synara/web`
+
+仓库指令禁止在未被当前对话明确要求时运行 `bun fmt`、`bun lint`、`bun typecheck`；实施者不得绕过该限制。PR 需要如实记录这些 heavyweight checks 未在本地运行，并依赖获授权的 CI/后续验证满足仓库完成门槛。
+
+### Manual/browser checks
+
+- 使用隔离 home 和非默认端口 dry-run 后启动，不影响用户当前 `localhost:51959` 实例。
+- 选择现有 Project，创建两张 Drawing，确认左栏切换与右栏长期 Thread 不串线。
+- 在第一张图手工移动元素并刷新，确认 scene 恢复；隐藏/显示 Chat，确认 transcript 和 draft 不被销毁。
+- 发送基准提示，确认 agent 只问“四层还是五层”这一结构性问题；回答后确认层级、协议归属、方向、标签和连线正确且可独立编辑。
+- AI 写入时确认元素不可修改但可 pan/zoom/interrupt；中断后确认立即解锁并恢复最近有效 scene。
+- 重启隔离 server 后打开相同 Drawing，确认 thread ID、对话、scene 与 MCP 工具都连续。
+
+### Evidence to retain
+
+- 聚焦测试与 build 命令的退出状态。
+- Canvas browser test 或真实浏览器的三栏与 TCP/IP 图截图。
+- ACP request fixture 中 new/resume/load 的等价 mcpServers 断言。
+- 文件失败注入前后 hash/JSON validity 断言。
+- PR 描述中的上游 fork commit、未运行 heavyweight checks 和剩余风险。
+
+---
+
+## Definition of Done
+
+- [ ] Product Contract 的 R1-R23、F1-F4、AE1-AE4 均至少映射到一个实现单元与可观察验证。
+- [ ] Canvas Drawing 使用稳定 Thread ID、固定长期本机对话和 Project 内 `.excalidraw` 文件，重启后恢复。
+- [ ] 人工保存、MCP 保存、冲突、失败、删除和中断均不会静默覆盖或损坏最后有效场景。
+- [ ] Grok ACP 在 new/resume/load/reconnect 全路径获得同一受限 MCP；普通 chat/provider 行为无回归。
+- [ ] 原生 Excalidraw 三栏 UI 可创建、切换、重命名、删除、编辑、隐藏/恢复对话，并符合 shared disclosure motion 与可访问性约定。
+- [ ] TCP/IP 基准先澄清结构歧义，再生成语义正确、层次清楚、逐元素可编辑的图。
+- [ ] 本地 fork 保留 LICENSE、UPSTREAM、固定 commit 与可运行的 workspace/desktop 构建入口。
+- [ ] 聚焦 unit/integration/browser tests 与受影响构建通过；未获授权的 heavyweight checks 被明确披露而未擅自运行。
+- [ ] 代码简化、结构化 code review、review fixes、浏览器 QA、commit/push/PR 和 CI babysit 已按 LFG pipeline 完成。
+
+## Planning Sources
+
+- [Excalidraw API — `excalidrawAPI`, `updateScene`, scene getters and history](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/props/excalidraw-api)
+- [Excalidraw `initialData` scene contract](https://docs.excalidraw.com/docs/@excalidraw/excalidraw/api/props/initialdata)
+- [Excalidraw repository and open `.excalidraw` JSON format](https://github.com/excalidraw/excalidraw)
+- [ACP session setup and MCP server configuration](https://agentclientprotocol.com/protocol/session-setup)
+- [ACP session resume behavior](https://agentclientprotocol.com/protocol/session-resume)
+- Repo implementation anchors listed in Product Contract `Sources / Research`, plus `apps/server/src/atomicWrite.ts`, `apps/server/src/workspace/Layers/WorkspaceFileSystem.ts`, `apps/server/src/persistence/Layers/ProjectionThreads.ts`, and `apps/web/src/diffRouteSearch.ts`.

--- a/packages/contracts/src/canvas.ts
+++ b/packages/contracts/src/canvas.ts
@@ -1,0 +1,47 @@
+import { Schema } from "effect";
+
+import { ThreadId, TrimmedNonEmptyString } from "./baseSchemas";
+
+export const CanvasScene = Schema.Struct({
+  type: Schema.optional(Schema.Literal("excalidraw")),
+  version: Schema.optional(Schema.Number),
+  source: Schema.optional(Schema.String),
+  elements: Schema.Array(Schema.Record(Schema.String, Schema.Unknown)),
+  appState: Schema.Record(Schema.String, Schema.Unknown),
+  files: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+});
+export type CanvasScene = typeof CanvasScene.Type;
+
+export const CanvasDrawingRef = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  threadId: ThreadId,
+});
+export type CanvasDrawingRef = typeof CanvasDrawingRef.Type;
+
+const CanvasDrawingTarget = Schema.Struct({ threadId: ThreadId });
+
+export const CanvasDrawingCreateInput = CanvasDrawingTarget;
+export type CanvasDrawingCreateInput = typeof CanvasDrawingCreateInput.Type;
+
+export const CanvasDrawingReadInput = CanvasDrawingTarget;
+export type CanvasDrawingReadInput = typeof CanvasDrawingReadInput.Type;
+
+export const CanvasDrawingSaveInput = Schema.Struct({
+  ...CanvasDrawingTarget.fields,
+  scene: CanvasScene,
+  expectedRevision: TrimmedNonEmptyString,
+});
+export type CanvasDrawingSaveInput = typeof CanvasDrawingSaveInput.Type;
+
+export const CanvasDrawingDeleteInput = CanvasDrawingTarget;
+export type CanvasDrawingDeleteInput = typeof CanvasDrawingDeleteInput.Type;
+
+export interface CanvasDrawingSnapshot {
+  readonly relativePath: string;
+  readonly scene: CanvasScene;
+  readonly revision: string;
+}
+
+export interface CanvasDrawingDeleteResult {
+  readonly deleted: boolean;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./auth";
+export * from "./canvas";
 export * from "./automation";
 export * from "./baseSchemas";
 export * from "./ipc";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1,4 +1,12 @@
 import type {
+  CanvasDrawingCreateInput,
+  CanvasDrawingDeleteInput,
+  CanvasDrawingDeleteResult,
+  CanvasDrawingReadInput,
+  CanvasDrawingSaveInput,
+  CanvasDrawingSnapshot,
+} from "./canvas";
+import type {
   AuthBearerBootstrapResult,
   AuthBootstrapInput,
   AuthBootstrapResult,
@@ -448,6 +456,12 @@ export interface NativeApi {
     stopDevServer: (input: ProjectStopDevServerInput) => Promise<ProjectStopDevServerResult>;
     listDevServers: () => Promise<ProjectListDevServersResult>;
     onDevServerEvent: (callback: (event: ProjectDevServerEvent) => void) => () => void;
+  };
+  canvas: {
+    createDrawing: (input: CanvasDrawingCreateInput) => Promise<CanvasDrawingSnapshot>;
+    readDrawing: (input: CanvasDrawingReadInput) => Promise<CanvasDrawingSnapshot>;
+    saveDrawing: (input: CanvasDrawingSaveInput) => Promise<CanvasDrawingSnapshot>;
+    deleteDrawing: (input: CanvasDrawingDeleteInput) => Promise<CanvasDrawingDeleteResult>;
   };
   filesystem: {
     browse: (input: FilesystemBrowseInput) => Promise<FilesystemBrowseResult>;

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -407,6 +407,7 @@ it.effect("decodes thread.created runtime mode for historical events", () =>
     });
 
     assert.strictEqual(parsed.runtimeMode, DEFAULT_RUNTIME_MODE);
+    assert.strictEqual(parsed.surface, "chat");
     assert.strictEqual(parsed.modelSelection.provider, "codex");
   }),
 );

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -76,6 +76,9 @@ export const ProviderSandboxMode = Schema.Literals([
 export type ProviderSandboxMode = typeof ProviderSandboxMode.Type;
 export const DEFAULT_PROVIDER_KIND: ProviderKind = "codex";
 
+export const ThreadSurface = Schema.Literals(["chat", "canvas"]);
+export type ThreadSurface = typeof ThreadSurface.Type;
+
 export const CodexModelSelection = Schema.Struct({
   provider: Schema.Literal("codex"),
   model: TrimmedNonEmptyString,
@@ -619,6 +622,7 @@ export type ThreadMarkers = typeof ThreadMarkers.Type;
 export const OrchestrationThread = Schema.Struct({
   id: ThreadId,
   projectId: ProjectId,
+  surface: Schema.optional(ThreadSurface).pipe(Schema.withDecodingDefault(() => "chat")),
   title: TrimmedNonEmptyString,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,
@@ -686,6 +690,7 @@ export type OrchestrationThread = typeof OrchestrationThread.Type;
 export const OrchestrationThreadShell = Schema.Struct({
   id: ThreadId,
   projectId: ProjectId,
+  surface: Schema.optional(ThreadSurface).pipe(Schema.withDecodingDefault(() => "chat")),
   title: TrimmedNonEmptyString,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,
@@ -832,6 +837,7 @@ const ThreadCreateCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   projectId: ProjectId,
+  surface: Schema.optional(ThreadSurface).pipe(Schema.withDecodingDefault(() => "chat")),
   title: TrimmedNonEmptyString,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,
@@ -1439,6 +1445,7 @@ export const ProjectDeletedPayload = Schema.Struct({
 export const ThreadCreatedPayload = Schema.Struct({
   threadId: ThreadId,
   projectId: ProjectId,
+  surface: Schema.optional(ThreadSurface).pipe(Schema.withDecodingDefault(() => "chat")),
   title: TrimmedNonEmptyString,
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(() => DEFAULT_RUNTIME_MODE)),

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -49,6 +49,15 @@ export const ProviderSession = Schema.Struct({
 });
 export type ProviderSession = typeof ProviderSession.Type;
 
+export const ProviderCanvasRuntime = Schema.Struct({
+  bridgeUrl: TrimmedNonEmptyString,
+  bridgeToken: TrimmedNonEmptyString,
+  threadId: ThreadId,
+  mcpCommand: TrimmedNonEmptyString,
+  mcpArgs: Schema.Array(TrimmedNonEmptyString),
+});
+export type ProviderCanvasRuntime = typeof ProviderCanvasRuntime.Type;
+
 export const ProviderSessionStartInput = Schema.Struct({
   threadId: ThreadId,
   provider: Schema.optional(ProviderKind),
@@ -58,6 +67,7 @@ export const ProviderSessionStartInput = Schema.Struct({
   approvalPolicy: Schema.optional(ProviderApprovalPolicy),
   sandboxMode: Schema.optional(ProviderSandboxMode),
   providerOptions: Schema.optional(ProviderStartOptions),
+  canvas: Schema.optional(ProviderCanvasRuntime),
   runtimeMode: RuntimeMode,
 });
 export type ProviderSessionStartInput = typeof ProviderSessionStartInput.Type;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -1,5 +1,11 @@
 import { Schema, Struct } from "effect";
 import { NonNegativeInt, ProjectId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas";
+import {
+  CanvasDrawingCreateInput,
+  CanvasDrawingDeleteInput,
+  CanvasDrawingReadInput,
+  CanvasDrawingSaveInput,
+} from "./canvas";
 
 import {
   AutomationCancelRunInput,
@@ -124,6 +130,10 @@ export const WS_METHODS = {
   projectsReadFile: "projects.readFile",
   projectsCreateLocalFilePreviewGrant: "projects.createLocalFilePreviewGrant",
   projectsWriteFile: "projects.writeFile",
+  canvasCreateDrawing: "canvas.createDrawing",
+  canvasReadDrawing: "canvas.readDrawing",
+  canvasSaveDrawing: "canvas.saveDrawing",
+  canvasDeleteDrawing: "canvas.deleteDrawing",
   projectsRunDevServer: "projects.runDevServer",
   projectsStopDevServer: "projects.stopDevServer",
   projectsListDevServers: "projects.listDevServers",
@@ -279,6 +289,10 @@ const WebSocketRequestBody = Schema.Union([
     ProjectCreateLocalFilePreviewGrantInput,
   ),
   tagRequestBody(WS_METHODS.projectsWriteFile, ProjectWriteFileInput),
+  tagRequestBody(WS_METHODS.canvasCreateDrawing, CanvasDrawingCreateInput),
+  tagRequestBody(WS_METHODS.canvasReadDrawing, CanvasDrawingReadInput),
+  tagRequestBody(WS_METHODS.canvasSaveDrawing, CanvasDrawingSaveInput),
+  tagRequestBody(WS_METHODS.canvasDeleteDrawing, CanvasDrawingDeleteInput),
   tagRequestBody(WS_METHODS.projectsRunDevServer, ProjectRunDevServerInput),
   tagRequestBody(WS_METHODS.projectsStopDevServer, ProjectStopDevServerInput),
   tagRequestBody(WS_METHODS.projectsListDevServers, Schema.Struct({})),

--- a/packages/excalidraw-mcp/LICENSE
+++ b/packages/excalidraw-mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Excalidraw contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/excalidraw-mcp/UPSTREAM.md
+++ b/packages/excalidraw-mcp/UPSTREAM.md
@@ -1,0 +1,33 @@
+# Upstream provenance
+
+This package is a Synara-focused fork/adaptation of
+[`excalidraw/excalidraw-mcp`](https://github.com/excalidraw/excalidraw-mcp).
+
+- Upstream version: `0.3.2`
+- Upstream commit: `157aa23ceb1976008aadc89eb05e3444060f09d6`
+- License: MIT (preserved in `LICENSE`)
+- Fork point verified: 2026-07-14
+
+Synara retains the upstream `read_me`, `create_view`, pseudo-element deletion,
+checkpoint, bounded-input, and stdio-server concepts. The MCP App iframe,
+public HTTP server, export proxy, and remote checkpoint stores are intentionally
+removed. This fork operates on one Drawing through a short-lived, thread-scoped
+Synara loopback capability and never receives a filesystem path.
+
+The upstream iframe converted shorthand elements with
+`convertToExcalidrawElements`. Synara performs that same conversion in the
+lazy-loaded Canvas workspace before applying and revision-saving the canonical
+scene, because the stdio MCP process is intentionally headless and importing the
+browser bundle under Node/Bun requires `window`.
+
+## Verified local entry points
+
+- Build: `bun run --cwd packages/excalidraw-mcp build`
+- Test: `bun run --cwd packages/excalidraw-mcp test`
+- Development stdio entry: `bun packages/excalidraw-mcp/src/main.ts`
+- Packaged Node stdio entry: `node packages/excalidraw-mcp/dist/main.mjs`
+
+The stdio process requires `SYNARA_CANVAS_BRIDGE_URL`,
+`SYNARA_CANVAS_BRIDGE_TOKEN`, and `SYNARA_CANVAS_THREAD_ID`. Synara creates all
+three values and does not expose them to the model or accept a drawing path from
+tool input.

--- a/packages/excalidraw-mcp/package.json
+++ b/packages/excalidraw-mcp/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@synara/excalidraw-mcp",
+  "version": "0.3.2-synara.1",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "bin": {
+    "synara-excalidraw-mcp": "./dist/main.mjs"
+  },
+  "files": ["dist", "LICENSE", "UPSTREAM.md"],
+  "exports": {
+    ".": {
+      "types": "./src/server.ts",
+      "import": "./src/server.ts"
+    },
+    "./bridge": {
+      "types": "./src/bridge.ts",
+      "import": "./src/bridge.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown src/main.ts src/server.ts src/bridge.ts --format esm --clean",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.25.2",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/excalidraw-mcp/src/bridge.ts
+++ b/packages/excalidraw-mcp/src/bridge.ts
@@ -1,0 +1,63 @@
+export interface BridgeSceneSnapshot {
+  readonly relativePath: string;
+  readonly scene: {
+    readonly elements: ReadonlyArray<Record<string, unknown>>;
+    readonly appState: Record<string, unknown>;
+    readonly files?: Record<string, unknown>;
+    readonly [key: string]: unknown;
+  };
+  readonly revision: string;
+}
+
+export interface CanvasBridgeConfig {
+  readonly baseUrl: string;
+  readonly token: string;
+  readonly threadId: string;
+}
+
+const BRIDGE_REQUEST_TIMEOUT_MS = 15_000;
+
+export function readBridgeConfig(env: NodeJS.ProcessEnv = process.env): CanvasBridgeConfig {
+  const baseUrl = env.SYNARA_CANVAS_BRIDGE_URL?.trim();
+  const token = env.SYNARA_CANVAS_BRIDGE_TOKEN?.trim();
+  const threadId = env.SYNARA_CANVAS_THREAD_ID?.trim();
+  if (!baseUrl || !token || !threadId) {
+    throw new Error("Synara Canvas bridge configuration is incomplete.");
+  }
+  const parsed = new URL(baseUrl);
+  if (parsed.protocol !== "http:" || !["127.0.0.1", "localhost", "::1"].includes(parsed.hostname)) {
+    throw new Error("Synara Canvas bridge must use a loopback HTTP URL.");
+  }
+  return { baseUrl: parsed.toString().replace(/\/$/, ""), token, threadId };
+}
+
+async function requestBridge(
+  config: CanvasBridgeConfig,
+  operation: "read" | "save",
+  body: Record<string, unknown>,
+): Promise<BridgeSceneSnapshot> {
+  const response = await fetch(`${config.baseUrl}/internal/canvas/${operation}`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${config.token}`,
+      "content-type": "application/json",
+    },
+    signal: AbortSignal.timeout(BRIDGE_REQUEST_TIMEOUT_MS),
+    body: JSON.stringify({ threadId: config.threadId, ...body }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      response.status === 409
+        ? "Drawing changed while the agent was editing it. Read the scene and retry."
+        : `Synara Canvas bridge ${operation} failed (${response.status}).`,
+    );
+  }
+  return (await response.json()) as BridgeSceneSnapshot;
+}
+
+export const readScene = (config: CanvasBridgeConfig) => requestBridge(config, "read", {});
+
+export const saveScene = (
+  config: CanvasBridgeConfig,
+  input: { readonly scene: BridgeSceneSnapshot["scene"]; readonly expectedRevision: string },
+) => requestBridge(config, "save", input);

--- a/packages/excalidraw-mcp/src/main.ts
+++ b/packages/excalidraw-mcp/src/main.ts
@@ -1,0 +1,5 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { createServer } from "./server";
+
+await createServer().connect(new StdioServerTransport());

--- a/packages/excalidraw-mcp/src/scene.test.ts
+++ b/packages/excalidraw-mcp/src/scene.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { applyElementOperations } from "./scene";
+
+describe("applyElementOperations", () => {
+  it("preserves unaffected elements, replaces stable ids, and deletes requested ids", () => {
+    const scene = {
+      elements: [
+        { id: "keep", type: "rectangle" },
+        { id: "replace", type: "text", text: "old" },
+        { id: "replace-label", type: "text", containerId: "replace", text: "old label" },
+        { id: "remove", type: "arrow" },
+      ],
+      appState: {},
+      files: {},
+    };
+    expect(
+      applyElementOperations(scene, [
+        { type: "delete", ids: "remove" },
+        { id: "replace", type: "text", text: "new" },
+      ]).elements,
+    ).toEqual([
+      { id: "keep", type: "rectangle" },
+      { id: "replace", type: "text", text: "new" },
+    ]);
+  });
+
+  it("rejects missing or duplicate ids instead of dropping unrelated elements", () => {
+    const scene = {
+      elements: [{ id: "keep", type: "rectangle" }],
+      appState: {},
+      files: {},
+    };
+
+    expect(() => applyElementOperations(scene, [{ type: "rectangle" }])).toThrow(
+      /non-empty string id/,
+    );
+    expect(() =>
+      applyElementOperations(scene, [
+        { id: "duplicate", type: "rectangle" },
+        { id: "duplicate", type: "text" },
+      ]),
+    ).toThrow(/Duplicate Excalidraw element id/);
+    expect(scene.elements).toEqual([{ id: "keep", type: "rectangle" }]);
+  });
+});

--- a/packages/excalidraw-mcp/src/scene.ts
+++ b/packages/excalidraw-mcp/src/scene.ts
@@ -1,0 +1,40 @@
+import type { BridgeSceneSnapshot } from "./bridge";
+
+const PSEUDO_TYPES = new Set(["cameraUpdate", "restoreCheckpoint", "delete"]);
+
+export function applyElementOperations(
+  scene: BridgeSceneSnapshot["scene"],
+  operations: ReadonlyArray<Record<string, unknown>>,
+): BridgeSceneSnapshot["scene"] {
+  const additions = operations.filter(
+    (operation) => !PSEUDO_TYPES.has(String(operation.type ?? "")),
+  );
+  const additionIds = new Set<string>();
+  for (const addition of additions) {
+    if (typeof addition.id !== "string" || addition.id.trim().length === 0) {
+      throw new Error("Every Excalidraw element operation must have a non-empty string id.");
+    }
+    if (additionIds.has(addition.id)) {
+      throw new Error(`Duplicate Excalidraw element id '${addition.id}'.`);
+    }
+    additionIds.add(addition.id);
+  }
+  const deleteIds = new Set<string>();
+  for (const operation of operations) {
+    if (operation.type !== "delete") continue;
+    for (const id of String(operation.ids ?? operation.id ?? "").split(",")) {
+      if (id.trim()) deleteIds.add(id.trim());
+    }
+  }
+  const retained = scene.elements.filter(
+    (element) =>
+      !deleteIds.has(String(element.id ?? "")) &&
+      !deleteIds.has(String(element.containerId ?? "")) &&
+      !additionIds.has(String(element.id ?? "")) &&
+      !additionIds.has(String(element.containerId ?? "")),
+  );
+  return {
+    ...scene,
+    elements: [...retained, ...additions],
+  };
+}

--- a/packages/excalidraw-mcp/src/server.test.ts
+++ b/packages/excalidraw-mcp/src/server.test.ts
@@ -1,0 +1,96 @@
+import { createServer as createHttpServer, type Server } from "node:http";
+import { once } from "node:events";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { BridgeSceneSnapshot } from "./bridge";
+import { createServer } from "./server";
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) => new Promise<void>((resolve) => server.close(() => resolve())),
+    ),
+  );
+});
+
+async function startBridge() {
+  let revision = "revision-1";
+  let scene: BridgeSceneSnapshot["scene"] = { elements: [], appState: {}, files: {} };
+  const server = createHttpServer(async (request, response) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of request) chunks.push(Buffer.from(chunk));
+    const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+    expect(request.headers.authorization).toBe("Bearer bridge-secret");
+    expect(body.threadId).toBe("drawing-1");
+
+    if (request.url?.endsWith("/save")) {
+      expect(body.expectedRevision).toBe(revision);
+      scene = body.scene as BridgeSceneSnapshot["scene"];
+      revision = `revision-${Number(revision.split("-")[1]) + 1}`;
+    }
+
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(
+      JSON.stringify({ relativePath: "drawings/drawing-1.excalidraw", scene, revision }),
+    );
+  });
+  servers.push(server);
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Bridge did not bind a port.");
+  return {
+    config: {
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      token: "bridge-secret",
+      threadId: "drawing-1",
+    },
+    readScene: () => scene,
+  };
+}
+
+describe("Synara Excalidraw MCP server", () => {
+  it("initializes, lists bounded tools, and edits only the configured drawing", async () => {
+    const bridge = await startBridge();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const mcpServer = createServer(bridge.config);
+    const client = new Client({ name: "synara-mcp-test", version: "1.0.0" });
+    await Promise.all([mcpServer.connect(serverTransport), client.connect(clientTransport)]);
+
+    expect((await client.listTools()).tools.map((tool) => tool.name)).toEqual([
+      "read_me",
+      "read_scene",
+      "create_view",
+    ]);
+    const read = await client.callTool({ name: "read_scene", arguments: {} });
+    expect(read.isError).not.toBe(true);
+
+    const first = await client.callTool({
+      name: "create_view",
+      arguments: {
+        elements: JSON.stringify([
+          {
+            id: "layer-transport",
+            type: "rectangle",
+            x: 100,
+            y: 200,
+            width: 500,
+            height: 100,
+            label: { text: "Transport · TCP · UDP" },
+          },
+        ]),
+      },
+    });
+    expect(first.isError).not.toBe(true);
+    expect(bridge.readScene().elements).toHaveLength(1);
+    expect(bridge.readScene().elements[0]?.id).toBe("layer-transport");
+
+    await client.close();
+    await mcpServer.close();
+  });
+});

--- a/packages/excalidraw-mcp/src/server.ts
+++ b/packages/excalidraw-mcp/src/server.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from "node:crypto";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+import { readBridgeConfig, readScene, saveScene, type CanvasBridgeConfig } from "./bridge";
+import { applyElementOperations } from "./scene";
+
+const MAX_INPUT_BYTES = 5 * 1024 * 1024;
+
+export const CANVAS_AGENT_GUIDE = `# Synara Excalidraw tools
+
+Always call read_scene before changing an existing drawing. Ask exactly one focused
+clarifying question when a choice changes factual structure (for example TCP/IP
+four-layer versus five-layer); choose sensible defaults for purely visual choices.
+Use stable unique ids and preserve elements the user did not ask to change.
+
+create_view accepts a JSON array string. Common elements use type, id, x, y, width,
+height; rectangles may include label: {text, fontSize}; arrows use points and
+endArrowhead. Use readable fonts (16+ body, 20+ headings), consistent directions,
+pastel fills, and clear hierarchy. A delete pseudo-element uses
+{"type":"delete","ids":"id1,id2"}. Changes are revision-checked and atomic.`;
+
+function toolError(error: unknown): CallToolResult {
+  return {
+    content: [{ type: "text", text: error instanceof Error ? error.message : String(error) }],
+    isError: true,
+  };
+}
+
+export function createServer(config: CanvasBridgeConfig = readBridgeConfig()): McpServer {
+  const server = new McpServer({ name: "Synara Excalidraw", version: "0.3.2-synara.1" });
+  const checkpoints = new Map<string, ReadonlyArray<Record<string, unknown>>>();
+
+  server.registerTool(
+    "read_me",
+    {
+      description: "Read the Synara Excalidraw scene and collaboration contract.",
+      annotations: { readOnlyHint: true },
+    },
+    async () => ({ content: [{ type: "text", text: CANVAS_AGENT_GUIDE }] }),
+  );
+
+  server.registerTool(
+    "read_scene",
+    {
+      description: "Read the current editable Excalidraw scene before modifying it.",
+      annotations: { readOnlyHint: true },
+    },
+    async () => {
+      try {
+        const snapshot = await readScene(config);
+        return {
+          content: [{ type: "text", text: JSON.stringify(snapshot.scene) }],
+          structuredContent: {
+            revision: snapshot.revision,
+            elementCount: snapshot.scene.elements.length,
+          },
+        };
+      } catch (error) {
+        return toolError(error);
+      }
+    },
+  );
+
+  server.registerTool(
+    "create_view",
+    {
+      description: "Atomically apply editable Excalidraw element operations to the current drawing.",
+      inputSchema: { elements: z.string().max(MAX_INPUT_BYTES) },
+    },
+    async ({ elements }) => {
+      try {
+        const operations = JSON.parse(elements) as unknown;
+        if (
+          !Array.isArray(operations) ||
+          !operations.every(
+            (entry) => entry && typeof entry === "object" && !Array.isArray(entry),
+          )
+        ) {
+          throw new Error("elements must be a JSON array of Excalidraw element objects.");
+        }
+        const current = await readScene(config);
+        const restoreOperation = operations.find(
+          (entry) => (entry as Record<string, unknown>).type === "restoreCheckpoint",
+        ) as Record<string, unknown> | undefined;
+        const restoreCheckpointId = restoreOperation?.id;
+        const restoredElements =
+          typeof restoreCheckpointId === "string"
+            ? checkpoints.get(restoreCheckpointId)
+            : undefined;
+        if (typeof restoreCheckpointId === "string" && !restoredElements) {
+          throw new Error(`Checkpoint '${restoreCheckpointId}' is unavailable.`);
+        }
+        const scene = applyElementOperations(
+          restoredElements ? { ...current.scene, elements: restoredElements } : current.scene,
+          operations as Array<Record<string, unknown>>,
+        );
+        const saved = await saveScene(config, { scene, expectedRevision: current.revision });
+        const checkpointId = randomUUID().replaceAll("-", "").slice(0, 18);
+        checkpoints.set(checkpointId, saved.scene.elements);
+        if (checkpoints.size > 100) checkpoints.delete(checkpoints.keys().next().value!);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Drawing saved with ${saved.scene.elements.length} editable elements. Checkpoint: ${checkpointId}`,
+            },
+          ],
+          structuredContent: {
+            checkpointId,
+            revision: saved.revision,
+            elementCount: saved.scene.elements.length,
+          },
+        };
+      } catch (error) {
+        return toolError(error);
+      }
+    },
+  );
+
+  return server;
+}

--- a/packages/excalidraw-mcp/src/tcpIpBenchmark.test.ts
+++ b/packages/excalidraw-mcp/src/tcpIpBenchmark.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { applyElementOperations } from "./scene";
+
+const TCP_IP_PROMPT = "绘制 TCP/IP 协议栈架构图，看到正确的分层架构展示";
+
+const layerOperations = [
+  {
+    id: "layer-application",
+    type: "rectangle",
+    x: 120,
+    y: 100,
+    width: 760,
+    height: 120,
+    backgroundColor: "#d0ebff",
+    fillStyle: "solid",
+    label: { text: "应用层 · HTTP / HTTPS · DNS · DHCP", fontSize: 22 },
+  },
+  {
+    id: "layer-transport",
+    type: "rectangle",
+    x: 120,
+    y: 250,
+    width: 760,
+    height: 120,
+    backgroundColor: "#d3f9d8",
+    fillStyle: "solid",
+    label: { text: "传输层 · TCP · UDP", fontSize: 22 },
+  },
+  {
+    id: "layer-internet",
+    type: "rectangle",
+    x: 120,
+    y: 400,
+    width: 760,
+    height: 120,
+    backgroundColor: "#fff3bf",
+    fillStyle: "solid",
+    label: { text: "网际层 · IPv4 / IPv6 · ICMP", fontSize: 22 },
+  },
+  {
+    id: "layer-access",
+    type: "rectangle",
+    x: 120,
+    y: 550,
+    width: 760,
+    height: 120,
+    backgroundColor: "#ffe8cc",
+    fillStyle: "solid",
+    label: { text: "网络接入层 · Ethernet · Wi-Fi · ARP", fontSize: 22 },
+  },
+  {
+    id: "encapsulation",
+    type: "arrow",
+    x: 920,
+    y: 150,
+    width: 0,
+    height: 450,
+    points: [
+      [0, 0],
+      [0, 450],
+    ],
+    endArrowhead: "arrow",
+    label: { text: "封装：数据 → 段/数据报 → 包 → 帧", fontSize: 16 },
+  },
+] satisfies Array<Record<string, unknown>>;
+
+describe(`TCP/IP benchmark: ${TCP_IP_PROMPT}`, () => {
+  it("produces the correct editable four-layer ordering and protocol ownership", () => {
+    const scene = applyElementOperations({ elements: [], appState: {}, files: {} }, layerOperations);
+    const layers = scene.elements.filter((element) => String(element.id).startsWith("layer-"));
+    expect(layers.map((element) => element.id)).toEqual([
+      "layer-application",
+      "layer-transport",
+      "layer-internet",
+      "layer-access",
+    ]);
+    expect(layers.map((element) => element.y)).toEqual([100, 250, 400, 550]);
+
+    const labels = layers.map((element) => String((element.label as { text: string }).text));
+    expect(labels[0]).toMatch(/HTTP.*DNS.*DHCP/);
+    expect(labels[1]).toMatch(/TCP.*UDP/);
+    expect(labels[2]).toMatch(/IPv4.*IPv6.*ICMP/);
+    expect(labels[3]).toMatch(/Ethernet.*Wi-Fi.*ARP/);
+    expect(scene.elements.at(-1)).toMatchObject({
+      id: "encapsulation",
+      type: "arrow",
+      endArrowhead: "arrow",
+    });
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -155,6 +155,10 @@
     "./formatBytes": {
       "types": "./src/formatBytes.ts",
       "import": "./src/formatBytes.ts"
+    },
+    "./excalidrawScene": {
+      "types": "./src/excalidrawScene.ts",
+      "import": "./src/excalidrawScene.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/excalidrawScene.test.ts
+++ b/packages/shared/src/excalidrawScene.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EMPTY_CANVAS_SCENE,
+  InvalidCanvasSceneError,
+  MAX_CANVAS_SCENE_ELEMENTS,
+  parseCanvasScene,
+  serializeCanvasScene,
+} from "./excalidrawScene";
+
+describe("excalidrawScene", () => {
+  it("round-trips an empty scene", () => {
+    expect(parseCanvasScene(serializeCanvasScene(EMPTY_CANVAS_SCENE))).toEqual(
+      EMPTY_CANVAS_SCENE,
+    );
+  });
+
+  it("normalizes omitted optional scene fields", () => {
+    expect(parseCanvasScene('{"elements":[],"appState":{}}')).toMatchObject({
+      type: "excalidraw",
+      version: 2,
+      files: {},
+    });
+  });
+
+  it("rejects malformed JSON and excessive elements", () => {
+    expect(() => parseCanvasScene("{")).toThrow(InvalidCanvasSceneError);
+    expect(() =>
+      serializeCanvasScene({
+        ...EMPTY_CANVAS_SCENE,
+        elements: Array.from({ length: MAX_CANVAS_SCENE_ELEMENTS + 1 }, () => ({})),
+      }),
+    ).toThrow(InvalidCanvasSceneError);
+  });
+});

--- a/packages/shared/src/excalidrawScene.ts
+++ b/packages/shared/src/excalidrawScene.ts
@@ -1,0 +1,73 @@
+import { CanvasScene, type CanvasScene as CanvasSceneType } from "@synara/contracts";
+import { Schema } from "effect";
+
+export const MAX_CANVAS_SCENE_BYTES = 5_000_000;
+export const MAX_CANVAS_SCENE_ELEMENTS = 20_000;
+
+export const EMPTY_CANVAS_SCENE: CanvasSceneType = {
+  type: "excalidraw",
+  version: 2,
+  source: "https://synara.app",
+  elements: [],
+  appState: {},
+  files: {},
+};
+
+export class InvalidCanvasSceneError extends Error {
+  readonly name = "InvalidCanvasSceneError";
+}
+
+export function normalizeCanvasScene(value: unknown): CanvasSceneType {
+  const candidate =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? {
+          type: "excalidraw",
+          version: 2,
+          source: "https://synara.app",
+          appState: {},
+          files: {},
+          ...value,
+        }
+      : value;
+
+  let scene: CanvasSceneType;
+  try {
+    scene = Schema.decodeUnknownSync(CanvasScene)(candidate);
+  } catch (cause) {
+    throw new InvalidCanvasSceneError(
+      cause instanceof Error ? cause.message : "Invalid Excalidraw scene",
+    );
+  }
+  if (scene.elements.length > MAX_CANVAS_SCENE_ELEMENTS) {
+    throw new InvalidCanvasSceneError(
+      `Canvas scene exceeds the ${MAX_CANVAS_SCENE_ELEMENTS} element limit.`,
+    );
+  }
+  return scene;
+}
+
+export function serializeCanvasScene(value: unknown): string {
+  const serialized = `${JSON.stringify(normalizeCanvasScene(value), null, 2)}\n`;
+  if (new TextEncoder().encode(serialized).byteLength > MAX_CANVAS_SCENE_BYTES) {
+    throw new InvalidCanvasSceneError(
+      `Canvas scene exceeds the ${MAX_CANVAS_SCENE_BYTES} byte limit.`,
+    );
+  }
+  return serialized;
+}
+
+export function parseCanvasScene(contents: string): CanvasSceneType {
+  if (new TextEncoder().encode(contents).byteLength > MAX_CANVAS_SCENE_BYTES) {
+    throw new InvalidCanvasSceneError(
+      `Canvas scene exceeds the ${MAX_CANVAS_SCENE_BYTES} byte limit.`,
+    );
+  }
+  try {
+    return normalizeCanvasScene(JSON.parse(contents));
+  } catch (cause) {
+    if (cause instanceof InvalidCanvasSceneError) throw cause;
+    throw new InvalidCanvasSceneError(
+      cause instanceof Error ? cause.message : "Invalid Excalidraw JSON",
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Synara now supports a canvas-first AI workspace: a project can own Excalidraw drawings backed by persistent `.excalidraw` files and a fixed Grok thread, so users can reopen a drawing and continue both the scene and the conversation instead of starting over.

The runtime path is now server-owned end to end. Manual edits, AI writes, session resume/load, and packaged desktop builds all flow through the same bounded drawing service and the same scoped MCP bridge, which keeps failure and recovery behavior predictable.

## What changed

- Added a `canvas` thread surface plus projection and migration support so drawings live inside the existing orchestration model rather than a parallel entity graph.
- Added server-side drawing lifecycle handling for create/read/save/delete, revision conflicts, symlink/path containment, trash-based delete compensation, and a short-lived loopback capability bridge.
- Wired Grok ACP session new/resume/load/reconnect paths to reattach the drawing MCP, inject bounded canvas context, and resolve the packaged MCP entry from the built server output.
- Added the native Excalidraw workspace UI with canvas routing, drawing navigation, a persistent resizable chat pane, autosave/conflict handling, and AI single-writer lock/reload behavior.
- Vendored a Synara-focused `excalidraw-mcp` fork from upstream commit `157aa23ceb1976008aadc89eb05e3444060f09d6`, preserving MIT license provenance and packaging it into `apps/server/dist/excalidraw-mcp`.
- Applied two review fixes before shipping: canvas threads now eagerly create their backing file on `thread.created`, and canvas lock detection still honors summary-only `create_view` activity rows.

## Validation

- `bun run --cwd packages/contracts test -- src/orchestration.test.ts`
- `bun run --cwd packages/shared test -- src/excalidrawScene.test.ts`
- `bun run --cwd packages/excalidraw-mcp test -- src/scene.test.ts src/server.test.ts src/tcpIpBenchmark.test.ts`
- `bun run --cwd apps/server test -- src/canvasAgentContext.test.ts src/canvasBridge.test.ts src/canvasDrawingFiles.test.ts src/orchestration/Layers/ProviderCommandReactor.test.ts src/orchestration/projector.test.ts src/persistence/Layers/ProjectionRepositories.test.ts src/persistence/Migrations.test.ts src/provider/acp/AcpJsonRpcConnection.test.ts src/provider/acp/AcpNativeLogging.test.ts`
- `bun run --cwd apps/web test -- src/diffRouteSearch.test.ts src/lib/canvasAgentState.test.ts src/wsNativeApi.test.ts`
- `bun run --cwd apps/web test:browser -- src/components/CanvasWorkspaceView.browser.tsx`
- `bun run build --filter=@synara/excalidraw-mcp --filter=@synara/cli --filter=@synara/web`

Local browser evidence came from the new `CanvasWorkspaceView.browser.tsx` Vitest browser test. The `agent-browser` fallback was unavailable on this machine because its installed wrapper points at a missing module path.

Per repo instructions, `bun fmt`, `bun lint`, and `bun typecheck` were not run locally in this PR and should be satisfied by authorized follow-up validation / CI.

## New concepts

### Thread-scoped loopback capability bridge

What it is:
A local MCP process never gets a project path directly. Instead, Synara issues a short-lived token bound to one thread and exposes a loopback-only HTTP bridge that delegates read/save calls into the server-owned drawing service.

Why here:
That keeps filesystem validation, atomic writes, revision checks, and delete compensation in one place. The MCP stays headless and narrowly scoped, while packaged builds avoid depending on source-tree paths or broad filesystem access.

Example from this PR:
The Grok canvas runtime now starts the forked `excalidraw-mcp` with `SYNARA_CANVAS_BRIDGE_URL`, `SYNARA_CANVAS_BRIDGE_TOKEN`, and `SYNARA_CANVAS_THREAD_ID`, and the packaged CLI bundles the MCP entry into `apps/server/dist/excalidraw-mcp` so the same path works after build.

When not to use it:
Do not add a bridge when the child process can safely stay in-process or when the caller genuinely needs broader workspace access; the bridge is for tightly bounded single-resource mutation paths.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5.4](https://img.shields.io/badge/GPT_5.4-000000)
