### PR TITLE
fix: reject duplicate approval responses at the decider

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -5962,17 +5962,20 @@ describe("ProviderCommandReactor", () => {
       resolvedAt: null,
     });
 
-    await Effect.runPromise(
-      harness.engine.dispatch({
-        type: "thread.approval.respond",
-        commandId: CommandId.makeUnsafe("cmd-approval-respond-duplicate"),
-        threadId: ThreadId.makeUnsafe("thread-1"),
-        requestId: asApprovalRequestId("approval-request-1"),
-        lifecycleGeneration: "approval-generation-1",
-        decision: "decline",
-        createdAt: now,
-      }),
+    const duplicateFailure = await Effect.runPromise(
+      harness.engine
+        .dispatch({
+          type: "thread.approval.respond",
+          commandId: CommandId.makeUnsafe("cmd-approval-respond-duplicate"),
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          requestId: asApprovalRequestId("approval-request-1"),
+          lifecycleGeneration: "approval-generation-1",
+          decision: "decline",
+          createdAt: now,
+        })
+        .pipe(Effect.flip),
     );
+    expect(duplicateFailure._tag).toBe("OrchestrationCommandInvariantError");
     await harness.drain();
     expect(harness.respondToRequest).toHaveBeenCalledTimes(1);
   });

--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -1,4 +1,5 @@
 import type {
+  ApprovalRequestId,
   OrchestrationCommand,
   OrchestrationProject,
   OrchestrationReadModel,
@@ -153,6 +154,25 @@ export function requireThread(input: {
       thread
         ? `Thread '${input.threadId}' was deleted and cannot handle command '${input.command.type}'.`
         : `Thread '${input.threadId}' does not exist for command '${input.command.type}'.`,
+    ),
+  );
+}
+
+export function requireApprovalNotResponded(input: {
+  readonly readModel: OrchestrationReadModel;
+  readonly command: OrchestrationCommand;
+  readonly threadId: ThreadId;
+  readonly requestId: ApprovalRequestId;
+}): Effect.Effect<void, OrchestrationCommandInvariantError> {
+  const thread = findThreadById(input.readModel, input.threadId);
+  const responded = thread?.respondedApprovalRequestIds ?? [];
+  if (!responded.includes(input.requestId)) {
+    return Effect.void;
+  }
+  return Effect.fail(
+    invariantError(
+      input.command.type,
+      `Approval request '${input.requestId}' on thread '${input.threadId}' was already answered.`,
     ),
   );
 }

--- a/apps/server/src/orchestration/decider.approvalIdempotency.test.ts
+++ b/apps/server/src/orchestration/decider.approvalIdempotency.test.ts
@@ -115,6 +115,47 @@ async function appendApprovalResponse(
   );
 }
 
+async function appendApprovalRespondFailure(
+  readModel: OrchestrationReadModel,
+  input: {
+    readonly sequence: number;
+    readonly requestId: ApprovalRequestId;
+    readonly occurredAt: string;
+    readonly settlementStatus: "retryable" | "uncertain";
+  },
+): Promise<OrchestrationReadModel> {
+  return Effect.runPromise(
+    projectEvent(readModel, {
+      sequence: input.sequence,
+      eventId: asEventId(`evt-approval-respond-failed-${input.sequence}`),
+      aggregateKind: "thread",
+      aggregateId: THREAD_ID,
+      type: "thread.activity-appended",
+      occurredAt: input.occurredAt,
+      commandId: CommandId.makeUnsafe(`cmd-approval-respond-failed-${input.sequence}`),
+      causationEventId: null,
+      correlationId: CommandId.makeUnsafe(`cmd-approval-respond-failed-${input.sequence}`),
+      metadata: {},
+      payload: {
+        threadId: THREAD_ID,
+        activity: {
+          id: asEventId(`activity-approval-respond-failed-${input.sequence}`),
+          tone: "error",
+          kind: "provider.approval.respond.failed",
+          summary: "Provider approval response failed",
+          payload: {
+            detail: "No active provider session is bound to this thread.",
+            requestId: input.requestId,
+            settlementStatus: input.settlementStatus,
+          },
+          turnId: null,
+          createdAt: input.occurredAt,
+        },
+      },
+    }),
+  );
+}
+
 describe("decider approval idempotency", () => {
   it("emits thread.approval-response-requested for a first response", async () => {
     const now = new Date().toISOString();
@@ -190,5 +231,70 @@ describe("decider approval idempotency", () => {
 
     const event = Array.isArray(result) ? result[0] : result;
     expect(event.type).toBe("thread.approval-response-requested");
+  });
+
+  it("accepts a retry after a retryable provider delivery failure", async () => {
+    const now = new Date().toISOString();
+    const withThread = await createThreadReadModel(now);
+    const withResponse = await appendApprovalResponse(withThread, {
+      sequence: 3,
+      requestId: REQUEST_ID,
+      occurredAt: now,
+    });
+    const readModel = await appendApprovalRespondFailure(withResponse, {
+      sequence: 4,
+      requestId: REQUEST_ID,
+      occurredAt: now,
+      settlementStatus: "retryable",
+    });
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.approval.respond",
+          commandId: CommandId.makeUnsafe("cmd-approval-respond-retry"),
+          threadId: THREAD_ID,
+          requestId: REQUEST_ID,
+          decision: "accept",
+          createdAt: now,
+        },
+        readModel,
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event.type).toBe("thread.approval-response-requested");
+  });
+
+  it("keeps rejecting retries after an uncertain provider delivery failure", async () => {
+    const now = new Date().toISOString();
+    const withThread = await createThreadReadModel(now);
+    const withResponse = await appendApprovalResponse(withThread, {
+      sequence: 3,
+      requestId: REQUEST_ID,
+      occurredAt: now,
+    });
+    const readModel = await appendApprovalRespondFailure(withResponse, {
+      sequence: 4,
+      requestId: REQUEST_ID,
+      occurredAt: now,
+      settlementStatus: "uncertain",
+    });
+
+    const failure = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.approval.respond",
+          commandId: CommandId.makeUnsafe("cmd-approval-respond-after-uncertain"),
+          threadId: THREAD_ID,
+          requestId: REQUEST_ID,
+          decision: "accept",
+          createdAt: now,
+        },
+        readModel,
+      }).pipe(Effect.flip),
+    );
+
+    expect(failure._tag).toBe("OrchestrationCommandInvariantError");
   });
 });

--- a/apps/server/src/orchestration/decider.approvalIdempotency.test.ts
+++ b/apps/server/src/orchestration/decider.approvalIdempotency.test.ts
@@ -1,0 +1,194 @@
+import {
+  ApprovalRequestId,
+  CommandId,
+  DEFAULT_PROVIDER_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  EventId,
+  ProjectId,
+  ThreadId,
+} from "@synara/contracts";
+import type { OrchestrationReadModel } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+
+import { decideOrchestrationCommand } from "./decider.ts";
+import { createEmptyReadModel, projectEvent } from "./projector.ts";
+
+const asEventId = (value: string): EventId => EventId.makeUnsafe(value);
+
+const PROJECT_ID = ProjectId.makeUnsafe("project-approvals");
+const THREAD_ID = ThreadId.makeUnsafe("thread-approvals");
+const REQUEST_ID = ApprovalRequestId.makeUnsafe("req-1");
+
+async function createThreadReadModel(now: string): Promise<OrchestrationReadModel> {
+  const withProject = await Effect.runPromise(
+    projectEvent(createEmptyReadModel(now), {
+      sequence: 1,
+      eventId: asEventId("evt-project-create"),
+      aggregateKind: "project",
+      aggregateId: PROJECT_ID,
+      type: "project.created",
+      occurredAt: now,
+      commandId: CommandId.makeUnsafe("cmd-project-create"),
+      causationEventId: null,
+      correlationId: CommandId.makeUnsafe("cmd-project-create"),
+      metadata: {},
+      payload: {
+        projectId: PROJECT_ID,
+        title: "Project",
+        workspaceRoot: "/tmp/project",
+        defaultModelSelection: null,
+        scripts: [],
+        createdAt: now,
+        updatedAt: now,
+      },
+    }),
+  );
+
+  return Effect.runPromise(
+    projectEvent(withProject, {
+      sequence: 2,
+      eventId: asEventId("evt-thread-create"),
+      aggregateKind: "thread",
+      aggregateId: THREAD_ID,
+      type: "thread.created",
+      occurredAt: now,
+      commandId: CommandId.makeUnsafe("cmd-thread-create"),
+      causationEventId: null,
+      correlationId: CommandId.makeUnsafe("cmd-thread-create"),
+      metadata: {},
+      payload: {
+        threadId: THREAD_ID,
+        projectId: PROJECT_ID,
+        title: "Approval thread",
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: DEFAULT_RUNTIME_MODE,
+        branch: null,
+        worktreePath: null,
+        parentThreadId: null,
+        subagentAgentId: null,
+        subagentNickname: null,
+        subagentRole: null,
+        forkSourceThreadId: null,
+        sidechatSourceThreadId: null,
+        handoff: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    }),
+  );
+}
+
+async function appendApprovalResponse(
+  readModel: OrchestrationReadModel,
+  input: {
+    readonly sequence: number;
+    readonly requestId: ApprovalRequestId;
+    readonly occurredAt: string;
+  },
+): Promise<OrchestrationReadModel> {
+  return Effect.runPromise(
+    projectEvent(readModel, {
+      sequence: input.sequence,
+      eventId: asEventId(`evt-approval-response-${input.sequence}`),
+      aggregateKind: "thread",
+      aggregateId: THREAD_ID,
+      type: "thread.approval-response-requested",
+      occurredAt: input.occurredAt,
+      commandId: CommandId.makeUnsafe(`cmd-approval-response-${input.sequence}`),
+      causationEventId: null,
+      correlationId: CommandId.makeUnsafe(`cmd-approval-response-${input.sequence}`),
+      metadata: {
+        requestId: input.requestId,
+      },
+      payload: {
+        threadId: THREAD_ID,
+        requestId: input.requestId,
+        decision: "accept",
+        createdAt: input.occurredAt,
+      },
+    }),
+  );
+}
+
+describe("decider approval idempotency", () => {
+  it("emits thread.approval-response-requested for a first response", async () => {
+    const now = new Date().toISOString();
+    const readModel = await createThreadReadModel(now);
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.approval.respond",
+          commandId: CommandId.makeUnsafe("cmd-approval-respond"),
+          threadId: THREAD_ID,
+          requestId: REQUEST_ID,
+          decision: "accept",
+          createdAt: now,
+        },
+        readModel,
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event.type).toBe("thread.approval-response-requested");
+  });
+
+  it("rejects a duplicate response for an already answered request", async () => {
+    const now = new Date().toISOString();
+    const withThread = await createThreadReadModel(now);
+    const readModel = await appendApprovalResponse(withThread, {
+      sequence: 3,
+      requestId: REQUEST_ID,
+      occurredAt: now,
+    });
+
+    const failure = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.approval.respond",
+          commandId: CommandId.makeUnsafe("cmd-approval-respond-duplicate"),
+          threadId: THREAD_ID,
+          requestId: REQUEST_ID,
+          decision: "decline",
+          createdAt: now,
+        },
+        readModel,
+      }).pipe(Effect.flip),
+    );
+
+    expect(failure._tag).toBe("OrchestrationCommandInvariantError");
+    expect(failure.detail).toContain("req-1");
+  });
+
+  it("still accepts responses for other approval requests on the same thread", async () => {
+    const now = new Date().toISOString();
+    const withThread = await createThreadReadModel(now);
+    const readModel = await appendApprovalResponse(withThread, {
+      sequence: 3,
+      requestId: REQUEST_ID,
+      occurredAt: now,
+    });
+
+    const result = await Effect.runPromise(
+      decideOrchestrationCommand({
+        command: {
+          type: "thread.approval.respond",
+          commandId: CommandId.makeUnsafe("cmd-approval-respond-other"),
+          threadId: THREAD_ID,
+          requestId: ApprovalRequestId.makeUnsafe("req-2"),
+          decision: "accept",
+          createdAt: now,
+        },
+        readModel,
+      }),
+    );
+
+    const event = Array.isArray(result) ? result[0] : result;
+    expect(event.type).toBe("thread.approval-response-requested");
+  });
+});

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -28,6 +28,7 @@ import { resolveStableMessageTurnId } from "./messageTurnId.ts";
 import {
   listActiveProjectsByWorkspaceRoot,
   listThreadsByProjectId,
+  requireApprovalNotResponded,
   requireProject,
   requireProjectAbsent,
   requireProjectHasNoThreads,
@@ -1331,6 +1332,12 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         readModel,
         command,
         threadId: command.threadId,
+      });
+      yield* requireApprovalNotResponded({
+        readModel,
+        command,
+        threadId: command.threadId,
+        requestId: command.requestId,
       });
       return {
         ...withEventBase({

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -1,5 +1,6 @@
 import type { OrchestrationEvent, OrchestrationReadModel, ThreadId } from "@synara/contracts";
 import {
+  ApprovalRequestId,
   OrchestrationCheckpointSummary,
   OrchestrationMessage,
   OrchestrationSession,
@@ -240,6 +241,35 @@ function compareThreadActivities(
   }
 
   return left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id);
+}
+
+/**
+ * Returns the responded-request list with the failed request re-opened, or null
+ * when the activity does not undo an approval response. Only `retryable`
+ * failures re-open: the pending-interaction projection keeps `uncertain`
+ * failures non-actionable, so the decider keeps rejecting retries for those.
+ */
+function reopenedApprovalRequestIds(
+  responded: OrchestrationThread["respondedApprovalRequestIds"],
+  activity: OrchestrationThread["activities"][number],
+): OrchestrationThread["respondedApprovalRequestIds"] | null {
+  if (activity.kind !== "provider.approval.respond.failed") {
+    return null;
+  }
+  const payload =
+    typeof activity.payload === "object" &&
+    activity.payload !== null &&
+    !Array.isArray(activity.payload)
+      ? (activity.payload as Record<string, unknown>)
+      : null;
+  if (payload?.settlementStatus !== "retryable" || typeof payload.requestId !== "string") {
+    return null;
+  }
+  const requestId = payload.requestId;
+  if (!responded?.includes(ApprovalRequestId.makeUnsafe(requestId))) {
+    return null;
+  }
+  return responded.filter((entry) => entry !== requestId);
 }
 
 function upsertThreadActivity(
@@ -1142,10 +1172,19 @@ export function projectEvent(
 
           const activities = upsertThreadActivity(thread.activities, payload.activity);
 
+          // A retryable delivery failure re-opens the approval request (matching
+          // the pending-interaction projection), so the decider must accept the
+          // retry instead of rejecting it as already answered.
+          const respondedApprovalRequestIds = reopenedApprovalRequestIds(
+            thread.respondedApprovalRequestIds,
+            payload.activity,
+          );
+
           return {
             ...nextBase,
             threads: updateThread(nextBase.threads, payload.threadId, {
               activities,
+              ...(respondedApprovalRequestIds !== null ? { respondedApprovalRequestIds } : {}),
               updatedAt: event.occurredAt,
             }),
           };

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -25,6 +25,7 @@ import {
   ProjectCreatedPayload,
   ProjectDeletedPayload,
   ProjectMetaUpdatedPayload,
+  ThreadApprovalResponseRequestedPayload,
   ThreadArchivedPayload,
   ThreadActivityAppendedPayload,
   ThreadCreatedPayload,
@@ -1092,6 +1093,34 @@ export function projectEvent(
                       completedAt: latestCheckpoint.completedAt,
                       assistantMessageId: latestCheckpoint.assistantMessageId,
                     },
+              updatedAt: event.occurredAt,
+            }),
+          };
+        }),
+      );
+
+    case "thread.approval-response-requested":
+      return decodeForEvent(
+        ThreadApprovalResponseRequestedPayload,
+        event.payload,
+        event.type,
+        "payload",
+      ).pipe(
+        Effect.map((payload) => {
+          const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+          if (!thread) {
+            return nextBase;
+          }
+
+          const responded = thread.respondedApprovalRequestIds ?? [];
+          if (responded.includes(payload.requestId)) {
+            return nextBase;
+          }
+
+          return {
+            ...nextBase,
+            threads: updateThread(nextBase.threads, payload.threadId, {
+              respondedApprovalRequestIds: [...responded, payload.requestId],
               updatedAt: event.occurredAt,
             }),
           };

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -681,6 +681,7 @@ export const OrchestrationThread = Schema.Struct({
   hasPendingApprovals: Schema.optional(Schema.Boolean),
   hasPendingUserInput: Schema.optional(Schema.Boolean),
   hasActionableProposedPlan: Schema.optional(Schema.Boolean),
+  respondedApprovalRequestIds: Schema.optional(Schema.Array(ApprovalRequestId)),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
   archivedAt: Schema.optional(Schema.NullOr(IsoDateTime)).pipe(


### PR DESCRIPTION
Closes #403. Part of the Phase 0 groundwork for #366.

## Problem

`thread.approval.respond` only checks that the thread exists. If the same approval request gets answered twice (double click, two open tabs, a client retry after a slow ack), the decider happily emits a second `thread.approval-response-requested` event and the provider gets a second response for a request it already resolved. With remote access on the horizon this gets worse, since multiple devices can race on the same approval.

## Fix

First response wins, at the event log level:

- `OrchestrationThread` gets an optional `respondedApprovalRequestIds` array in contracts. Optional keeps existing snapshots decodable, same approach as other later additions on that struct.
- The projector folds `thread.approval-response-requested` into that array (with dedupe).
- A new `requireApprovalNotResponded` invariant in `commandInvariants.ts` rejects a respond command whose request id was already answered, using the existing `OrchestrationCommandInvariantError` path, so the caller gets a typed "already answered" failure instead of a silent double dispatch.

## Testing

- New `decider.approvalIdempotency.test.ts`: first response emits the event, duplicate response fails with the invariant error, a different request id on the same thread still succeeds.
- Updated the existing `ProviderCommandReactor` test, which previously asserted that a duplicate respond dispatch was accepted and just not forwarded. It now asserts the duplicate is rejected with the invariant error and the provider still only sees one response.
- `bun fmt`, `bun lint`, `bun typecheck` and the orchestration test suite all pass.

Scoped to just this: no UI changes, no protocol changes.

