### PR TITLE
fix: replace Pierre side-panel diff headers with Synara chrome

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,7 +31,7 @@
     "@effect/platform-node": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
     "@opencode-ai/sdk": "^1.15.13",
-    "@pierre/diffs": "^1.1.0-beta.16",
+    "@pierre/diffs": "^1.2.12",
     "@xterm/headless": "^6.0.0",
     "effect": "catalog:",
     "node-pty": "^1.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,7 @@
     "@formkit/auto-animate": "^0.9.0",
     "@legendapp/list": "3.0.0-beta.44",
     "@lexical/react": "^0.41.0",
-    "@pierre/diffs": "^1.1.0-beta.16",
+    "@pierre/diffs": "^1.2.12",
     "@synara/contracts": "workspace:*",
     "@synara/shared": "workspace:*",
     "@tabler/icons-react": "^3.44.0",

--- a/apps/web/src/components/DiffPanelFileList.tsx
+++ b/apps/web/src/components/DiffPanelFileList.tsx
@@ -25,9 +25,9 @@ export interface DiffFileChatActions {
 
 const DIFF_FILE_ACTIONS_MENU_ICON_CLASS_NAME = "size-3.5 shrink-0 text-muted-foreground";
 
-// Per-file actions menu rendered inside the diff header, left of the collapse
-// chevron. Marked with data-diff-header-menu so header clicks on it do not
-// toggle the file collapse state.
+// Per-file actions menu rendered in the custom header's trailing slot, left of
+// the collapse chevron. Marked with data-diff-header-menu so header clicks on
+// it do not toggle the file collapse state.
 function DiffFileHeaderActionsMenu(props: { filePath: string; chatActions: DiffFileChatActions }) {
   return (
     <Menu>
@@ -112,16 +112,16 @@ const DiffPanelFileRow = memo(function DiffPanelFileRow(props: {
   const { chatActions, isCollapsed } = props;
   const shouldPreviewImage =
     !isCollapsed && props.workspaceRoot !== null && isSupportedLocalImagePath(filePath);
-  const renderHeaderMetadata = useCallback(
+  const renderHeaderTrailing = useCallback(
     () => (
-      <span style={{ display: "inline-flex", alignItems: "center", gap: "2px" }}>
+      <>
         {chatActions ? (
-          <span data-diff-header-menu="true" style={{ display: "inline-flex" }}>
+          <span data-diff-header-menu="true" className="inline-flex">
             <DiffFileHeaderActionsMenu filePath={filePath} chatActions={chatActions} />
           </span>
         ) : null}
         <DiffFileCollapseChevron collapsed={isCollapsed} />
-      </span>
+      </>
     ),
     [chatActions, filePath, isCollapsed],
   );
@@ -137,7 +137,11 @@ const DiffPanelFileRow = memo(function DiffPanelFileRow(props: {
       if (clickedHeaderMenu) return;
       const clickedHeader = composedPath.some((node: EventTarget) => {
         if (!(node instanceof Element)) return false;
-        return node.hasAttribute("data-diffs-header") || node.hasAttribute("data-file-info");
+        return (
+          node.hasAttribute("data-diff-file-header") ||
+          node.hasAttribute("data-diffs-header") ||
+          node.hasAttribute("data-file-info")
+        );
       });
       if (!clickedHeader) return;
       event.stopPropagation();
@@ -158,7 +162,7 @@ const DiffPanelFileRow = memo(function DiffPanelFileRow(props: {
         diffStyle={props.diffRenderMode === "split" ? "split" : "unified"}
         overflow={props.diffWordWrap ? "wrap" : "scroll"}
         collapsed={props.isCollapsed}
-        renderHeaderMetadata={renderHeaderMetadata}
+        renderHeaderTrailing={renderHeaderTrailing}
       />
       {shouldPreviewImage ? (
         <LocalImagePreview

--- a/apps/web/src/components/chat/FileDiffHeader.tsx
+++ b/apps/web/src/components/chat/FileDiffHeader.tsx
@@ -36,9 +36,7 @@ export const FileDiffHeader = memo(function FileDiffHeader(props: {
       ? splitRepoRelativePath(stripPatchPathPrefix(props.fileDiff.prevName)).name
       : null;
   const prevPath =
-    isRename && props.fileDiff.prevName
-      ? stripPatchPathPrefix(props.fileDiff.prevName)
-      : null;
+    isRename && props.fileDiff.prevName ? stripPatchPathPrefix(props.fileDiff.prevName) : null;
   const stat = useMemo(() => summarizeFileDiffStats([props.fileDiff]), [props.fileDiff]);
 
   return (

--- a/apps/web/src/components/chat/FileDiffHeader.tsx
+++ b/apps/web/src/components/chat/FileDiffHeader.tsx
@@ -1,0 +1,89 @@
+// FILE: FileDiffHeader.tsx
+// Purpose: Synara-styled file header for @pierre/diffs cards in side panels
+//          (PR Code tab, review DiffPanel, Git pane). Replaces Pierre's default
+//          path/+N chrome with the same icon / filename+dir / DiffStat language
+//          used by the jump menu and explorer rows.
+// Layer: Chat/diff UI primitives
+
+import type { FileDiffMetadata } from "@pierre/diffs/react";
+import { type ReactNode, memo, useMemo } from "react";
+
+import {
+  resolveFileDiffPath,
+  splitRepoRelativePath,
+  summarizeFileDiffStats,
+} from "~/lib/diffRendering";
+import { cn } from "~/lib/utils";
+import { DiffStat } from "./DiffStatLabel";
+import { FileEntryIcon } from "./FileEntryIcon";
+
+function stripPatchPathPrefix(path: string): string {
+  return path.startsWith("a/") || path.startsWith("b/") ? path.slice(2) : path;
+}
+
+export const FileDiffHeader = memo(function FileDiffHeader(props: {
+  fileDiff: FileDiffMetadata;
+  theme: "light" | "dark";
+  /** Optional trailing chrome (file-actions menu, collapse chevron, etc.). */
+  trailing?: ReactNode;
+}) {
+  const filePath = resolveFileDiffPath(props.fileDiff);
+  const { dir, name } = splitRepoRelativePath(filePath);
+  const changeType = props.fileDiff.type;
+  const isRename = changeType === "rename-pure" || changeType === "rename-changed";
+  const prevLeaf =
+    isRename && props.fileDiff.prevName
+      ? splitRepoRelativePath(stripPatchPathPrefix(props.fileDiff.prevName)).name
+      : null;
+  const prevPath =
+    isRename && props.fileDiff.prevName
+      ? stripPatchPathPrefix(props.fileDiff.prevName)
+      : null;
+  const stat = useMemo(() => summarizeFileDiffStats([props.fileDiff]), [props.fileDiff]);
+
+  return (
+    <div
+      data-diff-file-header=""
+      className={cn(
+        "font-system-ui flex w-full min-w-0 items-center gap-2 px-2.5 py-1.5",
+        "text-[length:var(--app-font-size-ui,12px)] text-foreground",
+      )}
+      title={prevPath ? `${prevPath} → ${filePath}` : filePath}
+    >
+      <span className="inline-flex size-4 shrink-0 items-center justify-center text-muted-foreground/60">
+        <FileEntryIcon
+          pathValue={filePath}
+          kind="file"
+          theme={props.theme}
+          className="size-3.5 text-[var(--color-text-foreground)] opacity-70 dark:opacity-80"
+        />
+      </span>
+      <div className="flex min-w-0 flex-1 items-baseline gap-1.5 overflow-hidden">
+        {prevLeaf ? (
+          <>
+            <span className="shrink-0 truncate text-[11.5px] text-muted-foreground/65 line-through">
+              {prevLeaf}
+            </span>
+            <span className="shrink-0 text-[11px] text-muted-foreground/45" aria-hidden>
+              →
+            </span>
+          </>
+        ) : null}
+        <span className="shrink-0 truncate text-[11.5px] font-medium text-foreground/85">
+          {name}
+        </span>
+        {dir ? (
+          <span className="min-w-0 truncate text-[11px] text-muted-foreground/55">{dir}</span>
+        ) : null}
+      </div>
+      <DiffStat
+        additions={stat.additions}
+        deletions={stat.deletions}
+        className="shrink-0 text-[10px] tabular-nums"
+      />
+      {props.trailing ? (
+        <span className="inline-flex shrink-0 items-center gap-0.5">{props.trailing}</span>
+      ) : null}
+    </div>
+  );
+});

--- a/apps/web/src/components/chat/FileDiffView.tsx
+++ b/apps/web/src/components/chat/FileDiffView.tsx
@@ -1,21 +1,17 @@
 // FILE: FileDiffView.tsx
 // Purpose: Shared diff viewer chrome — a virtualized scroll surface plus a themed
 //          per-file card — used by both the turn/repo DiffPanel and the source
-//          control GitPanel so they share font/theme behavior, the FileEntryIcon
-//          header prefix, and the @pierre/diffs `unsafeCSS` theming.
+//          control GitPanel so they share font/theme behavior, the Synara file
+//          header, and the @pierre/diffs `unsafeCSS` theming.
 // Layer: Chat/diff UI primitives
-// Depends on: @pierre/diffs FileDiff/Virtualizer, diffRendering (theme + unsafeCSS), FileEntryIcon
+// Depends on: @pierre/diffs FileDiff/Virtualizer, diffRendering (theme + unsafeCSS), FileDiffHeader
 
 import { FileDiff, type FileDiffMetadata, Virtualizer } from "@pierre/diffs/react";
 import { type ReactNode } from "react";
 
-import {
-  buildDiffPanelUnsafeCSS,
-  resolveDiffThemeName,
-  resolveFileDiffPath,
-} from "~/lib/diffRendering";
+import { buildDiffPanelUnsafeCSS, resolveDiffThemeName } from "~/lib/diffRendering";
 import { cn } from "~/lib/utils";
-import { FileEntryIcon } from "./FileEntryIcon";
+import { FileDiffHeader } from "./FileDiffHeader";
 
 // Keep diff virtualization tuning in one place so every diff surface scrolls identically.
 const DIFF_VIRTUALIZER_CONFIG = {
@@ -37,8 +33,8 @@ export function FileDiffSurface(props: { className?: string; children: ReactNode
   );
 }
 
-// A single themed file diff with the standard FileEntryIcon prefix. Bakes in the
-// shared `unsafeCSS` theming so every surface renders with the chat code font and
+// A single themed file diff with Synara's custom file header. Bakes in the shared
+// `unsafeCSS` theming so every surface renders with the chat code font and
 // themed addition/deletion backgrounds.
 export function FileDiffCard(props: {
   fileDiff: FileDiffMetadata;
@@ -46,9 +42,9 @@ export function FileDiffCard(props: {
   diffStyle?: "unified" | "split";
   overflow?: "scroll" | "wrap";
   collapsed?: boolean;
-  renderHeaderMetadata?: () => ReactNode;
+  /** Trailing header chrome (actions menu, collapse chevron). */
+  renderHeaderTrailing?: () => ReactNode;
 }) {
-  const filePath = resolveFileDiffPath(props.fileDiff);
   return (
     <FileDiff
       fileDiff={props.fileDiff}
@@ -61,17 +57,13 @@ export function FileDiffCard(props: {
         unsafeCSS: buildDiffPanelUnsafeCSS(props.theme),
         ...(props.collapsed !== undefined ? { collapsed: props.collapsed } : {}),
       }}
-      renderHeaderPrefix={() => (
-        <span className="inline-flex items-center justify-center leading-none">
-          <FileEntryIcon
-            pathValue={filePath}
-            kind="file"
-            theme={props.theme}
-            className="size-3.5 text-muted-foreground/70"
-          />
-        </span>
+      renderCustomHeader={(fileDiff) => (
+        <FileDiffHeader
+          fileDiff={fileDiff}
+          theme={props.theme}
+          trailing={props.renderHeaderTrailing?.()}
+        />
       )}
-      {...(props.renderHeaderMetadata ? { renderHeaderMetadata: props.renderHeaderMetadata } : {})}
     />
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2411,10 +2411,11 @@ diffs-container {
   border: 1px solid var(--border);
   border-radius: 0.5rem;
   overflow: clip;
-  background: color-mix(in srgb, var(--card) 92%, var(--background));
+  background: var(--background);
 }
 
 .diff-render-file [data-diffs-header],
+.diff-render-file [data-diff-file-header],
 .diff-render-file [data-file-info] {
   cursor: pointer;
 }

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -40,8 +40,51 @@ export function buildDiffPanelUnsafeCSS(theme: "light" | "dark"): string {
   --diffs-header-font-family: var(--font-ui-family);
   /* Honor the user-chosen chat code font size from settings instead of the library default (13px). */
   --diffs-font-size: var(--app-font-size-chat-code, 11px);
+  /* Match the app chrome — set on :host so hunk rows/gutters/separators inherit. */
+  --diffs-bg: var(--background) !important;
+  --diffs-light-bg: var(--background) !important;
+  --diffs-dark-bg: var(--background) !important;
+  --diffs-token-light-bg: transparent;
+  --diffs-token-dark-bg: transparent;
+
+  --diffs-bg-context-override: var(--background) !important;
+  --diffs-bg-context-number-override: var(--background) !important;
+  --diffs-bg-hover-override: color-mix(in srgb, var(--background) 96%, var(--foreground)) !important;
+  --diffs-bg-separator-override: color-mix(in srgb, var(--background) 95%, var(--foreground)) !important;
+  --diffs-bg-buffer-override: color-mix(in srgb, var(--background) 92%, var(--foreground)) !important;
+
+  --diffs-bg-addition-override: color-mix(in srgb, var(--background) 92%, var(--success)) !important;
+  --diffs-bg-addition-number-override: color-mix(in srgb, var(--background) 88%, var(--success)) !important;
+  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--background) 85%, var(--success)) !important;
+  --diffs-bg-addition-emphasis-override: color-mix(in srgb, var(--background) 80%, var(--success)) !important;
+
+  --diffs-bg-deletion-override: color-mix(in srgb, var(--background) 92%, var(--destructive)) !important;
+  --diffs-bg-deletion-number-override: color-mix(in srgb, var(--background) 88%, var(--destructive)) !important;
+  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--background) 85%, var(--destructive)) !important;
+  --diffs-bg-deletion-emphasis-override: color-mix(
+    in srgb,
+    var(--background) 80%,
+    var(--destructive)
+  ) !important;
+
+  /* Force the derived tokens Pierre reads for hunk rows (not only the *-override knobs).
+     Do not pin --diffs-line-bg on :host — addition/deletion rows set that per line-type. */
+  --diffs-bg-context: var(--background) !important;
+  --diffs-bg-context-number: var(--background) !important;
+  --diffs-bg-buffer: color-mix(in srgb, var(--background) 92%, var(--foreground)) !important;
+  --diffs-bg-separator: color-mix(in srgb, var(--background) 95%, var(--foreground)) !important;
+  --diffs-bg-addition: color-mix(in srgb, var(--background) 92%, var(--success)) !important;
+  --diffs-bg-addition-number: color-mix(in srgb, var(--background) 88%, var(--success)) !important;
+  --diffs-bg-addition-hover: color-mix(in srgb, var(--background) 85%, var(--success)) !important;
+  --diffs-bg-addition-emphasis: color-mix(in srgb, var(--background) 80%, var(--success)) !important;
+  --diffs-bg-deletion: color-mix(in srgb, var(--background) 92%, var(--destructive)) !important;
+  --diffs-bg-deletion-number: color-mix(in srgb, var(--background) 88%, var(--destructive)) !important;
+  --diffs-bg-deletion-hover: color-mix(in srgb, var(--background) 85%, var(--destructive)) !important;
+  --diffs-bg-deletion-emphasis: color-mix(in srgb, var(--background) 80%, var(--destructive)) !important;
+
   font-family: var(--font-chat-code-family) !important;
   font-size: var(--app-font-size-chat-code, 11px) !important;
+  background-color: var(--background) !important;
 }
 
 [data-diffs-header],
@@ -50,32 +93,24 @@ export function buildDiffPanelUnsafeCSS(theme: "light" | "dark"): string {
 [data-error-wrapper],
 [data-virtualizer-buffer] {
   --diffs-font-size: var(--app-font-size-chat-code, 11px) !important;
-  --diffs-bg: color-mix(in srgb, var(--card) 90%, var(--background)) !important;
-  --diffs-light-bg: color-mix(in srgb, var(--card) 90%, var(--background)) !important;
-  --diffs-dark-bg: color-mix(in srgb, var(--card) 90%, var(--background)) !important;
-  --diffs-token-light-bg: transparent;
-  --diffs-token-dark-bg: transparent;
+  --diffs-bg: var(--background) !important;
+  --diffs-light-bg: var(--background) !important;
+  --diffs-dark-bg: var(--background) !important;
+  --diffs-bg-context: var(--background) !important;
+  --diffs-bg-context-number: var(--background) !important;
+  background-color: var(--background) !important;
+}
 
-  --diffs-bg-context-override: color-mix(in srgb, var(--background) 97%, var(--foreground));
-  --diffs-bg-hover-override: color-mix(in srgb, var(--background) 94%, var(--foreground));
-  --diffs-bg-separator-override: color-mix(in srgb, var(--background) 95%, var(--foreground));
-  --diffs-bg-buffer-override: color-mix(in srgb, var(--background) 90%, var(--foreground));
-
-  --diffs-bg-addition-override: color-mix(in srgb, var(--background) 92%, var(--success));
-  --diffs-bg-addition-number-override: color-mix(in srgb, var(--background) 88%, var(--success));
-  --diffs-bg-addition-hover-override: color-mix(in srgb, var(--background) 85%, var(--success));
-  --diffs-bg-addition-emphasis-override: color-mix(in srgb, var(--background) 80%, var(--success));
-
-  --diffs-bg-deletion-override: color-mix(in srgb, var(--background) 92%, var(--destructive));
-  --diffs-bg-deletion-number-override: color-mix(in srgb, var(--background) 88%, var(--destructive));
-  --diffs-bg-deletion-hover-override: color-mix(in srgb, var(--background) 85%, var(--destructive));
-  --diffs-bg-deletion-emphasis-override: color-mix(
-    in srgb,
-    var(--background) 80%,
-    var(--destructive)
-  );
-
-  background-color: var(--diffs-bg) !important;
+/* Unmodified hunk chrome — pin to theme background without wiping +/- tints. */
+[data-line-type="context"],
+[data-line-type="context-expanded"],
+[data-column-number]:where([data-line-type="context"], [data-line-type="context-expanded"]),
+[data-gutter-buffer="buffer"],
+[data-separator],
+[data-separator-wrapper],
+[data-separator-content] {
+  --diffs-line-bg: var(--background) !important;
+  background-color: var(--background) !important;
 }
 
 [data-diff],
@@ -91,11 +126,13 @@ export function buildDiffPanelUnsafeCSS(theme: "light" | "dark"): string {
 [data-file-info] {
   font-family: var(--font-ui-family) !important;
   font-size: var(--app-font-size-ui, 12px) !important;
-  background-color: color-mix(in srgb, var(--card) 94%, var(--foreground)) !important;
+  background-color: var(--background) !important;
   border-block-color: var(--border) !important;
   color: var(--foreground) !important;
 }
 
+/* Sticky header chrome. Layout for the custom slot only — do not zero-out
+   Pierre's default header padding (that clips path/+N text). */
 [data-diffs-header] {
   --diffs-header-font-family: var(--font-ui-family) !important;
   font-family: var(--font-ui-family) !important;
@@ -103,51 +140,37 @@ export function buildDiffPanelUnsafeCSS(theme: "light" | "dark"): string {
   position: sticky !important;
   top: 0;
   z-index: 4;
-  background-color: color-mix(in srgb, var(--card) 94%, var(--foreground)) !important;
+  background-color: var(--background) !important;
   border-bottom: 1px solid var(--border) !important;
   cursor: pointer;
 }
 
-[data-header-content] {
+[data-diffs-header="custom"] {
+  display: flex !important;
   align-items: center !important;
+  min-height: 0 !important;
+  padding: 0 !important;
 }
 
-::slotted([slot="header-prefix"]) {
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-  flex-shrink: 0 !important;
-  line-height: 0 !important;
+::slotted([slot="header-custom"]) {
+  display: flex !important;
+  width: 100% !important;
+  min-width: 0 !important;
+  flex: 1 1 auto !important;
 }
 
-/* Hide the default change-type icon (blue circle) — replaced by chevron + file-type icon. */
-[data-change-icon] {
-  display: none;
-}
-
-[data-title],
-[data-prev-name] {
-  font-family: var(--font-ui-family) !important;
-  font-size: var(--app-font-size-ui, 12px) !important;
-  font-weight: 400 !important;
-  cursor: pointer;
-  color: var(--foreground) !important;
+/* Give gutters a little air so line numbers aren't clipped by the card edge. */
+[data-column-number] {
+  padding-left: 1.25ch !important;
 }
 
 /* Every number rendered inside a diff reads in the UI font (with tabular figures
-   so columns still line up), not the mono code font: gutter line numbers, the
-   "N unmodified lines" separators, and the header +/- counts. The library pins
-   the header counts to --diffs-font-family and the gutter/separators inherit it
+   so columns still line up), not the mono code font: gutter line numbers and the
+   "N unmodified lines" separators. The library pins these to --diffs-font-family
    from the hunk body, so each needs an explicit override. */
 [data-line-number-content],
 [data-column-number],
 [data-unmodified-lines] {
-  font-family: var(--font-ui-family) !important;
-  font-variant-numeric: tabular-nums !important;
-}
-
-[data-diffs-header] [data-additions-count],
-[data-diffs-header] [data-deletions-count] {
   font-family: var(--font-ui-family) !important;
   font-variant-numeric: tabular-nums !important;
 }

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
         "@effect/platform-node": "catalog:",
         "@effect/sql-sqlite-bun": "catalog:",
         "@opencode-ai/sdk": "^1.15.13",
-        "@pierre/diffs": "^1.1.0-beta.16",
+        "@pierre/diffs": "^1.2.12",
         "@xterm/headless": "^6.0.0",
         "effect": "catalog:",
         "node-pty": "^1.1.0",
@@ -93,7 +93,7 @@
         "@formkit/auto-animate": "^0.9.0",
         "@legendapp/list": "3.0.0-beta.44",
         "@lexical/react": "^0.41.0",
-        "@pierre/diffs": "^1.1.0-beta.16",
+        "@pierre/diffs": "^1.2.12",
         "@synara/contracts": "workspace:*",
         "@synara/shared": "workspace:*",
         "@tabler/icons-react": "^3.44.0",
@@ -817,9 +817,11 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.1.0", "", { "dependencies": { "@pierre/theme": "0.0.22", "@shikijs/transformers": "^3.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-wbxrzcmanJuHZb81iir09j42uU9AnKxXDtAuEQJbAnti5f2UfYdCQYejawuHZStFrlsMacCZLh/dDHmqvAaQCw=="],
+    "@pierre/diffs": ["@pierre/diffs@1.2.12", "", { "dependencies": { "@pierre/theme": "1.1.0", "@pierre/theming": "0.0.2", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ=="],
 
-    "@pierre/theme": ["@pierre/theme@0.0.22", "", {}, "sha512-ePUIdQRNGjrveELTU7fY89Xa7YGHHEy5Po5jQy/18lm32eRn96+tnYJEtFooGdffrx55KBUtOXfvVy/7LDFFhA=="],
+    "@pierre/theme": ["@pierre/theme@1.1.0", "", {}, "sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ=="],
+
+    "@pierre/theming": ["@pierre/theming@0.0.2", "", { "peerDependencies": { "@pierre/theme": "^1.1.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
 
@@ -921,15 +923,15 @@
 
     "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
-    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
 
-    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg=="],
 
-    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+    "@shikijs/langs": ["@shikijs/langs@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg=="],
 
     "@shikijs/primitive": ["@shikijs/primitive@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw=="],
 
-    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+    "@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
 
     "@shikijs/transformers": ["@shikijs/transformers@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/types": "3.23.0" } }, "sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ=="],
 
@@ -2293,7 +2295,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
+    "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
@@ -2617,8 +2619,6 @@
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
-    "@astrojs/markdown-remark/shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
-
     "@astrojs/yaml2ts/yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.974.0", "", { "dependencies": { "@smithy/types": "^4.16.0", "tslib": "^2.6.2" } }, "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg=="],
@@ -2781,7 +2781,7 @@
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@pierre/diffs/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
+    "@pierre/diffs/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "@radix-ui/react-dialog/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
@@ -2797,7 +2797,15 @@
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
+    "@shikijs/engine-javascript/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
+    "@shikijs/engine-oniguruma/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
+    "@shikijs/langs/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
     "@shikijs/primitive/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
+    "@shikijs/themes/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "@smithy/core/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
 
@@ -2850,8 +2858,6 @@
     "ast-kit/@babel/parser": ["@babel/parser@8.0.0-rc.2", "", { "dependencies": { "@babel/types": "^8.0.0-rc.2" }, "bin": "./bin/babel-parser.js" }, "sha512-29AhEtcq4x8Dp3T72qvUMZHx0OMXCj4Jy/TEReQa+KWLln524Cj1fWb3QFi0l/xSpptQBR6y9RNEXuxpFvwiUQ=="],
 
     "astro/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
-
-    "astro/shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -2919,6 +2925,10 @@
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "shiki/@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
+
+    "shiki/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
+
     "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
@@ -2942,18 +2952,6 @@
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "@astrojs/markdown-remark/shiki/@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
-
-    "@astrojs/markdown-remark/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
-
-    "@astrojs/markdown-remark/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg=="],
-
-    "@astrojs/markdown-remark/shiki/@shikijs/langs": ["@shikijs/langs@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg=="],
-
-    "@astrojs/markdown-remark/shiki/@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
-
-    "@astrojs/markdown-remark/shiki/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.2", "", {}, "sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ=="],
 
@@ -3118,18 +3116,6 @@
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.2", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.2", "@babel/helper-validator-identifier": "^8.0.0-rc.2" } }, "sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw=="],
-
-    "astro/shiki/@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
-
-    "astro/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag=="],
-
-    "astro/shiki/@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg=="],
-
-    "astro/shiki/@shikijs/langs": ["@shikijs/langs@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg=="],
-
-    "astro/shiki/@shikijs/themes": ["@shikijs/themes@4.0.2", "", { "dependencies": { "@shikijs/types": "4.0.2" } }, "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA=="],
-
-    "astro/shiki/@shikijs/types": ["@shikijs/types@4.0.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 


### PR DESCRIPTION
## What Changed

Use a custom file header and theme background tokens so PR/review/git diffs match the rest of the app instead of Pierre's default card styling.

## Why

The default styling doesn't match or use the user's choice of theme. This can make the UI look very off (especially for me when I like the Vercel theme making the entire app black, the gray diff headers really stand out and looks off 😅)

## UI Changes

### Before

<img width="1552" height="2236" alt="CleanShot 2026-07-16 at 20 56 23@2x" src="https://github.com/user-attachments/assets/386fbbb2-d527-4e56-a0d2-c4dc476fb137" />
<img width="1912" height="2234" alt="CleanShot 2026-07-16 at 20 58 03@2x" src="https://github.com/user-attachments/assets/76cce723-620a-4e23-a333-f86e7159a695" />


### After

<img width="1986" height="2232" alt="CleanShot 2026-07-16 at 20 55 32@2x" src="https://github.com/user-attachments/assets/83d83726-1e6b-48ce-b659-4d3c87262fd3" />
<img width="1848" height="2238" alt="CleanShot 2026-07-16 at 20 58 21@2x" src="https://github.com/user-attachments/assets/1a5ee606-fb83-4358-801d-2d4b67df5700" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
