### PR TITLE
fix: darken composer stacked rail and keep input outline visible

### DIFF
--- a/apps/web/src/components/chat/composerPickerStyles.ts
+++ b/apps/web/src/components/chat/composerPickerStyles.ts
@@ -125,9 +125,11 @@ export const COMPOSER_STACKED_HEADER_FRAME_CLASS_NAME = "mx-auto -mb-px w-11/12 
 
 /** Opaque base behind the composer shell: the composer overlaps the scrolling
  *  transcript (`-mt-5`), so without a solid backing the frosted surface would let
- *  transcript text bleed through its top edge. Match the chat surface to stay seamless. */
+ *  transcript text bleed through its top edge. Match the chat surface to stay seamless.
+ *  `relative z-[1]` keeps the full input outline above the inset stacked rail
+ *  (`-mb-px`), so the top border is never covered by live-changes / task / queue chrome. */
 export const COMPOSER_INPUT_SHELL_CLASS_NAME =
-  "group chat-composer-shell bg-[var(--color-background-surface)] transition-colors duration-200";
+  "group relative z-[1] chat-composer-shell bg-[var(--color-background-surface)] transition-colors duration-200";
 
 /** Defined composer border: the heaviest border token nudged a bit darker with foreground. */
 export const COMPOSER_SURFACE_BORDER_CLASS_NAME =

--- a/apps/web/src/components/chat/composerStackedPanelStyles.test.ts
+++ b/apps/web/src/components/chat/composerStackedPanelStyles.test.ts
@@ -12,9 +12,11 @@ import {
 } from "./composerStackedPanelStyles";
 
 describe("composerStackedPanelStyles", () => {
-  it("keeps stacked panel chrome on the composer surface treatment", () => {
+  it("keeps stacked panel chrome on the recessed stacked-top treatment", () => {
     expect(COMPOSER_STACKED_PANEL_CHROME_CLASS_NAME).toContain("chat-composer-stacked-top");
+    expect(COMPOSER_STACKED_PANEL_CHROME_CLASS_NAME).not.toContain("chat-composer-surface");
     expect(COMPOSER_STACKED_PANEL_CHROME_CLASS_NAME).toContain("border-b-0");
+    expect(COMPOSER_STACKED_PANEL_CHROME_CLASS_NAME).not.toContain("z-[1]");
   });
 
   it("keeps stacked panel rows on one shared padding and type scale", () => {

--- a/apps/web/src/components/chat/composerStackedPanelStyles.ts
+++ b/apps/web/src/components/chat/composerStackedPanelStyles.ts
@@ -7,9 +7,12 @@
 import { COMPACT_CHAT_MARKDOWN_TIGHT_CLASS_NAME } from "~/components/chatMarkdownSpacing";
 import { COMPOSER_STACKED_SURFACE_BORDER_CLASS_NAME } from "./composerPickerStyles";
 
-/** Frame, border, radius, and surface chrome for a stacked composer panel. */
+/** Frame, border, radius, and surface chrome for a stacked composer panel.
+ *  Uses `chat-composer-stacked-top` (not `chat-composer-surface`) so the rail
+ *  reads as a darker recessed strip above the input. No raised z-index: the
+ *  input shell paints later and keeps its top border visible across the seam. */
 export const COMPOSER_STACKED_PANEL_CHROME_CLASS_NAME = [
-  "chat-composer-surface chat-composer-stacked-top relative z-[1] overflow-hidden border border-b-0",
+  "chat-composer-stacked-top relative overflow-hidden border border-b-0",
   COMPOSER_STACKED_SURFACE_BORDER_CLASS_NAME,
 ].join(" ");
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2527,10 +2527,13 @@ diffs-container {
   border-top-right-radius: 0;
 }
 
-/* Recessed rail above the composer input: same hue as the input shell
-   (--composer-surface), darkened so the stacked strip reads as a variant
-   of that surface rather than a different theme token. */
+/* Stacked rail above the composer input: same hue as the input shell, gently
+   darkened. Light mode stays nearly white (a light wash); dark mode recesses more. */
 .chat-composer-stacked-top {
+  background: color-mix(in oklab, var(--composer-surface) 98%, black 2%);
+}
+
+.dark .chat-composer-stacked-top {
   background: color-mix(in oklab, var(--composer-surface) 84%, black 16%);
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2527,6 +2527,13 @@ diffs-container {
   border-top-right-radius: 0;
 }
 
+/* Recessed rail above the composer input: same hue as the input shell
+   (--composer-surface), darkened so the stacked strip reads as a variant
+   of that surface rather than a different theme token. */
+.chat-composer-stacked-top {
+  background: color-mix(in oklab, var(--composer-surface) 84%, black 16%);
+}
+
 .chat-composer-surface {
   background: var(--composer-surface);
   backdrop-filter: var(--app-composer-backdrop-filter, none);


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Give the composer stacked rail (live file changes / active tasks / queued follow-ups) its own darker fill derived from `--composer-surface`, instead of reusing the same `chat-composer-surface` background as the input.
- Stop raising the stacked panel above the input (`z-[1]`), and raise the input shell instead so the composer’s full border stays visible across the `-mb-px` seam.
- Update the stacked-panel chrome unit test to pin the recessed treatment.

## Why

When a task list or live-changes strip sat above the composer, it used the same grey as the input and its higher z-index covered the input’s top outline, so the two surfaces read as one fused block. The rail should stay the same hue as the input, just darker, with a clear bordered boundary between them.

## UI Changes

### Before

<img width="1534" height="714" alt="CleanShot 2026-07-17 at 15 24 41@2x" src="https://github.com/user-attachments/assets/c41a4770-6f33-4b53-acf0-78942af1572f" />


### After
Codex Theme:

<img width="2074" height="784" alt="CleanShot 2026-07-17 at 15 38 51@2x" src="https://github.com/user-attachments/assets/b84217d3-02a5-42b7-902b-29b31f4e66f9" />

Vercel Theme:

<img width="2170" height="688" alt="CleanShot 2026-07-17 at 15 38 30@2x" src="https://github.com/user-attachments/assets/2bcbf231-03a5-490b-af0a-b10aae719833" />

light mode:

<img width="1154" height="365" alt="CleanShot 2026-07-17 at 15 50 43" src="https://github.com/user-attachments/assets/e7d8810c-4755-4783-8b0c-aa2a23fca8b2" />



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
