### PR TITLE
fix: handle path drops with spaces/parentheses as mentions

### DIFF
--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 import type { DesktopBridge } from "@synara/contracts";
 import { BROWSER_IPC_CHANNELS } from "./browserIpc";
 import {
@@ -45,6 +45,15 @@ function getDesktopWsUrl(): string | null {
 
 contextBridge.exposeInMainWorld("desktopBridge", {
   getWsUrl: getDesktopWsUrl,
+  // Absolute path for OS-dropped File objects (folders with spaces/parens, etc.).
+  getPathForFile: (file: File) => {
+    try {
+      const path = webUtils.getPathForFile(file);
+      return typeof path === "string" && path.trim().length > 0 ? path : null;
+    } catch {
+      return null;
+    }
+  },
   pickFolder: () => ipcRenderer.invoke(PICK_FOLDER_CHANNEL),
   saveFile: (input) => ipcRenderer.invoke(SAVE_FILE_CHANNEL, input),
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -93,6 +93,7 @@ import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuer
 import { useRefreshProviderStatusesNow } from "~/hooks/useProviderStatusRefresh";
 import { SINGLE_CHAT_PANE_SCOPE_ID } from "~/lib/chatPaneScope";
 import {
+  composerMentionPathNeedsQuoting,
   formatComposerMentionToken,
   filterPromptProviderMentionReferences,
   filterPromptSkillReferences,
@@ -6348,6 +6349,11 @@ export default function ChatView({
       addFiles: addComposerFiles,
     },
     appendReferenceText: (referenceText) => appendComposerPromptText(threadId, referenceText),
+    appendPathMentions: (paths) => {
+      for (const absolutePath of paths) {
+        appendComposerPromptText(threadId, formatComposerMentionToken(absolutePath));
+      }
+    },
     dragDepthRef,
     focusComposer,
     setIsDragOverComposer,
@@ -9346,8 +9352,8 @@ export default function ChatView({
 
   // Rewrites the active `@...` mention to an absolute folder path with a trailing separator
   // so the local-folder picker stays open and the user can keep browsing by clicking or typing.
-  // Paths with whitespace are written as an unclosed `@"...` so detectComposerTrigger keeps
-  // matching and the picker stays open while the user descends into folders with spaces.
+  // Paths that need quoting (spaces, parentheses, …) are written as an unclosed
+  // `@"...` so detectComposerTrigger keeps matching while the user descends (#351).
   const handleNavigateLocalFolder = useCallback(
     (absolutePath: string) => {
       const { snapshot, trigger } = resolveActiveComposerTrigger();
@@ -9356,7 +9362,7 @@ export default function ChatView({
       const withTrailingSeparator = absolutePath.endsWith(separator)
         ? absolutePath
         : `${absolutePath}${separator}`;
-      const base = /\s/.test(withTrailingSeparator)
+      const base = composerMentionPathNeedsQuoting(withTrailingSeparator)
         ? `@"${withTrailingSeparator}`
         : `@${withTrailingSeparator}`;
       applyComposerTriggerReplacement({ snapshot, trigger, base });

--- a/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
+++ b/apps/web/src/components/kanban/KanbanNewTaskDialog.tsx
@@ -60,6 +60,7 @@ import { useComposerDropzone } from "~/hooks/useComposerDropzone";
 import { toastManager } from "~/components/ui/toast";
 import { useTheme } from "~/hooks/useTheme";
 import { ChevronRightIcon, PaperclipIcon } from "~/lib/icons";
+import { formatComposerMentionToken } from "~/lib/composerMentions";
 import { findProviderStatus } from "~/lib/providerAvailability";
 import { resolveProviderDiscoveryCwd } from "~/lib/providerDiscovery";
 import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
@@ -352,6 +353,11 @@ export function KanbanNewTaskDialog({
       },
     },
     appendReferenceText: appendComposerPromptText,
+    appendPathMentions: (paths) => {
+      for (const absolutePath of paths) {
+        appendComposerPromptText(formatComposerMentionToken(absolutePath));
+      }
+    },
     dragDepthRef,
     focusComposer: scheduleComposerFocus,
     setIsDragOverComposer,

--- a/apps/web/src/components/kanban/useKanbanTaskComposerEditor.ts
+++ b/apps/web/src/components/kanban/useKanbanTaskComposerEditor.ts
@@ -33,7 +33,11 @@ import {
   ensureLeadingSpaceForReplacement,
   extendReplacementRangeForTrailingSpace,
 } from "~/composerTriggerInsertion";
-import { formatComposerMentionToken, skillMentionPrefix } from "~/lib/composerMentions";
+import {
+  composerMentionPathNeedsQuoting,
+  formatComposerMentionToken,
+  skillMentionPrefix,
+} from "~/lib/composerMentions";
 import type { TerminalContextDraft } from "~/lib/terminalContext";
 import { useComposerDraftStore } from "../../composerDraftStore";
 import {
@@ -217,7 +221,7 @@ export function useKanbanTaskComposerEditor(input: UseKanbanTaskComposerEditorIn
       const withTrailingSeparator = absolutePath.endsWith(separator)
         ? absolutePath
         : `${absolutePath}${separator}`;
-      const base = /\s/.test(withTrailingSeparator)
+      const base = composerMentionPathNeedsQuoting(withTrailingSeparator)
         ? `@"${withTrailingSeparator}`
         : `@${withTrailingSeparator}`;
       applyComposerTriggerReplacement({ snapshot, trigger, base });

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -194,6 +194,18 @@ describe("detectComposerTrigger", () => {
     });
   });
 
+  it("keeps escaped quotes, backslashes, and @ signs inside an active quoted path", () => {
+    const text = String.raw`Look at @"C:\\A \"B\"/@scope`;
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "mention",
+      query: String.raw`C:\A "B"/@scope`,
+      rangeStart: "Look at ".length,
+      rangeEnd: text.length,
+    });
+  });
+
   it('does not treat a closed @"..." mention as still active', () => {
     const text = 'Look at @"/Users/John Smith/Docs" and more';
     const trigger = detectComposerTrigger(text, text.length);

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -1,5 +1,9 @@
 import { splitPromptIntoComposerSegments } from "./composer-editor-mentions";
 import { isBuiltInComposerSlashCommand, type ComposerSlashCommand } from "./composerSlashCommands";
+import {
+  composerMentionQuotedPathHasClosingQuote,
+  decodeComposerMentionQuotedPath,
+} from "./lib/composerMentions";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
 
 export type ComposerTriggerKind = "mention" | "slash-command" | "slash-model" | "skill";
@@ -362,10 +366,10 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
   const quotedMentionStart = linePrefix.lastIndexOf('@"');
   if (quotedMentionStart !== -1) {
     const afterOpen = linePrefix.slice(quotedMentionStart + 2);
-    if (!afterOpen.includes("@") && !afterOpen.includes('"')) {
+    if (!composerMentionQuotedPathHasClosingQuote(afterOpen)) {
       return {
         kind: "mention",
-        query: afterOpen,
+        query: decodeComposerMentionQuotedPath(afterOpen),
         rangeStart: lineStart + quotedMentionStart,
         rangeEnd: cursor,
       };

--- a/apps/web/src/hooks/useComposerDropzone.ts
+++ b/apps/web/src/hooks/useComposerDropzone.ts
@@ -6,7 +6,7 @@
 import { useCallback, useRef, type ClipboardEvent, type DragEvent } from "react";
 
 import { CHAT_FILE_REFERENCE_DRAG_TYPE } from "~/lib/chatReferences";
-import { splitDroppedComposerFiles } from "~/lib/composerDropPaths";
+import { isDroppedComposerDirectory, splitDroppedComposerFiles } from "~/lib/composerDropPaths";
 
 export function isComposerHandledDrag(dataTransfer: DataTransfer): boolean {
   return (
@@ -107,7 +107,10 @@ function isComposerHandledDragForMode(
   if (items.length === 0) {
     return true;
   }
-  return items.some((item) => item.kind === "file" && item.type.startsWith("image/"));
+  return items.some(
+    (item) =>
+      item.kind === "file" && (item.type.startsWith("image/") || isDroppedComposerDirectory(item)),
+  );
 }
 
 export function useComposerDropzone(input: {
@@ -224,7 +227,10 @@ export function useComposerDropzone(input: {
       }
       // Desktop OS drops: resolve absolute paths so folders become @mentions
       // instead of unreadable attachment blobs (#351).
-      const dropped = splitDroppedComposerFiles(event.dataTransfer.files);
+      const dropped = splitDroppedComposerFiles({
+        files: event.dataTransfer.files,
+        items: event.dataTransfer.items,
+      });
       const splitFiles = {
         imageFiles: dropped.imageFiles,
         genericFiles: dropped.genericFiles,

--- a/apps/web/src/hooks/useComposerDropzone.ts
+++ b/apps/web/src/hooks/useComposerDropzone.ts
@@ -6,6 +6,7 @@
 import { useCallback, useRef, type ClipboardEvent, type DragEvent } from "react";
 
 import { CHAT_FILE_REFERENCE_DRAG_TYPE } from "~/lib/chatReferences";
+import { splitDroppedComposerFiles } from "~/lib/composerDropPaths";
 
 export function isComposerHandledDrag(dataTransfer: DataTransfer): boolean {
   return (
@@ -124,12 +125,20 @@ export function useComposerDropzone(input: {
         readonly genericFiles: "fallthrough";
       };
   readonly appendReferenceText?: ((text: string) => void) | undefined;
+  /** Absolute paths from desktop OS drops that should become @mentions (folders). */
+  readonly appendPathMentions?: ((paths: readonly string[]) => void) | undefined;
   readonly focusComposer?: (() => void) | undefined;
   readonly dragDepthRef?: { current: number } | undefined;
   readonly setIsDragOverComposer: (dragging: boolean) => void;
 }) {
-  const { addImages, fileSupport, appendReferenceText, focusComposer, setIsDragOverComposer } =
-    input;
+  const {
+    addImages,
+    fileSupport,
+    appendReferenceText,
+    appendPathMentions,
+    focusComposer,
+    setIsDragOverComposer,
+  } = input;
   const internalDragDepthRef = useRef(0);
   const dragDepthRef = input.dragDepthRef ?? internalDragDepthRef;
 
@@ -213,8 +222,18 @@ export function useComposerDropzone(input: {
       if (!event.dataTransfer.types.includes("Files")) {
         return;
       }
-      const splitFiles = splitComposerDropzoneFiles(event.dataTransfer.files);
-      if (shouldResetComposerDropzoneAfterUnhandledFileDrop(splitFiles, fileSupport.genericFiles)) {
+      // Desktop OS drops: resolve absolute paths so folders become @mentions
+      // instead of unreadable attachment blobs (#351).
+      const dropped = splitDroppedComposerFiles(event.dataTransfer.files);
+      const splitFiles = {
+        imageFiles: dropped.imageFiles,
+        genericFiles: dropped.genericFiles,
+      };
+      const hasPathMentions = dropped.pathMentions.length > 0;
+      if (
+        !hasPathMentions &&
+        shouldResetComposerDropzoneAfterUnhandledFileDrop(splitFiles, fileSupport.genericFiles)
+      ) {
         if (shouldPreventDefaultForUnhandledFileDrop(splitFiles, fileSupport.genericFiles)) {
           event.preventDefault();
         }
@@ -223,10 +242,14 @@ export function useComposerDropzone(input: {
       }
       event.preventDefault();
       resetComposerDragState();
+      if (hasPathMentions) {
+        appendPathMentions?.(dropped.pathMentions);
+      }
       handleSplitFiles(splitFiles);
       focusComposer?.();
     },
     [
+      appendPathMentions,
       appendReferenceText,
       fileSupport.genericFiles,
       focusComposer,

--- a/apps/web/src/lib/composerDropPaths.test.ts
+++ b/apps/web/src/lib/composerDropPaths.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi, afterEach } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
-  isLikelyDroppedDirectory,
+  isDroppedComposerDirectory,
   resolveDroppedFileAbsolutePath,
   splitDroppedComposerFiles,
+  type ComposerDroppedFileItem,
 } from "./composerDropPaths";
 
 function makeFile(name: string, options?: { type?: string; size?: number }): File {
@@ -13,39 +14,48 @@ function makeFile(name: string, options?: { type?: string; size?: number }): Fil
   return new File([blob], name, { type });
 }
 
+function makeItem(file: File, options?: { directory?: boolean; entryUnavailable?: boolean }) {
+  return {
+    kind: "file",
+    getAsFile: () => file,
+    ...(options?.entryUnavailable
+      ? {}
+      : { webkitGetAsEntry: () => ({ isDirectory: options?.directory === true }) }),
+  } satisfies ComposerDroppedFileItem;
+}
+
 describe("composerDropPaths", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("resolves absolute paths via the desktop bridge", () => {
+  it("resolves absolute paths via the desktop bridge without rewriting path bytes", () => {
     vi.stubGlobal("window", {
       desktopBridge: {
-        getPathForFile: (file: File) => `/Users/me/Mac (2)/${file.name}`,
+        getPathForFile: () => " /Users/me/Mac (2)/Docs ",
       },
     });
-    const file = makeFile("Docs");
-    expect(resolveDroppedFileAbsolutePath(file)).toBe("/Users/me/Mac (2)/Docs");
+
+    expect(resolveDroppedFileAbsolutePath(makeFile("Docs"))).toBe(" /Users/me/Mac (2)/Docs ");
   });
 
-  it("returns null when the desktop bridge is unavailable", () => {
+  it("returns null when the desktop bridge is unavailable or returns only whitespace", () => {
     vi.stubGlobal("window", {});
+    expect(resolveDroppedFileAbsolutePath(makeFile("Docs"))).toBeNull();
+
+    vi.stubGlobal("window", { desktopBridge: { getPathForFile: () => "   " } });
     expect(resolveDroppedFileAbsolutePath(makeFile("Docs"))).toBeNull();
   });
 
-  it("treats zero-size empty-type drops with a path as directories (#351)", () => {
-    expect(
-      isLikelyDroppedDirectory(makeFile("project-space", { size: 0, type: "" }), "/tmp/a b/dir"),
-    ).toBe(true);
-    expect(
-      isLikelyDroppedDirectory(
-        makeFile("notes.txt", { size: 12, type: "text/plain" }),
-        "/tmp/a b/notes.txt",
-      ),
-    ).toBe(false);
+  it("identifies directories from the drag entry instead of file size or MIME type", () => {
+    const emptyFile = makeFile(".gitkeep");
+
+    expect(isDroppedComposerDirectory(makeItem(emptyFile, { directory: true }))).toBe(true);
+    expect(isDroppedComposerDirectory(makeItem(emptyFile))).toBe(false);
+    expect(isDroppedComposerDirectory(makeItem(emptyFile, { entryUnavailable: true }))).toBe(false);
   });
 
-  it("splits directory drops into path mentions and keeps regular files as attachments", () => {
+  it("splits explicit directory drops into mentions and keeps normal files as attachments", () => {
     vi.stubGlobal("window", {
       desktopBridge: {
         getPathForFile: (file: File) => {
@@ -56,13 +66,40 @@ describe("composerDropPaths", () => {
         },
       },
     });
-    const folder = makeFile("project-space", { size: 0, type: "" });
+    const folder = makeFile("project-space");
     const image = makeFile("shot.png", { size: 32, type: "image/png" });
     const doc = makeFile("readme.md", { size: 16, type: "text/markdown" });
 
-    const split = splitDroppedComposerFiles([folder, image, doc]);
+    const split = splitDroppedComposerFiles({
+      files: [folder, image, doc],
+      items: [makeItem(folder, { directory: true }), makeItem(image), makeItem(doc)],
+    });
     expect(split.pathMentions).toEqual(["/Users/me/Happy Dropbox/Mac (2)/project-space"]);
-    expect(split.imageFiles.map((file) => file.name)).toEqual(["shot.png"]);
-    expect(split.genericFiles.map((file) => file.name)).toEqual(["readme.md"]);
+    expect(split.imageFiles).toEqual([image]);
+    expect(split.genericFiles).toEqual([doc]);
+  });
+
+  it("keeps genuine empty files when directory metadata is absent", () => {
+    vi.stubGlobal("window", {
+      desktopBridge: { getPathForFile: () => "/Users/me/.gitkeep" },
+    });
+    const emptyFile = makeFile(".gitkeep");
+
+    expect(
+      splitDroppedComposerFiles({
+        files: [emptyFile],
+        items: [makeItem(emptyFile, { entryUnavailable: true })],
+      }),
+    ).toEqual({ pathMentions: [], imageFiles: [], genericFiles: [emptyFile] });
+  });
+
+  it("falls back to the FileList when drag items are unavailable", () => {
+    const emptyFile = makeFile("empty");
+
+    expect(splitDroppedComposerFiles({ files: [emptyFile] })).toEqual({
+      pathMentions: [],
+      imageFiles: [],
+      genericFiles: [emptyFile],
+    });
   });
 });

--- a/apps/web/src/lib/composerDropPaths.test.ts
+++ b/apps/web/src/lib/composerDropPaths.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import {
+  isLikelyDroppedDirectory,
+  resolveDroppedFileAbsolutePath,
+  splitDroppedComposerFiles,
+} from "./composerDropPaths";
+
+function makeFile(name: string, options?: { type?: string; size?: number }): File {
+  const size = options?.size ?? 0;
+  const type = options?.type ?? "";
+  const blob = new Blob([size > 0 ? "x".repeat(size) : ""], { type });
+  return new File([blob], name, { type });
+}
+
+describe("composerDropPaths", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves absolute paths via the desktop bridge", () => {
+    vi.stubGlobal("window", {
+      desktopBridge: {
+        getPathForFile: (file: File) => `/Users/me/Mac (2)/${file.name}`,
+      },
+    });
+    const file = makeFile("Docs");
+    expect(resolveDroppedFileAbsolutePath(file)).toBe("/Users/me/Mac (2)/Docs");
+  });
+
+  it("returns null when the desktop bridge is unavailable", () => {
+    vi.stubGlobal("window", {});
+    expect(resolveDroppedFileAbsolutePath(makeFile("Docs"))).toBeNull();
+  });
+
+  it("treats zero-size empty-type drops with a path as directories (#351)", () => {
+    expect(
+      isLikelyDroppedDirectory(makeFile("project-space", { size: 0, type: "" }), "/tmp/a b/dir"),
+    ).toBe(true);
+    expect(
+      isLikelyDroppedDirectory(
+        makeFile("notes.txt", { size: 12, type: "text/plain" }),
+        "/tmp/a b/notes.txt",
+      ),
+    ).toBe(false);
+  });
+
+  it("splits directory drops into path mentions and keeps regular files as attachments", () => {
+    vi.stubGlobal("window", {
+      desktopBridge: {
+        getPathForFile: (file: File) => {
+          if (file.name === "project-space") {
+            return "/Users/me/Happy Dropbox/Mac (2)/project-space";
+          }
+          return `/Users/me/${file.name}`;
+        },
+      },
+    });
+    const folder = makeFile("project-space", { size: 0, type: "" });
+    const image = makeFile("shot.png", { size: 32, type: "image/png" });
+    const doc = makeFile("readme.md", { size: 16, type: "text/markdown" });
+
+    const split = splitDroppedComposerFiles([folder, image, doc]);
+    expect(split.pathMentions).toEqual(["/Users/me/Happy Dropbox/Mac (2)/project-space"]);
+    expect(split.imageFiles.map((file) => file.name)).toEqual(["shot.png"]);
+    expect(split.genericFiles.map((file) => file.name)).toEqual(["readme.md"]);
+  });
+});

--- a/apps/web/src/lib/composerDropPaths.ts
+++ b/apps/web/src/lib/composerDropPaths.ts
@@ -3,6 +3,12 @@
 //          when a drop should become a path mention instead of a byte attachment.
 // Layer: Web composer utility (desktop-aware)
 
+export interface ComposerDroppedFileItem {
+  readonly kind: string;
+  readonly getAsFile: () => File | null;
+  readonly webkitGetAsEntry?: (() => { readonly isDirectory?: boolean } | null) | undefined;
+}
+
 /**
  * Best-effort absolute path for a File from a drag/drop or file picker.
  * On Electron, uses `webUtils.getPathForFile` via the desktop bridge.
@@ -15,58 +21,74 @@ export function resolveDroppedFileAbsolutePath(file: File): string | null {
   }
   try {
     const path = getPath(file);
-    if (typeof path !== "string") {
+    if (typeof path !== "string" || path.trim().length === 0) {
       return null;
     }
-    const trimmed = path.trim();
-    return trimmed.length > 0 ? trimmed : null;
+    return path;
   } catch {
     return null;
   }
 }
 
-/**
- * Heuristic for directory drops from Finder/Explorer: empty type, zero size,
- * and an absolute path from the desktop bridge. Real empty files are rare in
- * composer drops; folders cannot be read as attachment blobs (#351).
- */
-export function isLikelyDroppedDirectory(file: File, absolutePath: string | null): boolean {
-  if (!absolutePath) {
+/** Chromium exposes directory identity on the drag item, not reliably on File. */
+export function isDroppedComposerDirectory(item: ComposerDroppedFileItem | undefined): boolean {
+  if (!item || item.kind !== "file" || typeof item.webkitGetAsEntry !== "function") {
     return false;
   }
-  if (file.type.startsWith("image/")) {
+  try {
+    return item.webkitGetAsEntry()?.isDirectory === true;
+  } catch {
     return false;
   }
-  // Chromium often reports directories with empty type and size 0.
-  if (file.size === 0 && (file.type === "" || file.type === "application/x-directory")) {
-    return true;
-  }
-  // Path ends with a separator (some OS drags).
-  if (/[/\\]$/.test(absolutePath)) {
-    return true;
-  }
-  return false;
 }
 
-export function splitDroppedComposerFiles(files: Iterable<File>): {
+function getDroppedItemFile(item: ComposerDroppedFileItem | undefined): File | null {
+  if (!item) {
+    return null;
+  }
+  try {
+    return item.getAsFile();
+  } catch {
+    return null;
+  }
+}
+
+export function splitDroppedComposerFiles(input: {
+  readonly files: Iterable<File>;
+  readonly items?: Iterable<ComposerDroppedFileItem>;
+}): {
   readonly pathMentions: string[];
   readonly imageFiles: File[];
   readonly genericFiles: File[];
 } {
+  const fallbackFiles = Array.from(input.files);
+  const fileItems = input.items
+    ? Array.from(input.items).filter((item) => item.kind === "file")
+    : [];
   const pathMentions: string[] = [];
   const imageFiles: File[] = [];
   const genericFiles: File[] = [];
   const seenPaths = new Set<string>();
+  const itemCount = Math.max(fallbackFiles.length, fileItems.length);
 
-  for (const file of files) {
-    const absolutePath = resolveDroppedFileAbsolutePath(file);
-    if (isLikelyDroppedDirectory(file, absolutePath) && absolutePath) {
-      if (!seenPaths.has(absolutePath)) {
-        seenPaths.add(absolutePath);
-        pathMentions.push(absolutePath);
-      }
+  for (let index = 0; index < itemCount; index += 1) {
+    const item = fileItems[index];
+    const file = getDroppedItemFile(item) ?? fallbackFiles[index];
+    if (!file) {
       continue;
     }
+
+    if (isDroppedComposerDirectory(item)) {
+      const absolutePath = resolveDroppedFileAbsolutePath(file);
+      if (absolutePath) {
+        if (!seenPaths.has(absolutePath)) {
+          seenPaths.add(absolutePath);
+          pathMentions.push(absolutePath);
+        }
+        continue;
+      }
+    }
+
     if (file.type.startsWith("image/")) {
       imageFiles.push(file);
     } else {

--- a/apps/web/src/lib/composerDropPaths.ts
+++ b/apps/web/src/lib/composerDropPaths.ts
@@ -1,0 +1,78 @@
+// FILE: composerDropPaths.ts
+// Purpose: Resolve absolute paths for OS-dropped files on desktop and decide
+//          when a drop should become a path mention instead of a byte attachment.
+// Layer: Web composer utility (desktop-aware)
+
+/**
+ * Best-effort absolute path for a File from a drag/drop or file picker.
+ * On Electron, uses `webUtils.getPathForFile` via the desktop bridge.
+ */
+export function resolveDroppedFileAbsolutePath(file: File): string | null {
+  const bridge = typeof window !== "undefined" ? window.desktopBridge : undefined;
+  const getPath = bridge?.getPathForFile;
+  if (typeof getPath !== "function") {
+    return null;
+  }
+  try {
+    const path = getPath(file);
+    if (typeof path !== "string") {
+      return null;
+    }
+    const trimmed = path.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Heuristic for directory drops from Finder/Explorer: empty type, zero size,
+ * and an absolute path from the desktop bridge. Real empty files are rare in
+ * composer drops; folders cannot be read as attachment blobs (#351).
+ */
+export function isLikelyDroppedDirectory(file: File, absolutePath: string | null): boolean {
+  if (!absolutePath) {
+    return false;
+  }
+  if (file.type.startsWith("image/")) {
+    return false;
+  }
+  // Chromium often reports directories with empty type and size 0.
+  if (file.size === 0 && (file.type === "" || file.type === "application/x-directory")) {
+    return true;
+  }
+  // Path ends with a separator (some OS drags).
+  if (/[/\\]$/.test(absolutePath)) {
+    return true;
+  }
+  return false;
+}
+
+export function splitDroppedComposerFiles(files: Iterable<File>): {
+  readonly pathMentions: string[];
+  readonly imageFiles: File[];
+  readonly genericFiles: File[];
+} {
+  const pathMentions: string[] = [];
+  const imageFiles: File[] = [];
+  const genericFiles: File[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const file of files) {
+    const absolutePath = resolveDroppedFileAbsolutePath(file);
+    if (isLikelyDroppedDirectory(file, absolutePath) && absolutePath) {
+      if (!seenPaths.has(absolutePath)) {
+        seenPaths.add(absolutePath);
+        pathMentions.push(absolutePath);
+      }
+      continue;
+    }
+    if (file.type.startsWith("image/")) {
+      imageFiles.push(file);
+    } else {
+      genericFiles.push(file);
+    }
+  }
+
+  return { pathMentions, imageFiles, genericFiles };
+}

--- a/apps/web/src/lib/composerMentions.test.ts
+++ b/apps/web/src/lib/composerMentions.test.ts
@@ -83,4 +83,17 @@ describe("formatComposerMentionToken", () => {
   it("quotes mention tokens with whitespace", () => {
     expect(formatComposerMentionToken("Google Drive")).toBe('@"Google Drive"');
   });
+
+  it("quotes paths with parentheses so they stay one mention token (#351)", () => {
+    expect(formatComposerMentionToken("/Users/me/Mac (2)/Projects")).toBe(
+      '@"/Users/me/Mac (2)/Projects"',
+    );
+    expect(formatComposerMentionToken("/Users/me/Happy Dropbox/Mac (2)/app")).toBe(
+      '@"/Users/me/Happy Dropbox/Mac (2)/app"',
+    );
+  });
+
+  it("leaves simple paths unquoted", () => {
+    expect(formatComposerMentionToken("/Users/me/projects/app")).toBe("@/Users/me/projects/app");
+  });
 });

--- a/apps/web/src/lib/composerMentions.test.ts
+++ b/apps/web/src/lib/composerMentions.test.ts
@@ -123,4 +123,17 @@ describe("formatComposerMentionToken", () => {
   it("escapes embedded quotes and backslashes in quoted tokens", () => {
     expect(formatComposerMentionToken(String.raw`C:\A "B"`)).toBe(String.raw`@"C:\\A \"B\""`);
   });
+
+  it("parses an unclosed quote followed by a backslash run in linear time (no ReDoS)", () => {
+    // Regression guard: with an ambiguous escape alternation this backtracks
+    // exponentially and the test times out instead of finishing instantly.
+    const attack = `@"${"\\".repeat(512)}x no closing quote`;
+    const matches = [
+      ...attack.matchAll(createComposerMentionTokenRegex({ includeTrailingTokenAtEnd: true })),
+    ];
+    // Without a closing quote only the unquoted fallback token matches.
+    expect(matches.map((match) => extractComposerMentionPath(match))).toEqual([
+      `"${"\\".repeat(512)}x`,
+    ]);
+  });
 });

--- a/apps/web/src/lib/composerMentions.test.ts
+++ b/apps/web/src/lib/composerMentions.test.ts
@@ -5,11 +5,24 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createComposerMentionTokenRegex,
+  extractComposerMentionPath,
   filterPromptProviderMentionReferences,
   filterPromptSkillReferences,
   formatComposerMentionToken,
   resolveMentionChipKind,
 } from "./composerMentions";
+
+function parseMentionToken(token: string): string {
+  const match = createComposerMentionTokenRegex({
+    includeTrailingTokenAtEnd: true,
+    global: false,
+  }).exec(token);
+  if (!match) {
+    throw new Error(`Expected a valid composer mention token: ${token}`);
+  }
+  return extractComposerMentionPath(match);
+}
 
 describe("composer mention reference filtering", () => {
   it("does not invent plugin references for plain file or folder mentions", () => {
@@ -95,5 +108,19 @@ describe("formatComposerMentionToken", () => {
 
   it("leaves simple paths unquoted", () => {
     expect(formatComposerMentionToken("/Users/me/projects/app")).toBe("@/Users/me/projects/app");
+  });
+
+  it.each([
+    "/Users/me/Happy Dropbox/Mac (2)/app",
+    String.raw`C:\Users\me\Project (2)`,
+    '/tmp/A "B"/repo',
+    "/Users/me/@scope/package",
+    " /tmp/path with edge whitespace ",
+  ])("round-trips quoted path bytes for %s", (path) => {
+    expect(parseMentionToken(formatComposerMentionToken(path))).toBe(path);
+  });
+
+  it("escapes embedded quotes and backslashes in quoted tokens", () => {
+    expect(formatComposerMentionToken(String.raw`C:\A "B"`)).toBe(String.raw`@"C:\\A \"B\""`);
   });
 });

--- a/apps/web/src/lib/composerMentions.ts
+++ b/apps/web/src/lib/composerMentions.ts
@@ -9,7 +9,10 @@ export function skillMentionPrefix(provider: string): string {
   return provider === "pi" ? "/skill:" : "/";
 }
 
-const QUOTED_MENTION_PATH_SOURCE = String.raw`((?:\\["\\]|[^"])*)`;
+// The alternation must be unambiguous — a backslash may only match the escape
+// branch — or unclosed `@"` + a backslash run backtracks exponentially on the
+// per-keystroke composer parse (ReDoS).
+const QUOTED_MENTION_PATH_SOURCE = String.raw`((?:\\.|[^"\\])*)`;
 
 export function createComposerMentionTokenRegex(options: {
   includeTrailingTokenAtEnd: boolean;

--- a/apps/web/src/lib/composerMentions.ts
+++ b/apps/web/src/lib/composerMentions.ts
@@ -24,9 +24,21 @@ export function extractComposerMentionPath(match: RegExpExecArray | RegExpMatchA
   return (match[2] ?? match[3] ?? "").trim();
 }
 
+/**
+ * Paths that need quoting so spaces, parentheses, and shell-ish characters
+ * stay a single mention token (#351). Prefer quoting over relying on the
+ * unquoted `[^()\s@]+` trigger form.
+ */
+export function composerMentionPathNeedsQuoting(path: string): boolean {
+  return /[\s()"'`$\\]/.test(path);
+}
+
 export function formatComposerMentionToken(path: string): string {
   const normalizedPath = path.startsWith("@") ? path.slice(1) : path;
-  return /\s/.test(normalizedPath) ? `@"${normalizedPath}"` : `@${normalizedPath}`;
+  // Quoted form matches createComposerMentionTokenRegex: @"..." (no escapes inside).
+  return composerMentionPathNeedsQuoting(normalizedPath)
+    ? `@"${normalizedPath}"`
+    : `@${normalizedPath}`;
 }
 
 function escapeRegExp(value: string): string {

--- a/apps/web/src/lib/composerMentions.ts
+++ b/apps/web/src/lib/composerMentions.ts
@@ -9,19 +9,44 @@ export function skillMentionPrefix(provider: string): string {
   return provider === "pi" ? "/skill:" : "/";
 }
 
+const QUOTED_MENTION_PATH_SOURCE = String.raw`((?:\\["\\]|[^"])*)`;
+
 export function createComposerMentionTokenRegex(options: {
   includeTrailingTokenAtEnd: boolean;
   global?: boolean;
 }): RegExp {
   const suffix = options.includeTrailingTokenAtEnd ? "(?=\\s|$)" : "(?=\\s)";
   return new RegExp(
-    `(^|\\s)@(?:"([^"]+)"|([^\\s@]+))${suffix}`,
+    `(^|\\s)@(?:"${QUOTED_MENTION_PATH_SOURCE}"|([^\\s@]+))${suffix}`,
     options.global === false ? "" : "g",
   );
 }
 
+export function decodeComposerMentionQuotedPath(path: string): string {
+  return path.replace(/\\(["\\])/g, "$1");
+}
+
 export function extractComposerMentionPath(match: RegExpExecArray | RegExpMatchArray): string {
-  return (match[2] ?? match[3] ?? "").trim();
+  return match[2] === undefined ? (match[3] ?? "") : decodeComposerMentionQuotedPath(match[2]);
+}
+
+export function composerMentionQuotedPathHasClosingQuote(path: string): boolean {
+  let precedingBackslashes = 0;
+  for (const character of path) {
+    if (character === "\\") {
+      precedingBackslashes += 1;
+      continue;
+    }
+    if (character === '"' && precedingBackslashes % 2 === 0) {
+      return true;
+    }
+    precedingBackslashes = 0;
+  }
+  return false;
+}
+
+function encodeComposerMentionQuotedPath(path: string): string {
+  return path.replace(/["\\]/g, "\\$&");
 }
 
 /**
@@ -30,14 +55,13 @@ export function extractComposerMentionPath(match: RegExpExecArray | RegExpMatchA
  * unquoted `[^()\s@]+` trigger form.
  */
 export function composerMentionPathNeedsQuoting(path: string): boolean {
-  return /[\s()"'`$\\]/.test(path);
+  return /[\s()@"'`$\\]/.test(path);
 }
 
 export function formatComposerMentionToken(path: string): string {
   const normalizedPath = path.startsWith("@") ? path.slice(1) : path;
-  // Quoted form matches createComposerMentionTokenRegex: @"..." (no escapes inside).
   return composerMentionPathNeedsQuoting(normalizedPath)
-    ? `@"${normalizedPath}"`
+    ? `@"${encodeComposerMentionQuotedPath(normalizedPath)}"`
     : `@${normalizedPath}`;
 }
 

--- a/apps/web/src/lib/composerSend.test.ts
+++ b/apps/web/src/lib/composerSend.test.ts
@@ -12,6 +12,7 @@ import {
   effectiveComposerAttachmentCount,
   findPendingBlobComposerAttachments,
   hydratePendingBlobComposerAttachments,
+  readFileAsDataUrl,
 } from "./composerSend";
 
 describe("composerSend attachment builders", () => {
@@ -23,6 +24,7 @@ describe("composerSend attachment builders", () => {
 
   afterEach(() => {
     URL.createObjectURL = originalCreateObjectUrl;
+    vi.unstubAllGlobals();
   });
 
   it("keeps image-specific unsupported-file errors while sharing cap handling", () => {
@@ -77,6 +79,34 @@ describe("composerSend attachment builders", () => {
     expect(result.files).toEqual([]);
     expect(result.error).toBe(
       `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} references per message.`,
+    );
+  });
+
+  it("reads genuine empty files instead of treating them as folders", async () => {
+    vi.stubGlobal(
+      "FileReader",
+      class {
+        result: string | null = null;
+        error: Error | null = null;
+        private readonly listeners = new Map<string, Array<() => void>>();
+
+        addEventListener(type: string, listener: () => void) {
+          const listeners = this.listeners.get(type) ?? [];
+          listeners.push(listener);
+          this.listeners.set(type, listeners);
+        }
+
+        readAsDataURL() {
+          this.result = "data:application/octet-stream;base64,";
+          for (const listener of this.listeners.get("load") ?? []) {
+            listener();
+          }
+        }
+      },
+    );
+
+    await expect(readFileAsDataUrl(new File([], ".gitkeep"))).resolves.toBe(
+      "data:application/octet-stream;base64,",
     );
   });
 });

--- a/apps/web/src/lib/composerSend.ts
+++ b/apps/web/src/lib/composerSend.ts
@@ -131,6 +131,16 @@ export function buildComposerFileAttachmentsFromFiles(input: {
 
 export function readFileAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
+    // Directories (and other non-readable drops) fail here with a native Cocoa
+    // error on macOS desktop. Surface a clear composer-facing message (#351).
+    if (file.size === 0 && (file.type === "" || file.type === "application/x-directory")) {
+      reject(
+        new Error(
+          `Could not read '${file.name || "item"}'. Folders cannot be attached as files — drop them to insert a path mention, or attach individual files.`,
+        ),
+      );
+      return;
+    }
     const reader = new FileReader();
     reader.addEventListener("load", () => {
       if (typeof reader.result === "string") {
@@ -140,6 +150,21 @@ export function readFileAsDataUrl(file: File): Promise<string> {
       reject(new Error("Could not read attachment data."));
     });
     reader.addEventListener("error", () => {
+      const nativeMessage =
+        reader.error instanceof Error && reader.error.message.trim().length > 0
+          ? reader.error.message
+          : null;
+      if (
+        nativeMessage &&
+        /could not be found at the time an operation was processed/i.test(nativeMessage)
+      ) {
+        reject(
+          new Error(
+            `Could not read '${file.name || "item"}'. Paths with spaces or special characters may need a path mention (@\"…\") instead of a file attachment.`,
+          ),
+        );
+        return;
+      }
       reject(reader.error ?? new Error("Failed to read attachment."));
     });
     reader.readAsDataURL(file);

--- a/apps/web/src/lib/composerSend.ts
+++ b/apps/web/src/lib/composerSend.ts
@@ -131,16 +131,6 @@ export function buildComposerFileAttachmentsFromFiles(input: {
 
 export function readFileAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
-    // Directories (and other non-readable drops) fail here with a native Cocoa
-    // error on macOS desktop. Surface a clear composer-facing message (#351).
-    if (file.size === 0 && (file.type === "" || file.type === "application/x-directory")) {
-      reject(
-        new Error(
-          `Could not read '${file.name || "item"}'. Folders cannot be attached as files — drop them to insert a path mention, or attach individual files.`,
-        ),
-      );
-      return;
-    }
     const reader = new FileReader();
     reader.addEventListener("load", () => {
       if (typeof reader.result === "string") {

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -396,6 +396,11 @@ export interface SynaraStorageSnapshot {
 
 export interface DesktopBridge {
   getWsUrl: () => string | null;
+  /**
+   * Absolute filesystem path for a File from drag/drop or file inputs.
+   * Electron only (`webUtils.getPathForFile`). Returns null when unavailable.
+   */
+  getPathForFile?: (file: File) => string | null;
   pickFolder: () => Promise<string | null>;
   saveFile?: (input: {
     defaultFilename: string;


### PR DESCRIPTION
## Summary

Paths with **spaces or parentheses** (and OS-dropped **folders**) no longer fail as unreadable attachments. They become properly quoted `@path` mentions on desktop.

Closes #351

## Problem

Dragging a folder/path like `/Users/…/Happy Dropbox/Mac (2)/…` into the composer could surface the native macOS error:

> A requested file or directory could not be found at the time an operation was processed.

Root causes:

1. External Finder drops were treated only as **byte attachments** (no absolute path).
2. **Folders** cannot be `FileReader`’d; Cocoa reports a native not-found error.
3. Mention formatting only quoted **whitespace**, so parentheses-only path segments stayed fragile in browse/insert flows.

## Solution

| Area | Change |
|------|--------|
| Mentions | Quote paths containing spaces, `()`, and shell-ish chars (`formatComposerMentionToken`) |
| Local folder browse | Unclosed `@"…` while navigating special-char paths |
| Desktop bridge | `getPathForFile` via Electron `webUtils` |
| OS drop | Directories → `@path` mention; real files still attach |
| Attachment read | Clear error instead of raw Cocoa message when a folder/blob can’t be read |

## Evidence

| Before | After |
|--------|--------|
| Folder drop → FileReader / Cocoa error | Folder drop → `@"/…/Mac (2)/…"` mention |
| `formatComposerMentionToken("…/Mac (2)/…")` unquoted | Quoted `@"…"` token |
| Opaque native error on send | Friendly “folders cannot be attached as files…” message |

## Test plan

- [x] `bunx vitest run apps/web/src/lib/composerMentions.test.ts`
- [x] `bunx vitest run apps/web/src/lib/composerDropPaths.test.ts`
- [x] `bunx vitest run apps/web/src/lib/composerSend.test.ts` / `composer-logic.test.ts` / `useComposerDropzone.test.ts`
- [ ] Manual (desktop): drop a folder with spaces + parens into the composer; confirm a quoted path mention is inserted and send does not show the Cocoa error

## Files

- `apps/web/src/lib/composerMentions.ts` (+ tests)
- `apps/web/src/lib/composerDropPaths.ts` (+ tests)
- `apps/web/src/hooks/useComposerDropzone.ts`
- `apps/web/src/lib/composerSend.ts`
- `apps/web/src/components/ChatView.tsx`
- `apps/web/src/components/kanban/*`
- `apps/desktop/src/preload.ts`
- `packages/contracts/src/ipc.ts`