### PR TITLE
fix(web): stop prototype members rendering as phantom file chips

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -293,6 +293,17 @@ describe("ChatMarkdown user variant", () => {
     expect(markup).not.toContain("Deep Research");
   });
 
+  it("keeps Object.prototype member names as literal inline code", async () => {
+    // `inlineCodeFilePath` strips wrapping quotes, so the quoted forms reach the icon
+    // tables as the bare keys `constructor` / `__proto__`.
+    for (const token of ["constructor", "__proto__", '"constructor"', '"__proto__"']) {
+      const markup = await renderUserMarkdown(`what if a key is \`${token}\``);
+
+      expect(markup).toContain("<code>");
+      expect(markup).not.toContain('data-slot="central-icon"');
+    }
+  });
+
   it("renders @-mention tokens as mention chips", async () => {
     const markup = await renderUserMarkdown("check @src/utils/model.ts please");
 

--- a/apps/web/src/file-icons.test.ts
+++ b/apps/web/src/file-icons.test.ts
@@ -1,6 +1,24 @@
 import { assert, describe, it } from "vitest";
 
-import { getAttachmentIconName, getFileIconName, inferEntryKindFromPath } from "./file-icons";
+import {
+  getAttachmentIconName,
+  getFileIconName,
+  inferEntryKindFromPath,
+  pathLooksLikeKnownFile,
+} from "./file-icons";
+
+// Object.prototype member names, which lookup keys can collide with because they are
+// derived from untrusted text. Only `constructor` and `__proto__` survive the lowercased
+// basename (`toString` becomes `tostring` and misses by luck), so pin them all.
+const PROTOTYPE_MEMBER_TOKENS = [
+  "constructor",
+  "__proto__",
+  "toString",
+  "valueOf",
+  "hasOwnProperty",
+  "map.constructor",
+  "obj.__proto__",
+];
 
 describe("getFileIconName", () => {
   it("uses exact filename matches from the Central mapping", () => {
@@ -56,6 +74,25 @@ describe("getFileIconName", () => {
     assert.equal(inferEntryKindFromPath("C:\\repo\\.gitignore"), "file");
     assert.equal(inferEntryKindFromPath("scripts"), "directory");
   });
+
+  it("never resolves an inherited Object.prototype member as an icon name", () => {
+    for (const token of PROTOTYPE_MEMBER_TOKENS) {
+      assert.equal(getFileIconName(token), "code-brackets", token);
+    }
+  });
+});
+
+describe("pathLooksLikeKnownFile", () => {
+  it("does not mistake an Object.prototype member for a known file", () => {
+    for (const token of PROTOTYPE_MEMBER_TOKENS) {
+      assert.isFalse(pathLooksLikeKnownFile(token), `${token} must not look like a known file`);
+    }
+  });
+
+  it("still recognizes real files", () => {
+    assert.isTrue(pathLooksLikeKnownFile("src/index.ts"));
+    assert.isTrue(pathLooksLikeKnownFile("package.json"));
+  });
 });
 
 describe("getAttachmentIconName", () => {
@@ -83,6 +120,12 @@ describe("getAttachmentIconName", () => {
     assert.equal(getAttachmentIconName({ name: "clip", mimeType: "audio/x-wav" }), "audio");
     assert.equal(getAttachmentIconName({ name: "movie", mimeType: "video/quicktime" }), "video");
     assert.equal(getAttachmentIconName({ name: "notes", mimeType: "text/plain" }), "file-text");
+  });
+
+  it("never resolves an inherited Object.prototype member as an icon name", () => {
+    for (const token of PROTOTYPE_MEMBER_TOKENS) {
+      assert.equal(getAttachmentIconName({ name: token, mimeType: "" }), "file-text", token);
+    }
   });
 
   it("defaults to a document glyph rather than the source-code bracket", () => {

--- a/apps/web/src/file-icons.ts
+++ b/apps/web/src/file-icons.ts
@@ -8,9 +8,16 @@
 // Generic bracket glyph used whenever a file type has no dedicated Central icon.
 const DEFAULT_FILE_ICON = "code-brackets";
 
+// Lookup keys come from untrusted text (chat content, attachment names), so the
+// tables must be Maps: a plain-object lookup for `constructor` or `__proto__` walks
+// the prototype chain and returns an inherited member instead of an icon name.
+function createIconTable(entries: Record<string, string>): ReadonlyMap<string, string> {
+  return new Map(Object.entries(entries));
+}
+
 // Exact basename → Central icon name (case-insensitive lookup). Add entries here
 // when a well-known filename has a dedicated icon we want to surface.
-const FILE_ICON_BY_BASENAME: Record<string, string> = {
+const FILE_ICON_BY_BASENAME = createIconTable({
   "package.json": "npm",
   "package-lock.json": "npm",
   "npm-shrinkwrap.json": "npm",
@@ -51,12 +58,12 @@ const FILE_ICON_BY_BASENAME: Record<string, string> = {
   ".env.production": "settings-gear-1",
   ".env.test": "settings-gear-1",
   ".env.example": "settings-gear-1",
-};
+});
 
 // Extension → Central icon name. Longest extension wins because
 // `extensionCandidates` yields compound extensions first (e.g. `.d.ts` before
 // `.ts`). NOTE: the Python asset ships misspelled upstream as `phyton.svg`.
-const FILE_ICON_BY_EXTENSION: Record<string, string> = {
+const FILE_ICON_BY_EXTENSION = createIconTable({
   ts: "typescript",
   mts: "typescript",
   cts: "typescript",
@@ -149,7 +156,7 @@ const FILE_ICON_BY_EXTENSION: Record<string, string> = {
   ogg: "audio",
   m4a: "audio",
   aac: "audio",
-};
+});
 
 export function basenameOfPath(pathValue: string): string {
   const slashIndex = Math.max(pathValue.lastIndexOf("/"), pathValue.lastIndexOf("\\"));
@@ -162,10 +169,10 @@ export function basenameOfPath(pathValue: string): string {
 // assistant's `path/to/file.ts`) should render as a file mention chip.
 export function pathLooksLikeKnownFile(pathValue: string): boolean {
   const basename = basenameOfPath(pathValue).toLowerCase();
-  if (FILE_ICON_BY_BASENAME[basename]) {
+  if (FILE_ICON_BY_BASENAME.has(basename)) {
     return true;
   }
-  return extensionCandidates(basename).some((candidate) => FILE_ICON_BY_EXTENSION[candidate]);
+  return extensionCandidates(basename).some((candidate) => FILE_ICON_BY_EXTENSION.has(candidate));
 }
 
 export function inferEntryKindFromPath(pathValue: string): "file" | "directory" {
@@ -197,10 +204,10 @@ function extensionCandidates(fileName: string): string[] {
 // bracket glyph when the basename/extension has no dedicated icon.
 export function getFileIconName(pathValue: string): string {
   const basename = basenameOfPath(pathValue).toLowerCase();
-  const byName = FILE_ICON_BY_BASENAME[basename];
+  const byName = FILE_ICON_BY_BASENAME.get(basename);
   if (byName) return byName;
   for (const candidate of extensionCandidates(basename)) {
-    const byExt = FILE_ICON_BY_EXTENSION[candidate];
+    const byExt = FILE_ICON_BY_EXTENSION.get(candidate);
     if (byExt) return byExt;
   }
   return DEFAULT_FILE_ICON;
@@ -210,7 +217,7 @@ export function getFileIconName(pathValue: string): string {
 // filename has no recognizable extension (e.g. a download named only by its
 // Content-Type, like a UUID carrying a `text/calendar` body). Mirrors the
 // families covered by the extension map so the two stay visually consistent.
-const FILE_ICON_BY_MIME_TYPE: Record<string, string> = {
+const FILE_ICON_BY_MIME_TYPE = createIconTable({
   "application/pdf": "file-pdf",
   "application/json": "json",
   "application/xml": "code-brackets",
@@ -235,7 +242,7 @@ const FILE_ICON_BY_MIME_TYPE: Record<string, string> = {
   "text/markdown": "markdown",
   "text/html": "code-brackets",
   "text/xml": "code-brackets",
-};
+});
 
 // Attachments default to a neutral document glyph rather than the source-code
 // bracket: an arbitrary upload is far likelier to be a document than code.
@@ -250,16 +257,16 @@ export function getAttachmentIconName(attachment: {
   mimeType?: string | null | undefined;
 }): string {
   const basename = basenameOfPath(attachment.name).toLowerCase();
-  const byName = FILE_ICON_BY_BASENAME[basename];
+  const byName = FILE_ICON_BY_BASENAME.get(basename);
   if (byName) return byName;
   for (const candidate of extensionCandidates(basename)) {
-    const byExt = FILE_ICON_BY_EXTENSION[candidate];
+    const byExt = FILE_ICON_BY_EXTENSION.get(candidate);
     if (byExt) return byExt;
   }
 
   const mimeType = attachment.mimeType?.trim().toLowerCase() ?? "";
   if (mimeType.length > 0) {
-    const byMime = FILE_ICON_BY_MIME_TYPE[mimeType];
+    const byMime = FILE_ICON_BY_MIME_TYPE.get(mimeType);
     if (byMime) return byMime;
     const topLevelType = mimeType.split("/")[0];
     if (topLevelType === "image") return "image-alt-text";


### PR DESCRIPTION
The icon tables were plain objects, so a lookup keyed on `constructor` or `__proto__` walked the prototype chain and returned an inherited member instead of an icon name. `getFileIconName` handed that function to `CentralIcon`, where `name.endsWith(".svg")` threw and unmounted the app through the error boundary.

The keys come from untrusted text, so a message containing the inline code `constructor` crashed the thread permanently: the throw reproduced on every render, leaving no way to reopen the conversation. Attachment names reached the same defect through `getAttachmentIconName`.

Back the tables with Maps, which never consult the prototype chain.

Fixes #355

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

The three file-icon tables in `apps/web/src/file-icons.ts` (`FILE_ICON_BY_BASENAME`, `FILE_ICON_BY_EXTENSION`, `FILE_ICON_BY_MIME_TYPE`) are now `Map`s instead of plain objects, and the seven lookups use `.get()` / `.has()`.

One production file, 33 lines. Regression tests cover the lookups (`file-icons.test.ts`) and the render that actually crashed (`ChatMarkdown.test.tsx`).

## Why

A message containing the inline code `` `constructor` `` or `` `__proto__` `` crashes the app with `TypeError: name.endsWith is not a function`, and the thread becomes **permanently unopenable** — the crash reproduces on every render, so there is no way back into the conversation.

The lookup keys are derived from untrusted text (chat content, attachment filenames), and a plain-object lookup walks the prototype chain:

1. `ChatMarkdown.tsx:742` — `inlineCodeFilePath()` strips wrapping quotes, so `"constructor"` becomes the bare key `constructor`.
2. `file-icons.ts:165` — `pathLooksLikeKnownFile()` evaluates `FILE_ICON_BY_BASENAME["constructor"]`, inherits `Object.prototype.constructor`, and treats the truthy result as a known file — rendering a file chip.
3. `file-icons.ts:200` — `getFileIconName()` returns that inherited **function** as the icon name.
4. `central-icons.tsx:34` — `getCentralIconUrl()` calls `name.endsWith(".svg")` on the function and throws mid-render, unmounting the tree into the error boundary.

`constructor` and `__proto__` are the live triggers because the basename is lowercased first (`toString` becomes `tostring` and misses by luck).

`Map` fixes this at the root: it never consults the prototype chain, so `getFileIconName`'s `=> string` signature is enforced by the data structure rather than assumed. Attachments reached the same defect through `getAttachmentIconName()` (an upload named `notes.constructor`), and that is fixed by the same change.

I deliberately left `inlineCodeFilePath()`'s quote-stripping alone — it is load-bearing (it is why `` `'src/foo.ts'` `` renders a chip) and it is not the bug. Narrowing it there would hide the markdown symptom while leaving the attachment path broken.

Reproduces on `main` and in the v0.5.3 release. I hit it in a normal chat about JS `Map`/`Set`, where the agent wrote a sentence about prototype pollution — and that message prototype-polluted the renderer.

Verified with `bun fmt`, `bun lint`, `bun typecheck`, and `bun run test`. The new tests fail without the `file-icons.ts` change and pass with it.

### Known sibling, not included

`AGENT_CHIP_COLOR_BY_NAME` (`apps/web/src/components/composerInlineChip.ts:123`) has the same unsafe-lookup shape, keyed on an agent's `color:` frontmatter. It is cosmetic rather than a crash — an agent colored `constructor` resolves to a function, `?? DEFAULT` does not catch it, and the chip renders unstyled. Left out to keep this PR focused; happy to send a follow-up.

## UI Changes

Before: sending a message containing `` `constructor` `` replaces the app with the error boundary, and the thread cannot be reopened.
<img width="1002" height="608" alt="Screenshot 2026-07-14 at 18 03 03" src="https://github.com/user-attachments/assets/dcdbf2f6-0222-48e7-8655-67e8205a1423" />


After: the token renders as ordinary inline code.
<img width="906" height="279" alt="Screenshot 2026-07-14 at 19 11 09" src="https://github.com/user-attachments/assets/adc61b15-0cf9-4471-9a91-e873868ce56b" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
