### PR TITLE
Fix stale Codex steering fallback

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -212,7 +212,7 @@ describe("ProviderCommandReactor", () => {
         runtimeSessions.push(next);
       }
     };
-    const steerTurn = vi.fn((_: unknown) =>
+    const steerTurn = vi.fn<ProviderServiceShape["steerTurn"]>((_: unknown) =>
       Effect.succeed({
         threadId: ThreadId.makeUnsafe("thread-1"),
         turnId: asTurnId("turn-steer-1"),
@@ -2893,6 +2893,11 @@ describe("ProviderCommandReactor", () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
 
+    harness.setRuntimeSessionTurnState({
+      threadId: "thread-1",
+      status: "running",
+      activeTurnId: asTurnId("turn-running"),
+    });
     await Effect.runPromise(
       harness.engine.dispatch({
         type: "thread.session.set",
@@ -2940,6 +2945,121 @@ describe("ProviderCommandReactor", () => {
       threadId: ThreadId.makeUnsafe("thread-1"),
       input: "pivot now",
       interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+    });
+  });
+
+  it("starts a normal turn when a stale projection requests Codex steering", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-stale-running-steer-codex"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: asTurnId("turn-already-completed"),
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+
+    harness.sendTurn.mockClear();
+    harness.steerTurn.mockClear();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-stale-steer-codex"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("msg-stale-steer-codex"),
+          role: "user",
+          text: "continue after the stale turn",
+          attachments: [],
+        },
+        dispatchMode: "steer",
+        runtimeMode: "approval-required",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.steerTurn).not.toHaveBeenCalled();
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      input: "continue after the stale turn",
+    });
+  });
+
+  it("falls back to a normal turn when Codex finishes during steering", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.setRuntimeSessionTurnState({
+      threadId: "thread-1",
+      status: "running",
+      activeTurnId: asTurnId("turn-finishing-during-steer"),
+    });
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-finishing-steer-codex"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: asTurnId("turn-finishing-during-steer"),
+          lastError: null,
+          updatedAt: now,
+        },
+        createdAt: now,
+      }),
+    );
+    harness.steerTurn.mockImplementationOnce(() => {
+      harness.setRuntimeSessionTurnState({ threadId: "thread-1", status: "ready" });
+      return Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: "codex",
+          method: "turn/steer",
+          detail: "turn/steer failed: no active turn to steer",
+        }),
+      );
+    });
+    harness.sendTurn.mockClear();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-finishing-steer-codex"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("msg-finishing-steer-codex"),
+          role: "user",
+          text: "continue through the race",
+          attachments: [],
+        },
+        dispatchMode: "steer",
+        runtimeMode: "approval-required",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    expect(harness.steerTurn).toHaveBeenCalledTimes(1);
+    expect(harness.sendTurn.mock.calls[0]?.[0]).toMatchObject({
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      input: "continue through the race",
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -1215,10 +1215,6 @@ const make = Effect.gen(function* () {
       });
 
     const captureMessageStartCheckpoint = Effect.gen(function* () {
-      if ((input.dispatchMode ?? "queue") === "steer") {
-        return;
-      }
-
       const currentThread = yield* resolveThread(input.threadId);
       if (!currentThread) {
         return;
@@ -1274,15 +1270,43 @@ const make = Effect.gen(function* () {
         })
         .pipe(Effect.onError(() => cancelPendingStudioBaseline));
     } else if (input.dispatchMode === "steer") {
-      yield* providerService.steerTurn({
-        threadId: input.threadId,
-        ...(normalizedInput ? { input: normalizedInput } : {}),
-        ...(normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
-        ...(input.skills !== undefined ? { skills: input.skills } : {}),
-        ...(input.mentions !== undefined ? { mentions: input.mentions } : {}),
-        ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
-        ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
-      });
+      yield* providerService
+        .steerTurn({
+          threadId: input.threadId,
+          ...(normalizedInput ? { input: normalizedInput } : {}),
+          ...(normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
+          ...(input.skills !== undefined ? { skills: input.skills } : {}),
+          ...(input.mentions !== undefined ? { mentions: input.mentions } : {}),
+          ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
+          ...(input.interactionMode !== undefined
+            ? { interactionMode: input.interactionMode }
+            : {}),
+        })
+        .pipe(
+          Effect.catch((error) =>
+            Effect.gen(function* () {
+              if (yield* hasLiveProviderTurn(input.threadId)) {
+                return yield* Effect.fail(error);
+              }
+
+              // The active turn can settle after the live-state check but before
+              // Codex handles turn/steer. Preserve the submitted message by
+              // starting it as a normal turn once the provider is idle.
+              yield* Effect.logWarning(
+                "provider command reactor falling back after stale steer",
+                {
+                  threadId: input.threadId,
+                  messageId: input.messageId,
+                  error,
+                },
+              );
+              yield* capturePreTurnBaselines;
+              return yield* sendQueuedProviderTurn(normalizedInput).pipe(
+                Effect.onError(() => cancelPendingStudioBaseline),
+              );
+            }),
+          ),
+        );
     } else {
       yield* capturePreTurnBaselines;
       pendingContextBootstrapAttempt =
@@ -1692,13 +1716,14 @@ const make = Effect.gen(function* () {
     }
 
     // The decider routes turn starts from the projected session, which can lag
-    // the runtime: a message dispatched right as another turn begins (e.g. the
-    // gap between a steer interrupt and the steered turn's start) would race a
-    // live provider turn. Codex steers ride the live turn natively; everything
-    // else re-queues and is promoted when the live turn settles.
+    // the runtime in either direction. Only steer Codex when its adapter still
+    // reports a live turn; a stale projected running state must become a normal
+    // turn instead of sending turn/steer to an idle app-server.
     const providerName = thread.session?.providerName ?? thread.modelSelection.provider;
     const isCodexSteer = event.payload.dispatchMode === "steer" && providerName === "codex";
-    if (!isCodexSteer && (yield* hasLiveProviderTurn(event.payload.threadId))) {
+    const hasLiveTurn = yield* hasLiveProviderTurn(event.payload.threadId);
+    const shouldSteerCodex = isCodexSteer && hasLiveTurn;
+    if (!shouldSteerCodex && hasLiveTurn) {
       yield* enqueueQueuedTurnStart(event.payload);
       if (event.payload.dispatchMode === "steer") {
         // Preserve steer semantics: jump the queue (enqueue unshifts steers)
@@ -1711,15 +1736,10 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    // Surface the upcoming work immediately: provider session init can take
-    // seconds (e.g. Cursor), and without an early status the thread reads as
-    // idle until the runtime's first event. Mirrors the message-edit-resend
-    // path. Never touches a live session — a steer turn on a running Codex
-    // session must keep its running state and activeTurnId. Keeps the existing
-    // session's runtimeMode: ensureSessionForThread detects mode changes by
-    // comparing against it, and adopting the requested mode here would mask
-    // the restart.
-    if (thread.session?.status !== "running" && thread.session?.status !== "starting") {
+    // Surface upcoming work immediately and repair stale projected lifecycle
+    // state before dispatch. A genuine live Codex steer keeps the current
+    // running state and activeTurnId.
+    if (!hasLiveTurn) {
       yield* setThreadSession({
         threadId: event.payload.threadId,
         session: {
@@ -1763,8 +1783,7 @@ const make = Effect.gen(function* () {
         : {}),
     }).pipe(Effect.forkScoped);
     const immediateDispatchMode =
-      event.payload.dispatchMode === "steer" &&
-      (thread.session?.providerName ?? thread.modelSelection.provider) !== "codex"
+      event.payload.dispatchMode === "steer" && !shouldSteerCodex
         ? "queue"
         : event.payload.dispatchMode;
     const editResendKey = editResendTurnStartKey(event.payload.threadId, event.payload.messageId);


### PR DESCRIPTION
Fixes Codex steer submissions that race a completed turn.

Synara previously trusted projected session state when choosing `turn/steer`. If the terminal lifecycle update was delayed or missing, Codex rejected the request with `no active turn to steer` and the submitted message became a session error.

The reactor now verifies live provider state before steering, repairs stale projected state, and starts the submitted message as a normal turn when Codex is idle. It also rechecks after a steer failure and falls back if the active turn completed during the request.

Validation: `bun run --cwd apps/server test -- src/orchestration/Layers/ProviderCommandReactor.test.ts` (73 tests passed).