### PR TITLE
fix(canary): harden launcher and attachment uploads

### DIFF
--- a/apps/server/src/authEffectRoute.test.ts
+++ b/apps/server/src/authEffectRoute.test.ts
@@ -342,6 +342,40 @@ describe("authEffectRouteLayer", () => {
 });
 
 describe("binaryUploadEffectRouteLayer", () => {
+  it("allows credentialed Canary attachment upload preflights", async () => {
+    const config = {
+      host: "127.0.0.1",
+      attachmentsDir: fs.mkdtempSync(path.join(os.tmpdir(), "synara-upload-cors-")),
+    } as ServerConfigShape;
+    try {
+      await withAuthEffectServer(
+        config,
+        makeServerAuth({ count: 0 }),
+        async (serverOrigin) => {
+          const response = await fetch(`${serverOrigin}${ATTACHMENT_UPLOAD_ROUTE_PATH}`, {
+            method: "OPTIONS",
+            headers: {
+              Origin: "synara-canary://app",
+              "Access-Control-Request-Method": "POST",
+              "Access-Control-Request-Headers": "content-type",
+            },
+          });
+
+          expect(response.status).toBe(204);
+          expect(response.headers.get("access-control-allow-origin")).toBe("synara-canary://app");
+          expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+          expect(response.headers.get("access-control-allow-methods")).toContain("POST");
+          expect(response.headers.get("access-control-allow-headers")?.toLowerCase()).toContain(
+            "content-type",
+          );
+        },
+        binaryUploadEffectRouteLayer,
+      );
+    } finally {
+      fs.rmSync(config.attachmentsDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects ambient cookie uploads without an origin and accepts explicit bearer auth", async () => {
     const attachmentsDir = fs.mkdtempSync(path.join(os.tmpdir(), "synara-upload-route-"));
     const config = {

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -249,6 +249,7 @@ function trustedMutationCorsHeaders(input: {
   }
   return {
     "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Credentials": "true",
     "Access-Control-Allow-Methods": "POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
     Vary: "Origin",

--- a/scripts/canary.test.ts
+++ b/scripts/canary.test.ts
@@ -54,8 +54,8 @@ describe("canary tooling", () => {
     ]);
   });
 
-  it("starts desktop directly so Canary isolation variables bypass Turbo filtering", () => {
-    expect(canaryStartArgs()).toEqual(["run", "--cwd", "apps/desktop", "start"]);
+  it("starts the desktop launcher directly so the persisted PID stays alive", () => {
+    expect(canaryStartArgs()).toEqual(["apps/desktop/scripts/start-electron.mjs"]);
   });
 
   it("keeps updating the selected stacked ref until explicitly moved to main", () => {

--- a/scripts/canary.ts
+++ b/scripts/canary.ts
@@ -91,10 +91,12 @@ export function canaryCloneArgs(originUrl: string, source: string): ReadonlyArra
 }
 
 export function canaryStartArgs(): ReadonlyArray<string> {
-  // Starting through the root Turbo task filters undeclared environment
-  // variables before the desktop process is spawned. Canary's flavor, home,
-  // updater policy, and commit identity must reach Electron unchanged.
-  return ["run", "--cwd", "apps/desktop", "start"];
+  // Invoke the desktop launcher directly. `bun run --cwd apps/desktop start`
+  // adds a short-lived package-script process in front of the launcher, so the
+  // PID persisted by Canary goes stale while Electron is still running. The
+  // direct launcher remains alive for Electron's lifetime and also preserves
+  // Canary's flavor, home, updater policy, and commit identity.
+  return ["apps/desktop/scripts/start-electron.mjs"];
 }
 
 function run(command: string, args: ReadonlyArray<string>, cwd: string): void {


### PR DESCRIPTION
## Summary
- launch the desktop runner directly instead of through a short-lived Bun package-script wrapper
- keep the persisted Canary PID alive for Electron's lifetime so status, stop, and duplicate prevention remain reliable
- allow credentialed attachment upload preflights from the isolated synara-canary://app origin

## Root causes fixed
- the old launcher persisted the PID of a short-lived wrapper, allowing duplicate Canary instances
- image sends retried and eventually continued without the image because Chromium rejected the upload preflight without Access-Control-Allow-Credentials

## Verification
- Canary tooling tests: 7/7
- attachment route tests: 6/6, including a Canary credentialed CORS regression test
- targeted format and lint clean
- scripts TypeScript check clean
- real lifecycle smoke: status remains running and a second start is rejected
- real message smoke: Codex replied CANARY_OK
- reproduced image upload failure in Canary DevTools before the CORS fix