### PR TITLE
fix(server): recover Windows migrations and Codex startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
       - name: Test Effect Windows process spawn
         run: bun run --cwd apps/server test src/windowsProcessEffect.test.ts
 
+      - name: Test Windows migration backup and recovery
+        run: bun run --cwd apps/server test src/persistence/MigrationBackup.test.ts
+
   release_smoke:
     name: Release Smoke
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Test Windows migration backup and recovery
         run: bun run --cwd apps/server test src/persistence/MigrationBackup.test.ts
 
+      - name: Test Codex SQLite overlay and initialization recovery
+        run: bun run --cwd apps/server test src/codexProcessEnv.test.ts src/codexAppServerManager.test.ts
+
   release_smoke:
     name: Release Smoke
     runs-on: ubuntu-24.04

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -1070,6 +1070,99 @@ describe("startSession", () => {
   });
 });
 
+describe("sendRequest", () => {
+  function createRequestHarness() {
+    const manager = new CodexAppServerManager();
+    const context = {
+      nextRequestId: 1,
+      pending: new Map<string, unknown>(),
+    };
+    const writeMessage = vi
+      .spyOn(
+        manager as unknown as { writeMessage: (...args: unknown[]) => Promise<void> },
+        "writeMessage",
+      )
+      .mockResolvedValue(undefined);
+    const sendRequest = (
+      manager as unknown as {
+        sendRequest: (
+          context: unknown,
+          method: string,
+          params: unknown,
+          timeoutMs?: number,
+        ) => Promise<unknown>;
+      }
+    ).sendRequest.bind(manager);
+    const handleResponse = (
+      manager as unknown as {
+        handleResponse: (context: unknown, response: Record<string, unknown>) => void;
+      }
+    ).handleResponse.bind(manager);
+    return { context, handleResponse, sendRequest, writeMessage };
+  }
+
+  it("accepts an initialize response after the ordinary 20-second budget", async () => {
+    vi.useFakeTimers();
+    try {
+      const { context, handleResponse, sendRequest } = createRequestHarness();
+      const initializeRequest = sendRequest(context, "initialize", {});
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(context.pending.size).toBe(1);
+
+      handleResponse(context, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { ready: true },
+      });
+      await expect(initializeRequest).resolves.toEqual({ ready: true });
+      expect(context.pending.size).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(context.pending.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out initialize at 45 seconds and ordinary requests at 20 seconds", async () => {
+    vi.useFakeTimers();
+    try {
+      const { context, sendRequest } = createRequestHarness();
+      const initializeRequest = sendRequest(context, "initialize", {});
+      const initializeRejection = expect(initializeRequest).rejects.toThrow(
+        "Timed out waiting for initialize.",
+      );
+
+      await vi.advanceTimersByTimeAsync(44_999);
+      expect(context.pending.size).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await initializeRejection;
+      expect(context.pending.size).toBe(0);
+
+      const modelListRequest = sendRequest(context, "model/list", {});
+      const modelListRejection = expect(modelListRequest).rejects.toThrow(
+        "Timed out waiting for model/list.",
+      );
+      await vi.advanceTimersByTimeAsync(20_000);
+      await modelListRejection;
+      expect(context.pending.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects immediately and clears pending state when the transport write fails", async () => {
+    const { context, sendRequest, writeMessage } = createRequestHarness();
+    writeMessage.mockRejectedValueOnce(new Error("injected transport write failure"));
+
+    await expect(sendRequest(context, "initialize", {})).rejects.toThrow(
+      "injected transport write failure",
+    );
+    expect(context.pending.size).toBe(0);
+  });
+});
+
 describe("sendTurn", () => {
   it("sends text and image user input items to turn/start", async () => {
     const { manager, context, requireSession, sendRequest, updateSession } =

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -8,12 +8,14 @@ import {
   readFileSync,
   readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { ApprovalRequestId, ThreadId } from "@synara/contracts";
+import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
 
 import {
   buildCodexProcessEnv,
@@ -21,6 +23,7 @@ import {
   resolveCodexBrowserUsePipePath,
 } from "./codexProcessEnv";
 import {
+  buildCodexAppServerArgs,
   buildCodexInitializeParams,
   CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
   CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
@@ -645,28 +648,79 @@ describe("buildCodexProcessEnv", () => {
     }
   });
 
-  it("repairs stale real files in Synara's Codex home overlay", async () => {
+  it("preserves recovered SQLite state across repeated overlay preparation", async () => {
     const tempDir = mkdtempSync(path.join(os.tmpdir(), "synara-codex-env-"));
     const runtimeHome = mkdtempSync(path.join(os.tmpdir(), "synara-runtime-home-"));
     try {
-      const sourceMemoryPath = path.join(tempDir, "memories_1.sqlite");
       writeFileSync(path.join(tempDir, "config.toml"), 'model = "gpt-5.5"', "utf8");
-      writeFileSync(sourceMemoryPath, "fresh-source-db", "utf8");
-
       const overlayHome = path.join(runtimeHome, "codex-home-overlay");
-      const overlayMemoryPath = path.join(overlayHome, "memories_1.sqlite");
       mkdirSync(overlayHome, { recursive: true });
-      writeFileSync(overlayMemoryPath, "stale-overlay-db", "utf8");
+      const sqliteEntries = [
+        "state_5.sqlite",
+        "state_5.sqlite-wal",
+        "state_5.sqlite-shm",
+        "state_5.sqlite-journal",
+      ];
+      for (const entry of sqliteEntries) {
+        writeFileSync(path.join(tempDir, entry), `source-${entry}`, "utf8");
+        writeFileSync(path.join(overlayHome, entry), `recovered-${entry}`, "utf8");
+      }
 
-      const env = await buildCodexProcessEnv({
+      const input = {
+        env: { SYNARA_HOME: runtimeHome, CODEX_SQLITE_HOME: tempDir },
+        homePath: tempDir,
+        platform: "darwin",
+      } as const;
+      const env = await buildCodexProcessEnv(input);
+      await buildCodexProcessEnv(input);
+
+      expect(env.CODEX_HOME).toBe(overlayHome);
+      expect(env.CODEX_SQLITE_HOME).toBe(overlayHome);
+      for (const entry of sqliteEntries) {
+        const overlayPath = path.join(overlayHome, entry);
+        expect(lstatSync(overlayPath).isFile()).toBe(true);
+        expect(lstatSync(overlayPath).isSymbolicLink()).toBe(false);
+        expect(readFileSync(overlayPath, "utf8")).toBe(`recovered-${entry}`);
+        expect(readFileSync(path.join(tempDir, entry), "utf8")).toBe(`source-${entry}`);
+      }
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+      rmSync(runtimeHome, { recursive: true, force: true });
+    }
+  });
+
+  it("removes legacy SQLite family links without relinking source state", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "synara-codex-env-"));
+    const runtimeHome = mkdtempSync(path.join(os.tmpdir(), "synara-runtime-home-"));
+    try {
+      writeFileSync(path.join(tempDir, "config.toml"), 'model = "gpt-5.5"', "utf8");
+      const overlayHome = path.join(runtimeHome, "codex-home-overlay");
+      mkdirSync(overlayHome, { recursive: true });
+      const sqliteEntries = [
+        "state_5.sqlite",
+        "state_5.sqlite-wal",
+        "state_5.sqlite-shm",
+        "state_5.sqlite-journal",
+      ];
+      for (const entry of sqliteEntries) {
+        const sourcePath = path.join(tempDir, entry);
+        writeFileSync(sourcePath, `source-${entry}`, "utf8");
+        symlinkSync(sourcePath, path.join(overlayHome, entry), "file");
+      }
+
+      const input = {
         env: { SYNARA_HOME: runtimeHome },
         homePath: tempDir,
         platform: "darwin",
-      });
+      } as const;
+      const env = await buildCodexProcessEnv(input);
+      await buildCodexProcessEnv(input);
 
       expect(env.CODEX_HOME).toBe(overlayHome);
-      expect(lstatSync(overlayMemoryPath).isSymbolicLink()).toBe(true);
-      expect(readlinkSync(overlayMemoryPath)).toBe(sourceMemoryPath);
+      for (const entry of sqliteEntries) {
+        expect(() => lstatSync(path.join(overlayHome, entry))).toThrow();
+        expect(readFileSync(path.join(tempDir, entry), "utf8")).toBe(`source-${entry}`);
+      }
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
       rmSync(runtimeHome, { recursive: true, force: true });
@@ -741,6 +795,44 @@ describe("buildCodexProcessEnv", () => {
     ).toBe(
       '[plugins."historical-plugin@local"]\nenabled = false\n\n[plugins."other@local"]\nenabled = true',
     );
+  });
+});
+
+describe("buildCodexAppServerArgs", () => {
+  it("pins SQLite to the process overlay above project and user config", () => {
+    expect(
+      buildCodexAppServerArgs({
+        CODEX_SQLITE_HOME: String.raw`C:\Users\test\.synara\codex-home-overlay`,
+      }),
+    ).toEqual([
+      "-c",
+      'sqlite_home="C:\\\\Users\\\\test\\\\.synara\\\\codex-home-overlay"',
+      "app-server",
+    ]);
+  });
+
+  it("keeps the legacy invocation when no isolated SQLite home is configured", () => {
+    expect(buildCodexAppServerArgs({ CODEX_SQLITE_HOME: "  " })).toEqual(["app-server"]);
+  });
+
+  it("keeps valid cmd metacharacters inside the SQLite path inert", () => {
+    const args = buildCodexAppServerArgs({
+      CODEX_SQLITE_HOME: String.raw`D:\R&D\100% Local^State`,
+    });
+    expect(args).toEqual([
+      "-c",
+      String.raw`sqlite_home="D:\\R\u0026D\\100\u0025 Local\u005eState"`,
+      "app-server",
+    ]);
+    expect(args[1]).not.toMatch(/[&|<>^%]/);
+
+    expect(() =>
+      prepareWindowsSafeProcess("C:\\tools\\codex.cmd", args, {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" },
+      }),
+    ).not.toThrow();
   });
 });
 
@@ -3111,7 +3203,8 @@ describe.skipIf(!process.env.CODEX_BINARY_PATH)("startSession live Codex resume"
         },
       });
 
-      expect(resumedSession.threadId).toBe(originalThreadId);
+      expect(resumedSession.threadId).toBe(firstSession.threadId);
+      expect(resumedSession.resumeCursor).toMatchObject({ threadId: originalThreadId });
 
       const resumedSnapshotBeforeTurn = await manager.readThread(resumedSession.threadId);
       expect(resumedSnapshotBeforeTurn.threadId).toBe(originalThreadId);

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -63,6 +63,8 @@ import {
 } from "./codexAppServerTransport.ts";
 
 const log = createLogger("codex");
+const CODEX_DEFAULT_REQUEST_TIMEOUT_MS = 20_000;
+const CODEX_INITIALIZE_TIMEOUT_MS = 45_000;
 
 type PendingRequestKey = string;
 
@@ -2682,7 +2684,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     context: CodexSessionContext,
     method: string,
     params: unknown,
-    timeoutMs = 20_000,
+    timeoutMs =
+      method === "initialize" ? CODEX_INITIALIZE_TIMEOUT_MS : CODEX_DEFAULT_REQUEST_TIMEOUT_MS,
   ): Promise<TResponse> {
     const id = context.nextRequestId;
     context.nextRequestId += 1;

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -551,6 +551,24 @@ function resolveCodexTurnOverrides(context: CodexSessionContext): {
   );
 }
 
+function encodeCodexTomlBasicStringForCommand(value: string): string {
+  return JSON.stringify(value).replace(/[&|<>^%]/g, (character) =>
+    `\\u${character.codePointAt(0)!.toString(16).padStart(4, "0")}`,
+  );
+}
+
+export function buildCodexAppServerArgs(env: NodeJS.ProcessEnv): string[] {
+  const sqliteHome = env.CODEX_SQLITE_HOME?.trim();
+  if (!sqliteHome) {
+    return ["app-server"];
+  }
+
+  // Keep this as a root CLI override. Codex session flags outrank project,
+  // user, and system config, any of which can otherwise redirect sqlite_home
+  // away from Synara's process-owned overlay.
+  return ["-c", `sqlite_home=${encodeCodexTomlBasicStringForCommand(sqliteHome)}`, "app-server"];
+}
+
 export function resolveCodexModelForAccount(
   model: string | undefined,
   account: CodexAccountSnapshot,
@@ -567,7 +585,7 @@ function spawnCodexAppServer(input: {
   readonly cwd: string;
   readonly env: NodeJS.ProcessEnv;
 }): ChildProcessWithoutNullStreams {
-  const prepared = prepareWindowsSafeProcess(input.binaryPath, ["app-server"], {
+  const prepared = prepareWindowsSafeProcess(input.binaryPath, buildCodexAppServerArgs(input.env), {
     cwd: input.cwd,
     env: input.env,
   });

--- a/apps/server/src/codexProcessEnv.ts
+++ b/apps/server/src/codexProcessEnv.ts
@@ -20,6 +20,7 @@ import { buildProviderChildEnvironment } from "./providerChildEnvironment.ts";
 const CODEX_PROCESS_SHELL_ENV_NAMES = ["PATH", "SSH_AUTH_SOCK"] as const;
 const NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS = "NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS";
 const CODEX_OVERLAY_SHARED_STATE_FILES = new Set(["auth.json"]);
+const CODEX_SQLITE_STATE_ENTRY_PATTERN = /^.+\.sqlite(?:-(?:wal|shm|journal))?$/;
 const SYNARA_CONFIG_SUPPRESSIONS_FILE = "synara-config-suppressions-v1.json";
 const MAX_CONFIG_SUPPRESSION_SECTIONS = 32;
 const MAX_CONFIG_SUPPRESSION_HEADER_LENGTH = 256;
@@ -190,6 +191,22 @@ export function prioritizeCodexOverlayEntries(entries: readonly string[]): strin
   return [...sharedStateEntries, ...otherEntries];
 }
 
+async function removeLegacyCodexOverlaySqliteLink(targetPath: string): Promise<void> {
+  let targetStat: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    targetStat = await fs.lstat(targetPath);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  if (targetStat.isSymbolicLink()) {
+    await fs.rm(targetPath, { force: true });
+  }
+}
+
 async function ensureCodexOverlaySymlink(input: {
   readonly entryName: string;
   readonly sourcePath: string;
@@ -208,13 +225,9 @@ async function ensureCodexOverlaySymlink(input: {
       return;
     }
 
-    if (
-      targetStat.isSymbolicLink() ||
-      /^.+\.sqlite(?:-(?:wal|shm|journal))?$/.test(input.entryName) ||
-      CODEX_OVERLAY_SHARED_STATE_FILES.has(input.entryName)
-    ) {
-      // SQLite files must stay generation-matched, and auth must mirror the
-      // user's real Codex home so external `codex login` changes are visible.
+    if (targetStat.isSymbolicLink() || CODEX_OVERLAY_SHARED_STATE_FILES.has(input.entryName)) {
+      // Auth must mirror the user's real Codex home so external `codex login`
+      // changes are visible.
       await fs.rm(input.targetPath, { recursive: true, force: true });
     } else {
       return;
@@ -256,11 +269,21 @@ async function prepareSynaraCodexHomeOverlayUnlocked(input: {
 
   await fs.mkdir(overlayHomePath, { recursive: true });
 
+  for (const entry of await fs.readdir(overlayHomePath)) {
+    if (CODEX_SQLITE_STATE_ENTRY_PATTERN.test(entry)) {
+      await removeLegacyCodexOverlaySqliteLink(path.join(overlayHomePath, entry));
+    }
+  }
+
   try {
     // Auth must get a best-effort link/copy before optional entries whose
     // symlinks may fail on restricted Windows installs.
     for (const entry of prioritizeCodexOverlayEntries(await fs.readdir(sourceHomePath))) {
       if (entry === "config.toml") {
+        continue;
+      }
+      if (CODEX_SQLITE_STATE_ENTRY_PATTERN.test(entry)) {
+        // SQLite is mutable app-server state owned by this isolated overlay.
         continue;
       }
       const sourcePath = path.join(sourceHomePath, entry);
@@ -329,10 +352,15 @@ export async function buildCodexProcessEnv(
     env: baseEnv,
     ...(input.homePath ? { homePath: input.homePath } : {}),
   });
-  const configuredEnv =
-    overlayHomePath || input.homePath
-      ? { ...baseEnv, CODEX_HOME: overlayHomePath ?? input.homePath }
-      : baseEnv;
+  const configuredCodexHome =
+    overlayHomePath ?? input.homePath?.trim() ?? baseEnv.CODEX_HOME?.trim();
+  const configuredEnv = configuredCodexHome
+    ? {
+        ...baseEnv,
+        CODEX_HOME: configuredCodexHome,
+        CODEX_SQLITE_HOME: configuredCodexHome,
+      }
+    : baseEnv;
   const platform = input.platform ?? process.platform;
   const browserUsePipePath =
     platform === "win32"

--- a/apps/server/src/persistence/MigrationBackup.test.ts
+++ b/apps/server/src/persistence/MigrationBackup.test.ts
@@ -20,6 +20,7 @@ import {
   runWithPreMigrationBackup,
 } from "./MigrationBackup.ts";
 import { migrationEntries, runMigrations } from "./Migrations.ts";
+import ProjectPullRequestPinsMigration from "./Migrations/069_ProjectPullRequestPins.ts";
 import * as NodeSqliteClient from "./NodeSqliteClient.ts";
 import { makeSqlitePersistenceLive } from "./Layers/Sqlite.ts";
 
@@ -222,6 +223,31 @@ describe("migration backups", () => {
     }
   });
 
+  it("removes the current partial when backup publication fails", async () => {
+    const dbPath = await makeDbPath();
+
+    await expect(
+      runWithDatabase(
+        dbPath,
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql`CREATE TABLE publication_probe(value TEXT NOT NULL)`;
+          yield* createMigrationBackup(
+            dbPath,
+            { sourceVersion: "v52", targetVersion: 53 },
+            {
+              open: async () => {
+                throw new Error("injected backup publication failure");
+              },
+            },
+          );
+        }),
+      ),
+    ).rejects.toThrow("injected backup publication failure");
+
+    expect(await fs.readdir(migrationBackupDirectory(dbPath))).toEqual([]);
+  });
+
   it("rejects symlinked markers and non-generated nested backup paths", async () => {
     const dbPath = await makeDbPath();
     const markerPath = migrationRecoveryMarkerPath(dbPath);
@@ -335,6 +361,74 @@ describe("migration backups", () => {
     } finally {
       backup.close();
     }
+  });
+
+  it("backs up and upgrades the published v0.5.5 lineage without losing user data", async () => {
+    const dbPath = await makeDbPath();
+
+    await runWithDatabase(
+      dbPath,
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* runMigrations({ toMigrationInclusive: 53 });
+        yield* ProjectPullRequestPinsMigration;
+        yield* sql`
+          INSERT INTO effect_sql_migrations (migration_id, name)
+          VALUES (54, 'ProjectPullRequestPins')
+        `;
+        yield* sql`
+          INSERT INTO project_pull_request_pins (
+            project_id,
+            repository_key,
+            pull_request_number
+          ) VALUES ('project-v055', 'owner/repository', 393)
+        `;
+
+        yield* runWithPreMigrationBackup(dbPath, runMigrations());
+
+        const pins = yield* sql<{
+          readonly projectId: string;
+          readonly pullRequestNumber: number;
+        }>`
+          SELECT
+            project_id AS "projectId",
+            pull_request_number AS "pullRequestNumber"
+          FROM project_pull_request_pins
+        `;
+        expect(pins).toEqual([{ projectId: "project-v055", pullRequestNumber: 393 }]);
+
+        const tracker = yield* sql<{ readonly migrationId: number; readonly name: string }>`
+          SELECT migration_id AS "migrationId", name
+          FROM effect_sql_migrations
+          WHERE migration_id IN (54, 69)
+          ORDER BY migration_id
+        `;
+        expect(tracker).toEqual([
+          { migrationId: 54, name: "DurableProviderCommandDelivery" },
+          { migrationId: 69, name: "ProjectPullRequestPins" },
+        ]);
+      }),
+    );
+
+    const backups = await backupPaths(dbPath);
+    expect(backups).toHaveLength(1);
+    const backup = new DatabaseSync(backups[0]!, { readOnly: true });
+    try {
+      expect(
+        backup.prepare("SELECT name FROM effect_sql_migrations WHERE migration_id = 54").get(),
+      ).toMatchObject({ name: "ProjectPullRequestPins" });
+      expect(
+        backup.prepare("SELECT pull_request_number FROM project_pull_request_pins").get(),
+      ).toMatchObject({ pull_request_number: 393 });
+    } finally {
+      backup.close();
+    }
+
+    const backupEntries = await fs.readdir(migrationBackupDirectory(dbPath));
+    expect(backupEntries.some((name) => name.endsWith(".partial"))).toBe(false);
+    await expect(fs.stat(migrationRecoveryMarkerPath(dbPath))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("prunes versioned snapshots to the bounded retention count", async () => {

--- a/apps/server/src/persistence/MigrationBackup.ts
+++ b/apps/server/src/persistence/MigrationBackup.ts
@@ -48,6 +48,10 @@ type MigrationBackupPlan = {
   readonly targetVersion: number;
 };
 
+export type MigrationBackupFileOperations = {
+  readonly open?: typeof fs.open;
+};
+
 export type MigrationBackupResult = MigrationBackupPlan & {
   readonly backupPath: string;
 };
@@ -263,7 +267,11 @@ export const pruneMigrationBackups = (dbPath: string, retention = MIGRATION_BACK
     );
   });
 
-export const createMigrationBackup = (dbPath: string, plan: MigrationBackupPlan) =>
+export const createMigrationBackup = (
+  dbPath: string,
+  plan: MigrationBackupPlan,
+  fileOperations: MigrationBackupFileOperations = {},
+) =>
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient;
     const backupDirectory = migrationBackupDirectory(dbPath);
@@ -284,19 +292,24 @@ export const createMigrationBackup = (dbPath: string, plan: MigrationBackupPlan)
       Effect.tapError(() => attemptPromise(() => fs.unlink(temporaryPath)).pipe(Effect.ignore)),
     );
     yield* attemptPromise(async () => {
-      await ensurePrivateRegularFile(temporaryPath);
-      const flags =
-        process.platform === "win32"
-          ? fsConstants.O_RDONLY
-          : fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW;
-      const handle = await fs.open(temporaryPath, flags);
       try {
-        await handle.sync();
-      } finally {
-        await handle.close();
+        await ensurePrivateRegularFile(temporaryPath);
+        const flags =
+          process.platform === "win32"
+            ? fsConstants.O_RDWR
+            : fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW;
+        const handle = await (fileOperations.open ?? fs.open)(temporaryPath, flags);
+        try {
+          await handle.sync();
+        } finally {
+          await handle.close();
+        }
+        await fs.rename(temporaryPath, backupPath);
+        await syncDirectory(backupDirectory);
+      } catch (cause) {
+        await fs.unlink(temporaryPath).catch(() => undefined);
+        throw cause;
       }
-      await fs.rename(temporaryPath, backupPath);
-      await syncDirectory(backupDirectory);
     });
     yield* pruneMigrationBackups(dbPath);
     return { ...plan, backupPath } satisfies MigrationBackupResult;
@@ -325,7 +338,7 @@ const writeRecoveryMarker = (dbPath: string, backup: MigrationBackupResult) =>
       await ensurePrivateRegularFile(temporaryPath);
       const markerFlags =
         process.platform === "win32"
-          ? fsConstants.O_RDONLY
+          ? fsConstants.O_RDWR
           : fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW;
       const handle = await fs.open(temporaryPath, markerFlags);
       try {
@@ -389,7 +402,7 @@ const restoreSqliteMigrationBackup = (input: {
     await ensurePrivateRegularFile(restoredTemporaryPath);
     const restoredFlags =
       process.platform === "win32"
-        ? fsConstants.O_RDONLY
+        ? fsConstants.O_RDWR
         : fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW;
     const restoredHandle = await fs.open(restoredTemporaryPath, restoredFlags);
     try {


### PR DESCRIPTION
Fixes #393

## What Changed

This PR fixes one Windows recovery failure chain in three independently reviewable commits:

1. **Migration backup durability** (`29294143`)
   - Opens Synara-created temporary backup, marker, and restore files with read/write access before `fsync` on Windows.
   - Keeps the existing read-only, no-follow behavior for validation and Unix source reads.
   - Removes the current `.partial` artifact immediately if publication fails, so the next launch does not inherit a failed attempt.
   - Adds a v0.5.5-lineage migration regression through the current schema, including the historical ProjectPullRequestPins version-54 mismatch.

2. **Process-owned Codex SQLite recovery** (`5db8a602`)
   - Treats SQLite databases and their WAL, SHM, and rollback-journal sidecars as overlay-owned state instead of symlinking them back into the live source Codex home.
   - Preserves regular recovered overlay files across retries, removes legacy SQLite symlinks without following them, and leaves the source database untouched.
   - Pins both `CODEX_SQLITE_HOME` and the root Codex `-c sqlite_home=...` override to the per-process overlay. The CLI override is deliberately stronger than project, user, and system config; administrator-managed policy remains authoritative.
   - TOML-escapes the override and Unicode-escapes Windows batch metacharacters before invoking npm's `codex.cmd`.

3. **Recovery-specific initialize deadline** (`d3055257`)
   - Gives the mandatory app-server `initialize` handshake 45 seconds.
   - Keeps all ordinary JSON-RPC requests at the existing 20-second deadline.
   - Ensures success, timeout, and immediate transport-write failure all clear the pending request and timer.

## Why

On affected Windows upgrades, Synara could enter a deterministic restart loop:

1. migration-backup durability failed while syncing a Windows file descriptor;
2. Codex restart reused or linked the same mutable SQLite state instead of getting process-owned recovery state; and
3. Synara terminated the app server after the generic 20-second deadline while Codex was still recovering.

The result is not cosmetic degradation: the provider never completes initialization, existing threads cannot resume, and new Codex work cannot start. The three changes belong in one PR because they are consecutive stages of the same launch/recovery path, but each is isolated in its own commit and documented in its own PR comment for review and rollback.

## Happy and Failure Paths

| Part | Happy path retained | Failure/recovery path added |
| --- | --- | --- |
| Migration backup | Normal migration publishes a validated final backup and marker | Windows sync/publication failure removes the current partial; historical v0.5.5 schema reconciles without losing the pin |
| SQLite overlay | A regular recovered overlay database survives repeated preparation | Source DB/WAL/SHM/journal are never linked; legacy links are removed; inherited/configured SQLite locations cannot redirect the child |
| Initialize timeout | Fast initialization and normal requests behave as before | A recovering initialize may complete through 45s; it times out at 45s; non-initialize requests still time out at 20s; write failure rejects immediately |

## OpenAI Contract Checked

- [Codex app-server documentation](https://learn.chatgpt.com/docs/app-server): the client must send `initialize`, then `initialized`, before other methods; `thread/resume` continues an existing thread.
- [Codex environment-variable documentation](https://learn.chatgpt.com/docs/config-file/environment-variables#core-locations): `CODEX_SQLITE_HOME` is used by the CLI and app-server, while configured `sqlite_home` has precedence.
- [Codex 0.144.5 configuration source](https://github.com/openai/codex/blob/rust-v0.144.5/codex-rs/core/src/config/mod.rs): checked against the exact version used in the acceptance test.

## Verification

Passed on Windows PowerShell from the isolated worktree:

- Focused server suites: **104 passed, 2 skipped**.
- Shared Windows process suite: **22 passed**.
- `git diff --check origin/main...HEAD`.
- Real npm `@openai/codex@0.144.5` via `codex.cmd`: initialize, first harmless turn, stop/restart, exact `thread/resume`, and second harmless turn all passed.
- The live acceptance home deliberately included `R&D`, `100%`, spaces, and `^`; the resulting overlay SQLite DB/WAL/SHM files were regular files, not reparse points.

Broader local checks were attempted but do not provide a clean Windows baseline in the current checkout:

- Root `bun run test`: unrelated existing POSIX-path expectations in canary scripts and desktop profile/socket tests failed on Windows.
- Full server `bun run test`: unrelated existing CRLF, provider-health `.cmd` argument/casing, checkpoint newline, keybinding permission, and lifecycle-lock expectations failed; it was stopped before tests could exercise real provider state.
- `bun run release:smoke`: existing smoke harness stopped at `Expected a manual publication opt-in input.`
- `bun fmt`, `bun lint`, and `bun typecheck` were not run because repository instructions prohibit running them unless explicitly requested.

## Risk and Rollback

- Read/write access is limited to Synara-created temporary files that are immediately synced; source/validation reads remain read-only.
- SQLite ownership changes only the Windows-safe per-process Codex overlay; the user's source Codex state is not mutated.
- Managed Codex policy can still override the CLI flag by design; invalid duplicate root TOML assignments remain a separate configuration error.
- The longer deadline applies only to `initialize`, limiting the blast radius of a slow or wedged provider.
- Each stage can be reverted independently by reverting its corresponding commit.

## Checklist

- [x] Change is small and focused around one recovery chain
- [x] Root causes, behavior, and residual risks are explained
- [x] No UI changes; screenshots are not applicable
- [x] No interaction or motion changes; video is not applicable