### PR TITLE
Fix Canary setup checkout and runtime isolation

### DIFF
--- a/scripts/canary.test.ts
+++ b/scripts/canary.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { parseCanaryArgs, resolveCanaryPaths, resolveCanaryRef } from "./canary";
+import {
+  canaryCloneArgs,
+  canaryStartArgs,
+  parseCanaryArgs,
+  resolveCanaryPaths,
+  resolveCanaryRef,
+} from "./canary";
 
 describe("canary tooling", () => {
   it("keeps managed source and Canary data separate from Stable", () => {
@@ -37,6 +43,19 @@ describe("canary tooling", () => {
       command: "setup",
       ref: "codex/synara-canary",
     });
+  });
+
+  it("checks out the managed source during clone so the cleanliness guard starts clean", () => {
+    expect(canaryCloneArgs("git@example.com:synara.git", "/tmp/canary-source")).toEqual([
+      "clone",
+      "--",
+      "git@example.com:synara.git",
+      "/tmp/canary-source",
+    ]);
+  });
+
+  it("starts desktop directly so Canary isolation variables bypass Turbo filtering", () => {
+    expect(canaryStartArgs()).toEqual(["run", "--cwd", "apps/desktop", "start"]);
   });
 
   it("keeps updating the selected stacked ref until explicitly moved to main", () => {

--- a/scripts/canary.ts
+++ b/scripts/canary.ts
@@ -83,6 +83,20 @@ export function resolveCanaryRef(input: ParsedCanaryArgs, trackedRef: string | n
   return input.ref ?? (input.command === "update" ? trackedRef : null) ?? DEFAULT_REF;
 }
 
+export function canaryCloneArgs(originUrl: string, source: string): ReadonlyArray<string> {
+  // The cleanliness guard runs immediately after cloning. A --no-checkout clone
+  // reports every tracked file as deleted, so it is indistinguishable from a
+  // user-modified managed checkout at that point.
+  return ["clone", "--", originUrl, source];
+}
+
+export function canaryStartArgs(): ReadonlyArray<string> {
+  // Starting through the root Turbo task filters undeclared environment
+  // variables before the desktop process is spawned. Canary's flavor, home,
+  // updater policy, and commit identity must reach Electron unchanged.
+  return ["run", "--cwd", "apps/desktop", "start"];
+}
+
 function run(command: string, args: ReadonlyArray<string>, cwd: string): void {
   const result = spawnSync(command, [...args], {
     cwd,
@@ -187,7 +201,7 @@ function ensureManagedSource(paths: CanaryPaths): void {
     }
   }
   FS.mkdirSync(Path.dirname(paths.source), { recursive: true });
-  run("git", ["clone", "--no-checkout", resolveOriginUrl(), paths.source], REPO_ROOT);
+  run("git", canaryCloneArgs(resolveOriginUrl(), paths.source), REPO_ROOT);
 }
 
 function assertManagedSourceIsClean(paths: CanaryPaths): void {
@@ -253,7 +267,7 @@ function startCanary(paths: CanaryPaths): void {
   const logDescriptor = FS.openSync(paths.log, "a", 0o600);
   try {
     FS.writeSync(logDescriptor, `\n[${new Date().toISOString()}] Starting ${commit}\n`);
-    const child = spawn("bun", ["run", "start:desktop"], {
+    const child = spawn("bun", [...canaryStartArgs()], {
       cwd: paths.source,
       env,
       detached: true,


### PR DESCRIPTION
Fixes two first-run issues found while installing Synara Canary:\n\n- clone the managed source with a populated worktree so the cleanliness guard does not interpret every tracked file as deleted\n- start the desktop package directly instead of through Turbo, preserving Canary flavor, home, updater policy, and commit environment variables\n\nVerification:\n- focused Canary tests: 7/7\n- targeted format and lint: clean\n- real setup/build/release smoke: passed\n- runtime confirmed as Synara Canary.app with synara-canary user-data profile and scheme

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to local Canary scripts and improve isolation correctness; they do not alter Stable desktop or server auth paths.
> 
> **Overview**
> Fixes two Synara Canary first-run failures in the managed checkout tooling.
> 
> **Clone** no longer uses `git clone --no-checkout`. A normal clone populates the worktree so `assertManagedSourceIsClean` does not treat every tracked file as deleted right after setup.
> 
> **Start** bypasses the root `start:desktop` Turbo task and runs `bun run --cwd apps/desktop start` so Canary-specific env (`SYNARA_DESKTOP_FLAVOR`, `SYNARA_HOME`, updater disable, commit hash) is not stripped before Electron starts.
> 
> Clone and start argv are centralized in `canaryCloneArgs` and `canaryStartArgs`, with unit tests locking the expected behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33fdf6605c1e1466455a6f9979c6eb5f8f38ec82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->