### PR TITLE
feat: add a pair a device flow with QR code in settings

### DIFF
--- a/apps/server/src/auth/Layers/ServerAuth.ts
+++ b/apps/server/src/auth/Layers/ServerAuth.ts
@@ -6,6 +6,7 @@ import type {
   AuthSessionState,
   AuthWebSocketTokenResult,
 } from "@synara/contracts";
+import { buildPairingUrl } from "@synara/shared/pairingUrl";
 import { DateTime, Effect, Layer } from "effect";
 
 import { AuthControlPlane } from "../Services/AuthControlPlane";
@@ -392,13 +393,7 @@ export const makeServerAuth = Effect.gen(function* () {
 
   const issueStartupPairingUrl: ServerAuthShape["issueStartupPairingUrl"] = (baseUrl) =>
     issuePairingCredential({ role: "owner" }).pipe(
-      Effect.map((issued) => {
-        const url = new URL(baseUrl);
-        url.pathname = "/pair";
-        url.searchParams.delete("token");
-        url.hash = new URLSearchParams([["token", issued.credential]]).toString();
-        return url.toString();
-      }),
+      Effect.map((issued) => buildPairingUrl(baseUrl, issued.credential)),
     );
 
   return {

--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -20,6 +20,7 @@ import {
   isLegacyTokenAuthorized,
   makeHealthEffectRouteLayer,
   projectFaviconEffectRouteLayer,
+  resolvePairingBaseUrl,
   staticAndDevEffectRouteLayer,
 } from "./http";
 import {
@@ -158,6 +159,28 @@ async function withEffectServer(
     await Effect.runPromise(Scope.close(scope, Exit.void));
   }
 }
+
+describe("resolvePairingBaseUrl", () => {
+  it("prefers the configured public URL origin", () => {
+    const config = makeConfig({
+      publicUrl: new URL("https://synara.example.test/app"),
+      host: "192.168.1.50",
+    });
+    expect(resolvePairingBaseUrl(config)).toBe("https://synara.example.test");
+  });
+
+  it("uses a concrete non-loopback bind host", () => {
+    expect(resolvePairingBaseUrl(makeConfig({ host: "192.168.1.50", port: 3773 }))).toBe(
+      "http://192.168.1.50:3773",
+    );
+  });
+
+  it("returns undefined for loopback and wildcard binds", () => {
+    expect(resolvePairingBaseUrl(makeConfig({ host: "127.0.0.1" }))).toBeUndefined();
+    expect(resolvePairingBaseUrl(makeConfig({ host: "0.0.0.0" }))).toBeUndefined();
+    expect(resolvePairingBaseUrl(makeConfig({ host: undefined }))).toBeUndefined();
+  });
+});
 
 describe("production Effect HTTP routes", () => {
   it("preserves the loopback-only startup-token policy", () => {

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -39,7 +39,7 @@ import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnap
 import { ProviderAdapterRegistry } from "./provider/Services/ProviderAdapterRegistry";
 import { threadArchiveChunks, threadArchiveFileName } from "./orchestration/exportThreadArchive";
 import type { ServerReadiness } from "./server/readiness";
-import { isLoopbackHost } from "./startupAccess";
+import { formatHostForUrl, isLoopbackHost, isWildcardHost } from "./startupAccess";
 import {
   attachmentPrincipalForSession,
   LOCAL_LOOPBACK_ATTACHMENT_PRINCIPAL,
@@ -267,6 +267,23 @@ export function isLegacyTokenAuthorized(input: {
   return !input.config.authToken || legacyToken === input.config.authToken;
 }
 
+/**
+ * Origin other devices should use to reach this server, mirroring how startup
+ * builds its pairing link: the configured public URL wins, then a concrete
+ * non-loopback bind host. Wildcard and loopback binds return undefined because
+ * the server does not know a reachable address; clients fall back to their own
+ * origin, which is the address that demonstrably reached the server.
+ */
+export function resolvePairingBaseUrl(config: ServerConfigShape): string | undefined {
+  if (config.publicUrl) {
+    return config.publicUrl.origin;
+  }
+  if (config.host && !isWildcardHost(config.host) && !isLoopbackHost(config.host)) {
+    return `http://${formatHostForUrl(config.host)}:${config.port}`;
+  }
+  return undefined;
+}
+
 function encodeCookie(input: {
   readonly name: string;
   readonly value: string;
@@ -430,7 +447,9 @@ export const authEffectRouteLayer = HttpRouter.add(
               ),
             )
           : {};
-      return HttpServerResponse.jsonUnsafe(yield* serverAuth.issuePairingCredential(payload));
+      const issued = yield* serverAuth.issuePairingCredential(payload);
+      const pairingBaseUrl = resolvePairingBaseUrl(config);
+      return HttpServerResponse.jsonUnsafe(pairingBaseUrl ? { ...issued, pairingBaseUrl } : issued);
     }
 
     if (request.method === "POST" && url.pathname === "/api/auth/logout") {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,7 @@
     "katex": "^0.16.45",
     "lexical": "^0.41.0",
     "pdfjs-dist": "^5.4.296",
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^19.0.0",

--- a/apps/web/src/components/settings/PairDeviceCard.test.ts
+++ b/apps/web/src/components/settings/PairDeviceCard.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPairingUrl } from "./PairDeviceCard";
+
+describe("buildPairingUrl", () => {
+  it("puts the credential in the hash of the /pair route", () => {
+    expect(buildPairingUrl("https://synara.example:3773", "abc123")).toBe(
+      "https://synara.example:3773/pair#token=abc123",
+    );
+  });
+
+  it("percent-encodes credentials so the hash round-trips through URLSearchParams", () => {
+    const url = buildPairingUrl("http://127.0.0.1:3773", "a+b/c=");
+    const hash = new URL(url).hash.slice(1);
+    expect(new URLSearchParams(hash).get("token")).toBe("a+b/c=");
+  });
+});

--- a/apps/web/src/components/settings/PairDeviceCard.tsx
+++ b/apps/web/src/components/settings/PairDeviceCard.tsx
@@ -1,0 +1,101 @@
+// FILE: PairDeviceCard.tsx
+// Purpose: Mint a pairing credential and show it as a QR code plus copyable link in settings.
+// Layer: Settings UI components
+// Exports: buildPairingUrl, PairDeviceCard
+
+import { useCallback, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+
+import { Button } from "~/components/ui/button";
+import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { ensureNativeApi, readNativeApi } from "~/nativeApi";
+import { SettingsRow } from "~/components/settings/SettingsPanelPrimitives";
+
+/**
+ * Mirrors the server's `issueStartupPairingUrl` shape: the credential travels in the
+ * URL hash so it never reaches server logs, and `/pair` exchanges it for a session.
+ */
+export function buildPairingUrl(origin: string, credential: string): string {
+  const url = new URL("/pair", origin);
+  url.hash = new URLSearchParams([["token", credential]]).toString();
+  return url.toString();
+}
+
+function formatExpiry(expiresAt: string): string | null {
+  const expiresAtMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expiresAtMs)) {
+    return null;
+  }
+  const remainingMinutes = Math.round((expiresAtMs - Date.now()) / 60_000);
+  if (remainingMinutes <= 0) {
+    return "Expired";
+  }
+  if (remainingMinutes < 60) {
+    return `Expires in ${remainingMinutes} min`;
+  }
+  const remainingHours = Math.round(remainingMinutes / 60);
+  return `Expires in ${remainingHours} h`;
+}
+
+export function PairDeviceCard() {
+  const [pairingUrl, setPairingUrl] = useState<string | null>(null);
+  const [expiresAt, setExpiresAt] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { copyToClipboard, isCopied } = useCopyToClipboard();
+
+  const createPairingLink = useCallback(async () => {
+    if (isCreating) return;
+    const api = readNativeApi() ?? ensureNativeApi();
+    setIsCreating(true);
+    setError(null);
+    try {
+      const issued = await api.server.createAuthPairingToken({ label: "paired-device" });
+      setPairingUrl(buildPairingUrl(window.location.origin, issued.credential));
+      setExpiresAt(String(issued.expiresAt));
+    } catch (cause) {
+      setPairingUrl(null);
+      setExpiresAt(null);
+      setError(cause instanceof Error ? cause.message : "Unable to create a pairing link.");
+    } finally {
+      setIsCreating(false);
+    }
+  }, [isCreating]);
+
+  const expiryLabel = expiresAt ? formatExpiry(expiresAt) : null;
+
+  return (
+    <SettingsRow
+      title="Pair a device"
+      description="Create a one-time link that signs another device into this server. Scan the QR code or open the link on the other device."
+      status={error ? <span className="text-destructive">{error}</span> : undefined}
+      control={
+        <Button size="xs" variant="outline" disabled={isCreating} onClick={createPairingLink}>
+          {isCreating ? "Creating..." : pairingUrl ? "New link" : "Create pairing link"}
+        </Button>
+      }
+    >
+      {pairingUrl ? (
+        <div className="mt-3 flex flex-col gap-3 border-t border-border/70 pt-3 sm:flex-row sm:items-start">
+          <div className="w-fit shrink-0 rounded-md bg-white p-2">
+            <QRCodeSVG value={pairingUrl} size={160} aria-label="Pairing link QR code" />
+          </div>
+          <div className="min-w-0 space-y-2 text-xs text-muted-foreground">
+            <p className="break-all font-mono text-[11px] text-foreground">{pairingUrl}</p>
+            <div className="flex items-center gap-2">
+              <Button
+                size="xs"
+                variant="outline"
+                onClick={() => copyToClipboard(pairingUrl, undefined)}
+              >
+                {isCopied ? "Copied" : "Copy link"}
+              </Button>
+              {expiryLabel ? <span>{expiryLabel}</span> : null}
+            </div>
+            <p>Anyone with this link can access this server until it expires.</p>
+          </div>
+        </div>
+      ) : null}
+    </SettingsRow>
+  );
+}

--- a/apps/web/src/components/settings/PairDeviceCard.tsx
+++ b/apps/web/src/components/settings/PairDeviceCard.tsx
@@ -1,34 +1,25 @@
 // FILE: PairDeviceCard.tsx
 // Purpose: Mint a pairing credential and show it as a QR code plus copyable link in settings.
 // Layer: Settings UI components
-// Exports: buildPairingUrl, PairDeviceCard
+// Exports: PairDeviceCard
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { QRCodeSVG } from "qrcode.react";
+import { buildPairingUrl } from "@synara/shared/pairingUrl";
 
 import { Button } from "~/components/ui/button";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { ensureNativeApi, readNativeApi } from "~/nativeApi";
 import { SettingsRow } from "~/components/settings/SettingsPanelPrimitives";
 
-/**
- * Mirrors the server's `issueStartupPairingUrl` shape: the credential travels in the
- * URL hash so it never reaches server logs, and `/pair` exchanges it for a session.
- */
-export function buildPairingUrl(origin: string, credential: string): string {
-  const url = new URL("/pair", origin);
-  url.hash = new URLSearchParams([["token", credential]]).toString();
-  return url.toString();
-}
-
-function formatExpiry(expiresAt: string): string | null {
+function formatExpiry(expiresAt: string, nowMs: number): string | null {
   const expiresAtMs = Date.parse(expiresAt);
   if (!Number.isFinite(expiresAtMs)) {
     return null;
   }
-  const remainingMinutes = Math.round((expiresAtMs - Date.now()) / 60_000);
+  const remainingMinutes = Math.round((expiresAtMs - nowMs) / 60_000);
   if (remainingMinutes <= 0) {
-    return "Expired";
+    return null;
   }
   if (remainingMinutes < 60) {
     return `Expires in ${remainingMinutes} min`;
@@ -37,12 +28,27 @@ function formatExpiry(expiresAt: string): string | null {
   return `Expires in ${remainingHours} h`;
 }
 
+function isExpired(expiresAt: string, nowMs: number): boolean {
+  const expiresAtMs = Date.parse(expiresAt);
+  return Number.isFinite(expiresAtMs) && expiresAtMs <= nowMs;
+}
+
 export function PairDeviceCard() {
   const [pairingUrl, setPairingUrl] = useState<string | null>(null);
   const [expiresAt, setExpiresAt] = useState<string | null>(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { copyToClipboard, isCopied } = useCopyToClipboard();
+
+  // Pairing credentials are short-lived, so keep the expiry label and the
+  // expired state current while the link is showing instead of freezing the
+  // render-time value.
+  useEffect(() => {
+    if (!expiresAt) return;
+    const interval = window.setInterval(() => setNowMs(Date.now()), 10_000);
+    return () => window.clearInterval(interval);
+  }, [expiresAt]);
 
   const createPairingLink = useCallback(async () => {
     if (isCreating) return;
@@ -51,8 +57,13 @@ export function PairDeviceCard() {
     setError(null);
     try {
       const issued = await api.server.createAuthPairingToken({ label: "paired-device" });
-      setPairingUrl(buildPairingUrl(window.location.origin, issued.credential));
+      // Prefer the server-reported reachable origin: when the owner browses via
+      // localhost, this browser's origin would send other devices to their own
+      // loopback address.
+      const origin = issued.pairingBaseUrl ?? window.location.origin;
+      setPairingUrl(buildPairingUrl(origin, issued.credential));
       setExpiresAt(String(issued.expiresAt));
+      setNowMs(Date.now());
     } catch (cause) {
       setPairingUrl(null);
       setExpiresAt(null);
@@ -62,7 +73,10 @@ export function PairDeviceCard() {
     }
   }, [isCreating]);
 
-  const expiryLabel = expiresAt ? formatExpiry(expiresAt) : null;
+  const expired = expiresAt !== null && isExpired(expiresAt, nowMs);
+  const expiryLabel = expiresAt && !expired ? formatExpiry(expiresAt, nowMs) : null;
+  const showLocalOriginHint =
+    pairingUrl !== null && new URL(pairingUrl).hostname === "localhost" && !expired;
 
   return (
     <SettingsRow
@@ -75,7 +89,7 @@ export function PairDeviceCard() {
         </Button>
       }
     >
-      {pairingUrl ? (
+      {pairingUrl && !expired ? (
         <div className="mt-3 flex flex-col gap-3 border-t border-border/70 pt-3 sm:flex-row sm:items-start">
           <div className="w-fit shrink-0 rounded-md bg-white p-2">
             <QRCodeSVG value={pairingUrl} size={160} aria-label="Pairing link QR code" />
@@ -92,8 +106,19 @@ export function PairDeviceCard() {
               </Button>
               {expiryLabel ? <span>{expiryLabel}</span> : null}
             </div>
+            {showLocalOriginHint ? (
+              <p>
+                This link points at localhost, which other devices cannot reach. Open Synara via the
+                server&apos;s LAN or public address and create the link again.
+              </p>
+            ) : null}
             <p>Anyone with this link can access this server until it expires.</p>
           </div>
+        </div>
+      ) : null}
+      {pairingUrl && expired ? (
+        <div className="mt-3 border-t border-border/70 pt-3 text-xs text-muted-foreground">
+          This pairing link has expired. Create a new one to pair a device.
         </div>
       ) : null}
     </SettingsRow>

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -97,6 +97,7 @@ import {
   SettingsSelectPopup,
 } from "../components/settings/SettingsPanelPrimitives";
 import { ProviderUsageSettingsPanel } from "../components/settings/ProviderUsageSettingsPanel";
+import { PairDeviceCard } from "../components/settings/PairDeviceCard";
 import { ProfileSettingsPanel } from "../components/settings/ProfileSettingsPanel";
 import { KeyboardShortcutsSettingsPanel } from "../components/settings/KeyboardShortcutsSettingsPanel";
 import { SkillsSettingsPanel } from "../components/settings/SkillsSettingsPanel";
@@ -3568,6 +3569,7 @@ function SettingsRouteView() {
               </Button>
             }
           />
+          {serverAuthSessionQuery.data.role === "owner" ? <PairDeviceCard /> : null}
         </SettingsSection>
       ) : null}
 

--- a/bun.lock
+++ b/bun.lock
@@ -120,6 +120,7 @@
         "katex": "^0.16.45",
         "lexical": "^0.41.0",
         "pdfjs-dist": "^5.4.296",
+        "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-colorful": "^5.6.1",
         "react-dom": "^19.0.0",
@@ -2296,6 +2297,8 @@
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
 
     "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
+    "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 

--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -68,6 +68,12 @@ export const AuthPairingCredentialResult = Schema.Struct({
   credential: TrimmedNonEmptyString,
   label: Schema.optionalKey(TrimmedNonEmptyString),
   expiresAt: Schema.DateTimeUtc,
+  /**
+   * Origin other devices should use to reach this server (public URL or
+   * non-loopback bind). Absent when the server only knows loopback addresses,
+   * in which case clients fall back to their own origin.
+   */
+  pairingBaseUrl: Schema.optionalKey(TrimmedNonEmptyString),
 });
 export type AuthPairingCredentialResult = typeof AuthPairingCredentialResult.Type;
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -195,6 +195,10 @@
     "./migrationRecovery": {
       "types": "./src/migrationRecovery.ts",
       "import": "./src/migrationRecovery.ts"
+    },
+    "./pairingUrl": {
+      "types": "./src/pairingUrl.ts",
+      "import": "./src/pairingUrl.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/pairingUrl.test.ts
+++ b/packages/shared/src/pairingUrl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildPairingUrl } from "./PairDeviceCard";
+import { buildPairingUrl } from "./pairingUrl";
 
 describe("buildPairingUrl", () => {
   it("puts the credential in the hash of the /pair route", () => {
@@ -13,5 +13,11 @@ describe("buildPairingUrl", () => {
     const url = buildPairingUrl("http://127.0.0.1:3773", "a+b/c=");
     const hash = new URL(url).hash.slice(1);
     expect(new URLSearchParams(hash).get("token")).toBe("a+b/c=");
+  });
+
+  it("replaces any path or query on the base URL with the /pair route", () => {
+    expect(buildPairingUrl("http://192.168.1.10:3773/settings?tab=advanced", "tok")).toBe(
+      "http://192.168.1.10:3773/pair#token=tok",
+    );
   });
 });

--- a/packages/shared/src/pairingUrl.ts
+++ b/packages/shared/src/pairingUrl.ts
@@ -1,0 +1,15 @@
+// FILE: pairingUrl.ts
+// Purpose: Build /pair URLs with the credential in the hash so it never reaches server logs.
+// Layer: Shared runtime utilities (server + web)
+// Exports: buildPairingUrl
+
+/**
+ * The credential travels in the URL hash so it never reaches server logs; the
+ * `/pair` route exchanges it for a session. Used by the server's startup
+ * pairing link and the settings "Pair a device" card so the two cannot drift.
+ */
+export function buildPairingUrl(origin: string, credential: string): string {
+  const url = new URL("/pair", origin);
+  url.hash = new URLSearchParams([["token", credential]]).toString();
+  return url.toString();
+}


### PR DESCRIPTION
Closes #405. Part of the Phase 0 groundwork for #366.

## Problem

The server has a complete pairing system: `POST /api/auth/pairing-token` mints one-time credentials (owner only), the `/pair` route in the web client exchanges `#token=...` for a session cookie, and the CLI prints a startup pairing URL via `issueStartupPairingUrl`. What's missing is any way to pair a second device after startup without hand-crafting requests: `createAuthPairingToken` is bound in `wsNativeApi.ts` but has zero UI consumers.

## Change

A "Pair a device" row in Settings > Advanced, inside the existing Session section:

- Owner sessions get a "Create pairing link" button that calls `createAuthPairingToken` and shows the resulting `/pair#token=...` URL as a locally rendered QR code (new `qrcode.react` dependency, no network involved) plus a copy button and the expiry.
- The URL is built with the same shape as the server's `issueStartupPairingUrl`: the credential travels in the hash so it never shows up in server logs, and the existing `/pair` bootstrap handles the exchange unchanged.
- Non-owner sessions and unauthenticated setups don't see the row, matching the 403 the endpoint would return.
- A note under the QR warns that anyone with the link can access the server until it expires.

## Testing

- New unit test for `buildPairingUrl` covering the hash shape and percent-encoding round-trip; passes.
- Verified the existing web test failures on this branch (splitViewStore and friends) reproduce identically on a clean upstream/main checkout, so they are unrelated to this change.
- `bun fmt`, `bun lint`, `bun typecheck` pass.

