### PR TITLE
fix(web): run app-owned /review for OpenCode

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -208,6 +208,7 @@ import {
   canOfferSideSlashCommand,
   canOfferReviewSlashCommand,
   hasProviderNativeSlashCommand,
+  providerSupportsTextNativeReviewCommand,
   resolveComposerSlashRootBranch,
 } from "../composerSlashCommands";
 import {
@@ -3376,8 +3377,8 @@ export default function ChatView({
   }, [composerTrigger, providerNativeCommandNames, selectedProvider]);
   const effectiveComposerTriggerKind = effectiveComposerTrigger?.kind ?? null;
   const supportsTextNativeReviewCommand = useMemo(
-    () => providerNativeCommands.some((command) => command.name.toLowerCase() === "review"),
-    [providerNativeCommands],
+    () => providerSupportsTextNativeReviewCommand(selectedProvider, providerNativeCommands),
+    [providerNativeCommands, selectedProvider],
   );
   const providerSkills = providerSkillsQuery.data?.skills ?? EMPTY_PROVIDER_SKILLS;
   const selectedModelCaps = useMemo(

--- a/apps/web/src/composerSlashCommands.test.ts
+++ b/apps/web/src/composerSlashCommands.test.ts
@@ -14,6 +14,7 @@ import {
   parseComposerSlashInvocationForCommands,
   parseFastSlashCommandAction,
   parseForkSlashCommandArgs,
+  providerSupportsTextNativeReviewCommand,
   shouldHideProviderNativeCommandFromComposerMenu,
 } from "./composerSlashCommands";
 
@@ -232,6 +233,27 @@ describe("composerSlashCommands", () => {
     expect(availableCommands).toContain("review");
     expect(shouldHideProviderNativeCommandFromComposerMenu("codex", "review")).toBe(true);
     expect(shouldHideProviderNativeCommandFromComposerMenu("codex", "status")).toBe(false);
+  });
+
+  // #218: OpenCode lists native /review but does not honor bare `/review` text turns.
+  it("keeps app-level /review for opencode and does not treat review as text-native", () => {
+    const availableCommands = getAvailableComposerSlashCommands({
+      provider: "opencode",
+      supportsFastSlashCommand: false,
+      canOfferCompactCommand: true,
+      canOfferReviewCommand: true,
+      canOfferForkCommand: true,
+      canOfferSideCommand: true,
+      canOfferExportCommand: true,
+      providerNativeCommandNames: ["review", "status"],
+    });
+
+    expect(availableCommands).toContain("review");
+    expect(shouldHideProviderNativeCommandFromComposerMenu("opencode", "review")).toBe(true);
+    expect(providerSupportsTextNativeReviewCommand("opencode", ["review", "status"])).toBe(false);
+    expect(providerSupportsTextNativeReviewCommand("opencode", [{ name: "review" }])).toBe(false);
+    // Other providers with a native review still use text pass-through.
+    expect(providerSupportsTextNativeReviewCommand("claudeAgent", ["review"])).toBe(true);
   });
 
   it("keeps app-level /automation available even if a provider exposes a native collision", () => {

--- a/apps/web/src/composerSlashCommands.ts
+++ b/apps/web/src/composerSlashCommands.ts
@@ -68,6 +68,15 @@ function expandProviderNativeSlashCommandNames(
   return [...expandedNames];
 }
 
+/**
+ * Providers where app-owned /review (target picker + structured prompt) must
+ * win over listing a native "review" command. OpenCode exposes /review in its
+ * command list but does not honor bare `/review` text turns (#218).
+ */
+export function providerUsesAppOwnedReviewSlashCommand(provider: ProviderKind): boolean {
+  return provider === "codex" || provider === "opencode";
+}
+
 function shouldKeepBuiltInSlashCommandDespiteNativeCollision(
   provider: ProviderKind,
   command: ComposerSlashCommand,
@@ -76,7 +85,7 @@ function shouldKeepBuiltInSlashCommandDespiteNativeCollision(
     command === "automation" ||
     command === "export" ||
     command === "feedback" ||
-    (provider === "codex" && command === "review")
+    (providerUsesAppOwnedReviewSlashCommand(provider) && command === "review")
   );
 }
 
@@ -91,8 +100,25 @@ export function shouldHideProviderNativeCommandFromComposerMenu(
     normalizedCommand === "automation" ||
     (normalizedCommand === "export" && appCommandIsAvailable) ||
     (normalizedCommand === "feedback" && appCommandIsAvailable) ||
-    (provider === "codex" && normalizedCommand === "review")
+    (providerUsesAppOwnedReviewSlashCommand(provider) && normalizedCommand === "review")
   );
+}
+
+/**
+ * True when a discovered native "review" command should be sent as plain
+ * `/review` text. Codex/OpenCode use the app review UX instead (#218).
+ */
+export function providerSupportsTextNativeReviewCommand(
+  provider: ProviderKind,
+  nativeCommandNames: ReadonlyArray<{ readonly name: string } | string>,
+): boolean {
+  if (providerUsesAppOwnedReviewSlashCommand(provider)) {
+    return false;
+  }
+  return nativeCommandNames.some((command) => {
+    const name = typeof command === "string" ? command : command.name;
+    return name.trim().toLowerCase() === "review";
+  });
 }
 
 export function getProviderNativeSlashCommandSearchTerms(


### PR DESCRIPTION
## Summary

OpenCode **`/review`** now uses Synara’s app review flow (target picker + structured review prompt) instead of sending bare `/review` text that the model ignores.

Closes #218

## Problem

When OpenCode’s command discovery listed a native `review` command, the composer:

1. Treated review as **text-native** (`supportsTextNativeReviewCommand`)
2. On send with empty args, **returned false** so `/review` went out as a normal user message
3. OpenCode did **not** run a review subagent on that text

Users saw a chat turn containing only `/review`.

## Solution

Mirror Codex for OpenCode:

| Area | Change |
|------|--------|
| App `/review` | Kept even when native `review` is listed |
| Native menu row | Hidden for OpenCode `review` (avoid double entry) |
| Text pass-through | Disabled for OpenCode/Codex via `providerSupportsTextNativeReviewCommand` |
| Send / menu select | Opens app review target picker + review prompt path |

## Evidence

| | Before | After |
|--|--------|--------|
| OpenCode + native `review` listed | `/review` sent as plain message | App review UX (picker / structured prompt) |
| App slash menu | Could hide app `/review` behind native collision | App `/review` stays available |
| Codex | Already app-owned | Unchanged behavior |



## Screenshots

![before/after](https://files.catbox.moe/0mrekf.png)

## Test plan

- [x] `bunx vitest run apps/web/src/composerSlashCommands.test.ts` — **24 pass** (includes OpenCode #218 case)
- [ ] Manual: OpenCode thread → type `/review` → expect target picker / review prompt, not a bare `/review` message

## Files

- `apps/web/src/composerSlashCommands.ts`
- `apps/web/src/composerSlashCommands.test.ts`
- `apps/web/src/components/ChatView.tsx`
