### PR TITLE
feat(web): show Codex, Claude, and Cursor quota in composer

### DIFF
--- a/apps/server/src/providerUsage/index.test.ts
+++ b/apps/server/src/providerUsage/index.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ProviderKind, ServerProviderUsageSnapshot } from "@synara/contracts";
+import { PROVIDER_USAGE_PROVIDERS } from "@synara/shared/providerUsage";
+
+import { collectProviderUsageSnapshots } from "./index";
+import { PROVIDER_USAGE_FETCHERS } from "./registry";
+import type { ProviderUsageContext } from "./types";
+
+const { loadLocalProviderUsageLinesMock } = vi.hoisted(() => ({
+  loadLocalProviderUsageLinesMock: vi.fn(),
+}));
+
+vi.mock("../providerUsageSnapshot", () => ({
+  loadLocalProviderUsageLines: loadLocalProviderUsageLinesMock,
+}));
+
+const context: ProviderUsageContext = {
+  homeDir: "",
+  env: {},
+  platform: "linux",
+  nowMs: Date.parse("2026-07-18T12:00:00.000Z"),
+};
+
+// Codex is a required entry in the live provider-usage registry.
+const originalCodexFetcher = PROVIDER_USAGE_FETCHERS.codex!;
+
+afterEach(() => {
+  PROVIDER_USAGE_FETCHERS.codex = originalCodexFetcher;
+  loadLocalProviderUsageLinesMock.mockReset();
+});
+
+describe("collectProviderUsageSnapshots", () => {
+  it("keeps the shared supported-provider list aligned with live fetchers", () => {
+    expect([...PROVIDER_USAGE_PROVIDERS].sort()).toEqual(
+      Object.keys(PROVIDER_USAGE_FETCHERS).sort(),
+    );
+  });
+
+  it.each(["antigravity", "grok", "droid", "kilo", "opencode", "pi"] as const)(
+    "does not add out-of-scope provider %s",
+    async (provider) => {
+      const snapshots = await collectProviderUsageSnapshots(context, {
+        provider: provider as ProviderKind,
+      });
+
+      expect(snapshots).toEqual([]);
+    },
+  );
+
+  it("skips local archive enrichment when local usage is disabled", async () => {
+    const providerUsageLines = [{ label: "Credits", value: "$42.00 remaining" }];
+    const providerSnapshot: ServerProviderUsageSnapshot = {
+      provider: "codex",
+      updatedAt: "2026-07-18T12:00:00.000Z",
+      limits: [{ window: "5h", usedPercent: 25 }],
+      usageLines: providerUsageLines,
+      source: "codex-app-server",
+      status: "ok",
+    };
+    const fetch = vi.fn(async () => providerSnapshot);
+    PROVIDER_USAGE_FETCHERS.codex = { provider: "codex", fetch };
+    loadLocalProviderUsageLinesMock.mockResolvedValue([{ label: "24h tokens", value: "12,345" }]);
+
+    const snapshots = await collectProviderUsageSnapshots(context, {
+      provider: "codex",
+      includeLocalUsage: false,
+    });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(loadLocalProviderUsageLinesMock).not.toHaveBeenCalled();
+    expect(snapshots).toEqual([providerSnapshot]);
+    expect(snapshots[0]?.usageLines).toEqual(providerUsageLines);
+  });
+});

--- a/apps/server/src/providerUsage/index.ts
+++ b/apps/server/src/providerUsage/index.ts
@@ -10,6 +10,7 @@ import type {
   ServerListProviderUsageResult,
   ServerProviderUsageSnapshot,
 } from "@synara/contracts";
+import { PROVIDER_USAGE_PROVIDERS } from "@synara/shared/providerUsage";
 import { Effect } from "effect";
 
 import { ServerConfig } from "../config";
@@ -74,18 +75,25 @@ async function enrichWithLocalUsage(
   return { ...snapshot, usageLines: [...snapshot.usageLines, ...localLines] };
 }
 
-/** Plain async batch fetch for supported providers. Never throws. */
+/** Plain async batch fetch for providers with machine-readable account usage. Never throws. */
 export async function collectProviderUsageSnapshots(
   ctx: ProviderUsageContext,
-  options: { forceRefresh?: boolean; provider?: ProviderKind } = {},
+  options: {
+    forceRefresh?: boolean;
+    includeLocalUsage?: boolean;
+    provider?: ProviderKind;
+  } = {},
 ): Promise<ServerProviderUsageSnapshot[]> {
   const providers = options.provider
     ? ([options.provider] as ProviderKind[])
-    : (Object.keys(PROVIDER_USAGE_FETCHERS) as ProviderKind[]);
+    : [...PROVIDER_USAGE_PROVIDERS];
   const settled = await Promise.allSettled(
     providers.map(async (provider) => {
       const snapshot = await fetchProviderUsage(provider, ctx);
-      return snapshot ? enrichWithLocalUsage(snapshot, ctx) : null;
+      if (!snapshot || options.includeLocalUsage === false) {
+        return snapshot;
+      }
+      return enrichWithLocalUsage(snapshot, ctx);
     }),
   );
 
@@ -105,6 +113,7 @@ export const listProviderUsage = Effect.fn(function* (input: ServerListProviderU
         },
         {
           forceRefresh: input.forceRefresh === true,
+          includeLocalUsage: input.includeLocalUsage !== false,
           ...(input.provider ? { provider: input.provider } : {}),
         },
       ),

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -783,6 +783,15 @@ describe("AppSettingsSchema", () => {
     ).toBe(true);
   });
 
+  it("shows provider usage in the composer by default and preserves an explicit opt-out", () => {
+    const decode = Schema.decodeSync(Schema.fromJsonString(AppSettingsSchema));
+
+    expect(decode("{}").showComposerProviderUsage).toBe(true);
+    expect(
+      decode(JSON.stringify({ showComposerProviderUsage: false })).showComposerProviderUsage,
+    ).toBe(false);
+  });
+
   it("fills decoding defaults for persisted settings that predate newer keys", () => {
     const decode = Schema.decodeSync(Schema.fromJsonString(AppSettingsSchema));
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -206,6 +206,7 @@ export const AppSettingsSchema = Schema.Struct({
   // also write back here so the last explicit open/close survives reloads.
   environmentPanelDefaultOpen: Schema.Boolean.pipe(withDefaults(() => false)),
   showEnvironmentUsage: Schema.Boolean.pipe(withDefaults(() => true)),
+  showComposerProviderUsage: Schema.Boolean.pipe(withDefaults(() => true)),
   showEnvironmentRepository: Schema.Boolean.pipe(withDefaults(() => true)),
   showEnvironmentPullRequest: Schema.Boolean.pipe(withDefaults(() => true)),
   showEnvironmentEditor: Schema.Boolean.pipe(withDefaults(() => true)),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -42,6 +42,7 @@ import { getModelCapabilities, normalizeModelSlug } from "@synara/shared/model";
 import { resolveTailUserMessageEditTarget } from "@synara/shared/conversationEdit";
 import { threadExportBlockedReason } from "@synara/shared/threadExport";
 import { buildTemporaryWorktreeBranchName } from "@synara/shared/git";
+import { isProviderUsageSupported } from "@synara/shared/providerUsage";
 import { pendingRequestInstanceKey } from "@synara/shared/threadSummary";
 import {
   buildPromptThreadTitleFallback,
@@ -388,6 +389,8 @@ import {
 } from "../lib/contextWindow";
 import { formatVoiceRecordingDuration, useVoiceRecorder } from "../lib/voiceRecorder";
 import {
+  COMPOSER_FOOTER_MAX_TIER,
+  composerFooterMaxTier,
   composerFooterPlanForTier,
   resolveNextComposerFooterTier,
   shouldUseCompactComposerFooter,
@@ -459,6 +462,7 @@ import {
   resolveProviderModelLabel,
 } from "./chat/ProviderModelPicker";
 import { ComposerModelEffortPicker } from "./chat/ComposerModelEffortPicker";
+import { ComposerProviderUsageControl } from "./chat/ComposerProviderUsageControl";
 import { resolveTraitsTriggerSummary, TraitsPicker } from "./chat/TraitsPicker";
 import { ComposerCommandItem, ComposerCommandMenu } from "./chat/ComposerCommandMenu";
 import {
@@ -1327,6 +1331,7 @@ export default function ChatView({
   // so label changes can re-plan without a resize.
   const [composerFooterTier, setComposerFooterTier] = useState(0);
   const composerFooterTierRef = useRef(0);
+  const composerFooterMaxTierRef = useRef(COMPOSER_FOOTER_MAX_TIER);
   const composerFooterDemotionWidthsRef = useRef<ReadonlyArray<number | undefined>>([]);
   const composerFooterLayoutSyncRef = useRef<(() => void) | null>(null);
   const [confirmedCustomBinaryPathsByProvider, setConfirmedCustomBinaryPathsByProvider] = useState<
@@ -5436,6 +5441,7 @@ export default function ChatView({
           clientWidth: footerRow.clientWidth,
           isOverflowing: rowOverflows || leadingClips,
           demotionWidths: composerFooterDemotionWidthsRef.current,
+          maxTier: composerFooterMaxTierRef.current,
         });
         composerFooterDemotionWidthsRef.current = nextStep.demotionWidths;
         if (nextStep.tier !== composerFooterTierRef.current) {
@@ -9224,9 +9230,21 @@ export default function ChatView({
     [runtimeUsageContextWindow, composerTraitSelection.contextWindow, selectedProvider],
   );
   const useSplitComposerPickerControls = isLocalDraftThread && !hasThreadStarted;
+  const hasComposerProviderUsage =
+    settings.showComposerProviderUsage && isProviderUsageSupported(selectedProvider);
+  const activeComposerFooterMaxTier = composerFooterMaxTier(
+    Boolean(runtimeUsageContextWindow),
+    hasComposerProviderUsage,
+  );
+  composerFooterMaxTierRef.current = activeComposerFooterMaxTier;
   const composerFooterControlsPlan = useMemo(
-    () => composerFooterPlanForTier(composerFooterTier, Boolean(runtimeUsageContextWindow)),
-    [composerFooterTier, runtimeUsageContextWindow],
+    () =>
+      composerFooterPlanForTier(
+        composerFooterTier,
+        Boolean(runtimeUsageContextWindow),
+        hasComposerProviderUsage,
+      ),
+    [composerFooterTier, hasComposerProviderUsage, runtimeUsageContextWindow],
   );
   // The displayed labels changed (model switch, effort change, picker layout):
   // recorded overflow widths no longer apply, so reset to the richest tier and
@@ -9246,17 +9264,22 @@ export default function ChatView({
     runtimeAgents: dynamicAgents,
   });
   const composerFooterPlanInputsKey = [
+    selectedProvider,
     composerFooterModelLabel,
     composerFooterTraitsSummary.summaryText,
     Boolean(runtimeUsageContextWindow),
+    hasComposerProviderUsage,
     useSplitComposerPickerControls,
   ].join(":");
-  useLayoutEffect(() => {
+  const resetComposerFooterLayout = useCallback(() => {
     composerFooterDemotionWidthsRef.current = [];
     composerFooterTierRef.current = 0;
     setComposerFooterTier(0);
     composerFooterLayoutSyncRef.current?.();
-  }, [composerFooterPlanInputsKey]);
+  }, []);
+  useLayoutEffect(() => {
+    resetComposerFooterLayout();
+  }, [composerFooterPlanInputsKey, resetComposerFooterLayout]);
   // After a tier renders, re-measure before paint: a still-overflowing footer
   // demotes another step until it fits (bounded by COMPOSER_FOOTER_MAX_TIER).
   useLayoutEffect(() => {
@@ -11140,6 +11163,16 @@ export default function ChatView({
                         />
                       ) : null}
                       {!isVoiceRecording && !isVoiceTranscribing ? composerPickerControls : null}
+                      {!isVoiceRecording &&
+                      !isVoiceTranscribing &&
+                      composerFooterControlsPlan.showProviderUsage ? (
+                        <ComposerProviderUsageControl
+                          key={selectedProvider}
+                          provider={selectedProvider}
+                          showReset={composerFooterControlsPlan.showProviderUsageReset}
+                          onContentSizeChange={resetComposerFooterLayout}
+                        />
+                      ) : null}
                       {showVoiceNotesControl && (isVoiceRecording || isVoiceTranscribing) ? (
                         <ComposerVoiceRecorderBar
                           disabled={isComposerApprovalState || isConnecting || isSendBusy}

--- a/apps/web/src/components/ProviderUsageMenuControl.tsx
+++ b/apps/web/src/components/ProviderUsageMenuControl.tsx
@@ -1,7 +1,13 @@
 // FILE: ProviderUsageMenuControl.tsx
 // Purpose: Shared provider-usage chip/menu used in the chat header and Environment panel.
 
-import { PROVIDER_DISPLAY_NAMES, type ProviderKind } from "@synara/contracts";
+import {
+  PROVIDER_DISPLAY_NAMES,
+  type ProviderKind,
+  type ServerGetProviderUsageSnapshotResult,
+  type ServerProviderUsageSnapshot,
+} from "@synara/contracts";
+import { providerUsageNeedsAuthDetail } from "@synara/shared/providerUsage";
 import { useMemo, type ReactNode } from "react";
 
 import { useAppSettings } from "~/appSettings";
@@ -23,68 +29,189 @@ import { ProviderUsagePanelContent } from "./ProviderUsagePanelContent";
 import { Menu, MenuTrigger } from "./ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
+const NO_USAGE_THREADS = [] as const;
+
 export interface ProviderUsageMenuModel {
   menuTitle: string;
-  primaryRow: ProviderUsageDisplayRow;
+  primaryRow: ProviderUsageDisplayRow | null;
   rateLimits: ReadonlyArray<ProviderRateLimit>;
   usageLines: ReadonlyArray<OpenUsageUsageLine>;
+  planName: string | undefined;
   notice: string | undefined;
+  state: ProviderUsageMenuState;
+  detail: string | undefined;
   isLoading: boolean;
 }
 
-export function useProviderUsageMenuModel(provider: ProviderKind): ProviderUsageMenuModel | null {
+export interface ProviderUsageMenuModelWithPrimary extends ProviderUsageMenuModel {
+  primaryRow: ProviderUsageDisplayRow;
+}
+
+export type ProviderUsageMenuState =
+  | "ready"
+  | "loading"
+  | "needs-auth"
+  | "unsupported"
+  | "error"
+  | "no-data";
+
+export interface ProviderUsageMenuModelInput {
+  provider: ProviderKind;
+  rateLimits: ReadonlyArray<ProviderRateLimit>;
+  usageLines: ReadonlyArray<OpenUsageUsageLine>;
+  planName?: string | null | undefined;
+  notice: string | undefined;
+  isLoading: boolean;
+  snapshotStatus: ServerProviderUsageSnapshot["status"] | null;
+  snapshotDetail: string | null;
+}
+
+function providerUsageMenuState(input: ProviderUsageMenuModelInput): ProviderUsageMenuState {
+  if (input.snapshotStatus && input.snapshotStatus !== "ok") {
+    return input.snapshotStatus;
+  }
+  if (input.isLoading) {
+    return "loading";
+  }
+  if (input.rateLimits.length > 0 || input.usageLines.length > 0) {
+    return "ready";
+  }
+  return "no-data";
+}
+
+function providerUsageMenuDetail(
+  provider: ProviderKind,
+  state: ProviderUsageMenuState,
+  detail: string | null,
+): string | undefined {
+  if (detail) {
+    return detail;
+  }
+  switch (state) {
+    case "needs-auth":
+      return providerUsageNeedsAuthDetail(provider);
+    case "unsupported":
+      return "This provider does not expose usage data that Synara can read.";
+    case "error":
+      return "Usage is currently unavailable.";
+    case "no-data":
+      return "No usage data has been reported yet.";
+    default:
+      return undefined;
+  }
+}
+
+export function deriveProviderUsageMenuModel(
+  input: ProviderUsageMenuModelInput,
+): ProviderUsageMenuModel {
+  const usageRows = deriveProviderUsageDisplayRows(input.rateLimits);
+  const primaryRow = selectPrimaryProviderUsageDisplayRow(usageRows);
+  const state = providerUsageMenuState(input);
+
+  return {
+    menuTitle: `${PROVIDER_DISPLAY_NAMES[input.provider]} usage`,
+    primaryRow,
+    rateLimits: input.rateLimits,
+    usageLines: input.usageLines,
+    planName: input.planName?.trim() || undefined,
+    notice: input.notice,
+    state,
+    detail: providerUsageMenuDetail(input.provider, state, input.snapshotDetail),
+    isLoading: input.isLoading,
+  };
+}
+
+interface ProviderUsageMenuModelOptions {
+  fetchProviderData?: boolean;
+  providerSnapshot?: ServerGetProviderUsageSnapshotResult | undefined;
+  includeEmptyState?: boolean;
+  isLoading?: boolean;
+  includeSupplementalData?: boolean | undefined;
+}
+
+export function useProviderUsageMenuModel(
+  provider: ProviderKind,
+): ProviderUsageMenuModelWithPrimary | null;
+export function useProviderUsageMenuModel(
+  provider: ProviderKind,
+  options: ProviderUsageMenuModelOptions & { includeEmptyState: true },
+): ProviderUsageMenuModel;
+export function useProviderUsageMenuModel(
+  provider: ProviderKind,
+  options: ProviderUsageMenuModelOptions = {},
+): ProviderUsageMenuModel | null {
   const { settings } = useAppSettings();
-  const selectAllThreads = useMemo(() => createAllThreadsSelector(), []);
+  const selectAllThreads = useMemo(
+    () =>
+      options.includeSupplementalData === false
+        ? () => NO_USAGE_THREADS
+        : createAllThreadsSelector(),
+    [options.includeSupplementalData],
+  );
   const threads = useStore(selectAllThreads);
   const usageSummary = useProviderUsageSummary({
     provider,
     threads,
     codexHomePath: settings.codexHomePath || null,
-    fetchProviderData: false,
+    fetchProviderData: options.fetchProviderData ?? false,
+    includeSupplementalData: options.includeSupplementalData,
+    providerSnapshot: options.providerSnapshot,
   });
-  const usageRows = useMemo(
-    () => deriveProviderUsageDisplayRows(usageSummary.rateLimits),
-    [usageSummary.rateLimits],
+  const model = useMemo(
+    () =>
+      deriveProviderUsageMenuModel({
+        provider,
+        rateLimits: usageSummary.rateLimits,
+        usageLines: usageSummary.usageLines,
+        planName: usageSummary.planName,
+        notice: usageSummary.usageNotice,
+        isLoading: options.isLoading ?? usageSummary.isLoading,
+        snapshotStatus: usageSummary.snapshotStatus,
+        snapshotDetail: usageSummary.snapshotDetail,
+      }),
+    [options.isLoading, provider, usageSummary],
   );
-  const primaryRow = useMemo(() => selectPrimaryProviderUsageDisplayRow(usageRows), [usageRows]);
 
-  if (!primaryRow) {
+  if (!model.primaryRow && options.includeEmptyState !== true) {
     return null;
   }
-
-  return {
-    menuTitle: `${PROVIDER_DISPLAY_NAMES[provider]} usage`,
-    primaryRow,
-    rateLimits: usageSummary.rateLimits,
-    usageLines: usageSummary.usageLines,
-    notice: usageSummary.usageNotice,
-    isLoading: usageSummary.isLoading,
-  };
+  return model;
 }
 
 export function ProviderUsageMenuPopup({
   provider,
   model,
   align = "end",
+  side = "bottom",
+  showTitle = false,
+  showUsageLines = false,
+  showLearnMore = false,
   children,
 }: {
   provider: ProviderKind;
   model: ProviderUsageMenuModel;
   align?: "start" | "end";
+  side?: "top" | "bottom";
+  showTitle?: boolean;
+  showUsageLines?: boolean;
+  showLearnMore?: boolean;
   children: ReactNode;
 }) {
   return (
     <Menu modal={false}>
       {children}
-      <ComposerPickerMenuPopup align={align} side="bottom" className="w-64 min-w-64">
+      <ComposerPickerMenuPopup align={align} side={side} className="w-64 min-w-64">
         <ProviderUsagePanelContent
           provider={provider}
           rateLimits={model.rateLimits}
           usageLines={model.usageLines}
+          planName={model.planName}
           notice={model.notice}
           isLoading={model.isLoading}
-          showUsageLines={false}
-          showTitle={false}
+          emptyMessage={model.detail}
+          showUsageLines={showUsageLines}
+          showTitle={showTitle}
+          showLearnMore={showLearnMore}
           className="px-2 pb-1 pt-1"
         />
       </ComposerPickerMenuPopup>

--- a/apps/web/src/components/ProviderUsagePanelContent.test.tsx
+++ b/apps/web/src/components/ProviderUsagePanelContent.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ProviderUsagePanelContent } from "./ProviderUsagePanelContent";
+
+describe("ProviderUsagePanelContent", () => {
+  it("shows plan metadata in the detailed usage view", () => {
+    const markup = renderToStaticMarkup(
+      <ProviderUsagePanelContent provider="codex" planName="Plus" rateLimits={[]} showTitle />,
+    );
+
+    expect(markup).toContain("Codex usage");
+    expect(markup).toContain("Plus");
+    expect(markup).toContain('title="Plus"');
+  });
+});

--- a/apps/web/src/components/ProviderUsagePanelContent.tsx
+++ b/apps/web/src/components/ProviderUsagePanelContent.tsx
@@ -21,12 +21,31 @@ import { ProviderUsageLineList } from "./ProviderUsageLineList";
 
 export { providerUsageLabel };
 
+export const PROVIDER_USAGE_PILL_CLASS_NAME =
+  "shrink-0 rounded-full px-2 py-1 text-[11px] font-medium leading-none";
+
+export function ProviderUsagePlanPill({ planName }: { planName: string }) {
+  return (
+    <span
+      className={cn(
+        PROVIDER_USAGE_PILL_CLASS_NAME,
+        "max-w-32 truncate bg-muted text-muted-foreground",
+      )}
+      title={planName}
+    >
+      {planName}
+    </span>
+  );
+}
+
 export const ProviderUsagePanelContent = memo(function ProviderUsagePanelContent(props: {
   provider: ProviderKind | null | undefined;
   rateLimits: ReadonlyArray<ProviderRateLimit>;
   usageLines?: ReadonlyArray<OpenUsageUsageLine> | undefined;
+  planName?: string | null | undefined;
   notice?: string | null | undefined;
   isLoading?: boolean | undefined;
+  emptyMessage?: string | null | undefined;
   learnMoreHref?: string | null | undefined;
   showUsageLines?: boolean | undefined;
   showTitle?: boolean | undefined;
@@ -48,8 +67,11 @@ export const ProviderUsagePanelContent = memo(function ProviderUsagePanelContent
   return (
     <div className={cn("space-y-2", props.className)}>
       {props.showTitle !== false ? (
-        <div className="text-[length:var(--app-font-size-chat-meta,10px)] font-medium text-muted-foreground">
-          {providerUsageLabel(props.provider)}
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-[length:var(--app-font-size-chat-meta,10px)] font-medium text-muted-foreground">
+            {providerUsageLabel(props.provider)}
+          </div>
+          {props.planName ? <ProviderUsagePlanPill planName={props.planName} /> : null}
         </div>
       ) : null}
       {props.notice ? (
@@ -67,13 +89,14 @@ export const ProviderUsagePanelContent = memo(function ProviderUsagePanelContent
         />
       ) : visibleRows.length === 0 && props.isLoading ? (
         <p className="text-[length:var(--app-font-size-chat-meta,10px)] leading-relaxed text-muted-foreground">
-          Scanning local usage data for the selected provider.
+          Checking usage for the selected provider…
         </p>
       ) : visibleRows.length === 0 ? (
         <p className="text-[length:var(--app-font-size-chat-meta,10px)] leading-relaxed text-muted-foreground">
-          {props.provider
-            ? "No local usage data was found yet for the selected provider."
-            : "No local usage data was found yet."}
+          {props.emptyMessage ??
+            (props.provider
+              ? "No usage data was found yet for the selected provider."
+              : "No usage data was found yet.")}
         </p>
       ) : null}
       {props.showLearnMore === true && learnMoreHref ? (

--- a/apps/web/src/components/SettingsSidebarNav.test.tsx
+++ b/apps/web/src/components/SettingsSidebarNav.test.tsx
@@ -35,6 +35,16 @@ describe("rankSettingsSearchEntries", () => {
     expect(results.some((entry) => entry.id === "notifications:activity-toasts")).toBe(true);
   });
 
+  it("finds the composer provider-usage preference by quota terminology", () => {
+    const results = rankSettingsSearchEntries("quota", 12);
+    const entry = results.find((candidate) => candidate.id === "usage:composer-usage");
+
+    expect(entry).toBeDefined();
+    expect(entry ? settingsSearchEntryTarget(entry) : null).toBe(
+      "setting-show-provider-quota-in-composer",
+    );
+  });
+
   it("surfaces every row in a section when searching the section label", () => {
     const results = rankSettingsSearchEntries("appearance", SETTINGS_SEARCH_ENTRIES.length);
     expect(results.some((entry) => entry.section === "appearance")).toBe(true);

--- a/apps/web/src/components/chat/ComposerProviderUsageControl.test.ts
+++ b/apps/web/src/components/chat/ComposerProviderUsageControl.test.ts
@@ -1,0 +1,156 @@
+import type { ServerProviderUsageSnapshot } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveProviderUsageMenuModel,
+  type ProviderUsageMenuModel,
+} from "~/components/ProviderUsageMenuControl";
+
+import {
+  composerProviderUsageContentSizeKey,
+  deriveComposerProviderUsageTriggerPresentation,
+  resolveComposerProviderUsageSnapshot,
+} from "./ComposerProviderUsageControl";
+
+function snapshotModel(
+  status: ServerProviderUsageSnapshot["status"],
+  detail?: string,
+): ProviderUsageMenuModel {
+  return deriveProviderUsageMenuModel({
+    provider: "codex",
+    rateLimits: [],
+    usageLines: [],
+    notice: undefined,
+    isLoading: false,
+    snapshotStatus: status ?? null,
+    snapshotDetail: detail ?? null,
+  });
+}
+
+describe("ComposerProviderUsageControl", () => {
+  it("uses only the exact selected-provider result and makes missing or failed queries explicit", () => {
+    const codexSnapshot: ServerProviderUsageSnapshot = {
+      provider: "codex",
+      updatedAt: "2026-07-18T12:00:00.000Z",
+      limits: [{ window: "Weekly", usedPercent: 40 }],
+      usageLines: [],
+      source: "test",
+      status: "ok",
+      planName: "Plus",
+    };
+    const claudeSnapshot = { ...codexSnapshot, provider: "claudeAgent" as const };
+
+    expect(
+      resolveComposerProviderUsageSnapshot({
+        provider: "codex",
+        snapshots: [claudeSnapshot, codexSnapshot],
+        querySettled: true,
+        queryFailed: false,
+      }),
+    ).toBe(codexSnapshot);
+    expect(
+      resolveComposerProviderUsageSnapshot({
+        provider: "codex",
+        snapshots: [],
+        querySettled: false,
+        queryFailed: false,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveComposerProviderUsageSnapshot({
+        provider: "codex",
+        snapshots: [],
+        querySettled: true,
+        queryFailed: false,
+      }),
+    ).toMatchObject({ provider: "codex", status: "error" });
+    expect(
+      resolveComposerProviderUsageSnapshot({
+        provider: "codex",
+        snapshots: [codexSnapshot],
+        querySettled: true,
+        queryFailed: true,
+      }),
+    ).toMatchObject({ provider: "codex", status: "error" });
+  });
+
+  it("presents a primary remaining value and hides only its reset suffix", () => {
+    const model = deriveProviderUsageMenuModel({
+      provider: "codex",
+      rateLimits: [
+        {
+          provider: "codex",
+          updatedAt: "2099-04-08T18:00:00.000Z",
+          limits: [
+            {
+              window: "Weekly",
+              usedPercent: 84,
+              resetsAt: "2099-04-14T18:00:00.000Z",
+              windowDurationMins: 10_080,
+            },
+          ],
+        },
+      ],
+      usageLines: [],
+      notice: undefined,
+      isLoading: false,
+      snapshotStatus: "ok",
+      snapshotDetail: null,
+    });
+
+    expect(deriveComposerProviderUsageTriggerPresentation(model, true)).toMatchObject({
+      primaryText: "16% left",
+      resetText: expect.stringMatching(/^Resets /),
+    });
+    expect(deriveComposerProviderUsageTriggerPresentation(model, false)).toMatchObject({
+      primaryText: "16% left",
+      resetText: null,
+      accessibleLabel: expect.stringMatching(/Resets /),
+    });
+    expect(composerProviderUsageContentSizeKey(model)).toMatch(/16% left:Resets /);
+  });
+
+  it("keeps not-authenticated, unsupported, error, and no-data states distinct", () => {
+    const loadingModel = deriveProviderUsageMenuModel({
+      provider: "codex",
+      rateLimits: [],
+      usageLines: [],
+      notice: undefined,
+      isLoading: true,
+      snapshotStatus: null,
+      snapshotDetail: null,
+    });
+
+    expect(deriveComposerProviderUsageTriggerPresentation(loadingModel, true)).toHaveProperty(
+      "primaryText",
+      "Checking…",
+    );
+    expect(
+      deriveComposerProviderUsageTriggerPresentation(snapshotModel("needs-auth"), true),
+    ).toHaveProperty("primaryText", "Sign in");
+    expect(
+      deriveComposerProviderUsageTriggerPresentation(snapshotModel("unsupported"), true),
+    ).toHaveProperty("primaryText", "Unsupported");
+    expect(
+      deriveComposerProviderUsageTriggerPresentation(snapshotModel("error"), true),
+    ).toHaveProperty("primaryText", "Unavailable");
+    expect(
+      deriveComposerProviderUsageTriggerPresentation(snapshotModel(undefined), true),
+    ).toHaveProperty("primaryText", "No data");
+  });
+
+  it("carries plan metadata through the shared detailed-view model", () => {
+    const model = deriveProviderUsageMenuModel({
+      provider: "codex",
+      rateLimits: [],
+      usageLines: [],
+      planName: "Plus",
+      notice: undefined,
+      isLoading: false,
+      snapshotStatus: "ok",
+      snapshotDetail: null,
+    });
+
+    expect(model.planName).toBe("Plus");
+  });
+});

--- a/apps/web/src/components/chat/ComposerProviderUsageControl.tsx
+++ b/apps/web/src/components/chat/ComposerProviderUsageControl.tsx
@@ -1,0 +1,169 @@
+// FILE: ComposerProviderUsageControl.tsx
+// Purpose: Active-provider quota trigger in the composer footer. Supported providers
+// query one scoped, account-only server snapshot.
+
+import type { ProviderKind, ServerProviderUsageSnapshot } from "@synara/contracts";
+import { isProviderUsageSupported } from "@synara/shared/providerUsage";
+import { useQuery } from "@tanstack/react-query";
+import { useLayoutEffect, useMemo } from "react";
+
+import {
+  ProviderUsageMenuPopup,
+  type ProviderUsageMenuModel,
+  useProviderUsageMenuModel,
+} from "~/components/ProviderUsageMenuControl";
+import { ProviderIcon } from "~/components/ProviderIcon";
+import { Button } from "~/components/ui/button";
+import { MenuTrigger } from "~/components/ui/menu";
+import { ChevronDownIcon } from "~/lib/icons";
+import { createUnavailableProviderUsageSnapshot } from "~/lib/providerUsageSnapshot";
+import { serverAllProviderUsageQueryOptions } from "~/lib/serverReactQuery";
+import { cn } from "~/lib/utils";
+
+import { COMPOSER_MUTED_ACCENT_TEXT_CLASS_NAME } from "./composerPickerStyles";
+
+export function resolveComposerProviderUsageSnapshot(input: {
+  provider: ProviderKind;
+  snapshots: readonly ServerProviderUsageSnapshot[] | undefined;
+  querySettled: boolean;
+  queryFailed: boolean;
+}): ServerProviderUsageSnapshot | undefined {
+  if (input.queryFailed) {
+    return createUnavailableProviderUsageSnapshot(input.provider, "provider-usage-query");
+  }
+
+  const exactSnapshot = input.snapshots?.find((snapshot) => snapshot.provider === input.provider);
+  if (exactSnapshot) {
+    return exactSnapshot;
+  }
+
+  if (!input.querySettled) {
+    return undefined;
+  }
+  return createUnavailableProviderUsageSnapshot(input.provider, "provider-usage-query");
+}
+
+export interface ComposerProviderUsageTriggerPresentation {
+  primaryText: string;
+  resetText: string | null;
+  accessibleLabel: string;
+}
+
+export function composerProviderUsageContentSizeKey(model: ProviderUsageMenuModel): string {
+  return [model.state, model.primaryRow?.leftText, model.primaryRow?.resetText].join(":");
+}
+
+export function deriveComposerProviderUsageTriggerPresentation(
+  model: ProviderUsageMenuModel,
+  showReset: boolean,
+): ComposerProviderUsageTriggerPresentation {
+  const primaryText = model.primaryRow
+    ? model.primaryRow.leftText
+    : model.state === "loading"
+      ? "Checking…"
+      : model.state === "needs-auth"
+        ? "Sign in"
+        : model.state === "unsupported"
+          ? "Unsupported"
+          : model.state === "error"
+            ? "Unavailable"
+            : model.state === "ready"
+              ? "Usage"
+              : "No data";
+  const accessibleResetText = model.primaryRow?.resetText ?? null;
+  const resetText = showReset ? accessibleResetText : null;
+  const accessibleLabel = [model.menuTitle, primaryText, accessibleResetText]
+    .filter(Boolean)
+    .join(": ");
+
+  return { primaryText, resetText, accessibleLabel };
+}
+
+export function ComposerProviderUsageControl({
+  provider,
+  showReset,
+  onContentSizeChange,
+}: {
+  provider: ProviderKind;
+  showReset: boolean;
+  onContentSizeChange?: () => void;
+}) {
+  const queryEnabled = isProviderUsageSupported(provider);
+  const usageQuery = useQuery(
+    serverAllProviderUsageQueryOptions({
+      enabled: queryEnabled,
+      includeLocalUsage: false,
+      provider,
+    }),
+  );
+  const providerSnapshot = useMemo(
+    () =>
+      resolveComposerProviderUsageSnapshot({
+        provider,
+        snapshots: usageQuery.data,
+        querySettled: usageQuery.isSuccess || usageQuery.isError,
+        queryFailed: usageQuery.isError || usageQuery.isRefetchError,
+      }),
+    [
+      provider,
+      usageQuery.data,
+      usageQuery.isError,
+      usageQuery.isRefetchError,
+      usageQuery.isSuccess,
+    ],
+  );
+  const model = useProviderUsageMenuModel(provider, {
+    includeEmptyState: true,
+    includeSupplementalData: false,
+    fetchProviderData: false,
+    providerSnapshot,
+    isLoading: queryEnabled && usageQuery.isPending && providerSnapshot === undefined,
+  });
+  const contentSizeKey = composerProviderUsageContentSizeKey(model);
+
+  useLayoutEffect(() => {
+    onContentSizeChange?.();
+  }, [contentSizeKey, onContentSizeChange]);
+
+  if (!isProviderUsageSupported(provider)) {
+    return null;
+  }
+
+  const presentation = deriveComposerProviderUsageTriggerPresentation(model, showReset);
+
+  return (
+    <ProviderUsageMenuPopup
+      provider={provider}
+      model={model}
+      align="end"
+      side="top"
+      showTitle
+      showUsageLines
+    >
+      <MenuTrigger
+        render={
+          <Button
+            type="button"
+            size="sm"
+            variant="chrome"
+            className="min-w-0 shrink-0 justify-start gap-1.5 px-2 tabular-nums sm:px-2.5 [&_svg]:mx-0"
+            aria-label={presentation.accessibleLabel}
+            title={presentation.accessibleLabel}
+            data-provider-usage-state={model.state}
+          />
+        }
+      >
+        <ProviderIcon provider={provider} className="size-3.5 shrink-0" />
+        <span className="shrink-0 text-[var(--color-text-foreground)]">
+          {presentation.primaryText}
+        </span>
+        {presentation.resetText ? (
+          <span className={cn("max-w-28 truncate", COMPOSER_MUTED_ACCENT_TEXT_CLASS_NAME)}>
+            {presentation.resetText}
+          </span>
+        ) : null}
+        <ChevronDownIcon aria-hidden="true" className="ms-0.5 size-3 shrink-0 opacity-60" />
+      </MenuTrigger>
+    </ProviderUsageMenuPopup>
+  );
+}

--- a/apps/web/src/components/composerFooterLayout.test.ts
+++ b/apps/web/src/components/composerFooterLayout.test.ts
@@ -5,6 +5,7 @@ import {
   COMPOSER_FOOTER_MAX_TIER,
   COMPOSER_FOOTER_TIER_PROMOTION_SLACK_PX,
   COMPOSER_FOOTER_WIDE_ACTIONS_COMPACT_BREAKPOINT_PX,
+  composerFooterMaxTier,
   composerFooterPlanForTier,
   resolveNextComposerFooterTier,
   shouldUseCompactComposerFooter,
@@ -39,33 +40,59 @@ describe("shouldUseCompactComposerFooter", () => {
 });
 
 describe("composerFooterPlanForTier", () => {
-  it("maps tiers to the degradation order: meter, traits label, model label, relocation", () => {
-    expect(composerFooterPlanForTier(0, true)).toEqual({
+  it("maps tiers to the degradation order: context, reset, quota, traits, model, relocation", () => {
+    expect(composerFooterPlanForTier(0, true, true)).toEqual({
       showContextMeter: true,
+      showProviderUsageReset: true,
+      showProviderUsage: true,
       showTraitsLabel: true,
       showModelLabel: true,
       relocateLeadingControls: false,
     });
-    expect(composerFooterPlanForTier(1, true)).toEqual({
+    expect(composerFooterPlanForTier(1, true, true)).toEqual({
       showContextMeter: false,
+      showProviderUsageReset: true,
+      showProviderUsage: true,
       showTraitsLabel: true,
       showModelLabel: true,
       relocateLeadingControls: false,
     });
-    expect(composerFooterPlanForTier(2, true)).toEqual({
+    expect(composerFooterPlanForTier(2, true, true)).toEqual({
       showContextMeter: false,
+      showProviderUsageReset: false,
+      showProviderUsage: true,
+      showTraitsLabel: true,
+      showModelLabel: true,
+      relocateLeadingControls: false,
+    });
+    expect(composerFooterPlanForTier(3, true, true)).toEqual({
+      showContextMeter: false,
+      showProviderUsageReset: false,
+      showProviderUsage: false,
+      showTraitsLabel: true,
+      showModelLabel: true,
+      relocateLeadingControls: false,
+    });
+    expect(composerFooterPlanForTier(4, true, true)).toEqual({
+      showContextMeter: false,
+      showProviderUsageReset: false,
+      showProviderUsage: false,
       showTraitsLabel: false,
       showModelLabel: true,
       relocateLeadingControls: false,
     });
-    expect(composerFooterPlanForTier(3, true)).toEqual({
+    expect(composerFooterPlanForTier(5, true, true)).toEqual({
       showContextMeter: false,
+      showProviderUsageReset: false,
+      showProviderUsage: false,
       showTraitsLabel: false,
       showModelLabel: false,
       relocateLeadingControls: false,
     });
-    expect(composerFooterPlanForTier(COMPOSER_FOOTER_MAX_TIER, true)).toEqual({
+    expect(composerFooterPlanForTier(COMPOSER_FOOTER_MAX_TIER, true, true)).toEqual({
       showContextMeter: false,
+      showProviderUsageReset: false,
+      showProviderUsage: false,
       showTraitsLabel: false,
       showModelLabel: false,
       relocateLeadingControls: true,
@@ -74,6 +101,59 @@ describe("composerFooterPlanForTier", () => {
 
   it("never shows the context meter when the thread has none", () => {
     expect(composerFooterPlanForTier(0, false).showContextMeter).toBe(false);
+  });
+
+  it("never reserves quota tiers when the active provider has no usage capability", () => {
+    expect(
+      Array.from({ length: 5 }, (_, tier) => composerFooterPlanForTier(tier, true, false)),
+    ).toEqual([
+      {
+        showContextMeter: true,
+        showProviderUsage: false,
+        showProviderUsageReset: false,
+        showTraitsLabel: true,
+        showModelLabel: true,
+        relocateLeadingControls: false,
+      },
+      {
+        showContextMeter: false,
+        showProviderUsage: false,
+        showProviderUsageReset: false,
+        showTraitsLabel: true,
+        showModelLabel: true,
+        relocateLeadingControls: false,
+      },
+      {
+        showContextMeter: false,
+        showProviderUsage: false,
+        showProviderUsageReset: false,
+        showTraitsLabel: false,
+        showModelLabel: true,
+        relocateLeadingControls: false,
+      },
+      {
+        showContextMeter: false,
+        showProviderUsage: false,
+        showProviderUsageReset: false,
+        showTraitsLabel: false,
+        showModelLabel: false,
+        relocateLeadingControls: false,
+      },
+      {
+        showContextMeter: false,
+        showProviderUsage: false,
+        showProviderUsageReset: false,
+        showTraitsLabel: false,
+        showModelLabel: false,
+        relocateLeadingControls: true,
+      },
+    ]);
+    expect(composerFooterMaxTier(true, false)).toBe(4);
+  });
+
+  it("does not reserve a tier for a missing context meter", () => {
+    expect(composerFooterPlanForTier(1, false, true).showProviderUsageReset).toBe(false);
+    expect(composerFooterMaxTier(false, true)).toBe(5);
   });
 });
 
@@ -116,6 +196,24 @@ describe("resolveNextComposerFooterTier", () => {
     expect(tier).toBe(COMPOSER_FOOTER_MAX_TIER);
   });
 
+  it("stops at the active control set's max tier", () => {
+    let demotionWidths: ReadonlyArray<number | undefined> = [];
+    let tier = 0;
+    const maxTier = composerFooterMaxTier(false, false);
+    for (let pass = 0; pass < COMPOSER_FOOTER_MAX_TIER; pass += 1) {
+      const step = resolveNextComposerFooterTier({
+        currentTier: tier,
+        clientWidth: 300,
+        isOverflowing: true,
+        demotionWidths,
+        maxTier,
+      });
+      tier = step.tier;
+      demotionWidths = step.demotionWidths;
+    }
+    expect(tier).toBe(3);
+  });
+
   it("promotes back only after clearing the recorded width plus slack", () => {
     const demotionWidths = [400];
     const tooNarrow = resolveNextComposerFooterTier({
@@ -139,7 +237,7 @@ describe("resolveNextComposerFooterTier", () => {
       currentTier: COMPOSER_FOOTER_MAX_TIER,
       clientWidth: 900,
       isOverflowing: false,
-      demotionWidths: [400, 360, 320, 300],
+      demotionWidths: [400, 380, 360, 340, 320, 300],
     });
     expect(step.tier).toBe(0);
   });

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -12,10 +12,11 @@ export function shouldUseCompactComposerFooter(
 }
 
 // Progressive degradation for the footer's picker cluster.
-// Degradation order (first thing to go first): context-window meter ->
-// traits/effort label (gear icon stays) -> model name (provider icon stays) ->
-// relocate the leading controls (extras "+" menu, access-rules indicator) into
-// the row below the input, next to the branch toolbar.
+// Degradation order (first thing to go first): context-window meter -> quota
+// reset suffix -> quota control -> traits/effort label (gear icon stays) ->
+// model name (provider icon stays) -> relocate the leading controls (extras
+// "+" menu, access-rules indicator) into the row below the input, next to the
+// branch toolbar.
 //
 // Visibility is driven by MEASURED overflow, not estimated widths: label
 // lengths vary per provider/model and the app supports UI font scaling, so any
@@ -26,14 +27,17 @@ export function shouldUseCompactComposerFooter(
 // pane promotes back with hysteresis instead of flickering at the boundary.
 export interface ComposerFooterControlsPlan {
   showContextMeter: boolean;
+  showProviderUsage: boolean;
+  showProviderUsageReset: boolean;
   showModelLabel: boolean;
   showTraitsLabel: boolean;
   relocateLeadingControls: boolean;
 }
 
-// Tier 0 = everything visible ... tier 3 = icons only, tier 4 = leading
-// controls move below the input.
-export const COMPOSER_FOOTER_MAX_TIER = 4;
+// The maximum applies when every optional control is present. Call
+// composerFooterMaxTier for the active control set so absent controls do not
+// create no-op measurement passes.
+export const COMPOSER_FOOTER_MAX_TIER = 6;
 // Extra width (px) required beyond the recorded overflow point before stepping
 // back to a richer tier, so a 1px resize cannot oscillate between tiers.
 export const COMPOSER_FOOTER_TIER_PROMOTION_SLACK_PX = 32;
@@ -41,13 +45,27 @@ export const COMPOSER_FOOTER_TIER_PROMOTION_SLACK_PX = 32;
 export function composerFooterPlanForTier(
   tier: number,
   hasContextMeter: boolean,
+  hasProviderUsage = false,
 ): ComposerFooterControlsPlan {
+  let nextTier = 0;
+  const showContextMeter = hasContextMeter && tier < (nextTier += 1);
+  const showProviderUsageReset = hasProviderUsage && tier < (nextTier += 1);
+  const showProviderUsage = hasProviderUsage && tier < (nextTier += 1);
+  const showTraitsLabel = tier < (nextTier += 1);
+  const showModelLabel = tier < (nextTier += 1);
+
   return {
-    showContextMeter: hasContextMeter && tier < 1,
-    showTraitsLabel: tier < 2,
-    showModelLabel: tier < 3,
-    relocateLeadingControls: tier >= 4,
+    showContextMeter,
+    showProviderUsageReset,
+    showProviderUsage,
+    showTraitsLabel,
+    showModelLabel,
+    relocateLeadingControls: tier >= nextTier + 1,
   };
+}
+
+export function composerFooterMaxTier(hasContextMeter: boolean, hasProviderUsage = false): number {
+  return (hasContextMeter ? 1 : 0) + (hasProviderUsage ? 2 : 0) + 3;
 }
 
 export interface ComposerFooterTierStep {
@@ -65,9 +83,14 @@ export function resolveNextComposerFooterTier(input: {
   // the row's scrollWidth — e.g. the leading "+"/access-rules cluster.
   isOverflowing: boolean;
   demotionWidths: ReadonlyArray<number | undefined>;
+  maxTier?: number;
 }): ComposerFooterTierStep {
   const demotionWidths = [...input.demotionWidths];
-  let tier = Math.max(0, Math.min(input.currentTier, COMPOSER_FOOTER_MAX_TIER));
+  const maxTier = Math.max(
+    0,
+    Math.min(input.maxTier ?? COMPOSER_FOOTER_MAX_TIER, COMPOSER_FOOTER_MAX_TIER),
+  );
+  let tier = Math.max(0, Math.min(input.currentTier, maxTier));
 
   // Promote toward richer tiers while the footer is comfortably wider than the
   // width at which the richer tier last overflowed. An unknown demotion width
@@ -85,7 +108,7 @@ export function resolveNextComposerFooterTier(input: {
 
   // Demote one step when the rendered content overflows; the caller re-renders
   // and re-measures, stepping again until the footer fits or tiers run out.
-  if (input.isOverflowing && tier < COMPOSER_FOOTER_MAX_TIER) {
+  if (input.isOverflowing && tier < maxTier) {
     demotionWidths[tier] = input.clientWidth;
     tier += 1;
   }

--- a/apps/web/src/components/settings/ProviderUsageSettingsPanel.test.ts
+++ b/apps/web/src/components/settings/ProviderUsageSettingsPanel.test.ts
@@ -1,0 +1,31 @@
+import type { ServerProviderUsageSnapshot } from "@synara/contracts";
+import { describe, expect, it } from "vitest";
+
+import { completeProviderUsageRefresh } from "./ProviderUsageSettingsPanel";
+
+describe("completeProviderUsageRefresh", () => {
+  it("returns only supported providers and replaces omitted snapshots", () => {
+    const claudeSnapshot: ServerProviderUsageSnapshot = {
+      provider: "claudeAgent",
+      updatedAt: "2026-07-18T12:00:00.000Z",
+      limits: [{ window: "Weekly", usedPercent: 42 }],
+      usageLines: [],
+      source: "test",
+      status: "ok",
+    };
+
+    const snapshots = completeProviderUsageRefresh([claudeSnapshot]);
+
+    expect(snapshots.map((snapshot) => snapshot.provider)).toEqual([
+      "codex",
+      "claudeAgent",
+      "cursor",
+    ]);
+    expect(snapshots.find((snapshot) => snapshot.provider === "claudeAgent")).toBe(claudeSnapshot);
+    expect(snapshots.find((snapshot) => snapshot.provider === "codex")).toMatchObject({
+      status: "error",
+      detail: "Usage is currently unavailable.",
+    });
+    expect(snapshots.some((snapshot) => snapshot.provider === "antigravity")).toBe(false);
+  });
+});

--- a/apps/web/src/components/settings/ProviderUsageSettingsPanel.tsx
+++ b/apps/web/src/components/settings/ProviderUsageSettingsPanel.tsx
@@ -1,7 +1,7 @@
 // FILE: ProviderUsageSettingsPanel.tsx
 // Purpose: Settings → Usage panel. One card per supported provider showing live remaining
 // quota/credits with linear progress meters, the provider brand icon, and plan/status pills.
-// Usage is fetched read-only from each CLI's stored credentials by the server.
+// Only providers with a machine-readable account-quota source are included.
 
 import type { ProviderKind, ServerProviderUsageSnapshot } from "@synara/contracts";
 import {
@@ -16,12 +16,21 @@ import { useAppSettings } from "~/appSettings";
 import { ProviderIcon } from "~/components/ProviderIcon";
 import { ProviderUsageLimitRows } from "~/components/ProviderUsageLimitRows";
 import { ProviderUsageLineList } from "~/components/ProviderUsageLineList";
-import { SettingsCard } from "~/components/settings/SettingsPanelPrimitives";
+import {
+  ProviderUsagePlanPill,
+  PROVIDER_USAGE_PILL_CLASS_NAME,
+} from "~/components/ProviderUsagePanelContent";
+import {
+  SettingsCard,
+  SettingsRow,
+  SettingsSection,
+} from "~/components/settings/SettingsPanelPrimitives";
 import { Button } from "~/components/ui/button";
+import { Switch } from "~/components/ui/switch";
 import { useProviderUsageSummary } from "~/hooks/useProviderUsageSummary";
 import { RotateCcwIcon, TriangleAlertIcon } from "~/lib/icons";
 import { deriveProviderUsageDisplayRows } from "~/lib/providerUsageDisplay";
-import { deriveAccountRateLimits, type ProviderRateLimit } from "~/lib/rateLimits";
+import { createUnavailableProviderUsageSnapshot } from "~/lib/providerUsageSnapshot";
 import {
   fetchAllProviderUsage,
   serverAllProviderUsageQueryOptions,
@@ -32,10 +41,6 @@ import {
   SETTINGS_PANEL_SECTION_CLASS_NAME,
   SETTINGS_SECTION_LABEL_CLASS_NAME,
 } from "~/settingsPanelStyles";
-import { useStore } from "~/store";
-import { createAllThreadsSelector } from "~/storeSelectors";
-
-const PILL_CLASS_NAME = "shrink-0 rounded-full px-2 py-1 text-[11px] font-medium leading-none";
 
 interface StatusPill {
   label: string;
@@ -50,7 +55,10 @@ function statusPill(status: ServerProviderUsageSnapshot["status"]): StatusPill |
         className: "bg-amber-500/12 text-amber-600 dark:text-amber-400",
       };
     case "unsupported":
-      return { label: "Unsupported", className: "bg-muted text-muted-foreground" };
+      return {
+        label: "Unsupported",
+        className: "bg-muted text-muted-foreground",
+      };
     case "error":
       return { label: "Unavailable", className: "bg-red-500/12 text-red-600 dark:text-red-400" };
     default:
@@ -58,22 +66,14 @@ function statusPill(status: ServerProviderUsageSnapshot["status"]): StatusPill |
   }
 }
 
-function ProviderUsageCard({
-  snapshot,
-  threadRateLimits,
-  codexHomePath,
-}: {
-  snapshot: ServerProviderUsageSnapshot;
-  threadRateLimits: ReadonlyArray<ProviderRateLimit>;
-  codexHomePath: string | null;
-}) {
+function ProviderUsageCard({ snapshot }: { snapshot: ServerProviderUsageSnapshot }) {
   const provider = snapshot.provider;
   const status = snapshot.status ?? "ok";
   const usageSummary = useProviderUsageSummary({
     provider,
-    threadRateLimits,
-    codexHomePath,
     providerSnapshot: snapshot,
+    fetchProviderData: false,
+    includeSupplementalData: false,
   });
   const meterRows = useMemo(
     () => deriveProviderUsageDisplayRows(usageSummary.rateLimits),
@@ -97,11 +97,9 @@ function ProviderUsageCard({
             </span>
           </div>
           {status === "ok" && snapshot.planName ? (
-            <span className={cn(PILL_CLASS_NAME, "bg-muted text-muted-foreground")}>
-              {snapshot.planName}
-            </span>
+            <ProviderUsagePlanPill planName={snapshot.planName} />
           ) : pill ? (
-            <span className={cn(PILL_CLASS_NAME, pill.className)}>{pill.label}</span>
+            <span className={cn(PROVIDER_USAGE_PILL_CLASS_NAME, pill.className)}>{pill.label}</span>
           ) : null}
         </div>
 
@@ -139,45 +137,28 @@ function ProviderUsageCard({
 }
 
 function missingSnapshot(provider: ProviderKind): ServerProviderUsageSnapshot {
-  return {
-    provider,
-    updatedAt: new Date(0).toISOString(),
-    limits: [],
-    usageLines: [],
-    source: "unavailable",
-    status: "error",
-    detail: "Usage is currently unavailable.",
-  };
+  return createUnavailableProviderUsageSnapshot(provider, "provider-usage-query");
 }
 
-function mergeProviderUsageRefresh(
-  previous: readonly ServerProviderUsageSnapshot[] | undefined,
+export function completeProviderUsageRefresh(
   next: readonly ServerProviderUsageSnapshot[],
 ): readonly ServerProviderUsageSnapshot[] {
-  if (!previous) {
-    return next;
-  }
-  const previousByProvider = new Map(previous.map((snapshot) => [snapshot.provider, snapshot]));
   const nextByProvider = new Map(next.map((snapshot) => [snapshot.provider, snapshot]));
   return PROVIDER_USAGE_PROVIDERS.map(
-    (provider) => nextByProvider.get(provider) ?? previousByProvider.get(provider),
-  ).filter((snapshot): snapshot is ServerProviderUsageSnapshot => snapshot !== undefined);
+    (provider) => nextByProvider.get(provider) ?? missingSnapshot(provider),
+  );
 }
 
 export function ProviderUsageSettingsPanel() {
   const queryClient = useQueryClient();
-  const { settings } = useAppSettings();
-  const codexHomePath = settings.codexHomePath || null;
-  const threads = useStore(useMemo(() => createAllThreadsSelector(), []));
-  // Account/thread fallback rows are shared by every provider card; derive them once per panel.
-  const threadRateLimits = useMemo(() => deriveAccountRateLimits(threads), [threads]);
+  const { settings, updateSettings } = useAppSettings();
   const usageQuery = useQuery(serverAllProviderUsageQueryOptions());
   const refreshMutation = useMutation({
     mutationFn: () => fetchAllProviderUsage({ forceRefresh: true }),
     onSuccess: (data) => {
       queryClient.setQueryData<readonly ServerProviderUsageSnapshot[]>(
         serverQueryKeys.allProviderUsage(),
-        (previous) => mergeProviderUsageRefresh(previous, data),
+        completeProviderUsageRefresh(data),
       );
     },
   });
@@ -185,13 +166,7 @@ export function ProviderUsageSettingsPanel() {
   // Always render a card per supported provider, ordered consistently, even if the batch
   // omitted one (e.g. a transient server error) — fall back to an "unavailable" placeholder.
   const cards = useMemo(() => {
-    const byProvider = new Map<ProviderKind, ServerProviderUsageSnapshot>();
-    for (const snapshot of usageQuery.data ?? []) {
-      byProvider.set(snapshot.provider, snapshot);
-    }
-    return PROVIDER_USAGE_PROVIDERS.map(
-      (provider) => byProvider.get(provider) ?? missingSnapshot(provider),
-    );
+    return completeProviderUsageRefresh(usageQuery.data ?? []);
   }, [usageQuery.data]);
 
   const showInitialLoading = usageQuery.isPending && !usageQuery.data;
@@ -199,43 +174,58 @@ export function ProviderUsageSettingsPanel() {
   const isRefreshing = usageQuery.isFetching || refreshMutation.isPending;
 
   return (
-    <section className={SETTINGS_PANEL_SECTION_CLASS_NAME}>
-      <div className="flex items-center justify-between gap-2">
-        <h2 className={SETTINGS_SECTION_LABEL_CLASS_NAME}>Provider usage</h2>
-        <Button
-          size="xs"
-          variant="outline"
-          className="shrink-0"
-          disabled={isRefreshing}
-          onClick={() => refreshMutation.mutate()}
-        >
-          <RotateCcwIcon className={cn("size-3.5", isRefreshing && "animate-spin")} />
-          Refresh
-        </Button>
-      </div>
-
-      {showInitialLoading ? (
-        <SettingsCard>
-          <div className="px-4 py-3.5 text-xs text-muted-foreground">Loading provider usage…</div>
-        </SettingsCard>
-      ) : (
-        <div className="flex flex-col gap-3">
-          {cards.map((snapshot) => (
-            <ProviderUsageCard
-              key={snapshot.provider}
-              snapshot={snapshot}
-              threadRateLimits={threadRateLimits}
-              codexHomePath={codexHomePath}
+    <>
+      <SettingsSection title="Composer">
+        <SettingsRow
+          title="Show provider quota in composer"
+          description="Show the selected provider's remaining account allowance beside the model controls. Context usage remains separate."
+          control={
+            <Switch
+              checked={settings.showComposerProviderUsage}
+              onCheckedChange={(checked) =>
+                updateSettings({ showComposerProviderUsage: Boolean(checked) })
+              }
+              aria-label="Show provider quota in composer"
             />
-          ))}
-        </div>
-      )}
+          }
+        />
+      </SettingsSection>
 
-      <p className="px-2 text-[11px] leading-relaxed text-muted-foreground">
-        Usage is read locally from each provider CLI&apos;s stored credentials and fetched directly
-        from the provider. OAuth providers may refresh short-lived tokens through their official
-        token endpoint; if a provider shows “Not signed in”, re-authenticate with its CLI.
-      </p>
-    </section>
+      <section className={SETTINGS_PANEL_SECTION_CLASS_NAME}>
+        <div className="flex items-center justify-between gap-2">
+          <h2 className={SETTINGS_SECTION_LABEL_CLASS_NAME}>Provider usage</h2>
+          <Button
+            size="xs"
+            variant="outline"
+            className="shrink-0"
+            disabled={isRefreshing}
+            onClick={() => refreshMutation.mutate()}
+          >
+            <RotateCcwIcon className={cn("size-3.5", isRefreshing && "animate-spin")} />
+            Refresh
+          </Button>
+        </div>
+
+        {showInitialLoading ? (
+          <SettingsCard>
+            <div className="px-4 py-3.5 text-xs text-muted-foreground">Loading provider usage…</div>
+          </SettingsCard>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {cards.map((snapshot) => (
+              <ProviderUsageCard key={snapshot.provider} snapshot={snapshot} />
+            ))}
+          </div>
+        )}
+
+        <p className="px-2 text-[11px] leading-relaxed text-muted-foreground">
+          Synara includes only providers with a machine-readable account-quota source. Other
+          providers require additional work and may be added in a future release. Synara reads the
+          included provider CLIs&apos; stored credentials and requests quota directly from the
+          providers. OAuth providers may refresh short-lived tokens through their official token
+          endpoint. If a provider shows “Not signed in”, re-authenticate with its CLI.
+        </p>
+      </section>
+    </>
   );
 }

--- a/apps/web/src/hooks/useProviderUsageSummary.test.tsx
+++ b/apps/web/src/hooks/useProviderUsageSummary.test.tsx
@@ -2,7 +2,7 @@
 // Purpose: Verifies how the shared provider-usage summary hook arbitrates live,
 // local, OpenUsage, and thread-derived fallback usage signals.
 
-import type { ServerProviderUsageSnapshot } from "@synara/contracts";
+import type { ProviderKind, ServerProviderUsageSnapshot } from "@synara/contracts";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -45,8 +45,10 @@ function renderWithQueryClient(queryClient: QueryClient, node: ReactNode) {
 
 function readProviderUsageSummary(input: {
   queryClient: QueryClient;
+  provider?: ProviderKind | undefined;
   threadRateLimits?: ReadonlyArray<ProviderRateLimit> | undefined;
   providerSnapshot?: ServerProviderUsageSnapshot | undefined;
+  includeSupplementalData?: boolean | undefined;
 }) {
   // Capture into a ref-style holder: the hook only runs inside the closure, so a
   // plain `let` would narrow to `never` after the guard (TS can't see <Probe/> run).
@@ -56,10 +58,11 @@ function readProviderUsageSummary(input: {
 
   function Probe() {
     captured.current = useProviderUsageSummary({
-      provider: "claudeAgent",
+      provider: input.provider ?? "claudeAgent",
       threads: [],
       threadRateLimits: input.threadRateLimits,
       providerSnapshot: input.providerSnapshot,
+      includeSupplementalData: input.includeSupplementalData,
     });
     return <span />;
   }
@@ -83,6 +86,34 @@ function createQueryClient() {
 }
 
 describe("useProviderUsageSummary", () => {
+  it("scopes live snapshots to the selected provider across provider switches", () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(serverQueryKeys.allProviderUsage("codex"), [
+      snapshot({
+        provider: "codex",
+        status: "ok",
+        limits: [{ window: "Weekly", usedPercent: 20 }],
+      }),
+    ]);
+    queryClient.setQueryData(serverQueryKeys.allProviderUsage("claudeAgent"), [
+      snapshot({
+        provider: "claudeAgent",
+        status: "ok",
+        limits: [{ window: "Weekly", usedPercent: 70 }],
+      }),
+    ]);
+
+    const codexSummary = readProviderUsageSummary({ queryClient, provider: "codex" });
+    const claudeSummary = readProviderUsageSummary({ queryClient, provider: "claudeAgent" });
+
+    expect(codexSummary.rateLimits).toMatchObject([
+      { provider: "codex", limits: [{ window: "Weekly", usedPercent: 20 }] },
+    ]);
+    expect(claudeSummary.rateLimits).toMatchObject([
+      { provider: "claudeAgent", limits: [{ window: "Weekly", usedPercent: 70 }] },
+    ]);
+  });
+
   it("does not show local fallback rows when the live batch reports a non-ok status", () => {
     const queryClient = createQueryClient();
     queryClient.setQueryData(serverQueryKeys.allProviderUsage("claudeAgent"), [
@@ -148,6 +179,7 @@ describe("useProviderUsageSummary", () => {
     queryClient.setQueryData(serverQueryKeys.allProviderUsage("claudeAgent"), [
       snapshot({
         status: "ok",
+        planName: "Max (5x)",
         detail: "Anthropic is rate-limiting usage checks — showing your last values.",
         limits: [
           {
@@ -163,6 +195,7 @@ describe("useProviderUsageSummary", () => {
     const summary = readProviderUsageSummary({ queryClient });
 
     expect(summary.rateLimits).toHaveLength(1);
+    expect(summary.planName).toBe("Max (5x)");
     expect(summary.usageNotice).toContain("rate-limiting");
   });
 
@@ -192,5 +225,36 @@ describe("useProviderUsageSummary", () => {
 
     expect(summary.rateLimits).toEqual([]);
     expect(summary.usageLines).toEqual([]);
+  });
+
+  it("keeps an explicit composer snapshot authoritative over cached supplemental data", () => {
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(serverQueryKeys.allProviderUsage("claudeAgent"), [
+      snapshot({
+        status: "ok",
+        planName: "Cached plan",
+        limits: [{ window: "Weekly", usedPercent: 70 }],
+      }),
+    ]);
+    queryClient.setQueryData(
+      serverQueryKeys.providerUsage("claudeAgent", null),
+      fallbackSnapshot(),
+    );
+
+    const summary = readProviderUsageSummary({
+      queryClient,
+      includeSupplementalData: false,
+      providerSnapshot: snapshot({
+        status: "ok",
+        planName: "Authoritative plan",
+        limits: [{ window: "Weekly", usedPercent: 20 }],
+      }),
+    });
+
+    expect(summary.rateLimits).toMatchObject([
+      { provider: "claudeAgent", limits: [{ window: "Weekly", usedPercent: 20 }] },
+    ]);
+    expect(summary.usageLines).toEqual([]);
+    expect(summary.planName).toBe("Authoritative plan");
   });
 });

--- a/apps/web/src/hooks/useProviderUsageSummary.ts
+++ b/apps/web/src/hooks/useProviderUsageSummary.ts
@@ -39,12 +39,14 @@ export function useProviderUsageSummary(input: {
   codexHomePath?: string | null;
   providerSnapshot?: ServerGetProviderUsageSnapshotResult | undefined;
   fetchProviderData?: boolean;
+  includeSupplementalData?: boolean | undefined;
 }) {
   const provider = input.provider ?? null;
   const shouldFetchProviderData = input.fetchProviderData ?? true;
+  const includeSupplementalData = input.includeSupplementalData ?? true;
   const shouldFetchLiveProviderUsage =
     shouldFetchProviderData && provider !== null && input.providerSnapshot === undefined;
-  const shouldFetchLocalProviderUsage = shouldFetchLiveProviderUsage;
+  const shouldFetchLocalProviderUsage = shouldFetchLiveProviderUsage && includeSupplementalData;
   const allProviderUsageQuery = useQuery(
     serverAllProviderUsageQueryOptions({
       enabled: shouldFetchLiveProviderUsage,
@@ -59,21 +61,29 @@ export function useProviderUsageSummary(input: {
     }),
   );
   const openUsageSnapshotQuery = useQuery(
-    openUsageProviderSnapshotQueryOptions(provider, { enabled: shouldFetchProviderData }),
+    openUsageProviderSnapshotQueryOptions(provider, {
+      enabled: shouldFetchProviderData && includeSupplementalData,
+    }),
   );
   const liveProviderSnapshot = useMemo(
-    () => (allProviderUsageQuery.data ?? []).find((snapshot) => snapshot.provider === provider),
-    [allProviderUsageQuery.data, provider],
+    () =>
+      shouldFetchLiveProviderUsage
+        ? (allProviderUsageQuery.data ?? []).find((snapshot) => snapshot.provider === provider)
+        : undefined,
+    [allProviderUsageQuery.data, provider, shouldFetchLiveProviderUsage],
   );
   const authoritativeLiveSnapshot = useMemo(
-    () => liveProviderSnapshot ?? input.providerSnapshot ?? null,
+    () => input.providerSnapshot ?? liveProviderSnapshot ?? null,
     [input.providerSnapshot, liveProviderSnapshot],
   );
   // Explicit live failures are authoritative; only fall back when no live snapshot exists.
   const blocksProviderUsageFallback = isProviderUsageSnapshotNonOk(authoritativeLiveSnapshot);
   const accountRateLimits = useMemo(
-    () => input.threadRateLimits ?? deriveAccountRateLimits(input.threads ?? []),
-    [input.threadRateLimits, input.threads],
+    () =>
+      includeSupplementalData
+        ? (input.threadRateLimits ?? deriveAccountRateLimits(input.threads ?? []))
+        : [],
+    [includeSupplementalData, input.threadRateLimits, input.threads],
   );
 
   const rateLimits = useMemo<ReadonlyArray<ProviderRateLimit>>(() => {
@@ -81,13 +91,15 @@ export function useProviderUsageSummary(input: {
       return [];
     }
 
-    const localSnapshot = localUsageSnapshotQuery.data ?? null;
+    const localSnapshot = includeSupplementalData ? (localUsageSnapshotQuery.data ?? null) : null;
     const derivedRateLimits = accountRateLimits.filter((rateLimit) =>
       provider ? rateLimit.provider === provider : true,
     );
     const liveUsageRateLimit = normalizeServerProviderUsageRateLimit(authoritativeLiveSnapshot);
     const localUsageRateLimit = normalizeServerProviderUsageRateLimit(localSnapshot);
-    const openUsageSnapshot = normalizeOpenUsageSnapshot(openUsageSnapshotQuery.data, provider);
+    const openUsageSnapshot = includeSupplementalData
+      ? normalizeOpenUsageSnapshot(openUsageSnapshotQuery.data, provider)
+      : null;
     return mergeProviderRateLimits(
       derivedRateLimits,
       mergeProviderRateLimits(
@@ -102,6 +114,7 @@ export function useProviderUsageSummary(input: {
     accountRateLimits,
     authoritativeLiveSnapshot,
     blocksProviderUsageFallback,
+    includeSupplementalData,
     localUsageSnapshotQuery.data,
     openUsageSnapshotQuery.data,
     provider,
@@ -116,14 +129,17 @@ export function useProviderUsageSummary(input: {
     if (liveUsageLines.length > 0) {
       return liveUsageLines;
     }
-    const localUsageLines = normalizeServerProviderUsageLines(localUsageSnapshotQuery.data);
+    const localUsageLines = includeSupplementalData
+      ? normalizeServerProviderUsageLines(localUsageSnapshotQuery.data)
+      : [];
     if (localUsageLines.length > 0) {
       return localUsageLines;
     }
-    return normalizeOpenUsageUsageLines(openUsageSnapshotQuery.data);
+    return includeSupplementalData ? normalizeOpenUsageUsageLines(openUsageSnapshotQuery.data) : [];
   }, [
     authoritativeLiveSnapshot,
     blocksProviderUsageFallback,
+    includeSupplementalData,
     localUsageSnapshotQuery.data,
     openUsageSnapshotQuery.data,
   ]);
@@ -151,10 +167,17 @@ export function useProviderUsageSummary(input: {
     rateLimits.length === 0 &&
     usageLines.length === 0;
 
+  const snapshotStatus = authoritativeLiveSnapshot?.status ?? null;
+  const snapshotDetail = authoritativeLiveSnapshot?.detail?.trim() || null;
+  const planName = authoritativeLiveSnapshot?.planName?.trim() || null;
+
   return {
     isLoading,
     learnMoreHref,
+    planName,
     rateLimits,
+    snapshotDetail,
+    snapshotStatus,
     usageLines,
     usageNotice,
   } as const;

--- a/apps/web/src/lib/providerUsageSnapshot.test.ts
+++ b/apps/web/src/lib/providerUsageSnapshot.test.ts
@@ -5,7 +5,10 @@
 import type { ServerProviderUsageSnapshot } from "@synara/contracts";
 import { describe, expect, it } from "vitest";
 
-import { isProviderUsageSnapshotNonOk } from "./providerUsageSnapshot";
+import {
+  createUnavailableProviderUsageSnapshot,
+  isProviderUsageSnapshotNonOk,
+} from "./providerUsageSnapshot";
 
 function snapshot(input: Partial<ServerProviderUsageSnapshot> = {}): ServerProviderUsageSnapshot {
   return {
@@ -19,6 +22,14 @@ function snapshot(input: Partial<ServerProviderUsageSnapshot> = {}): ServerProvi
 }
 
 describe("providerUsageSnapshot", () => {
+  it("creates unavailable placeholders with explicit provenance", () => {
+    expect(createUnavailableProviderUsageSnapshot("codex", "test")).toMatchObject({
+      provider: "codex",
+      source: "test",
+      status: "error",
+    });
+  });
+
   it("only treats explicit non-ok live statuses as fallback blockers", () => {
     expect(isProviderUsageSnapshotNonOk(null)).toBe(false);
     expect(isProviderUsageSnapshotNonOk(undefined)).toBe(false);

--- a/apps/web/src/lib/providerUsageSnapshot.ts
+++ b/apps/web/src/lib/providerUsageSnapshot.ts
@@ -2,10 +2,31 @@
 // Purpose: Normalize provider usage snapshots returned by the server into the
 // same shapes consumed by the shared usage/rate-limit UI in the web app.
 
-import type { ServerGetProviderUsageSnapshotResult } from "@synara/contracts";
+import type {
+  ProviderKind,
+  ServerGetProviderUsageSnapshotResult,
+  ServerProviderUsageSnapshot,
+} from "@synara/contracts";
 
 import type { OpenUsageUsageLine } from "./openUsageRateLimits";
 import type { ProviderRateLimit } from "./rateLimits";
+
+const EMPTY_PROVIDER_USAGE_UPDATED_AT = "1970-01-01T00:00:00.000Z";
+
+export function createUnavailableProviderUsageSnapshot(
+  provider: ProviderKind,
+  source: string,
+): ServerProviderUsageSnapshot {
+  return {
+    provider,
+    updatedAt: EMPTY_PROVIDER_USAGE_UPDATED_AT,
+    limits: [],
+    usageLines: [],
+    source,
+    status: "error",
+    detail: "Usage is currently unavailable.",
+  };
+}
 
 export function isProviderUsageSnapshotNonOk(
   snapshot: ServerGetProviderUsageSnapshotResult | null | undefined,

--- a/apps/web/src/lib/serverReactQuery.test.ts
+++ b/apps/web/src/lib/serverReactQuery.test.ts
@@ -69,9 +69,14 @@ describe("serverAllProviderUsageQueryOptions", () => {
 
   it("keys provider-scoped usage separately from the all-provider batch", () => {
     const scoped = serverAllProviderUsageQueryOptions({ provider: "claudeAgent" });
+    const accountOnly = serverAllProviderUsageQueryOptions({
+      provider: "claudeAgent",
+      includeLocalUsage: false,
+    });
     const all = serverAllProviderUsageQueryOptions();
 
     expect(scoped.queryKey).toEqual(serverQueryKeys.allProviderUsage("claudeAgent"));
+    expect(accountOnly.queryKey).toEqual(serverQueryKeys.allProviderUsage("claudeAgent", false));
     expect(all.queryKey).toEqual(serverQueryKeys.allProviderUsage(null));
   });
 });

--- a/apps/web/src/lib/serverReactQuery.ts
+++ b/apps/web/src/lib/serverReactQuery.ts
@@ -21,8 +21,8 @@ export const serverQueryKeys = {
   localServers: () => ["server", "localServers"] as const,
   providerUsage: (provider: ProviderKind | null | undefined, homePath?: string | null) =>
     ["server", "providerUsage", provider ?? null, homePath ?? null] as const,
-  allProviderUsage: (provider?: ProviderKind | null) =>
-    ["server", "allProviderUsage", provider ?? null] as const,
+  allProviderUsage: (provider?: ProviderKind | null, includeLocalUsage = true) =>
+    ["server", "allProviderUsage", provider ?? null, includeLocalUsage] as const,
   profileStats: (utcOffsetMinutes: number) =>
     ["server", "profileStats", "peak-hour-v2", utcOffsetMinutes] as const,
   profileTokenStats: (utcOffsetMinutes: number) =>
@@ -244,18 +244,24 @@ export function serverAllProviderUsageQueryOptions(
     | boolean
     | {
         enabled?: boolean;
+        includeLocalUsage?: boolean;
         provider?: ProviderKind | null;
       } = true,
 ) {
   const enabled = typeof input === "boolean" ? input : (input.enabled ?? true);
+  const includeLocalUsage = typeof input === "boolean" ? true : (input.includeLocalUsage ?? true);
   const provider = typeof input === "boolean" ? null : (input.provider ?? null);
   return queryOptions({
-    queryKey: serverQueryKeys.allProviderUsage(provider),
+    queryKey: serverQueryKeys.allProviderUsage(provider, includeLocalUsage),
     enabled,
     staleTime: 60_000,
     refetchInterval: 60_000,
     refetchOnWindowFocus: false,
     retry: false,
-    queryFn: async () => fetchAllProviderUsage(provider ? { provider } : {}),
+    queryFn: async () =>
+      fetchAllProviderUsage({
+        ...(provider ? { provider } : {}),
+        ...(includeLocalUsage ? {} : { includeLocalUsage: false }),
+      }),
   });
 }

--- a/apps/web/src/settingsSearchIndex.ts
+++ b/apps/web/src/settingsSearchIndex.ts
@@ -352,6 +352,13 @@ export const SETTINGS_SEARCH_ENTRIES: readonly SettingsSearchEntry[] = [
 
   // ── Usage ─────────────────────────────────────────────────────────────────────
   {
+    id: "usage:composer-usage",
+    section: "usage",
+    title: "Show provider quota in composer",
+    keywords:
+      "Show the active provider quota and reset time beside the model picker. remaining limits credits footer",
+  },
+  {
     id: "usage:usage",
     section: "usage",
     title: "Usage and billing",

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -1,0 +1,15 @@
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+
+import { ServerListProviderUsageInput } from "./server";
+
+describe("provider usage contracts", () => {
+  it("accepts a scoped account-only query without local archive enrichment", () => {
+    const decode = Schema.decodeUnknownSync(ServerListProviderUsageInput);
+
+    expect(decode({ provider: "codex", includeLocalUsage: false })).toEqual({
+      provider: "codex",
+      includeLocalUsage: false,
+    });
+  });
+});

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -162,6 +162,7 @@ export type ServerGetProviderUsageSnapshotResult = typeof ServerGetProviderUsage
 // (including needs-auth/error) so the UI can render a row each.
 export const ServerListProviderUsageInput = Schema.Struct({
   forceRefresh: Schema.optional(Schema.Boolean),
+  includeLocalUsage: Schema.optional(Schema.Boolean),
   provider: Schema.optional(ProviderKind),
 });
 export type ServerListProviderUsageInput = typeof ServerListProviderUsageInput.Type;

--- a/packages/shared/src/providerUsage.test.ts
+++ b/packages/shared/src/providerUsage.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { PROVIDER_USAGE_PROVIDERS, isProviderUsageSupported } from "./providerUsage";
+
+describe("provider usage metadata", () => {
+  it("lists exactly the providers with machine-readable account quota", () => {
+    expect(PROVIDER_USAGE_PROVIDERS).toEqual(["codex", "claudeAgent", "cursor"]);
+  });
+
+  it.each(["codex", "claudeAgent", "cursor"] as const)("supports %s", (provider) => {
+    expect(isProviderUsageSupported(provider)).toBe(true);
+  });
+
+  it.each(["antigravity", "grok", "droid", "kilo", "opencode", "pi"] as const)(
+    "excludes %s without a machine-readable account-quota source",
+    (provider) => {
+      expect(isProviderUsageSupported(provider)).toBe(false);
+    },
+  );
+});


### PR DESCRIPTION
## What

- Show the selected provider's remaining account allowance in the composer for Codex, Claude, and Cursor.
- Reuse the existing provider snapshot, query, menu, panel, formatting, status, icon, and settings paths.
- Add a default-on Show provider quota in composer preference.
- Keep provider quota separate from thread context usage and fail closed when live account usage is missing or unavailable.
- Query only the active provider, exclude local archive enrichment, and prevent stale values when providers change or refreshes fail.
- Preserve plan, credits, every reported window, resets, and notices in the detail popover.
- Integrate the control into the measured footer degradation sequence without no-op layout tiers.

## Provider scope

This release includes Codex, Claude, and Cursor.

Other providers require additional source and integration work before Synara can retrieve their current quota reliably. They are deferred to a future release after that work is complete.

## Verification

- CI Format, Lint, Typecheck, Test, Browser Test, Build: passed
- CI Windows Process Regression: passed
- CI Release Smoke: passed
- packages/shared locally: 34 files, 373 tests passed
- packages/contracts locally: 13 files, 126 tests passed
- apps/web locally: 232 files, 2,841 tests passed
- apps/server provider-usage slice locally: 5 files, 28 tests passed
- Independent final review: 9 focused files, 54 tests passed; no findings
- Diff check passed

Closes #381