### PR TITLE
fix(web): isolate Cursor model discovery failures from picker

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1118,6 +1118,23 @@ describe("shouldShowComposerModelBootstrapSkeleton", () => {
     ).toBe(false);
   });
 
+  // #103: Cursor CLI missing must not leave the whole model control in a permanent loading state.
+  it("does not keep the Cursor bootstrap skeleton after discovery is no longer loading", () => {
+    expect(
+      shouldShowComposerModelBootstrapSkeleton({
+        selectedProvider: "cursor",
+        selectedModel: "auto",
+        persistedModelSelection: {
+          provider: "cursor",
+          model: "auto",
+        },
+        draftModelSelection: null,
+        providerModelsLoading: false,
+        requiresDiscoveredModels: true,
+      }),
+    ).toBe(false);
+  });
+
   it("prefers an explicit draft selection over persisted thread state", () => {
     expect(
       shouldShowComposerModelBootstrapSkeleton({

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2157,44 +2157,39 @@ export default function ChatView({
   const cursorModelDiscoveryEnabled =
     selectedProvider === "cursor" || lockedProvider === "cursor" || isModelPickerOpen;
   const hasResolvedCursorModelDiscovery =
-    ((cursorDynamicModelsQuery.data?.source === "cursor.cli" ||
+    (cursorDynamicModelsQuery.data?.source === "cursor.cli" ||
       cursorDynamicModelsQuery.data?.source === "cursor.acp") &&
-      (cursorDynamicModelsQuery.data.models.length ?? 0) > 0) ||
-    cursorDynamicModelsQuery.data?.source === "error";
+    (cursorDynamicModelsQuery.data.models.length ?? 0) > 0;
   const cursorModelDiscoveryPending =
     cursorModelDiscoveryEnabled &&
     !hasResolvedCursorModelDiscovery &&
     isInitialModelDiscoveryPending(cursorDynamicModelsQuery);
   const hasResolvedDroidModelDiscovery =
-    (droidDynamicModelsQuery.data?.source === "droid-acp" &&
-      (droidDynamicModelsQuery.data.models.length ?? 0) > 0) ||
-    droidDynamicModelsQuery.data?.source === "error";
+    droidDynamicModelsQuery.data?.source === "droid-acp" &&
+    (droidDynamicModelsQuery.data.models.length ?? 0) > 0;
   const droidModelDiscoveryPending =
     droidModelDiscoveryEnabled &&
     !hasResolvedDroidModelDiscovery &&
     isInitialModelDiscoveryPending(droidDynamicModelsQuery);
   const hasResolvedKiloModelDiscovery =
-    ((kiloDynamicModelsQuery.data?.source === "kilo-cli" ||
+    (kiloDynamicModelsQuery.data?.source === "kilo-cli" ||
       kiloDynamicModelsQuery.data?.source === "kilo") &&
-      (kiloDynamicModelsQuery.data.models.length ?? 0) > 0) ||
-    kiloDynamicModelsQuery.data?.source === "error";
+    (kiloDynamicModelsQuery.data.models.length ?? 0) > 0;
   const kiloModelDiscoveryPending =
     kiloModelDiscoveryEnabled &&
     !hasResolvedKiloModelDiscovery &&
     isInitialModelDiscoveryPending(kiloDynamicModelsQuery);
   const hasResolvedOpenCodeModelDiscovery =
-    ((openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
+    (openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
       openCodeDynamicModelsQuery.data?.source === "opencode") &&
-      (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0) ||
-    openCodeDynamicModelsQuery.data?.source === "error";
+    (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0;
   const openCodeModelDiscoveryPending =
     openCodeModelDiscoveryEnabled &&
     !hasResolvedOpenCodeModelDiscovery &&
     isInitialModelDiscoveryPending(openCodeDynamicModelsQuery);
   const hasResolvedPiModelDiscovery =
-    (piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
-      (piDynamicModelsQuery.data.models.length ?? 0) > 0) ||
-    piDynamicModelsQuery.data?.source === "error";
+    piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
+    (piDynamicModelsQuery.data.models.length ?? 0) > 0;
   const piModelDiscoveryPending =
     piModelDiscoveryEnabled &&
     !hasResolvedPiModelDiscovery &&

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -77,6 +77,7 @@ import {
 } from "~/lib/gitReactQuery";
 import { resolveProviderDiscoveryCwd } from "~/lib/providerDiscovery";
 import {
+  isInitialModelDiscoveryPending,
   providerAgentsQueryOptions,
   providerComposerCapabilitiesQueryOptions,
   providerCommandsQueryOptions,
@@ -2156,49 +2157,53 @@ export default function ChatView({
   const cursorModelDiscoveryEnabled =
     selectedProvider === "cursor" || lockedProvider === "cursor" || isModelPickerOpen;
   const hasResolvedCursorModelDiscovery =
-    (cursorDynamicModelsQuery.data?.source === "cursor.cli" ||
+    ((cursorDynamicModelsQuery.data?.source === "cursor.cli" ||
       cursorDynamicModelsQuery.data?.source === "cursor.acp") &&
-    (cursorDynamicModelsQuery.data.models.length ?? 0) > 0;
+      (cursorDynamicModelsQuery.data.models.length ?? 0) > 0) ||
+    cursorDynamicModelsQuery.data?.source === "error";
   const cursorModelDiscoveryPending =
     cursorModelDiscoveryEnabled &&
     !hasResolvedCursorModelDiscovery &&
-    (cursorDynamicModelsQuery.isLoading || cursorDynamicModelsQuery.isFetching);
+    isInitialModelDiscoveryPending(cursorDynamicModelsQuery);
   const hasResolvedDroidModelDiscovery =
-    droidDynamicModelsQuery.data?.source === "droid-acp" &&
-    (droidDynamicModelsQuery.data.models.length ?? 0) > 0;
+    (droidDynamicModelsQuery.data?.source === "droid-acp" &&
+      (droidDynamicModelsQuery.data.models.length ?? 0) > 0) ||
+    droidDynamicModelsQuery.data?.source === "error";
   const droidModelDiscoveryPending =
     droidModelDiscoveryEnabled &&
     !hasResolvedDroidModelDiscovery &&
-    (droidDynamicModelsQuery.isLoading || droidDynamicModelsQuery.isFetching);
+    isInitialModelDiscoveryPending(droidDynamicModelsQuery);
   const hasResolvedKiloModelDiscovery =
-    (kiloDynamicModelsQuery.data?.source === "kilo-cli" ||
+    ((kiloDynamicModelsQuery.data?.source === "kilo-cli" ||
       kiloDynamicModelsQuery.data?.source === "kilo") &&
-    (kiloDynamicModelsQuery.data.models.length ?? 0) > 0;
+      (kiloDynamicModelsQuery.data.models.length ?? 0) > 0) ||
+    kiloDynamicModelsQuery.data?.source === "error";
   const kiloModelDiscoveryPending =
     kiloModelDiscoveryEnabled &&
     !hasResolvedKiloModelDiscovery &&
-    (kiloDynamicModelsQuery.isLoading || kiloDynamicModelsQuery.isFetching);
+    isInitialModelDiscoveryPending(kiloDynamicModelsQuery);
   const hasResolvedOpenCodeModelDiscovery =
-    (openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
+    ((openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
       openCodeDynamicModelsQuery.data?.source === "opencode") &&
-    (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0;
+      (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0) ||
+    openCodeDynamicModelsQuery.data?.source === "error";
   const openCodeModelDiscoveryPending =
     openCodeModelDiscoveryEnabled &&
     !hasResolvedOpenCodeModelDiscovery &&
-    (openCodeDynamicModelsQuery.isLoading || openCodeDynamicModelsQuery.isFetching);
+    isInitialModelDiscoveryPending(openCodeDynamicModelsQuery);
   const hasResolvedPiModelDiscovery =
-    piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
-    (piDynamicModelsQuery.data.models.length ?? 0) > 0;
+    (piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
+      (piDynamicModelsQuery.data.models.length ?? 0) > 0) ||
+    piDynamicModelsQuery.data?.source === "error";
   const piModelDiscoveryPending =
     piModelDiscoveryEnabled &&
     !hasResolvedPiModelDiscovery &&
-    (piDynamicModelsQuery.isLoading || piDynamicModelsQuery.isFetching);
+    isInitialModelDiscoveryPending(piDynamicModelsQuery);
   const antigravityModelDiscoveryPending =
     !(
       antigravityModelsQuery.data?.source === "antigravity.cli" &&
       (antigravityModelsQuery.data.models.length ?? 0) > 0
-    ) &&
-    (antigravityModelsQuery.isLoading || antigravityModelsQuery.isFetching);
+    ) && isInitialModelDiscoveryPending(antigravityModelsQuery);
   const modelOptionsByProvider = useMemo(() => {
     const staticOptions: Record<ProviderKind, ReturnType<typeof getAppModelOptions>> = {
       codex: getAppModelOptions(

--- a/apps/web/src/hooks/useProviderModelCatalog.ts
+++ b/apps/web/src/hooks/useProviderModelCatalog.ts
@@ -16,6 +16,7 @@ import { getAppModelOptions, getCustomModelsByProvider, useAppSettings } from ".
 import { resolveRuntimeModelDescriptor } from "../components/chat/runtimeModelCapabilities";
 import { collapseCursorModelVariants } from "../cursorModelVariants";
 import {
+  isInitialModelDiscoveryPending,
   providerAgentsQueryOptions,
   providerModelsQueryOptions,
 } from "../lib/providerDiscoveryReactQuery";
@@ -158,53 +159,57 @@ export function useProviderModelCatalog(input: {
 
   const cursorModelDiscoveryEnabled = selectedProvider === "cursor" || discoveryEnabled;
   const hasResolvedCursorModelDiscovery =
-    (cursorDynamicModelsQuery.data?.source === "cursor.cli" ||
+    ((cursorDynamicModelsQuery.data?.source === "cursor.cli" ||
       cursorDynamicModelsQuery.data?.source === "cursor.acp") &&
-    (cursorDynamicModelsQuery.data.models.length ?? 0) > 0;
+      (cursorDynamicModelsQuery.data.models.length ?? 0) > 0) ||
+    cursorDynamicModelsQuery.data?.source === "error";
   const cursorModelDiscoveryPending =
     cursorModelDiscoveryEnabled &&
     !hasResolvedCursorModelDiscovery &&
-    (cursorDynamicModelsQuery.isLoading || cursorDynamicModelsQuery.isFetching);
+    isInitialModelDiscoveryPending(cursorDynamicModelsQuery);
   const droidModelDiscoveryEnabled = selectedProvider === "droid";
   const hasResolvedDroidModelDiscovery =
-    droidDynamicModelsQuery.data?.source === "droid-acp" &&
-    (droidDynamicModelsQuery.data.models.length ?? 0) > 0;
+    (droidDynamicModelsQuery.data?.source === "droid-acp" &&
+      (droidDynamicModelsQuery.data.models.length ?? 0) > 0) ||
+    droidDynamicModelsQuery.data?.source === "error";
   const droidModelDiscoveryPending =
     droidModelDiscoveryEnabled &&
     !hasResolvedDroidModelDiscovery &&
-    (droidDynamicModelsQuery.isLoading || droidDynamicModelsQuery.isFetching);
+    isInitialModelDiscoveryPending(droidDynamicModelsQuery);
   const kiloModelDiscoveryEnabled = selectedProvider === "kilo" || discoveryEnabled;
   const hasResolvedKiloModelDiscovery =
-    (kiloDynamicModelsQuery.data?.source === "kilo-cli" ||
+    ((kiloDynamicModelsQuery.data?.source === "kilo-cli" ||
       kiloDynamicModelsQuery.data?.source === "kilo") &&
-    (kiloDynamicModelsQuery.data.models.length ?? 0) > 0;
+      (kiloDynamicModelsQuery.data.models.length ?? 0) > 0) ||
+    kiloDynamicModelsQuery.data?.source === "error";
   const kiloModelDiscoveryPending =
     kiloModelDiscoveryEnabled &&
     !hasResolvedKiloModelDiscovery &&
-    (kiloDynamicModelsQuery.isLoading || kiloDynamicModelsQuery.isFetching);
+    isInitialModelDiscoveryPending(kiloDynamicModelsQuery);
   const openCodeModelDiscoveryEnabled = selectedProvider === "opencode" || discoveryEnabled;
   const hasResolvedOpenCodeModelDiscovery =
-    (openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
+    ((openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
       openCodeDynamicModelsQuery.data?.source === "opencode") &&
-    (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0;
+      (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0) ||
+    openCodeDynamicModelsQuery.data?.source === "error";
   const openCodeModelDiscoveryPending =
     openCodeModelDiscoveryEnabled &&
     !hasResolvedOpenCodeModelDiscovery &&
-    (openCodeDynamicModelsQuery.isLoading || openCodeDynamicModelsQuery.isFetching);
+    isInitialModelDiscoveryPending(openCodeDynamicModelsQuery);
   const piModelDiscoveryEnabled = selectedProvider === "pi" || discoveryEnabled;
   const hasResolvedPiModelDiscovery =
-    piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
-    (piDynamicModelsQuery.data.models.length ?? 0) > 0;
+    (piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
+      (piDynamicModelsQuery.data.models.length ?? 0) > 0) ||
+    piDynamicModelsQuery.data?.source === "error";
   const piModelDiscoveryPending =
     piModelDiscoveryEnabled &&
     !hasResolvedPiModelDiscovery &&
-    (piDynamicModelsQuery.isLoading || piDynamicModelsQuery.isFetching);
+    isInitialModelDiscoveryPending(piDynamicModelsQuery);
   const antigravityModelDiscoveryPending =
     !(
       antigravityModelsQuery.data?.source === "antigravity.cli" &&
       (antigravityModelsQuery.data.models.length ?? 0) > 0
-    ) &&
-    (antigravityModelsQuery.isLoading || antigravityModelsQuery.isFetching);
+    ) && isInitialModelDiscoveryPending(antigravityModelsQuery);
 
   const modelOptionsByProvider = useMemo(() => {
     const staticOptions: Record<ProviderKind, ReturnType<typeof getAppModelOptions>> = {

--- a/apps/web/src/hooks/useProviderModelCatalog.ts
+++ b/apps/web/src/hooks/useProviderModelCatalog.ts
@@ -159,48 +159,43 @@ export function useProviderModelCatalog(input: {
 
   const cursorModelDiscoveryEnabled = selectedProvider === "cursor" || discoveryEnabled;
   const hasResolvedCursorModelDiscovery =
-    ((cursorDynamicModelsQuery.data?.source === "cursor.cli" ||
+    (cursorDynamicModelsQuery.data?.source === "cursor.cli" ||
       cursorDynamicModelsQuery.data?.source === "cursor.acp") &&
-      (cursorDynamicModelsQuery.data.models.length ?? 0) > 0) ||
-    cursorDynamicModelsQuery.data?.source === "error";
+    (cursorDynamicModelsQuery.data.models.length ?? 0) > 0;
   const cursorModelDiscoveryPending =
     cursorModelDiscoveryEnabled &&
     !hasResolvedCursorModelDiscovery &&
     isInitialModelDiscoveryPending(cursorDynamicModelsQuery);
   const droidModelDiscoveryEnabled = selectedProvider === "droid";
   const hasResolvedDroidModelDiscovery =
-    (droidDynamicModelsQuery.data?.source === "droid-acp" &&
-      (droidDynamicModelsQuery.data.models.length ?? 0) > 0) ||
-    droidDynamicModelsQuery.data?.source === "error";
+    droidDynamicModelsQuery.data?.source === "droid-acp" &&
+    (droidDynamicModelsQuery.data.models.length ?? 0) > 0;
   const droidModelDiscoveryPending =
     droidModelDiscoveryEnabled &&
     !hasResolvedDroidModelDiscovery &&
     isInitialModelDiscoveryPending(droidDynamicModelsQuery);
   const kiloModelDiscoveryEnabled = selectedProvider === "kilo" || discoveryEnabled;
   const hasResolvedKiloModelDiscovery =
-    ((kiloDynamicModelsQuery.data?.source === "kilo-cli" ||
+    (kiloDynamicModelsQuery.data?.source === "kilo-cli" ||
       kiloDynamicModelsQuery.data?.source === "kilo") &&
-      (kiloDynamicModelsQuery.data.models.length ?? 0) > 0) ||
-    kiloDynamicModelsQuery.data?.source === "error";
+    (kiloDynamicModelsQuery.data.models.length ?? 0) > 0;
   const kiloModelDiscoveryPending =
     kiloModelDiscoveryEnabled &&
     !hasResolvedKiloModelDiscovery &&
     isInitialModelDiscoveryPending(kiloDynamicModelsQuery);
   const openCodeModelDiscoveryEnabled = selectedProvider === "opencode" || discoveryEnabled;
   const hasResolvedOpenCodeModelDiscovery =
-    ((openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
+    (openCodeDynamicModelsQuery.data?.source === "opencode-cli" ||
       openCodeDynamicModelsQuery.data?.source === "opencode") &&
-      (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0) ||
-    openCodeDynamicModelsQuery.data?.source === "error";
+    (openCodeDynamicModelsQuery.data.models.length ?? 0) > 0;
   const openCodeModelDiscoveryPending =
     openCodeModelDiscoveryEnabled &&
     !hasResolvedOpenCodeModelDiscovery &&
     isInitialModelDiscoveryPending(openCodeDynamicModelsQuery);
   const piModelDiscoveryEnabled = selectedProvider === "pi" || discoveryEnabled;
   const hasResolvedPiModelDiscovery =
-    (piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
-      (piDynamicModelsQuery.data.models.length ?? 0) > 0) ||
-    piDynamicModelsQuery.data?.source === "error";
+    piDynamicModelsQuery.data?.source?.startsWith("pi.sdk") === true &&
+    (piDynamicModelsQuery.data.models.length ?? 0) > 0;
   const piModelDiscoveryPending =
     piModelDiscoveryEnabled &&
     !hasResolvedPiModelDiscovery &&

--- a/apps/web/src/lib/providerDiscoveryReactQuery.test.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.test.ts
@@ -1,26 +1,28 @@
-import { describe, expect, it, vi } from "vitest";
+// FILE: providerDiscoveryReactQuery.test.ts
+// Purpose: Locks provider model discovery query semantics — retry policy,
+//          stale-catalog preservation, and initial-vs-background pending (#103).
+// Layer: Web data fetching tests
+
+import type { NativeApi } from "@synara/contracts";
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   isInitialModelDiscoveryPending,
   providerModelsQueryOptions,
 } from "./providerDiscoveryReactQuery";
+import * as nativeApi from "../nativeApi";
 
-vi.mock("~/nativeApi", () => ({
-  ensureNativeApi: () => ({
-    provider: {
-      listModels: vi.fn(async ({ provider }: { provider: string }) => {
-        if (provider === "cursor") {
-          throw new Error("Cursor CLI is not installed or not on PATH");
-        }
-        return {
-          models: [{ slug: "gpt-5.4", name: "GPT-5.4" }],
-          source: "codex",
-          cached: false,
-        };
-      }),
-    },
-  }),
-}));
+function mockListModels(listModels: ReturnType<typeof vi.fn>) {
+  vi.spyOn(nativeApi, "ensureNativeApi").mockReturnValue({
+    provider: { listModels },
+  } as unknown as NativeApi);
+  return listModels;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("isInitialModelDiscoveryPending", () => {
   it("is pending only for the first fetch (loading or placeholder fetch)", () => {
@@ -57,24 +59,64 @@ describe("isInitialModelDiscoveryPending", () => {
 });
 
 describe("providerModelsQueryOptions", () => {
-  it("soft-fails Cursor listModels so discovery settles as empty instead of rejecting", async () => {
+  it("fails fast for Cursor so a missing CLI settles instead of spinning (#103)", async () => {
+    const listModels = mockListModels(
+      vi.fn().mockRejectedValue(new Error("Cursor CLI is not installed or not on PATH")),
+    );
     const options = providerModelsQueryOptions({ provider: "cursor", enabled: true });
-    const result = await options.queryFn!({} as never);
-    expect(result).toEqual({
-      models: [],
-      source: "error",
-      cached: false,
-    });
     expect(options.retry).toBe(0);
+
+    const queryClient = new QueryClient();
+    await expect(queryClient.fetchQuery(options)).rejects.toThrow(
+      "Cursor CLI is not installed or not on PATH",
+    );
+    expect(listModels).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryState(options.queryKey)?.status).toBe("error");
   });
 
-  it("still returns successful catalogs for other providers", async () => {
-    const options = providerModelsQueryOptions({ provider: "codex", enabled: true });
-    const result = await options.queryFn!({} as never);
-    expect(result).toEqual({
+  it("keeps retrying transient failures for other providers", () => {
+    expect(providerModelsQueryOptions({ provider: "codex" }).retry).toBe(3);
+    expect(providerModelsQueryOptions({ provider: "droid" }).retry).toBe(0);
+  });
+
+  it("surfaces real errors instead of masking them as empty catalogs", async () => {
+    mockListModels(vi.fn().mockRejectedValue(new Error("discovery exploded")));
+    const options = providerModelsQueryOptions({ provider: "cursor", enabled: true });
+
+    const queryClient = new QueryClient();
+    await expect(queryClient.fetchQuery(options)).rejects.toThrow("discovery exploded");
+    expect(queryClient.getQueryData(options.queryKey)).toBeUndefined();
+  });
+
+  it("preserves the cached catalog when a background refetch fails", async () => {
+    const catalog = {
+      models: [{ slug: "auto", name: "Auto" }],
+      source: "cursor.cli",
+      cached: false,
+    };
+    const listModels = mockListModels(
+      vi.fn().mockResolvedValueOnce(catalog).mockRejectedValue(new Error("cursor went away")),
+    );
+    const options = providerModelsQueryOptions({ provider: "cursor", enabled: true });
+
+    const queryClient = new QueryClient();
+    await expect(queryClient.fetchQuery(options)).resolves.toEqual(catalog);
+    await queryClient.refetchQueries({ queryKey: options.queryKey });
+
+    expect(listModels).toHaveBeenCalledTimes(2);
+    expect(queryClient.getQueryData(options.queryKey)).toEqual(catalog);
+  });
+
+  it("returns successful catalogs unchanged", async () => {
+    const catalog = {
       models: [{ slug: "gpt-5.4", name: "GPT-5.4" }],
       source: "codex",
       cached: false,
-    });
+    };
+    mockListModels(vi.fn().mockResolvedValue(catalog));
+    const options = providerModelsQueryOptions({ provider: "codex", enabled: true });
+
+    const queryClient = new QueryClient();
+    await expect(queryClient.fetchQuery(options)).resolves.toEqual(catalog);
   });
 });

--- a/apps/web/src/lib/providerDiscoveryReactQuery.test.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  isInitialModelDiscoveryPending,
+  providerModelsQueryOptions,
+} from "./providerDiscoveryReactQuery";
+
+vi.mock("~/nativeApi", () => ({
+  ensureNativeApi: () => ({
+    provider: {
+      listModels: vi.fn(async ({ provider }: { provider: string }) => {
+        if (provider === "cursor") {
+          throw new Error("Cursor CLI is not installed or not on PATH");
+        }
+        return {
+          models: [{ slug: "gpt-5.4", name: "GPT-5.4" }],
+          source: "codex",
+          cached: false,
+        };
+      }),
+    },
+  }),
+}));
+
+describe("isInitialModelDiscoveryPending", () => {
+  it("is pending only for the first fetch (loading or placeholder fetch)", () => {
+    expect(
+      isInitialModelDiscoveryPending({
+        isLoading: true,
+        isFetching: true,
+        isPlaceholderData: true,
+      }),
+    ).toBe(true);
+    expect(
+      isInitialModelDiscoveryPending({
+        isLoading: false,
+        isFetching: true,
+        isPlaceholderData: true,
+      }),
+    ).toBe(true);
+    // Settled catalog + background refetch must not blank the picker (#103).
+    expect(
+      isInitialModelDiscoveryPending({
+        isLoading: false,
+        isFetching: true,
+        isPlaceholderData: false,
+      }),
+    ).toBe(false);
+    expect(
+      isInitialModelDiscoveryPending({
+        isLoading: false,
+        isFetching: false,
+        isPlaceholderData: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("providerModelsQueryOptions", () => {
+  it("soft-fails Cursor listModels so discovery settles as empty instead of rejecting", async () => {
+    const options = providerModelsQueryOptions({ provider: "cursor", enabled: true });
+    const result = await options.queryFn!({} as never);
+    expect(result).toEqual({
+      models: [],
+      source: "error",
+      cached: false,
+    });
+    expect(options.retry).toBe(0);
+  });
+
+  it("still returns successful catalogs for other providers", async () => {
+    const options = providerModelsQueryOptions({ provider: "codex", enabled: true });
+    const result = await options.queryFn!({} as never);
+    expect(result).toEqual({
+      models: [{ slug: "gpt-5.4", name: "GPT-5.4" }],
+      source: "codex",
+      cached: false,
+    });
+  });
+});

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -187,6 +187,19 @@ export function providerCommandsQueryOptions(input: {
   });
 }
 
+/**
+ * True only while the first real models fetch is still outstanding.
+ * Background refetches after settle (or after a soft-failed discovery) must not
+ * re-blank the composer model picker (#103).
+ */
+export function isInitialModelDiscoveryPending(query: {
+  readonly isLoading: boolean;
+  readonly isFetching: boolean;
+  readonly isPlaceholderData: boolean;
+}): boolean {
+  return query.isLoading || (query.isFetching && query.isPlaceholderData);
+}
+
 export function providerModelsQueryOptions(input: {
   provider: ProviderKind;
   binaryPath?: string | null;
@@ -203,18 +216,30 @@ export function providerModelsQueryOptions(input: {
       input.agentDir ?? null,
       input.cwd ?? null,
     ),
-    queryFn: async () => {
+    queryFn: async (): Promise<ProviderListModelsResult> => {
       const api = ensureNativeApi();
-      return api.provider.listModels({
-        provider: input.provider,
-        ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
-        ...(input.apiEndpoint ? { apiEndpoint: input.apiEndpoint } : {}),
-        ...(input.agentDir ? { agentDir: input.agentDir } : {}),
-        ...(input.cwd ? { cwd: input.cwd } : {}),
-      });
+      try {
+        return await api.provider.listModels({
+          provider: input.provider,
+          ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
+          ...(input.apiEndpoint ? { apiEndpoint: input.apiEndpoint } : {}),
+          ...(input.agentDir ? { agentDir: input.agentDir } : {}),
+          ...(input.cwd ? { cwd: input.cwd } : {}),
+        });
+      } catch {
+        // Soft-fail so one provider (e.g. missing Cursor CLI) cannot reject the
+        // shared query into a permanent "loading/retry" state that blanks the
+        // whole model picker. Callers fall back to static options.
+        return {
+          models: [],
+          source: "error",
+          cached: false,
+        };
+      }
     },
     enabled: input.enabled ?? true,
-    retry: input.provider === "droid" ? 0 : input.provider === "cursor" ? 1 : 3,
+    // Cursor/droid failures are permanent for a session (missing CLI/auth); do not spin.
+    retry: input.provider === "droid" || input.provider === "cursor" ? 0 : 3,
     staleTime: input.provider === "droid" ? 5 * 60_000 : 60_000,
     ...(input.provider === "droid" ? { refetchOnWindowFocus: false } : {}),
     placeholderData: (previous) => previous ?? EMPTY_MODELS_RESULT,

--- a/apps/web/src/lib/providerDiscoveryReactQuery.ts
+++ b/apps/web/src/lib/providerDiscoveryReactQuery.ts
@@ -189,8 +189,9 @@ export function providerCommandsQueryOptions(input: {
 
 /**
  * True only while the first real models fetch is still outstanding.
- * Background refetches after settle (or after a soft-failed discovery) must not
- * re-blank the composer model picker (#103).
+ * Once discovery settles — with a catalog OR a failure (e.g. missing Cursor
+ * CLI, #103) — background refetches must not re-blank the composer picker,
+ * and a failed provider must not park the model control on a skeleton.
  */
 export function isInitialModelDiscoveryPending(query: {
   readonly isLoading: boolean;
@@ -218,27 +219,17 @@ export function providerModelsQueryOptions(input: {
     ),
     queryFn: async (): Promise<ProviderListModelsResult> => {
       const api = ensureNativeApi();
-      try {
-        return await api.provider.listModels({
-          provider: input.provider,
-          ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
-          ...(input.apiEndpoint ? { apiEndpoint: input.apiEndpoint } : {}),
-          ...(input.agentDir ? { agentDir: input.agentDir } : {}),
-          ...(input.cwd ? { cwd: input.cwd } : {}),
-        });
-      } catch {
-        // Soft-fail so one provider (e.g. missing Cursor CLI) cannot reject the
-        // shared query into a permanent "loading/retry" state that blanks the
-        // whole model picker. Callers fall back to static options.
-        return {
-          models: [],
-          source: "error",
-          cached: false,
-        };
-      }
+      return api.provider.listModels({
+        provider: input.provider,
+        ...(input.binaryPath ? { binaryPath: input.binaryPath } : {}),
+        ...(input.apiEndpoint ? { apiEndpoint: input.apiEndpoint } : {}),
+        ...(input.agentDir ? { agentDir: input.agentDir } : {}),
+        ...(input.cwd ? { cwd: input.cwd } : {}),
+      });
     },
     enabled: input.enabled ?? true,
-    // Cursor/droid failures are permanent for a session (missing CLI/auth); do not spin.
+    // Cursor/droid failures are permanent for a session (missing CLI/auth): fail
+    // fast so the picker settles to static options instead of spinning (#103).
     retry: input.provider === "droid" || input.provider === "cursor" ? 0 : 3,
     staleTime: input.provider === "droid" ? 5 * 60_000 : 60_000,
     ...(input.provider === "droid" ? { refetchOnWindowFocus: false } : {}),


### PR DESCRIPTION
## Summary

Missing or unauthenticated **Cursor CLI** no longer blanks the entire composer model selector. Discovery soft-fails to an empty catalog; other providers stay usable.

Closes #103

## Problem

When Cursor CLI is missing/unavailable, `listModels` rejected into React Query. The composer treated unresolved Cursor discovery as a **global** bootstrap load (`Loading models` / “retry models” UX), so the whole model control stayed blocked instead of only affecting Cursor.

## Solution

| Area | Change |
|------|--------|
| `providerModelsQueryOptions` | Soft-fail `listModels` → `{ models: [], source: "error" }` |
| Cursor/droid retries | `retry: 0` (permanent session failures) |
| Pending gate | `isInitialModelDiscoveryPending` — only first fetch blanks; background refetch does not |
| Settled error | `source === "error"` counts as resolved for cursor/droid/kilo/opencode/pi |
| Call sites | `ChatView` + `useProviderModelCatalog` |

Static/fallback model options remain available when discovery fails.

## Evidence

| Before | After |
|--------|--------|
| Cursor discovery throws → whole picker stuck loading | Discovery settles with `source: "error"` |
| Other providers blocked while Cursor pending/retrying | Other providers stay selectable |
| Background refetch re-opens bootstrap skeleton | Initial fetch only |

## Test plan

- [x] `bunx vitest run apps/web/src/lib/providerDiscoveryReactQuery.test.ts` — soft-fail + pending helper
- [x] `bunx vitest run apps/web/src/components/ChatView.logic.test.ts` — skeleton gate (#103 case)
- [ ] Manual (optional): hide/remove Cursor CLI, open composer model picker, confirm Codex/Claude still open and Cursor does not lock the control

## Files

- `apps/web/src/lib/providerDiscoveryReactQuery.ts`
- `apps/web/src/lib/providerDiscoveryReactQuery.test.ts`
- `apps/web/src/components/ChatView.tsx`
- `apps/web/src/hooks/useProviderModelCatalog.ts`
- `apps/web/src/components/ChatView.logic.test.ts`