### PR TITLE
Add isolated Synara Canary workflow

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -13,13 +13,18 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createRequire } from "node:module";
-import { synaraBundleId } from "@synara/shared/desktopIdentity";
+import { resolveSynaraDesktopFlavor, synaraDesktopIdentity } from "@synara/shared/desktopIdentity";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
-const APP_DISPLAY_NAME = isDevelopment ? "Synara (Dev)" : "Synara";
-const APP_BUNDLE_ID = synaraBundleId(isDevelopment);
+const desktopFlavor = resolveSynaraDesktopFlavor({
+  isDevelopment,
+  requestedFlavor: process.env.SYNARA_DESKTOP_FLAVOR,
+});
+const desktopIdentity = synaraDesktopIdentity(desktopFlavor);
+const APP_DISPLAY_NAME = desktopIdentity.displayName;
+const APP_BUNDLE_ID = desktopIdentity.bundleId;
 const LAUNCHER_VERSION = 2;
 const MICROPHONE_USAGE_DESCRIPTION =
   "Synara needs microphone access so you can record voice notes and transcribe them into the chat composer.";

--- a/apps/desktop/src/desktopUserDataProfile.test.ts
+++ b/apps/desktop/src/desktopUserDataProfile.test.ts
@@ -27,12 +27,15 @@ afterEach(() => {
 describe("desktopUserDataProfile", () => {
   it("resolves the canonical Synara profile names", () => {
     const appDataBase = "/Users/tester/Library/Application Support";
-    expect(resolveDesktopUserDataPath({ appDataBase, isDevelopment: true })).toBe(
+    expect(resolveDesktopUserDataPath({ appDataBase, userDataDirectoryName: "synara-dev" })).toBe(
       "/Users/tester/Library/Application Support/synara-dev",
     );
-    expect(resolveDesktopUserDataPath({ appDataBase, isDevelopment: false })).toBe(
+    expect(resolveDesktopUserDataPath({ appDataBase, userDataDirectoryName: "synara" })).toBe(
       "/Users/tester/Library/Application Support/synara",
     );
+    expect(
+      resolveDesktopUserDataPath({ appDataBase, userDataDirectoryName: "synara-canary" }),
+    ).toBe("/Users/tester/Library/Application Support/synara-canary");
   });
 
   it("uses XDG_CONFIG_HOME on Linux when available", () => {

--- a/apps/desktop/src/desktopUserDataProfile.ts
+++ b/apps/desktop/src/desktopUserDataProfile.ts
@@ -5,8 +5,6 @@ import * as FS from "node:fs";
 import * as OS from "node:os";
 import * as Path from "node:path";
 
-const DEV_USER_DATA_DIR_NAME = "synara-dev";
-const PROD_USER_DATA_DIR_NAME = "synara";
 const BRIDGE_PROFILE_MANIFEST_FILE_NAME = "synara-profile-seed.json";
 const CANONICAL_BROWSER_PARTITION_NAME = "synara-browser";
 const BROWSER_PARTITION_SEED_ENTRY_GROUPS = [
@@ -53,12 +51,9 @@ export function resolveDesktopAppDataBase(input?: {
 
 export function resolveDesktopUserDataPath(input: {
   readonly appDataBase: string;
-  readonly isDevelopment: boolean;
+  readonly userDataDirectoryName: string;
 }): string {
-  return Path.join(
-    input.appDataBase,
-    input.isDevelopment ? DEV_USER_DATA_DIR_NAME : PROD_USER_DATA_DIR_NAME,
-  );
+  return Path.join(input.appDataBase, input.userDataDirectoryName);
 }
 
 function readBridgeProfileSourcePath(targetPath: string): string | null {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -50,10 +50,9 @@ import {
 import type { ContextMenuItem } from "@synara/contracts";
 import { getMacTrafficLightPosition } from "@synara/shared/desktopChrome";
 import {
-  SYNARA_DESKTOP_ENTRY_URL,
-  SYNARA_DESKTOP_SCHEME,
   SYNARA_DESKTOP_UPDATE_CHANNEL,
-  synaraBundleId,
+  resolveSynaraDesktopFlavor,
+  synaraDesktopIdentity,
 } from "@synara/shared/desktopIdentity";
 import { NetService } from "@synara/shared/Net";
 import { RotatingFileSink } from "@synara/shared/logging";
@@ -188,20 +187,32 @@ syncShellEnvironment();
 
 const IPC = DESKTOP_IPC_CHANNELS;
 const MAX_CLIPBOARD_IMAGE_DATA_URL_LENGTH = 16 * 1024 * 1024;
-const BASE_DIR = process.env.SYNARA_HOME?.trim() || Path.join(OS.homedir(), ".synara");
+const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
+const desktopFlavor = resolveSynaraDesktopFlavor({
+  isDevelopment,
+  requestedFlavor: process.env.SYNARA_DESKTOP_FLAVOR,
+});
+const desktopIdentity = synaraDesktopIdentity(desktopFlavor);
+const BASE_DIR =
+  process.env.SYNARA_HOME?.trim() ||
+  Path.join(OS.homedir(), desktopIdentity.defaultHomeDirectoryName);
 const STATE_DIR = Path.join(BASE_DIR, "userdata");
 const DESKTOP_WINDOW_STATE_PATH = Path.join(STATE_DIR, "desktop-window-state.json");
-const DESKTOP_SCHEME = SYNARA_DESKTOP_SCHEME;
+const DESKTOP_SCHEME = desktopIdentity.scheme;
 const ROOT_DIR = Path.resolve(__dirname, "../../..");
-const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
-const APP_DISPLAY_NAME = isDevelopment ? "Synara (Dev)" : "Synara";
-const APP_USER_MODEL_ID = synaraBundleId(isDevelopment);
+const APP_DISPLAY_NAME = desktopIdentity.displayName;
+const APP_USER_MODEL_ID = desktopIdentity.bundleId;
 const COMMIT_HASH_PATTERN = /^[0-9a-f]{7,40}$/i;
 const COMMIT_HASH_DISPLAY_LENGTH = 12;
 const LOG_DIR = Path.join(STATE_DIR, "logs");
 const LOG_FILE_MAX_BYTES = 10 * 1024 * 1024;
 const LOG_FILE_MAX_FILES = 10;
 const APP_RUN_ID = Crypto.randomBytes(6).toString("hex");
+// Electron's single-instance lock is scoped through userData on Windows/Linux.
+// Set the flavor-specific profile first so Stable, Dev, and Canary never contend
+// for the same lock even when they use the same Electron executable.
+const userDataPath = resolveUserDataPath();
+app.setPath("userData", userDataPath);
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
 const AUTO_UPDATE_STARTUP_DELAY_MS = 15_000;
 const AUTO_UPDATE_POLL_INTERVAL_MS = 4 * 60 * 60 * 1000;
@@ -1258,7 +1269,8 @@ function resolveAutoUpdateDisabledReason(): string | null {
     isPackaged: app.isPackaged,
     platform: process.platform,
     appImage: process.env.APPIMAGE,
-    disabledByEnv: process.env.SYNARA_DISABLE_AUTO_UPDATE === "1",
+    disabledByEnv:
+      desktopIdentity.usesScriptedUpdates || process.env.SYNARA_DISABLE_AUTO_UPDATE === "1",
     hasUpdateFeedConfig: hasConfiguredUpdateFeed(),
   });
 }
@@ -1642,7 +1654,10 @@ function showDesktopNotification(input: {
  */
 function resolveUserDataPath(): string {
   const appDataBase = resolveDesktopAppDataBase();
-  return resolveDesktopUserDataPath({ appDataBase, isDevelopment });
+  return resolveDesktopUserDataPath({
+    appDataBase,
+    userDataDirectoryName: desktopIdentity.userDataDirectoryName,
+  });
 }
 
 function repairBrowserProfileBeforeElectronReady(userDataPath: string): void {
@@ -3438,7 +3453,7 @@ function createWindow(): BrowserWindow {
     void window.loadURL(process.env.VITE_DEV_SERVER_URL as string);
     window.webContents.openDevTools({ mode: "detach" });
   } else {
-    void window.loadURL(SYNARA_DESKTOP_ENTRY_URL);
+    void window.loadURL(desktopIdentity.entryUrl);
   }
 
   window.on("closed", () => {
@@ -3494,11 +3509,9 @@ function configureMediaPermissions(): void {
 // Override Electron's userData path before the `ready` event so that
 // Chromium session data uses a filesystem-friendly directory name.
 // Must be called synchronously at the top level — before `app.whenReady()`.
-const userDataPath = resolveUserDataPath();
 if (hasSingleInstanceLock) {
   repairBrowserProfileBeforeElectronReady(userDataPath);
 }
-app.setPath("userData", userDataPath);
 
 configureAppIdentity();
 

--- a/apps/server/src/trustedOrigins.test.ts
+++ b/apps/server/src/trustedOrigins.test.ts
@@ -40,6 +40,13 @@ describe("trustedOrigins", () => {
         config,
       }),
     ).toBe(true);
+    expect(
+      isTrustedAppOrigin({
+        origin: "synara-canary://app",
+        requestOrigin: "http://127.0.0.1:58090",
+        config,
+      }),
+    ).toBe(true);
   });
 
   it("rejects unrelated browser origins but allows non-browser requests without Origin", () => {
@@ -107,6 +114,7 @@ describe("trustedOrigins", () => {
 
   it("normalizes desktop origins with trailing slashes", () => {
     expect(normalizeCorsOrigin("synara://app/")).toBe("synara://app");
+    expect(normalizeCorsOrigin("synara-canary://app/")).toBe("synara-canary://app");
   });
 
   it("rejects present but untrusted request origins for websocket-style gates", () => {

--- a/apps/server/src/trustedOrigins.ts
+++ b/apps/server/src/trustedOrigins.ts
@@ -5,12 +5,19 @@
 // Exports: normalizeCorsOrigin, isTrustedAppOrigin,
 //          shouldRejectUntrustedRequestOrigin
 
-import { SYNARA_DESKTOP_ORIGIN } from "@synara/shared/desktopIdentity";
+import {
+  SYNARA_CANARY_DESKTOP_ORIGIN,
+  SYNARA_DESKTOP_ORIGIN,
+} from "@synara/shared/desktopIdentity";
 
 import type { ServerConfigShape } from "./config";
 import { isLoopbackHost, isWildcardHost } from "./startupAccess";
 
 export const DESKTOP_APP_CORS_ORIGIN = SYNARA_DESKTOP_ORIGIN;
+export const DESKTOP_APP_CORS_ORIGINS: ReadonlySet<string> = new Set([
+  SYNARA_DESKTOP_ORIGIN,
+  SYNARA_CANARY_DESKTOP_ORIGIN,
+]);
 
 export function normalizeCorsOrigin(rawOrigin: string | ReadonlyArray<string> | undefined) {
   const value = Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin;
@@ -18,8 +25,9 @@ export function normalizeCorsOrigin(rawOrigin: string | ReadonlyArray<string> | 
   if (!trimmed || trimmed === "null") {
     return null;
   }
-  if (trimmed.replace(/\/+$/, "") === DESKTOP_APP_CORS_ORIGIN) {
-    return DESKTOP_APP_CORS_ORIGIN;
+  const normalizedDesktopOrigin = trimmed.replace(/\/+$/, "");
+  if (DESKTOP_APP_CORS_ORIGINS.has(normalizedDesktopOrigin)) {
+    return normalizedDesktopOrigin;
   }
   try {
     const origin = new URL(trimmed).origin;
@@ -70,7 +78,7 @@ export function isTrustedAppOrigin(input: {
     (input.origin === input.requestOrigin &&
       isTrustedRequestOriginHost(input.requestOrigin, input.config)) ||
     input.origin === input.config.devUrl?.origin ||
-    input.origin === DESKTOP_APP_CORS_ORIGIN
+    DESKTOP_APP_CORS_ORIGINS.has(input.origin)
   );
 }
 

--- a/docs/canary.md
+++ b/docs/canary.md
@@ -1,0 +1,69 @@
+# Synara Canary
+
+Synara Canary is a frozen local build of a chosen remote Git ref. It is intentionally separate
+from both Synara Stable and the HMR development process.
+
+## Isolation
+
+- App name: `Synara Canary`
+- Bundle ID: `com.emanueledipietro.synara.canary`
+- Desktop origin: `synara-canary://app`
+- Synara data: `~/.synara-canary`
+- Electron profile: `synara-canary`
+- Managed source: `~/.cache/synara-canary/source`
+- Runtime log: `~/.synara-canary/canary.log`
+- Updates: only through the Canary scripts; the production updater is disabled
+
+Canary starts with an empty data directory. It never copies or shares Stable data.
+
+## Install and update
+
+After the Canary tooling has landed on `main`:
+
+```bash
+bun run canary:setup
+bun run canary:update
+```
+
+Both commands fetch `origin/main`, install from the lockfile, build static desktop/server assets,
+run the release smoke test, and start the resulting commit. Source edits in another worktree do not
+affect the running Canary.
+
+While this change is still a stacked PR, it can be tested explicitly from its remote branch:
+
+```bash
+bun run canary:setup -- --ref codex/synara-canary
+```
+
+## Operations
+
+```bash
+bun run canary:start
+bun run canary:stop
+bun run canary:status
+bun run canary:rollback
+```
+
+`canary:rollback` rebuilds and starts the previous successful commit. An update refuses to overwrite
+tracked edits in the managed source checkout. If a new build fails, the script restores and rebuilds
+the previous commit before restarting Canary.
+
+Paths can be overridden without touching Stable:
+
+```bash
+SYNARA_CANARY_HOME=/path/to/data \
+SYNARA_CANARY_SOURCE=/path/to/source \
+bun run canary:update
+```
+
+## Running Dev beside Canary
+
+Use a named dev instance and a separate home:
+
+```bash
+env -u SYNARA_AUTH_TOKEN \
+  SYNARA_DEV_INSTANCE=my-feature \
+  bun run dev -- --home-dir ./.synara/dev-my-feature
+```
+
+Canary remains pinned to its compiled commit while the development instance continues to use HMR.

--- a/docs/canary.md
+++ b/docs/canary.md
@@ -35,6 +35,13 @@ While this change is still a stacked PR, it can be tested explicitly from its re
 bun run canary:setup -- --ref codex/synara-canary
 ```
 
+Later `canary:update` calls keep using that tracked ref automatically. After this PR lands on `main`,
+switch the installation to the normal channel once:
+
+```bash
+bun run canary:update -- --ref main
+```
+
 ## Operations
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -52,6 +52,12 @@
     "dist:desktop:win": "node scripts/build-desktop-artifact.ts --platform win --target nsis --arch x64",
     "release:smoke": "node scripts/release-smoke.ts",
     "release:smoke:mac-update": "node scripts/smoke-mac-update-artifact.ts",
+    "canary:setup": "node scripts/canary.ts setup",
+    "canary:update": "node scripts/canary.ts update",
+    "canary:start": "node scripts/canary.ts start",
+    "canary:stop": "node scripts/canary.ts stop",
+    "canary:status": "node scripts/canary.ts status",
+    "canary:rollback": "node scripts/canary.ts rollback",
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules scripts/node_modules apps/*/dist apps/*/dist-electron packages/*/dist .turbo apps/*/.turbo packages/*/.turbo"
   },
   "devDependencies": {

--- a/packages/shared/src/desktopIdentity.test.ts
+++ b/packages/shared/src/desktopIdentity.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  resolveSynaraDesktopFlavor,
+  SYNARA_CANARY_BUNDLE_ID,
+  SYNARA_CANARY_DESKTOP_ENTRY_URL,
+  SYNARA_CANARY_DESKTOP_ORIGIN,
   SYNARA_DESKTOP_ENTRY_URL,
   SYNARA_DESKTOP_ORIGIN,
   SYNARA_DESKTOP_UPDATE_CHANNEL,
   SYNARA_DEVELOPMENT_BUNDLE_ID,
   SYNARA_PRODUCTION_BUNDLE_ID,
   synaraBundleId,
+  synaraDesktopIdentity,
 } from "./desktopIdentity";
 
 describe("desktopIdentity", () => {
@@ -24,5 +29,33 @@ describe("desktopIdentity", () => {
 
   it("uses the isolated Synara desktop update channel", () => {
     expect(SYNARA_DESKTOP_UPDATE_CHANNEL).toBe("synara");
+  });
+
+  it("gives Canary a fully separate desktop identity and storage profile", () => {
+    expect(SYNARA_CANARY_BUNDLE_ID).toBe("com.emanueledipietro.synara.canary");
+    expect(SYNARA_CANARY_DESKTOP_ORIGIN).toBe("synara-canary://app");
+    expect(SYNARA_CANARY_DESKTOP_ENTRY_URL).toBe("synara-canary://app/index.html");
+    expect(synaraDesktopIdentity("canary")).toEqual({
+      flavor: "canary",
+      displayName: "Synara Canary",
+      bundleId: SYNARA_CANARY_BUNDLE_ID,
+      scheme: "synara-canary",
+      origin: SYNARA_CANARY_DESKTOP_ORIGIN,
+      entryUrl: SYNARA_CANARY_DESKTOP_ENTRY_URL,
+      userDataDirectoryName: "synara-canary",
+      defaultHomeDirectoryName: ".synara-canary",
+      usesScriptedUpdates: true,
+    });
+  });
+
+  it("selects Canary explicitly without changing normal dev and production defaults", () => {
+    expect(resolveSynaraDesktopFlavor({ isDevelopment: false })).toBe("production");
+    expect(resolveSynaraDesktopFlavor({ isDevelopment: true })).toBe("development");
+    expect(resolveSynaraDesktopFlavor({ isDevelopment: false, requestedFlavor: " canary " })).toBe(
+      "canary",
+    );
+    expect(resolveSynaraDesktopFlavor({ isDevelopment: true, requestedFlavor: "canary" })).toBe(
+      "canary",
+    );
   });
 });

--- a/packages/shared/src/desktopIdentity.ts
+++ b/packages/shared/src/desktopIdentity.ts
@@ -7,7 +7,75 @@ export const SYNARA_DESKTOP_ENTRY_URL = `${SYNARA_DESKTOP_ORIGIN}/index.html`;
 export const SYNARA_DESKTOP_UPDATE_CHANNEL = "synara";
 export const SYNARA_PRODUCTION_BUNDLE_ID = "com.emanueledipietro.synara";
 export const SYNARA_DEVELOPMENT_BUNDLE_ID = `${SYNARA_PRODUCTION_BUNDLE_ID}.dev`;
+export const SYNARA_CANARY_BUNDLE_ID = `${SYNARA_PRODUCTION_BUNDLE_ID}.canary`;
+export const SYNARA_CANARY_DESKTOP_SCHEME = "synara-canary";
+export const SYNARA_CANARY_DESKTOP_ORIGIN = `${SYNARA_CANARY_DESKTOP_SCHEME}://app`;
+export const SYNARA_CANARY_DESKTOP_ENTRY_URL = `${SYNARA_CANARY_DESKTOP_ORIGIN}/index.html`;
+
+export type SynaraDesktopFlavor = "production" | "development" | "canary";
+
+export interface SynaraDesktopIdentity {
+  readonly flavor: SynaraDesktopFlavor;
+  readonly displayName: string;
+  readonly bundleId: string;
+  readonly scheme: string;
+  readonly origin: string;
+  readonly entryUrl: string;
+  readonly userDataDirectoryName: string;
+  readonly defaultHomeDirectoryName: string;
+  readonly usesScriptedUpdates: boolean;
+}
+
+export function resolveSynaraDesktopFlavor(input: {
+  readonly isDevelopment: boolean;
+  readonly requestedFlavor?: string | undefined;
+}): SynaraDesktopFlavor {
+  if (input.requestedFlavor?.trim().toLowerCase() === "canary") {
+    return "canary";
+  }
+  return input.isDevelopment ? "development" : "production";
+}
+
+export function synaraDesktopIdentity(flavor: SynaraDesktopFlavor): SynaraDesktopIdentity {
+  if (flavor === "canary") {
+    return {
+      flavor,
+      displayName: "Synara Canary",
+      bundleId: SYNARA_CANARY_BUNDLE_ID,
+      scheme: SYNARA_CANARY_DESKTOP_SCHEME,
+      origin: SYNARA_CANARY_DESKTOP_ORIGIN,
+      entryUrl: SYNARA_CANARY_DESKTOP_ENTRY_URL,
+      userDataDirectoryName: "synara-canary",
+      defaultHomeDirectoryName: ".synara-canary",
+      usesScriptedUpdates: true,
+    };
+  }
+  if (flavor === "development") {
+    return {
+      flavor,
+      displayName: "Synara (Dev)",
+      bundleId: SYNARA_DEVELOPMENT_BUNDLE_ID,
+      scheme: SYNARA_DESKTOP_SCHEME,
+      origin: SYNARA_DESKTOP_ORIGIN,
+      entryUrl: SYNARA_DESKTOP_ENTRY_URL,
+      userDataDirectoryName: "synara-dev",
+      defaultHomeDirectoryName: ".synara",
+      usesScriptedUpdates: false,
+    };
+  }
+  return {
+    flavor,
+    displayName: "Synara",
+    bundleId: SYNARA_PRODUCTION_BUNDLE_ID,
+    scheme: SYNARA_DESKTOP_SCHEME,
+    origin: SYNARA_DESKTOP_ORIGIN,
+    entryUrl: SYNARA_DESKTOP_ENTRY_URL,
+    userDataDirectoryName: "synara",
+    defaultHomeDirectoryName: ".synara",
+    usesScriptedUpdates: false,
+  };
+}
 
 export function synaraBundleId(isDevelopment: boolean): string {
-  return isDevelopment ? SYNARA_DEVELOPMENT_BUNDLE_ID : SYNARA_PRODUCTION_BUNDLE_ID;
+  return synaraDesktopIdentity(isDevelopment ? "development" : "production").bundleId;
 }

--- a/scripts/canary.test.ts
+++ b/scripts/canary.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCanaryArgs, resolveCanaryPaths } from "./canary";
+
+describe("canary tooling", () => {
+  it("keeps managed source and Canary data separate from Stable", () => {
+    expect(resolveCanaryPaths({}, "/Users/tester")).toEqual({
+      home: "/Users/tester/.synara-canary",
+      source: "/Users/tester/.cache/synara-canary/source",
+      state: "/Users/tester/.synara-canary/canary-state.json",
+      pid: "/Users/tester/.synara-canary/canary.pid",
+      log: "/Users/tester/.synara-canary/canary.log",
+    });
+  });
+
+  it("supports explicit path overrides", () => {
+    expect(
+      resolveCanaryPaths(
+        {
+          SYNARA_CANARY_HOME: "/tmp/canary-data",
+          SYNARA_CANARY_SOURCE: "/tmp/canary-source",
+        },
+        "/Users/tester",
+      ),
+    ).toEqual({
+      home: "/tmp/canary-data",
+      source: "/tmp/canary-source",
+      state: "/tmp/canary-data/canary-state.json",
+      pid: "/tmp/canary-data/canary.pid",
+      log: "/tmp/canary-data/canary.log",
+    });
+  });
+
+  it("tracks main by default and accepts a stacked PR ref", () => {
+    expect(parseCanaryArgs(["update"])).toEqual({ command: "update", ref: "main" });
+    expect(parseCanaryArgs(["setup", "--ref", "codex/synara-canary"])).toEqual({
+      command: "setup",
+      ref: "codex/synara-canary",
+    });
+  });
+
+  it("rejects unsupported commands and incomplete refs", () => {
+    expect(() => parseCanaryArgs(["reset"])).toThrow(/Unknown Canary command/u);
+    expect(() => parseCanaryArgs(["update", "--ref"])).toThrow(/Missing value/u);
+  });
+});

--- a/scripts/canary.test.ts
+++ b/scripts/canary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseCanaryArgs, resolveCanaryPaths } from "./canary";
+import { parseCanaryArgs, resolveCanaryPaths, resolveCanaryRef } from "./canary";
 
 describe("canary tooling", () => {
   it("keeps managed source and Canary data separate from Stable", () => {
@@ -32,11 +32,19 @@ describe("canary tooling", () => {
   });
 
   it("tracks main by default and accepts a stacked PR ref", () => {
-    expect(parseCanaryArgs(["update"])).toEqual({ command: "update", ref: "main" });
+    expect(parseCanaryArgs(["update"])).toEqual({ command: "update", ref: null });
     expect(parseCanaryArgs(["setup", "--ref", "codex/synara-canary"])).toEqual({
       command: "setup",
       ref: "codex/synara-canary",
     });
+  });
+
+  it("keeps updating the selected stacked ref until explicitly moved to main", () => {
+    expect(resolveCanaryRef(parseCanaryArgs(["setup"]), null)).toBe("main");
+    expect(resolveCanaryRef(parseCanaryArgs(["update"]), "codex/synara-canary")).toBe(
+      "codex/synara-canary",
+    );
+    expect(resolveCanaryRef(parseCanaryArgs(["update", "--ref", "main"]), "old-ref")).toBe("main");
   });
 
   it("rejects unsupported commands and incomplete refs", () => {

--- a/scripts/canary.ts
+++ b/scripts/canary.ts
@@ -1,0 +1,383 @@
+// FILE: canary.ts
+// Purpose: Maintains and launches an isolated, frozen Synara Canary checkout.
+// Layer: Local developer tooling
+
+import { spawn, spawnSync } from "node:child_process";
+import * as FS from "node:fs";
+import * as OS from "node:os";
+import * as Path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type CanaryCommand = "setup" | "update" | "start" | "stop" | "status" | "rollback";
+
+export interface CanaryPaths {
+  readonly home: string;
+  readonly source: string;
+  readonly state: string;
+  readonly pid: string;
+  readonly log: string;
+}
+
+interface CanaryState {
+  readonly currentCommit: string;
+  readonly previousCommit: string | null;
+  readonly trackedRef: string;
+  readonly updatedAt: string;
+}
+
+interface ParsedCanaryArgs {
+  readonly command: CanaryCommand;
+  readonly ref: string;
+}
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const REPO_ROOT = Path.resolve(Path.dirname(SCRIPT_PATH), "..");
+const DEFAULT_REF = "main";
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/iu;
+
+export function resolveCanaryPaths(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDirectory = OS.homedir(),
+): CanaryPaths {
+  const home = Path.resolve(
+    env.SYNARA_CANARY_HOME?.trim() || Path.join(homeDirectory, ".synara-canary"),
+  );
+  const cacheBase = env.XDG_CACHE_HOME?.trim() || Path.join(homeDirectory, ".cache");
+  const source = Path.resolve(
+    env.SYNARA_CANARY_SOURCE?.trim() || Path.join(cacheBase, "synara-canary", "source"),
+  );
+  return {
+    home,
+    source,
+    state: Path.join(home, "canary-state.json"),
+    pid: Path.join(home, "canary.pid"),
+    log: Path.join(home, "canary.log"),
+  };
+}
+
+export function parseCanaryArgs(argv: ReadonlyArray<string>): ParsedCanaryArgs {
+  const rawCommand = argv[0] ?? "status";
+  if (
+    !(["setup", "update", "start", "stop", "status", "rollback"] as const).includes(
+      rawCommand as CanaryCommand,
+    )
+  ) {
+    throw new Error(`Unknown Canary command: ${rawCommand}`);
+  }
+  let ref = DEFAULT_REF;
+  for (let index = 1; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--ref") {
+      const value = argv[index + 1]?.trim();
+      if (!value) throw new Error("Missing value for --ref.");
+      ref = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown Canary argument: ${String(argument)}`);
+  }
+  return { command: rawCommand as CanaryCommand, ref };
+}
+
+function run(command: string, args: ReadonlyArray<string>, cwd: string): void {
+  const result = spawnSync(command, [...args], {
+    cwd,
+    env: process.env,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} exited with ${String(result.status)}.`);
+  }
+}
+
+function capture(command: string, args: ReadonlyArray<string>, cwd: string): string {
+  const result = spawnSync(command, [...args], {
+    cwd,
+    env: process.env,
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} exited with ${String(result.status)}: ${result.stderr.trim()}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+function readState(paths: CanaryPaths): CanaryState | null {
+  try {
+    const state = JSON.parse(FS.readFileSync(paths.state, "utf8")) as Partial<CanaryState>;
+    if (
+      typeof state.currentCommit !== "string" ||
+      !COMMIT_PATTERN.test(state.currentCommit) ||
+      (state.previousCommit !== null &&
+        (typeof state.previousCommit !== "string" || !COMMIT_PATTERN.test(state.previousCommit))) ||
+      typeof state.trackedRef !== "string" ||
+      typeof state.updatedAt !== "string"
+    ) {
+      return null;
+    }
+    return state as CanaryState;
+  } catch {
+    return null;
+  }
+}
+
+function writeState(paths: CanaryPaths, state: CanaryState): void {
+  FS.mkdirSync(paths.home, { recursive: true });
+  const temporaryPath = `${paths.state}.tmp`;
+  FS.writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  FS.renameSync(temporaryPath, paths.state);
+}
+
+function readPid(paths: CanaryPaths): number | null {
+  try {
+    const pid = Number(FS.readFileSync(paths.pid, "utf8").trim());
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function isRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stopCanary(paths: CanaryPaths): void {
+  const pid = readPid(paths);
+  if (pid === null || !isRunning(pid)) {
+    FS.rmSync(paths.pid, { force: true });
+    return;
+  }
+  if (process.platform === "win32") {
+    spawnSync("taskkill", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore" });
+  } else {
+    try {
+      process.kill(-pid, "SIGTERM");
+    } catch {
+      process.kill(pid, "SIGTERM");
+    }
+  }
+  FS.rmSync(paths.pid, { force: true });
+}
+
+function resolveOriginUrl(): string {
+  return capture("git", ["remote", "get-url", "origin"], REPO_ROOT);
+}
+
+function ensureManagedSource(paths: CanaryPaths): void {
+  if (FS.existsSync(Path.join(paths.source, ".git"))) return;
+  if (FS.existsSync(paths.source)) {
+    const entries = FS.readdirSync(paths.source);
+    if (entries.length > 0) {
+      throw new Error(`Canary source path exists but is not a Git checkout: ${paths.source}`);
+    }
+  }
+  FS.mkdirSync(Path.dirname(paths.source), { recursive: true });
+  run("git", ["clone", "--no-checkout", resolveOriginUrl(), paths.source], REPO_ROOT);
+}
+
+function assertManagedSourceIsClean(paths: CanaryPaths): void {
+  const status = capture("git", ["status", "--porcelain", "--untracked-files=no"], paths.source);
+  if (status.length > 0) {
+    throw new Error(
+      `Synara Canary's managed source has tracked local changes. Refusing to overwrite ${paths.source}.`,
+    );
+  }
+}
+
+function fetchRef(paths: CanaryPaths, ref: string): string {
+  run("git", ["fetch", "--prune", "origin", ref], paths.source);
+  const commit = capture("git", ["rev-parse", "FETCH_HEAD"], paths.source);
+  if (!COMMIT_PATTERN.test(commit)) throw new Error(`Invalid fetched commit: ${commit}`);
+  return commit;
+}
+
+function checkout(paths: CanaryPaths, commit: string): void {
+  run("git", ["checkout", "--detach", "--force", commit], paths.source);
+}
+
+function build(paths: CanaryPaths): void {
+  run("bun", ["install", "--frozen-lockfile"], paths.source);
+  run("bun", ["run", "build:desktop"], paths.source);
+  run("bun", ["run", "release:smoke"], paths.source);
+}
+
+function currentSourceCommit(paths: CanaryPaths): string | null {
+  if (!FS.existsSync(Path.join(paths.source, ".git"))) return null;
+  try {
+    const commit = capture("git", ["rev-parse", "HEAD"], paths.source);
+    return COMMIT_PATTERN.test(commit) ? commit : null;
+  } catch {
+    return null;
+  }
+}
+
+function startCanary(paths: CanaryPaths): void {
+  const existingPid = readPid(paths);
+  if (existingPid !== null && isRunning(existingPid)) {
+    console.log(`Synara Canary is already running (pid ${String(existingPid)}).`);
+    return;
+  }
+  const commit = currentSourceCommit(paths);
+  if (
+    commit === null ||
+    !FS.existsSync(Path.join(paths.source, "apps/desktop/dist-electron/main.js"))
+  ) {
+    throw new Error("Synara Canary is not built. Run `bun run canary:setup` first.");
+  }
+  FS.mkdirSync(paths.home, { recursive: true });
+  const env = { ...process.env };
+  delete env.VITE_DEV_SERVER_URL;
+  delete env.ELECTRON_RENDERER_PORT;
+  delete env.SYNARA_AUTH_TOKEN;
+  Object.assign(env, {
+    SYNARA_DESKTOP_FLAVOR: "canary",
+    SYNARA_DISABLE_AUTO_UPDATE: "1",
+    SYNARA_HOME: paths.home,
+    SYNARA_COMMIT_HASH: commit,
+  });
+  const logDescriptor = FS.openSync(paths.log, "a", 0o600);
+  try {
+    FS.writeSync(logDescriptor, `\n[${new Date().toISOString()}] Starting ${commit}\n`);
+    const child = spawn("bun", ["run", "start:desktop"], {
+      cwd: paths.source,
+      env,
+      detached: true,
+      stdio: ["ignore", logDescriptor, logDescriptor],
+      shell: process.platform === "win32",
+    });
+    if (child.pid === undefined) {
+      throw new Error("Synara Canary failed to return a process id.");
+    }
+    child.unref();
+    FS.writeFileSync(paths.pid, `${String(child.pid)}\n`, { mode: 0o600 });
+    console.log(`Started Synara Canary at ${commit.slice(0, 12)} (pid ${String(child.pid)}).`);
+    console.log(`Log: ${paths.log}`);
+  } finally {
+    FS.closeSync(logDescriptor);
+  }
+}
+
+function updateCanary(paths: CanaryPaths, ref: string): void {
+  ensureManagedSource(paths);
+  assertManagedSourceIsClean(paths);
+  const previousCommit = currentSourceCommit(paths);
+  const targetCommit = fetchRef(paths, ref);
+  if (
+    previousCommit === targetCommit &&
+    FS.existsSync(Path.join(paths.source, "apps/desktop/dist-electron/main.js"))
+  ) {
+    const previousState = readState(paths);
+    writeState(paths, {
+      currentCommit: targetCommit,
+      previousCommit: previousState?.previousCommit ?? null,
+      trackedRef: ref,
+      updatedAt: new Date().toISOString(),
+    });
+    startCanary(paths);
+    return;
+  }
+  stopCanary(paths);
+  try {
+    checkout(paths, targetCommit);
+    build(paths);
+  } catch (error) {
+    if (previousCommit !== null && previousCommit !== targetCommit) {
+      console.error(`Canary update failed; restoring ${previousCommit.slice(0, 12)}.`);
+      checkout(paths, previousCommit);
+      build(paths);
+      startCanary(paths);
+    }
+    throw error;
+  }
+  const previousState = readState(paths);
+  writeState(paths, {
+    currentCommit: targetCommit,
+    previousCommit:
+      previousCommit !== null && previousCommit !== targetCommit
+        ? previousCommit
+        : (previousState?.previousCommit ?? null),
+    trackedRef: ref,
+    updatedAt: new Date().toISOString(),
+  });
+  startCanary(paths);
+}
+
+function rollbackCanary(paths: CanaryPaths): void {
+  const state = readState(paths);
+  if (state?.previousCommit === null || state?.previousCommit === undefined) {
+    throw new Error("Synara Canary has no previous successful commit to restore.");
+  }
+  assertManagedSourceIsClean(paths);
+  stopCanary(paths);
+  const rollbackCommit = state.previousCommit;
+  try {
+    checkout(paths, rollbackCommit);
+    build(paths);
+  } catch (error) {
+    console.error(`Canary rollback failed; restoring ${state.currentCommit.slice(0, 12)}.`);
+    checkout(paths, state.currentCommit);
+    build(paths);
+    startCanary(paths);
+    throw error;
+  }
+  writeState(paths, {
+    currentCommit: rollbackCommit,
+    previousCommit: state.currentCommit,
+    trackedRef: state.trackedRef,
+    updatedAt: new Date().toISOString(),
+  });
+  startCanary(paths);
+}
+
+function printStatus(paths: CanaryPaths): void {
+  const state = readState(paths);
+  const pid = readPid(paths);
+  const running = pid !== null && isRunning(pid);
+  console.log(`Synara Canary: ${running ? `running (pid ${String(pid)})` : "stopped"}`);
+  console.log(`Source: ${paths.source}`);
+  console.log(`Data: ${paths.home}`);
+  console.log(`Log: ${paths.log}`);
+  console.log(`Commit: ${state?.currentCommit ?? currentSourceCommit(paths) ?? "not installed"}`);
+  console.log(`Tracked ref: ${state?.trackedRef ?? "not configured"}`);
+}
+
+export function runCanaryCommand(input: ParsedCanaryArgs, paths = resolveCanaryPaths()): void {
+  if (input.command === "setup" || input.command === "update") {
+    updateCanary(paths, input.ref);
+    return;
+  }
+  if (input.command === "start") {
+    startCanary(paths);
+    return;
+  }
+  if (input.command === "stop") {
+    stopCanary(paths);
+    return;
+  }
+  if (input.command === "rollback") {
+    rollbackCanary(paths);
+    return;
+  }
+  printStatus(paths);
+}
+
+const isMain = process.argv[1] !== undefined && Path.resolve(process.argv[1]) === SCRIPT_PATH;
+if (isMain) {
+  try {
+    runCanaryCommand(parseCanaryArgs(process.argv.slice(2)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/canary.ts
+++ b/scripts/canary.ts
@@ -27,7 +27,7 @@ interface CanaryState {
 
 interface ParsedCanaryArgs {
   readonly command: CanaryCommand;
-  readonly ref: string;
+  readonly ref: string | null;
 }
 
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
@@ -64,7 +64,7 @@ export function parseCanaryArgs(argv: ReadonlyArray<string>): ParsedCanaryArgs {
   ) {
     throw new Error(`Unknown Canary command: ${rawCommand}`);
   }
-  let ref = DEFAULT_REF;
+  let ref: string | null = null;
   for (let index = 1; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === "--ref") {
@@ -77,6 +77,10 @@ export function parseCanaryArgs(argv: ReadonlyArray<string>): ParsedCanaryArgs {
     throw new Error(`Unknown Canary argument: ${String(argument)}`);
   }
   return { command: rawCommand as CanaryCommand, ref };
+}
+
+export function resolveCanaryRef(input: ParsedCanaryArgs, trackedRef: string | null): string {
+  return input.ref ?? (input.command === "update" ? trackedRef : null) ?? DEFAULT_REF;
 }
 
 function run(command: string, args: ReadonlyArray<string>, cwd: string): void {
@@ -354,7 +358,7 @@ function printStatus(paths: CanaryPaths): void {
 
 export function runCanaryCommand(input: ParsedCanaryArgs, paths = resolveCanaryPaths()): void {
   if (input.command === "setup" || input.command === "update") {
-    updateCanary(paths, input.ref);
+    updateCanary(paths, resolveCanaryRef(input, readState(paths)?.trackedRef ?? null));
     return;
   }
   if (input.command === "start") {


### PR DESCRIPTION
## Summary
- add a distinct Synara Canary desktop identity, protocol origin, bundle ID, Electron profile, and data home
- add script-controlled setup/update/start/stop/status/rollback commands backed by a managed checkout
- disable production auto-updates for Canary and preserve Stable/Dev isolation, including the single-instance lock
- add focused tests and operating documentation

## Isolation
Canary starts from an empty ~/.synara-canary data directory and never copies Stable data. Its managed source lives under ~/.cache/synara-canary/source.

## Verification
- bun fmt
- bun lint (0 errors; existing warnings only)
- bun typecheck
- bun run test
- bun run build:desktop
- bun run release:smoke
- macOS launcher plist verified as Synara Canary / com.emanueledipietro.synara.canary

## Stack
Depends on #357. Once #357 merges, rebase/change this PR base to main before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop startup (userData timing, single-instance lock), origin trust, and new local tooling that runs git/build/spawn; isolation is intentional but misconfiguration could still affect the wrong profile.
> 
> **Overview**
> Introduces **Synara Canary**, a third desktop flavor with its own bundle ID, `synara-canary://` origin, `~/.synara-canary` data home, and Electron `synara-canary` profile—fully isolated from Stable and Dev.
> 
> Desktop identity is refactored from dev/prod booleans into **`resolveSynaraDesktopFlavor`** / **`synaraDesktopIdentity`**, driven by `SYNARA_DESKTOP_FLAVOR`. The Electron main process and launcher use that for display name, scheme, entry URL, and userData; **userData is set before the single-instance lock** so flavors do not contend. Canary disables production auto-updates via `usesScriptedUpdates`.
> 
> **`scripts/canary.ts`** adds setup/update/start/stop/status/rollback: a managed git checkout, frozen-lockfile build, release smoke, detached launch with canary env, rollback on failure, and path overrides. Root **`canary:*`** npm scripts and **`docs/canary.md`** document usage.
> 
> The server trusts **`synara-canary://app`** alongside the stable desktop origin in CORS/origin checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de385d257afc470ea49ce26b651f41209d43293c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->