### PR TITLE
fix: prefer native Codex CLI on Windows

### DIFF
--- a/apps/desktop/src/voiceTranscription.ts
+++ b/apps/desktop/src/voiceTranscription.ts
@@ -15,12 +15,13 @@ import {
   CHATGPT_VOICE_TRANSCRIPTION_URL,
   requestChatGptVoiceTranscription,
 } from "@synara/shared/chatGptVoiceTranscription";
+import { resolveCodexCliExecutable } from "@synara/shared/codexCliExecutable";
 import {
   decodeOutboundJson,
   decodeOutboundText,
   type OutboundHttpResponse,
 } from "@synara/shared/outboundHttp";
-import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
+import { prepareResolvedWindowsSafeProcess } from "@synara/shared/windowsProcess";
 import { SERVER_TRANSCRIBE_VOICE_CHANNEL } from "./ipcChannels";
 
 const MAX_VOICE_DURATION_MS = 120_000;
@@ -88,13 +89,15 @@ async function resolveDesktopVoiceAuth(
   cwd: string,
 ): Promise<{ token: string; transcriptionUrl: string }> {
   return new Promise((resolve, reject) => {
-    const prepared = prepareWindowsSafeProcess("codex", ["app-server"], {
+    const env = process.env;
+    const executable = resolveCodexCliExecutable("codex", { cwd, env });
+    const prepared = prepareResolvedWindowsSafeProcess(executable, ["app-server"], {
       cwd,
-      env: process.env,
+      env,
     });
     const child = ChildProcess.spawn(prepared.command, prepared.args, {
       cwd,
-      env: process.env,
+      env,
       stdio: ["pipe", "pipe", "pipe"],
       shell: prepared.shell,
       windowsHide: prepared.windowsHide,

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -983,7 +983,7 @@ describe("startSession", () => {
           assertSupportedCodexCliVersion: (input: {
             binaryPath: string;
             cwd: string;
-            homePath?: string;
+            env: NodeJS.ProcessEnv;
           }) => void;
         },
         "assertSupportedCodexCliVersion",

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -37,9 +37,10 @@ import {
   type ServerVoiceTranscriptionInput,
   type ServerVoiceTranscriptionResult,
 } from "@synara/contracts";
+import { resolveCodexCliExecutable } from "@synara/shared/codexCliExecutable";
 import { getModelSelectionBooleanOptionValue, normalizeModelSlug } from "@synara/shared/model";
 import { decodeSubagentReceiverThreadIds } from "@synara/shared/subagents";
-import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
+import { prepareResolvedWindowsSafeProcess } from "@synara/shared/windowsProcess";
 import { Effect, ServiceMap } from "effect";
 
 import {
@@ -580,7 +581,7 @@ function spawnCodexAppServer(input: {
   readonly cwd: string;
   readonly env: NodeJS.ProcessEnv;
 }): ChildProcessWithoutNullStreams {
-  const prepared = prepareWindowsSafeProcess(input.binaryPath, ["app-server"], {
+  const prepared = prepareResolvedWindowsSafeProcess(input.binaryPath, ["app-server"], {
     cwd: input.cwd,
     env: input.env,
   });
@@ -592,6 +593,20 @@ function spawnCodexAppServer(input: {
     windowsHide: prepared.windowsHide,
     windowsVerbatimArguments: prepared.windowsVerbatimArguments,
   });
+}
+
+async function resolveCodexLaunch(input: {
+  readonly binaryPath: string;
+  readonly cwd: string;
+  readonly homePath?: string;
+}): Promise<{ readonly binaryPath: string; readonly env: NodeJS.ProcessEnv }> {
+  const env = await buildCodexProcessEnv({
+    ...(input.homePath ? { homePath: input.homePath } : {}),
+  });
+  return {
+    binaryPath: resolveCodexCliExecutable(input.binaryPath, { cwd: input.cwd, env }),
+    env,
+  };
 }
 
 export function normalizeCodexModelSlug(
@@ -819,19 +834,21 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       };
 
       const codexOptions = readCodexProviderOptions(input);
-      const codexBinaryPath = codexOptions.binaryPath ?? "codex";
       const codexHomePath = codexOptions.homePath;
-      await this.assertSupportedCodexCliVersion({
-        binaryPath: codexBinaryPath,
+      const codexLaunch = await resolveCodexLaunch({
+        binaryPath: codexOptions.binaryPath ?? "codex",
         cwd: resolvedCwd,
         ...(codexHomePath ? { homePath: codexHomePath } : {}),
       });
-      const child = spawnCodexAppServer({
-        binaryPath: codexBinaryPath,
+      await this.assertSupportedCodexCliVersion({
+        binaryPath: codexLaunch.binaryPath,
         cwd: resolvedCwd,
-        env: await buildCodexProcessEnv({
-          ...(codexHomePath ? { homePath: codexHomePath } : {}),
-        }),
+        env: codexLaunch.env,
+      });
+      const child = spawnCodexAppServer({
+        binaryPath: codexLaunch.binaryPath,
+        cwd: resolvedCwd,
+        env: codexLaunch.env,
       });
 
       context = {
@@ -1447,19 +1464,21 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         runtimeMode: input.runtimeMode,
         ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
       });
-      const codexBinaryPath = codexOptions.binaryPath ?? "codex";
       const codexHomePath = codexOptions.homePath;
-      await this.assertSupportedCodexCliVersion({
-        binaryPath: codexBinaryPath,
+      const codexLaunch = await resolveCodexLaunch({
+        binaryPath: codexOptions.binaryPath ?? "codex",
         cwd: resolvedCwd,
         ...(codexHomePath ? { homePath: codexHomePath } : {}),
       });
-      const child = spawnCodexAppServer({
-        binaryPath: codexBinaryPath,
+      await this.assertSupportedCodexCliVersion({
+        binaryPath: codexLaunch.binaryPath,
         cwd: resolvedCwd,
-        env: await buildCodexProcessEnv({
-          ...(codexHomePath ? { homePath: codexHomePath } : {}),
-        }),
+        env: codexLaunch.env,
+      });
+      const child = spawnCodexAppServer({
+        binaryPath: codexLaunch.binaryPath,
+        cwd: resolvedCwd,
+        env: codexLaunch.env,
       });
 
       context = {
@@ -2082,14 +2101,19 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
 
     const now = new Date().toISOString();
-    await this.assertSupportedCodexCliVersion({
+    const codexLaunch = await resolveCodexLaunch({
       binaryPath: "codex",
       cwd: normalizedCwd,
     });
-    const child = spawnCodexAppServer({
-      binaryPath: "codex",
+    await this.assertSupportedCodexCliVersion({
+      binaryPath: codexLaunch.binaryPath,
       cwd: normalizedCwd,
-      env: await buildCodexProcessEnv(),
+      env: codexLaunch.env,
+    });
+    const child = spawnCodexAppServer({
+      binaryPath: codexLaunch.binaryPath,
+      cwd: normalizedCwd,
+      env: codexLaunch.env,
     });
     const context: CodexSessionContext = {
       session: {
@@ -2794,7 +2818,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
   private async assertSupportedCodexCliVersion(input: {
     readonly binaryPath: string;
     readonly cwd: string;
-    readonly homePath?: string;
+    readonly env: NodeJS.ProcessEnv;
   }): Promise<void> {
     await assertSupportedCodexCliVersion(input);
   }
@@ -3562,18 +3586,15 @@ function readCodexProviderOptions(input: CodexAppServerStartSessionInput): {
 async function assertSupportedCodexCliVersion(input: {
   readonly binaryPath: string;
   readonly cwd: string;
-  readonly homePath?: string;
+  readonly env: NodeJS.ProcessEnv;
 }): Promise<void> {
-  const env = await buildCodexProcessEnv({
-    ...(input.homePath ? { homePath: input.homePath } : {}),
-  });
-  const prepared = prepareWindowsSafeProcess(input.binaryPath, ["--version"], {
+  const prepared = prepareResolvedWindowsSafeProcess(input.binaryPath, ["--version"], {
     cwd: input.cwd,
-    env,
+    env: input.env,
   });
   const result = spawnSync(prepared.command, prepared.args, {
     cwd: input.cwd,
-    env,
+    env: input.env,
     encoding: "utf8",
     shell: prepared.shell,
     stdio: ["ignore", "pipe", "pipe"],

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -600,9 +600,7 @@ async function resolveCodexLaunch(input: {
   readonly cwd: string;
   readonly homePath?: string;
 }): Promise<{ readonly binaryPath: string; readonly env: NodeJS.ProcessEnv }> {
-  const env = await buildCodexProcessEnv({
-    ...(input.homePath ? { homePath: input.homePath } : {}),
-  });
+  const env = await buildCodexProcessEnv(input.homePath ? { homePath: input.homePath } : {});
   return {
     binaryPath: resolveCodexCliExecutable(input.binaryPath, { cwd: input.cwd, env }),
     env,

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -5,9 +5,10 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { DEFAULT_GIT_TEXT_GENERATION_MODEL } from "@synara/contracts";
 import { sanitizeGeneratedThreadTitle } from "@synara/shared/chatThreads";
+import { resolveCodexCliExecutable } from "@synara/shared/codexCliExecutable";
 import { resolveCodexHome } from "@synara/shared/codexConfig";
 import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@synara/shared/git";
-import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
+import { prepareResolvedWindowsSafeProcess } from "@synara/shared/windowsProcess";
 
 import { resolveProviderAttachmentPath } from "../../provider/providerAttachmentPaths.ts";
 import { buildCodexProcessEnv } from "../../codexProcessEnv.ts";
@@ -324,7 +325,8 @@ const makeCodexTextGeneration = Effect.gen(function* () {
           ...imagePaths.flatMap((imagePath) => ["--image", imagePath]),
           "-",
         ];
-        const prepared = prepareWindowsSafeProcess(codexBinaryPath, args, { cwd, env });
+        const executable = resolveCodexCliExecutable(codexBinaryPath, { cwd, env });
+        const prepared = prepareResolvedWindowsSafeProcess(executable, args, { cwd, env });
         const command = ChildProcess.make(prepared.command, prepared.args, {
           cwd,
           env,

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -777,7 +777,7 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
     it.effect("uses configured codex binary for version and auth probes", () =>
       Effect.gen(function* () {
         yield* withTempCodexHome();
-        const status = yield* makeCheckCodexProviderStatus("/custom/bin/codex");
+        const status = yield* makeCheckCodexProviderStatus("  /custom/bin/codex  ");
         assert.strictEqual(status.status, "ready");
       }).pipe(
         Effect.provide(
@@ -801,7 +801,7 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
       }).pipe(
         Effect.provide(
           mockSpawnerLayer((args, command, _env, options) => {
-            assert.strictEqual(command, "C:\\Windows\\System32\\cmd.exe");
+            assert.strictEqual(command.toLowerCase(), "c:\\windows\\system32\\cmd.exe");
             assert.strictEqual(options?.windowsVerbatimArguments, true);
             const commandLine = args.at(-1) ?? "";
             if (commandLine.includes('"--version"')) {

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -18,9 +18,13 @@ import type {
   ServerProviderUpdateState,
 } from "@synara/contracts";
 import { ServerProviderUpdateError } from "@synara/contracts";
+import { resolveCodexCliExecutable } from "@synara/shared/codexCliExecutable";
 import { parseCodexConfigModelProvider } from "@synara/shared/codexConfig";
 import { decodeJsonResult } from "@synara/shared/schemaJson";
-import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
+import {
+  prepareResolvedWindowsSafeProcess,
+  prepareWindowsSafeProcess,
+} from "@synara/shared/windowsProcess";
 import { query as claudeQuery, type SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
 import {
   Array,
@@ -649,10 +653,13 @@ const runProviderCommand = (
   executable: string,
   args: ReadonlyArray<string>,
   env: NodeJS.ProcessEnv,
+  executableAlreadyResolved = false,
 ) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const prepared = prepareWindowsSafeProcess(executable, args, { env });
+    const prepared = executableAlreadyResolved
+      ? prepareResolvedWindowsSafeProcess(executable, args, { env })
+      : prepareWindowsSafeProcess(executable, args, { env });
     const command = ChildProcess.make(prepared.command, prepared.args, {
       shell: prepared.shell,
       ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
@@ -681,7 +688,7 @@ const runCodexCommand = (
   executable = "codex",
   env: NodeJS.ProcessEnv = providerCommandEnv(CODEX_PROVIDER),
 ) =>
-  runProviderCommand(executable, args, env).pipe(
+  runProviderCommand(executable, args, env, true).pipe(
     Effect.flatMap((result) =>
       isWindowsShellCommandMissingResult({ code: result.code, stderr: result.stderr })
         ? Effect.fail(new Error(`spawn ${executable} ENOENT`))
@@ -875,8 +882,9 @@ export const makeCheckCodexProviderStatus = (
 > =>
   Effect.gen(function* () {
     const checkedAt = new Date().toISOString();
-    const executable = nonEmptyTrimmed(binaryPath) ?? "codex";
     const probeEnv = yield* Effect.promise(() => makeCodexProbeEnv(homePath));
+    const configuredExecutable = nonEmptyTrimmed(binaryPath) ?? "codex";
+    const executable = resolveCodexCliExecutable(configuredExecutable, { env: probeEnv });
 
     // Probe 1: `codex --version` — is the CLI reachable?
     const versionProbe = yield* runCodexCommand(["--version"], executable, probeEnv).pipe(

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -40,6 +40,10 @@
       "types": "./src/windowsProcess.ts",
       "import": "./src/windowsProcess.ts"
     },
+    "./codexCliExecutable": {
+      "types": "./src/codexCliExecutable.ts",
+      "import": "./src/codexCliExecutable.ts"
+    },
     "./windowsCertificate": {
       "types": "./src/windowsCertificate.ts",
       "import": "./src/windowsCertificate.ts"

--- a/packages/shared/src/codexCliExecutable.test.ts
+++ b/packages/shared/src/codexCliExecutable.test.ts
@@ -1,0 +1,285 @@
+// FILE: codexCliExecutable.test.ts
+// Purpose: Verifies deterministic Windows Codex CLI executable selection.
+// Layer: Shared Node runtime utility tests
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveCodexCliExecutable } from "./codexCliExecutable.ts";
+
+function whereOutput(...candidates: string[]) {
+  return vi.fn(() => ({ stdout: candidates.join("\r\n"), status: 0 }));
+}
+
+function regularFiles(...paths: string[]) {
+  const files = new Set(paths.map((path) => path.toLowerCase()));
+  return vi.fn((path: string) => {
+    if (!files.has(path.toLowerCase())) {
+      throw Object.assign(new Error(`Missing file: ${path}`), { code: "ENOENT" });
+    }
+    return { isFile: () => true };
+  });
+}
+
+describe("resolveCodexCliExecutable", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("preserves non-Windows commands exactly without probing", () => {
+    const spawnSync = vi.fn();
+    const readStat = vi.fn();
+
+    expect(
+      resolveCodexCliExecutable(" CoDeX ", {
+        platform: "linux",
+        env: {},
+        spawnSync,
+        statSync: readStat,
+      }),
+    ).toBe(" CoDeX ");
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(readStat).not.toHaveBeenCalled();
+  });
+
+  it("returns an explicit executable path without probing", () => {
+    const spawnSync = vi.fn();
+    const readStat = vi.fn();
+    const configured = "C:\\Program Files (x86)\\Codex Tools\\custom.exe";
+
+    expect(
+      resolveCodexCliExecutable(configured, {
+        platform: "win32",
+        env: {},
+        spawnSync,
+        statSync: readStat,
+      }),
+    ).toBe(configured);
+    expect(spawnSync).not.toHaveBeenCalled();
+    expect(readStat).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      configured: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
+      resolved: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+    },
+    {
+      configured: "custom-codex",
+      resolved: "C:\\tools\\custom-codex.cmd",
+    },
+  ])(
+    "resolves the explicit extensionless command $configured exactly once",
+    ({ configured, resolved }) => {
+      const spawnSync = whereOutput(configured, resolved);
+
+      expect(
+        resolveCodexCliExecutable(configured, {
+          platform: "win32",
+          cwd: "C:\\projects\\synara",
+          env: { SystemRoot: "C:\\Windows" },
+          spawnSync,
+          statSync: vi.fn(),
+        }),
+      ).toBe(resolved);
+      expect(spawnSync).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("keeps a failed explicit alias without consulting default fallbacks", () => {
+    const fallback = "D:\\Codex\\codex.exe";
+    const spawnSync = vi.fn(() => ({ stdout: "", status: 1 }));
+    const readStat = regularFiles(fallback);
+
+    expect(
+      resolveCodexCliExecutable("custom-codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows", CODEX_INSTALL_DIR: "D:\\Codex" },
+        spawnSync,
+        statSync: readStat,
+      }),
+    ).toBe("custom-codex");
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+    expect(readStat).not.toHaveBeenCalled();
+  });
+
+  it("prefers a valid native PATH executable over batch and documented fallbacks", () => {
+    const extensionless = "C:\\Users\\Test User\\AppData\\Roaming\\npm\\codex";
+    const batch = "C:\\Users\\Test User\\AppData\\Roaming\\npm\\codex.cmd";
+    const native =
+      "C:\\Users\\Test User\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.exe";
+    const installDirNative = "D:\\Codex\\codex.exe";
+    const spawnSync = whereOutput(extensionless, batch, native);
+    const readStat = regularFiles(batch, native, installDirNative);
+
+    expect(
+      resolveCodexCliExecutable(" CoDeX ", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows", CODEX_INSTALL_DIR: "D:\\Codex" },
+        spawnSync,
+        statSync: readStat,
+      }),
+    ).toBe(native);
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a native .com PATH executable", () => {
+    const native = "C:\\tools\\codex.com";
+
+    expect(
+      resolveCodexCliExecutable("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync: whereOutput(native),
+        statSync: regularFiles(native),
+      }),
+    ).toBe(native);
+  });
+
+  it("honors a case-insensitive CODEX_INSTALL_DIR before a PATH batch shim", () => {
+    const batch = "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd";
+    const native = "D:\\OpenAI CLI\\codex.exe";
+
+    expect(
+      resolveCodexCliExecutable("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { systemroot: "C:\\Windows", codex_install_dir: " D:\\OpenAI CLI " },
+        spawnSync: whereOutput(batch),
+        statSync: regularFiles(batch, native),
+      }),
+    ).toBe(native);
+  });
+
+  it("uses the documented standalone install before a PATH batch shim", () => {
+    const batch = "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd";
+    const native =
+      "C:\\Users\\Test User\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.exe";
+
+    expect(
+      resolveCodexCliExecutable("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: {
+          SystemRoot: "C:\\Windows",
+          localappdata: "C:\\Users\\Test User\\AppData\\Local",
+        },
+        spawnSync: whereOutput(batch),
+        statSync: regularFiles(batch, native),
+      }),
+    ).toBe(native);
+  });
+
+  it("uses a valid PATH batch shim before the APPDATA npm fallback", () => {
+    const pathBatch = "D:\\node\\codex.bat";
+    const npmBatch = "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd";
+
+    expect(
+      resolveCodexCliExecutable("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: {
+          SystemRoot: "C:\\Windows",
+          AppData: "C:\\Users\\test\\AppData\\Roaming",
+        },
+        spawnSync: whereOutput(pathBatch),
+        statSync: regularFiles(pathBatch, npmBatch),
+      }),
+    ).toBe(pathBatch);
+  });
+
+  it("uses the case-insensitive APPDATA npm fallback when PATH resolution fails", () => {
+    const npmBatch = "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd";
+
+    expect(
+      resolveCodexCliExecutable("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: {
+          SystemRoot: "C:\\Windows",
+          appdata: "C:\\Users\\test\\AppData\\Roaming",
+        },
+        spawnSync: vi.fn(() => ({ stdout: "", status: 1 })),
+        statSync: regularFiles(npmBatch),
+      }),
+    ).toBe(npmBatch);
+  });
+
+  it("rejects current-directory where.exe hits before validating candidates", () => {
+    const cwdHit = "C:\\projects\\synara\\codex.exe";
+    const safeNative = "C:\\tools\\codex.exe";
+    const readStat = regularFiles(cwdHit, safeNative);
+
+    expect(
+      resolveCodexCliExecutable("codex", {
+        platform: "win32",
+        cwd: "C:\\PROJECTS\\SYNARA",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync: whereOutput(cwdHit, safeNative),
+        statSync: readStat,
+      }),
+    ).toBe(safeNative);
+    expect(readStat).not.toHaveBeenCalledWith(cwdHit);
+  });
+
+  it("rejects relative, drive-root-relative, missing, and non-file candidates", () => {
+    const relative = "tools\\codex.exe";
+    const driveRootRelative = "\\tools\\codex.exe";
+    const missing = "C:\\missing\\codex.exe";
+    const directory = "C:\\directory\\codex.exe";
+    const fallback = "D:\\Codex\\codex.exe";
+    const readStat = vi.fn((path: string) => {
+      if (path === directory) {
+        return { isFile: () => false };
+      }
+      if (path === fallback) {
+        return { isFile: () => true };
+      }
+      throw Object.assign(new Error(`Missing file: ${path}`), { code: "ENOENT" });
+    });
+
+    expect(
+      resolveCodexCliExecutable("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows", CODEX_INSTALL_DIR: "D:\\Codex" },
+        spawnSync: whereOutput(relative, driveRootRelative, missing, directory),
+        statSync: readStat,
+      }),
+    ).toBe(fallback);
+    expect(readStat).not.toHaveBeenCalledWith(relative);
+    expect(readStat).not.toHaveBeenCalledWith(driveRootRelative);
+  });
+
+  it("does not read fallback values from process.env when an env is supplied", () => {
+    const globalNative = "C:\\Global\\Programs\\OpenAI\\Codex\\bin\\codex.exe";
+    vi.stubEnv("LOCALAPPDATA", "C:\\Global");
+    const readStat = regularFiles(globalNative);
+
+    expect(
+      resolveCodexCliExecutable("codex", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync: vi.fn(() => ({ stdout: "", status: 1 })),
+        statSync: readStat,
+      }),
+    ).toBe("codex");
+    expect(readStat).not.toHaveBeenCalled();
+  });
+
+  it("returns bare codex when no valid candidate exists", () => {
+    expect(
+      resolveCodexCliExecutable("CODEX", {
+        platform: "win32",
+        cwd: "C:\\projects\\synara",
+        env: { SystemRoot: "C:\\Windows" },
+        spawnSync: whereOutput("codex", "C:\\missing\\codex.cmd"),
+        statSync: regularFiles(),
+      }),
+    ).toBe("codex");
+  });
+});

--- a/packages/shared/src/codexCliExecutable.test.ts
+++ b/packages/shared/src/codexCliExecutable.test.ts
@@ -4,7 +4,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { resolveCodexCliExecutable } from "./codexCliExecutable.ts";
+import { resolveCodexCliExecutable } from "./codexCliExecutable";
 
 function whereOutput(...candidates: string[]) {
   return vi.fn(() => ({ stdout: candidates.join("\r\n"), status: 0 }));
@@ -107,8 +107,7 @@ describe("resolveCodexCliExecutable", () => {
   it("prefers a valid native PATH executable over batch and documented fallbacks", () => {
     const extensionless = "C:\\Users\\Test User\\AppData\\Roaming\\npm\\codex";
     const batch = "C:\\Users\\Test User\\AppData\\Roaming\\npm\\codex.cmd";
-    const native =
-      "C:\\Users\\Test User\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.exe";
+    const native = "C:\\Users\\Test User\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.exe";
     const installDirNative = "D:\\Codex\\codex.exe";
     const spawnSync = whereOutput(extensionless, batch, native);
     const readStat = regularFiles(batch, native, installDirNative);
@@ -156,8 +155,7 @@ describe("resolveCodexCliExecutable", () => {
 
   it("uses the documented standalone install before a PATH batch shim", () => {
     const batch = "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd";
-    const native =
-      "C:\\Users\\Test User\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.exe";
+    const native = "C:\\Users\\Test User\\AppData\\Local\\Programs\\OpenAI\\Codex\\bin\\codex.exe";
 
     expect(
       resolveCodexCliExecutable("codex", {

--- a/packages/shared/src/codexCliExecutable.ts
+++ b/packages/shared/src/codexCliExecutable.ts
@@ -1,0 +1,128 @@
+// FILE: codexCliExecutable.ts
+// Purpose: Resolves the native Codex CLI executable on Windows before batch shims.
+// Layer: Shared Node runtime utility
+
+import { statSync } from "node:fs";
+import * as Path from "node:path";
+
+import {
+  resolveWindowsCommandCandidates,
+  resolveWindowsCommandPath,
+  type WindowsSafeProcessInput,
+} from "./windowsProcess.ts";
+
+interface FileStatLike {
+  isFile(): boolean;
+}
+
+type StatSyncLike = (path: string) => FileStatLike;
+
+export interface CodexCliExecutableInput extends WindowsSafeProcessInput {
+  readonly statSync?: StatSyncLike | undefined;
+}
+
+const DEFAULT_CODEX_COMMAND = "codex";
+const WINDOWS_NATIVE_EXECUTABLE_PATTERN = /\.(?:exe|com)$/i;
+const WINDOWS_BATCH_EXECUTABLE_PATTERN = /\.(?:cmd|bat)$/i;
+const WINDOWS_FULLY_QUALIFIED_PATH_PATTERN =
+  /^(?:[a-z]:[\\/]|\\\\[^\\/]+[\\/][^\\/]+)/i;
+
+function readEnvironmentValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const exact = env[name];
+  if (typeof exact === "string") {
+    return exact;
+  }
+
+  const normalizedName = name.toUpperCase();
+  for (const [key, value] of Object.entries(env)) {
+    if (key.toUpperCase() === normalizedName && typeof value === "string") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function nonEmptyEnvironmentValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = readEnvironmentValue(env, name)?.trim();
+  return value ? value : undefined;
+}
+
+function isAbsoluteRegularFile(candidate: string, readStat: StatSyncLike): boolean {
+  if (
+    !Path.win32.isAbsolute(candidate) ||
+    !WINDOWS_FULLY_QUALIFIED_PATH_PATTERN.test(candidate)
+  ) {
+    return false;
+  }
+
+  try {
+    return readStat(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function firstValidCandidate(
+  candidates: ReadonlyArray<string>,
+  pattern: RegExp,
+  readStat: StatSyncLike,
+): string | undefined {
+  return candidates.find(
+    (candidate) => pattern.test(candidate) && isAbsoluteRegularFile(candidate, readStat),
+  );
+}
+
+function validCodexExecutableInDirectory(
+  directory: string | undefined,
+  readStat: StatSyncLike,
+): string | undefined {
+  if (!directory) {
+    return undefined;
+  }
+  const candidate = Path.win32.join(directory, "codex.exe");
+  return isAbsoluteRegularFile(candidate, readStat) ? candidate : undefined;
+}
+
+function validNpmCodexShim(
+  appData: string | undefined,
+  readStat: StatSyncLike,
+): string | undefined {
+  if (!appData) {
+    return undefined;
+  }
+  const candidate = Path.win32.join(appData, "npm", "codex.cmd");
+  return isAbsoluteRegularFile(candidate, readStat) ? candidate : undefined;
+}
+
+export function resolveCodexCliExecutable(
+  command: string,
+  input: CodexCliExecutableInput = {},
+): string {
+  const platform = input.platform ?? process.platform;
+  if (platform !== "win32") {
+    return command;
+  }
+  if (command.trim().toLowerCase() !== DEFAULT_CODEX_COMMAND) {
+    return resolveWindowsCommandPath(command, input);
+  }
+
+  const env = input.env ?? process.env;
+  const readStat = input.statSync ?? statSync;
+  const whereCandidates = resolveWindowsCommandCandidates(DEFAULT_CODEX_COMMAND, input);
+  const localAppData = nonEmptyEnvironmentValue(env, "LOCALAPPDATA");
+  const standaloneInstallDirectory = localAppData
+    ? Path.win32.join(localAppData, "Programs", "OpenAI", "Codex", "bin")
+    : undefined;
+
+  return (
+    firstValidCandidate(whereCandidates, WINDOWS_NATIVE_EXECUTABLE_PATTERN, readStat) ??
+    validCodexExecutableInDirectory(
+      nonEmptyEnvironmentValue(env, "CODEX_INSTALL_DIR"),
+      readStat,
+    ) ??
+    validCodexExecutableInDirectory(standaloneInstallDirectory, readStat) ??
+    firstValidCandidate(whereCandidates, WINDOWS_BATCH_EXECUTABLE_PATTERN, readStat) ??
+    validNpmCodexShim(nonEmptyEnvironmentValue(env, "APPDATA"), readStat) ??
+    DEFAULT_CODEX_COMMAND
+  );
+}

--- a/packages/shared/src/codexCliExecutable.ts
+++ b/packages/shared/src/codexCliExecutable.ts
@@ -9,7 +9,7 @@ import {
   resolveWindowsCommandCandidates,
   resolveWindowsCommandPath,
   type WindowsSafeProcessInput,
-} from "./windowsProcess.ts";
+} from "./windowsProcess";
 
 interface FileStatLike {
   isFile(): boolean;
@@ -24,8 +24,7 @@ export interface CodexCliExecutableInput extends WindowsSafeProcessInput {
 const DEFAULT_CODEX_COMMAND = "codex";
 const WINDOWS_NATIVE_EXECUTABLE_PATTERN = /\.(?:exe|com)$/i;
 const WINDOWS_BATCH_EXECUTABLE_PATTERN = /\.(?:cmd|bat)$/i;
-const WINDOWS_FULLY_QUALIFIED_PATH_PATTERN =
-  /^(?:[a-z]:[\\/]|\\\\[^\\/]+[\\/][^\\/]+)/i;
+const WINDOWS_FULLY_QUALIFIED_PATH_PATTERN = /^(?:[a-z]:[\\/]|\\\\[^\\/]+[\\/][^\\/]+)/i;
 
 function readEnvironmentValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
   const exact = env[name];
@@ -48,10 +47,7 @@ function nonEmptyEnvironmentValue(env: NodeJS.ProcessEnv, name: string): string 
 }
 
 function isAbsoluteRegularFile(candidate: string, readStat: StatSyncLike): boolean {
-  if (
-    !Path.win32.isAbsolute(candidate) ||
-    !WINDOWS_FULLY_QUALIFIED_PATH_PATTERN.test(candidate)
-  ) {
+  if (!Path.win32.isAbsolute(candidate) || !WINDOWS_FULLY_QUALIFIED_PATH_PATTERN.test(candidate)) {
     return false;
   }
 
@@ -116,10 +112,7 @@ export function resolveCodexCliExecutable(
 
   return (
     firstValidCandidate(whereCandidates, WINDOWS_NATIVE_EXECUTABLE_PATTERN, readStat) ??
-    validCodexExecutableInDirectory(
-      nonEmptyEnvironmentValue(env, "CODEX_INSTALL_DIR"),
-      readStat,
-    ) ??
+    validCodexExecutableInDirectory(nonEmptyEnvironmentValue(env, "CODEX_INSTALL_DIR"), readStat) ??
     validCodexExecutableInDirectory(standaloneInstallDirectory, readStat) ??
     firstValidCandidate(whereCandidates, WINDOWS_BATCH_EXECUTABLE_PATTERN, readStat) ??
     validNpmCodexShim(nonEmptyEnvironmentValue(env, "APPDATA"), readStat) ??

--- a/packages/shared/src/windowsProcess.test.ts
+++ b/packages/shared/src/windowsProcess.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildWindowsBatchCommandArgs,
   isWindowsBatchCommand,
+  prepareResolvedWindowsSafeProcess,
   prepareWindowsSafeProcess,
   resolveWindowsCommandPath,
   resolveWindowsComSpec,
@@ -207,36 +208,39 @@ describe("windowsProcess", () => {
     });
   });
 
-  it("wraps resolved extensionless path-like shims through cmd.exe", () => {
-    const spawnSync = vi.fn(() => ({
-      stdout: [
-        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
-        "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
-      ].join("\r\n"),
-      status: 0,
-    }));
+  it.each([
+    {
+      configured: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex",
+      resolved: "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd",
+    },
+    {
+      configured: "custom-codex",
+      resolved: "C:\\tools\\custom-codex.cmd",
+    },
+  ])(
+    "resolves and wraps the explicit extensionless command $configured",
+    ({ configured, resolved }) => {
+      const spawnSync = vi.fn(() => ({
+        stdout: [configured, resolved].join("\r\n"),
+        status: 0,
+      }));
 
-    expect(
-      prepareWindowsSafeProcess("C:\\Users\\test\\AppData\\Roaming\\npm\\codex", ["app-server"], {
-        platform: "win32",
-        cwd: "C:\\projects\\synara",
-        env: { ComSpec: "C:\\Windows\\System32\\cmd.exe", SystemRoot: "C:\\Windows" },
-        spawnSync,
-      }),
-    ).toEqual({
-      command: "C:\\Windows\\System32\\cmd.exe",
-      args: [
-        "/d",
-        "/s",
-        "/v:off",
-        "/c",
-        'call "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
-      ],
-      shell: false,
-      windowsHide: true,
-      windowsVerbatimArguments: true,
-    });
-  });
+      expect(
+        prepareWindowsSafeProcess(configured, ["app-server"], {
+          platform: "win32",
+          cwd: "C:\\projects\\synara",
+          env: { ComSpec: "C:\\Windows\\System32\\cmd.exe", SystemRoot: "C:\\Windows" },
+          spawnSync,
+        }),
+      ).toEqual({
+        command: "C:\\Windows\\System32\\cmd.exe",
+        args: ["/d", "/s", "/v:off", "/c", `call "${resolved}" "app-server"`],
+        shell: false,
+        windowsHide: true,
+        windowsVerbatimArguments: true,
+      });
+    },
+  );
 
   it("wraps a configured .cmd Codex path without truncating it", () => {
     const spawnSync = vi.fn();
@@ -258,6 +262,26 @@ describe("windowsProcess", () => {
         "/c",
         'call "C:\\Users\\Test User\\AppData\\Roaming\\npm\\codex.cmd" "app-server"',
       ],
+      shell: false,
+      windowsHide: true,
+      windowsVerbatimArguments: true,
+    });
+    expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it("wraps an already-resolved .cmd command without probing again", () => {
+    const spawnSync = vi.fn();
+    const resolved = "C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd";
+
+    expect(
+      prepareResolvedWindowsSafeProcess(resolved, ["app-server"], {
+        platform: "win32",
+        env: { ComSpec: "C:\\Windows\\System32\\cmd.exe" },
+        spawnSync,
+      }),
+    ).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/v:off", "/c", `call "${resolved}" "app-server"`],
       shell: false,
       windowsHide: true,
       windowsVerbatimArguments: true,

--- a/packages/shared/src/windowsProcess.ts
+++ b/packages/shared/src/windowsProcess.ts
@@ -111,28 +111,21 @@ function isWindowsSpawnSafeResolvedCommand(command: string): boolean {
   return WINDOWS_SPAWN_SAFE_EXTENSION_PATTERN.test(command);
 }
 
-function selectWindowsCommandCandidate(
-  candidates: ReadonlyArray<string>,
-  cwd: string | undefined,
-  pathLikeCommand: boolean,
-): string | undefined {
-  const allowedCandidates = pathLikeCommand
-    ? candidates
-    : candidates.filter((candidate) => !isFromCurrentDirectory(candidate, cwd));
-  return allowedCandidates.find(isWindowsSpawnSafeResolvedCommand) ?? allowedCandidates[0];
+function selectWindowsCommandCandidate(candidates: ReadonlyArray<string>): string | undefined {
+  return candidates.find(isWindowsSpawnSafeResolvedCommand) ?? candidates[0];
 }
 
-// Resolve PATH/PATHEXT commands through where.exe so `.cmd` shims can be wrapped
-// explicitly. Prefer candidates that native spawn can execute or that we can
-// wrap, and skip current-directory hits for PATH commands to avoid restoring
-// shell-style CWD command hijacking.
-export function resolveWindowsCommandPath(
+// Return every where.exe result in PATH order after applying the same
+// current-directory protection used by resolveWindowsCommandPath. Consumers
+// with command-specific precedence rules can inspect the full list without
+// changing the generic launcher selection behavior.
+export function resolveWindowsCommandCandidates(
   command: string,
   input: WindowsSafeProcessInput = {},
-): string {
+): string[] {
   const pathLikeCommand = isPathLikeCommand(command);
   if (pathLikeCommand && hasWindowsExecutableExtension(command)) {
-    return command;
+    return [command];
   }
 
   const env = input.env ?? process.env;
@@ -147,7 +140,7 @@ export function resolveWindowsCommandPath(
     windowsHide: true,
   });
   if (result.error || result.status !== 0) {
-    return command;
+    return [];
   }
 
   const stdout = typeof result.stdout === "string" ? result.stdout : "";
@@ -155,7 +148,24 @@ export function resolveWindowsCommandPath(
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
-  return selectWindowsCommandCandidate(candidates, cwd, pathLikeCommand) ?? command;
+  return pathLikeCommand
+    ? candidates
+    : candidates.filter((candidate) => !isFromCurrentDirectory(candidate, cwd));
+}
+
+// Resolve PATH/PATHEXT commands through where.exe so `.cmd` shims can be wrapped
+// explicitly. Prefer candidates that native spawn can execute or that we can
+// wrap, and skip current-directory hits for PATH commands to avoid restoring
+// shell-style CWD command hijacking.
+export function resolveWindowsCommandPath(
+  command: string,
+  input: WindowsSafeProcessInput = {},
+): string {
+  const pathLikeCommand = isPathLikeCommand(command);
+  if (pathLikeCommand && hasWindowsExecutableExtension(command)) {
+    return command;
+  }
+  return selectWindowsCommandCandidate(resolveWindowsCommandCandidates(command, input)) ?? command;
 }
 
 export function prepareWindowsSafeProcess(
@@ -168,11 +178,26 @@ export function prepareWindowsSafeProcess(
     return { command, args: [...args], shell: false };
   }
 
+  return prepareResolvedWindowsSafeProcess(resolveWindowsCommandPath(command, input), args, input);
+}
+
+// Prepare a command whose PATH/PATHEXT resolution has already been finalized.
+// This keeps batch wrapping separate from command discovery so callers can
+// prove that validation and launch use the same executable.
+export function prepareResolvedWindowsSafeProcess(
+  command: string,
+  args: ReadonlyArray<string>,
+  input: WindowsSafeProcessInput = {},
+): WindowsSafeProcessCommand {
+  const platform = input.platform ?? process.platform;
+  if (platform !== "win32") {
+    return { command, args: [...args], shell: false };
+  }
+
   const env = input.env ?? process.env;
-  const resolvedCommand = resolveWindowsCommandPath(command, input);
-  if (!isWindowsBatchCommand(resolvedCommand)) {
+  if (!isWindowsBatchCommand(command)) {
     return {
-      command: resolvedCommand,
+      command,
       args: [...args],
       shell: false,
       windowsHide: true,
@@ -181,7 +206,7 @@ export function prepareWindowsSafeProcess(
 
   return {
     command: resolveWindowsComSpec(env),
-    args: buildWindowsBatchCommandArgs(resolvedCommand, args),
+    args: buildWindowsBatchCommandArgs(command, args),
     shell: false,
     windowsHide: true,
     windowsVerbatimArguments: true,


### PR DESCRIPTION
Fixes #385

## What changed

- Add a Codex-specific Windows executable resolver that prefers valid native executables before batch shims.
- Honor the documented `CODEX_INSTALL_DIR` and `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin` standalone locations, with the npm shim retained as a fallback.
- Resolve once against the effective environment, then reuse the exact executable for health probes, app-server startup, discovery, text generation, and desktop voice authentication.
- Preserve configured executable aliases and paths through the existing safe Windows command preparation.
- Add regression coverage for the exact `where.exe` ordering reported in #385, CWD filtering, case-insensitive environment keys, file validation, explicit aliases, and batch wrapping.

## Root cause

The generic Windows selector chose the first spawn-safe `where.exe` result. When npm's extensionless entry and `.cmd` shim appeared before the native `codex.exe`, Synara selected the batch shim even though a directly launchable native executable was available.

## Validation

- Shared Windows resolver tests: 39 passed
- Codex health checks: 12 passed
- Codex app-server manager tests: 83 passed, 2 skipped
- Desktop voice tests: 2 passed
- Live Windows native `app-server` initialize handshake: passed
- `git diff --check`: passed