### PR TITLE
fix(providers): converge Windows-safe spawning

### DIFF
--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -1,20 +1,178 @@
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import crypto from "node:crypto";
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 
-import { describe, expect, it } from "vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ThreadId } from "@synara/contracts";
+import type { WindowsSafeProcessInput } from "@synara/shared/windowsProcess";
+import { Effect, Layer } from "effect";
+import { describe, expect, it, vi } from "vitest";
 
+import { ServerConfig } from "../../config";
+import { AntigravityAdapter, type AntigravityAdapterShape } from "../Services/AntigravityAdapter";
 import {
+  ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES,
+  type AntigravityAdapterLiveOptions,
+  type AntigravityProcessDependencies,
+  type AntigravityTurnProcessResult,
   buildAntigravityHookConfig,
   antigravityPromptCommandLineIssue,
   hookScriptSource,
+  makeAntigravityAdapterLive,
   makeAntigravityRuntimeEventBase,
   parseAntigravityCliModelLabel,
   parseAntigravityModelLines,
   readCompleteAntigravityLines,
   resolveAntigravityCliModelLabel,
   runAntigravityHelperProcess,
+  startAntigravityTurnProcess,
 } from "./AntigravityAdapter";
+
+type Deferred<T> = {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+  readonly reject: (cause?: unknown) => void;
+};
+
+function deferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (cause?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for test condition.");
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
+async function expectPending(promise: Promise<unknown>): Promise<void> {
+  let settled = false;
+  void promise.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(settled).toBe(false);
+}
+
+type FakeChild = {
+  readonly child: ChildProcess;
+  readonly stdout: PassThrough;
+  readonly stderr: PassThrough;
+  readonly emitError: (cause: Error) => void;
+  readonly emitClose: (code: number | null, signal?: NodeJS.Signals | null) => void;
+};
+
+function makeFakeChild(pid = 42_000): FakeChild {
+  const emitter = new EventEmitter();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  Object.assign(emitter, {
+    pid,
+    stdin: null,
+    stdout,
+    stderr,
+    stdio: [null, stdout, stderr],
+    connected: false,
+    killed: false,
+    exitCode: null,
+    signalCode: null,
+    kill: () => true,
+  });
+  const child = emitter as unknown as ChildProcess;
+  return {
+    child,
+    stdout,
+    stderr,
+    emitError: (cause) => child.emit("error", cause),
+    emitClose: (code, signal = null) => {
+      Object.assign(emitter, { exitCode: code, signalCode: signal });
+      child.emit("exit", code, signal);
+      child.emit("close", code, signal);
+    },
+  };
+}
+
+function fakeProcessDependencies(
+  fake: FakeChild,
+  overrides: Partial<AntigravityProcessDependencies> = {},
+): AntigravityProcessDependencies {
+  return {
+    prepareProcess: (command, args) => ({ command, args: [...args], shell: false }),
+    spawnProcess: (_command: string, _args: ReadonlyArray<string>, _options: SpawnOptions) =>
+      fake.child,
+    teardownProcessTree: async () => undefined,
+    ...overrides,
+  };
+}
+
+async function runWithAdapter<T>(
+  options: AntigravityAdapterLiveOptions,
+  use: (adapter: AntigravityAdapterShape) => Promise<T>,
+): Promise<T> {
+  const layer = makeAntigravityAdapterLive(options).pipe(
+    Layer.provideMerge(
+      ServerConfig.layerTest(process.cwd(), { prefix: "synara-antigravity-adapter-test-" }),
+    ),
+    Layer.provideMerge(NodeServices.layer),
+  );
+  return await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const adapter = yield* AntigravityAdapter;
+        return yield* Effect.promise(() => use(adapter));
+      }).pipe(Effect.provide(layer)),
+    ),
+  );
+}
+
+async function startFakeAdapterTurn(input: {
+  readonly fake: FakeChild;
+  readonly teardownProcessTree: NonNullable<AntigravityProcessDependencies["teardownProcessTree"]>;
+  readonly beforeTurnFinalization?: AntigravityAdapterLiveOptions["beforeTurnFinalization"];
+  readonly use: (adapter: AntigravityAdapterShape, threadId: ThreadId) => Promise<void>;
+}): Promise<void> {
+  const threadId = ThreadId.makeUnsafe(`antigravity-test-${crypto.randomUUID()}`);
+  await runWithAdapter(
+    {
+      ...fakeProcessDependencies(input.fake, {
+        teardownProcessTree: input.teardownProcessTree,
+      }),
+      installCapturePlugin: async () => undefined,
+      ...(input.beforeTurnFinalization
+        ? { beforeTurnFinalization: input.beforeTurnFinalization }
+        : {}),
+      pollIntervalMs: 5,
+    },
+    async (adapter) => {
+      await Effect.runPromise(
+        adapter.startSession({
+          provider: "antigravity",
+          threadId,
+          runtimeMode: "full-access",
+          providerOptions: { antigravity: { binaryPath: "fake-antigravity" } },
+        }),
+      );
+      await Effect.runPromise(adapter.sendTurn({ threadId, input: "test prompt" }));
+      await input.use(adapter, threadId);
+    },
+  );
+}
 
 describe("Antigravity CLI model translation", () => {
   it("collapses CLI model/effort labels into base models with effort ladders", () => {
@@ -209,5 +367,628 @@ describe("Antigravity CLI integration helpers", () => {
         timeoutMs: 50,
       }),
     ).rejects.toThrow("Antigravity helper timed out after 50ms");
+  });
+});
+
+describe("Antigravity process spawning and output ownership", () => {
+  it.runIf(process.platform === "win32")(
+    "preserves native Windows helper and turn arguments plus under-cap stdout/stderr",
+    async () => {
+      const values = ["plain", "value with spaces", 'quote " inside', "café-東京"];
+      const stderr = 'native stderr "exact" café-東京';
+      const script =
+        `process.stdout.write(JSON.stringify(process.argv.slice(1)));` +
+        `process.stderr.write(${JSON.stringify(stderr)});`;
+      const args = ["-e", script, ...values];
+
+      const helper = await runAntigravityHelperProcess(process.execPath, args, {
+        timeoutMs: 2_000,
+      });
+      expect(helper).toMatchObject({
+        code: 0,
+        stdout: JSON.stringify(values),
+        stderr,
+        outputTruncated: false,
+      });
+      expect(helper.retainedOutputBytes).toBe(
+        Buffer.byteLength(helper.stdout) + Buffer.byteLength(helper.stderr),
+      );
+
+      let finalized: AntigravityTurnProcessResult | undefined;
+      const lifecycle = startAntigravityTurnProcess({
+        command: process.execPath,
+        args,
+        cwd: process.cwd(),
+        env: process.env,
+        onFinalize: async (result) => {
+          finalized = result;
+        },
+      });
+      const turn = await lifecycle.finalization;
+      expect(turn).toMatchObject({
+        code: 0,
+        signal: null,
+        stdout: JSON.stringify(values),
+        stderr,
+        outputTruncated: false,
+        teardownRequested: false,
+      });
+      expect(finalized).toEqual(turn);
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "runs a real .cmd helper and turn from a path with spaces and non-ASCII",
+    async () => {
+      const directory = await fs.mkdtemp(path.join(os.tmpdir(), "synara agy café 東京 "));
+      const scriptPath = path.join(directory, "echo args.cjs");
+      const commandPath = path.join(directory, "echo args.cmd");
+      const values = ["ordinary", "space value", 'quoted " value', "naïve-東京"];
+      const stderr = "cmd stderr café-東京";
+      try {
+        await fs.writeFile(
+          scriptPath,
+          `process.stdout.write(JSON.stringify(process.argv.slice(2)));process.stderr.write(${JSON.stringify(stderr)});`,
+        );
+        await fs.writeFile(
+          commandPath,
+          `@echo off\r\n"${process.execPath}" "%~dp0echo args.cjs" %*\r\n`,
+        );
+
+        const helper = await runAntigravityHelperProcess(commandPath, values, {
+          cwd: directory,
+          timeoutMs: 2_000,
+        });
+        expect(helper).toMatchObject({
+          code: 0,
+          stdout: JSON.stringify(values),
+          stderr,
+          outputTruncated: false,
+        });
+
+        let finalized: AntigravityTurnProcessResult | undefined;
+        const lifecycle = startAntigravityTurnProcess({
+          command: commandPath,
+          args: values,
+          cwd: directory,
+          env: process.env,
+          onFinalize: async (result) => {
+            finalized = result;
+          },
+        });
+        const turn = await lifecycle.finalization;
+        expect(turn).toMatchObject({
+          code: 0,
+          signal: null,
+          stdout: JSON.stringify(values),
+          stderr,
+          outputTruncated: false,
+        });
+        expect(finalized).toEqual(turn);
+      } finally {
+        await fs.rm(directory, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects .cmd command and argument metacharacters before spawn without executing a sentinel",
+    async () => {
+      const directory = await fs.mkdtemp(path.join(os.tmpdir(), "synara-agy-sentinel-"));
+      const sentinel = path.join(directory, "executed.txt");
+      const commandPath = path.join(directory, "sentinel.cmd");
+      const fake = makeFakeChild();
+      const spawnProcess = vi.fn(
+        (_command: string, _args: ReadonlyArray<string>, _options: SpawnOptions) => fake.child,
+      );
+      const dependencies: AntigravityProcessDependencies = { spawnProcess };
+      const onFinalize = async () => undefined;
+      try {
+        await fs.writeFile(commandPath, `@echo executed>"${sentinel}"\r\n`);
+
+        await expect(
+          runAntigravityHelperProcess(commandPath, ["safe & unsafe"], {
+            cwd: directory,
+            dependencies,
+          }),
+        ).rejects.toThrow("cmd.exe control characters");
+        await expect(
+          runAntigravityHelperProcess(`${commandPath}&unsafe.cmd`, ["safe"], {
+            cwd: directory,
+            dependencies,
+          }),
+        ).rejects.toThrow("cmd.exe control characters");
+        expect(() =>
+          startAntigravityTurnProcess({
+            command: commandPath,
+            args: ["safe | unsafe"],
+            cwd: directory,
+            env: process.env,
+            dependencies,
+            onFinalize,
+          }),
+        ).toThrow("cmd.exe control characters");
+        expect(() =>
+          startAntigravityTurnProcess({
+            command: `${commandPath}^unsafe.cmd`,
+            args: ["safe"],
+            cwd: directory,
+            env: process.env,
+            dependencies,
+            onFinalize,
+          }),
+        ).toThrow("cmd.exe control characters");
+
+        expect(spawnProcess).not.toHaveBeenCalled();
+        await expect(fs.access(sentinel)).rejects.toThrow();
+      } finally {
+        await fs.rm(directory, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("propagates prepared shell options for helper and turn launches", async () => {
+    const helperFake = makeFakeChild(42_001);
+    let helperPreparedInput: WindowsSafeProcessInput | undefined;
+    const helperPrepare = vi.fn(
+      (command: string, args: ReadonlyArray<string>, input: WindowsSafeProcessInput = {}) => {
+        helperPreparedInput = input;
+        return {
+          command: `prepared-${command}`,
+          args: [...args, "prepared"],
+          shell: false as const,
+          windowsHide: true as const,
+          windowsVerbatimArguments: true as const,
+          input,
+        };
+      },
+    );
+    let helperSpawnOptions: SpawnOptions | undefined;
+    const helperPromise = runAntigravityHelperProcess("helper.exe", ["one"], {
+      cwd: "C:\\helper cwd",
+      dependencies: {
+        prepareProcess: helperPrepare,
+        spawnProcess: (_command, _args, options) => {
+          helperSpawnOptions = options;
+          return helperFake.child;
+        },
+      },
+    });
+    helperFake.emitClose(0);
+    await helperPromise;
+    expect(helperPrepare).toHaveBeenCalledOnce();
+    expect(helperSpawnOptions).toMatchObject({
+      cwd: "C:\\helper cwd",
+      shell: false,
+      windowsHide: true,
+      windowsVerbatimArguments: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    expect(helperSpawnOptions?.env).toBe(helperPreparedInput?.env);
+
+    const turnFake = makeFakeChild(42_002);
+    const turnEnv = { TEST_ENV: "turn" };
+    let turnSpawnOptions: SpawnOptions | undefined;
+    const lifecycle = startAntigravityTurnProcess({
+      command: "turn.exe",
+      args: ["two"],
+      cwd: "C:\\turn cwd",
+      env: turnEnv,
+      dependencies: {
+        prepareProcess: (command, args, input) => {
+          expect(input).toEqual({ cwd: "C:\\turn cwd", env: turnEnv });
+          return {
+            command: `prepared-${command}`,
+            args: [...args],
+            shell: false,
+            windowsHide: true,
+            windowsVerbatimArguments: true,
+          };
+        },
+        spawnProcess: (_command, _args, options) => {
+          turnSpawnOptions = options;
+          return turnFake.child;
+        },
+      },
+      onFinalize: async () => undefined,
+    });
+    turnFake.emitClose(0);
+    await lifecycle.finalization;
+    expect(turnSpawnOptions).toMatchObject({
+      cwd: "C:\\turn cwd",
+      env: turnEnv,
+      shell: false,
+      windowsHide: true,
+      windowsVerbatimArguments: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  });
+
+  it.each([
+    {
+      name: "stdout-only",
+      write: (fake: FakeChild) =>
+        fake.stdout.write("a".repeat(ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES + 9)),
+      stdout: "a".repeat(ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES),
+      stderr: "",
+      bytes: ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES,
+    },
+    {
+      name: "stderr-only",
+      write: (fake: FakeChild) =>
+        fake.stderr.write("b".repeat(ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES + 9)),
+      stdout: "",
+      stderr: "b".repeat(ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES),
+      bytes: ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES,
+    },
+    {
+      name: "combined with a split multibyte boundary",
+      write: (fake: FakeChild) => {
+        fake.stdout.write("c".repeat(ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES - 5));
+        fake.stderr.write("ééé-tail");
+        fake.stdout.write("ignored-after-overflow");
+      },
+      stdout: "c".repeat(ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES - 5),
+      stderr: "éé",
+      bytes: ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES - 1,
+    },
+  ])("bounds $name helper output at ingestion", async ({ write, stdout, stderr, bytes }) => {
+    const fake = makeFakeChild();
+    const promise = runAntigravityHelperProcess("fake-helper", [], {
+      dependencies: fakeProcessDependencies(fake),
+    });
+    write(fake);
+    fake.emitClose(0);
+    const result = await promise;
+    expect(result).toEqual({
+      code: 0,
+      stdout,
+      stderr,
+      outputTruncated: true,
+      retainedOutputBytes: bytes,
+    });
+    expect(Buffer.byteLength(result.stdout) + Buffer.byteLength(result.stderr)).toBeLessThanOrEqual(
+      ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES,
+    );
+  });
+
+  it("applies the same combined byte cap to turn output", async () => {
+    const fake = makeFakeChild();
+    let finalized: AntigravityTurnProcessResult | undefined;
+    const lifecycle = startAntigravityTurnProcess({
+      command: "fake-turn",
+      args: [],
+      env: process.env,
+      dependencies: fakeProcessDependencies(fake),
+      onFinalize: async (result) => {
+        finalized = result;
+      },
+    });
+    fake.stderr.write("d".repeat(ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES - 2));
+    fake.stdout.write("é-more");
+    fake.stderr.write("ignored");
+    fake.emitClose(0);
+
+    const result = await lifecycle.finalization;
+    expect(result.stderr).toBe("d".repeat(ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES - 2));
+    expect(result.stdout).toBe("é");
+    expect(result.outputTruncated).toBe(true);
+    expect(result.retainedOutputBytes).toBe(ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES);
+    expect(finalized).toEqual(result);
+  });
+
+  it("keeps helper timeout pending until supervised teardown completes", async () => {
+    const fake = makeFakeChild();
+    const teardown = deferred<void>();
+    const teardownProcessTree = vi.fn(() => teardown.promise);
+    const helper = runAntigravityHelperProcess("fake-helper", [], {
+      timeoutMs: 10,
+      dependencies: fakeProcessDependencies(fake, { teardownProcessTree }),
+    });
+
+    await waitFor(() => teardownProcessTree.mock.calls.length === 1);
+    await expectPending(helper);
+    fake.emitClose(null, "SIGKILL");
+    await expectPending(helper);
+    teardown.resolve(undefined);
+    await expect(helper).rejects.toThrow("Antigravity helper timed out after 10ms");
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+    expect(fake.child.listenerCount("error")).toBe(0);
+    expect(fake.child.listenerCount("close")).toBe(0);
+    expect(fake.stdout.listenerCount("data")).toBe(0);
+    expect(fake.stderr.listenerCount("data")).toBe(0);
+  });
+
+  it("settles helper spawn error and early close once without timers or listeners leaking", async () => {
+    const spawnErrorFake = makeFakeChild(42_003);
+    const spawnErrorTeardown = vi.fn(async () => undefined);
+    const spawnFailure = new Error("simulated spawn failure");
+    const spawnErrorResult = runAntigravityHelperProcess("fake-helper", [], {
+      timeoutMs: 20,
+      dependencies: fakeProcessDependencies(spawnErrorFake, {
+        teardownProcessTree: spawnErrorTeardown,
+      }),
+    });
+    spawnErrorFake.emitError(spawnFailure);
+    spawnErrorFake.emitClose(1);
+    await expect(spawnErrorResult).rejects.toBe(spawnFailure);
+
+    const closeFake = makeFakeChild(42_004);
+    const closeTeardown = vi.fn(async () => undefined);
+    const closeResult = runAntigravityHelperProcess("fake-helper", [], {
+      timeoutMs: 20,
+      dependencies: fakeProcessDependencies(closeFake, { teardownProcessTree: closeTeardown }),
+    });
+    closeFake.emitClose(0);
+    await expect(closeResult).resolves.toMatchObject({ code: 0 });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(spawnErrorTeardown).not.toHaveBeenCalled();
+    expect(closeTeardown).not.toHaveBeenCalled();
+    for (const fake of [spawnErrorFake, closeFake]) {
+      expect(fake.child.listenerCount("error")).toBe(0);
+      expect(fake.child.listenerCount("close")).toBe(0);
+      expect(fake.stdout.listenerCount("data")).toBe(0);
+      expect(fake.stderr.listenerCount("data")).toBe(0);
+    }
+  });
+
+  it("finalizes a turn spawn error once when close races behind it", async () => {
+    const fake = makeFakeChild(42_005);
+    const failure = new Error("turn spawn failed");
+    const teardownProcessTree = vi.fn(async () => undefined);
+    const onFinalize = vi.fn(async () => undefined);
+    const lifecycle = startAntigravityTurnProcess({
+      command: "fake-turn",
+      args: [],
+      env: process.env,
+      dependencies: fakeProcessDependencies(fake, { teardownProcessTree }),
+      onFinalize,
+    });
+
+    fake.emitError(failure);
+    fake.emitClose(1);
+    await expect(lifecycle.finalization).rejects.toBe(failure);
+    expect(onFinalize).toHaveBeenCalledOnce();
+    expect(teardownProcessTree).not.toHaveBeenCalled();
+    expect(fake.child.listenerCount("error")).toBe(0);
+    expect(fake.child.listenerCount("close")).toBe(0);
+    expect(fake.stdout.listenerCount("data")).toBe(0);
+    expect(fake.stderr.listenerCount("data")).toBe(0);
+  });
+
+  it("awaits requested teardown when spawn error and close race behind it", async () => {
+    const fake = makeFakeChild(42_006);
+    const teardown = deferred<void>();
+    const spawnFailure = new Error("turn spawn failed during teardown");
+    const teardownFailure = new Error("process-tree exit could not be proven");
+    let finalized: AntigravityTurnProcessResult | undefined;
+    const teardownProcessTree = vi.fn(() => teardown.promise);
+    const onFinalize = vi.fn(async (result: AntigravityTurnProcessResult) => {
+      finalized = result;
+    });
+    const lifecycle = startAntigravityTurnProcess({
+      command: "fake-turn",
+      args: [],
+      env: process.env,
+      dependencies: fakeProcessDependencies(fake, { teardownProcessTree }),
+      onFinalize,
+    });
+
+    const teardownAndFinalize = lifecycle.teardownAndFinalize();
+    await waitFor(() => teardownProcessTree.mock.calls.length === 1);
+    fake.emitError(spawnFailure);
+    fake.emitClose(1);
+
+    await expectPending(lifecycle.finalization);
+    await expectPending(teardownAndFinalize);
+    expect(onFinalize).not.toHaveBeenCalled();
+
+    const finalizationAssertion = expect(lifecycle.finalization).rejects.toBe(teardownFailure);
+    const teardownAssertion = expect(teardownAndFinalize).rejects.toBe(teardownFailure);
+    teardown.reject(teardownFailure);
+    await Promise.all([finalizationAssertion, teardownAssertion]);
+
+    expect(onFinalize).toHaveBeenCalledOnce();
+    expect(finalized).toMatchObject({
+      spawnError: spawnFailure,
+      teardownError: teardownFailure,
+      teardownRequested: true,
+    });
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+    expect(fake.child.listenerCount("error")).toBe(0);
+    expect(fake.child.listenerCount("close")).toBe(0);
+    expect(fake.stdout.listenerCount("data")).toBe(0);
+    expect(fake.stderr.listenerCount("data")).toBe(0);
+  });
+
+  it("makes late lifecycle callers await an already observed normal close", async () => {
+    const fake = makeFakeChild(42_007);
+    const finalizationGate = deferred<void>();
+    const teardownProcessTree = vi.fn(async () => undefined);
+    const onFinalize = vi.fn(() => finalizationGate.promise);
+    const lifecycle = startAntigravityTurnProcess({
+      command: "fake-turn",
+      args: [],
+      env: process.env,
+      dependencies: fakeProcessDependencies(fake, { teardownProcessTree }),
+      onFinalize,
+    });
+
+    fake.emitClose(0);
+    await waitFor(() => onFinalize.mock.calls.length === 1);
+    const lateLifecycleCall = lifecycle.teardownAndFinalize();
+    await expectPending(lateLifecycleCall);
+    expect(teardownProcessTree).not.toHaveBeenCalled();
+
+    finalizationGate.resolve(undefined);
+    const [terminalResult, lateResult] = await Promise.all([
+      lifecycle.finalization,
+      lateLifecycleCall,
+    ]);
+    expect(lateResult).toEqual(terminalResult);
+    expect(onFinalize).toHaveBeenCalledOnce();
+  });
+
+  it("rejects abnormal turn exit when descendant survival cannot be disproven", async () => {
+    const fake = makeFakeChild();
+    const failure = new Error("descendants still running after supervised teardown");
+    const teardown = deferred<void>();
+    let finalized: AntigravityTurnProcessResult | undefined;
+    const onFinalize = vi.fn(async (result: AntigravityTurnProcessResult) => {
+      finalized = result;
+    });
+    const teardownProcessTree = vi.fn(() => teardown.promise);
+    const lifecycle = startAntigravityTurnProcess({
+      command: "fake-turn",
+      args: [],
+      env: process.env,
+      dependencies: fakeProcessDependencies(fake, { teardownProcessTree }),
+      onFinalize,
+    });
+
+    fake.emitClose(17);
+    await waitFor(() => teardownProcessTree.mock.calls.length === 1);
+    await expectPending(lifecycle.finalization);
+    expect(onFinalize).not.toHaveBeenCalled();
+    teardown.reject(failure);
+    await expect(lifecycle.finalization).rejects.toBe(failure);
+    expect(teardownProcessTree).toHaveBeenCalledOnce();
+    expect(onFinalize).toHaveBeenCalledOnce();
+    expect(finalized).toMatchObject({
+      code: 17,
+      teardownError: failure,
+      teardownRequested: true,
+    });
+  });
+});
+
+describe("Antigravity active turn lifecycle", () => {
+  it("keeps interrupt pending through shared teardown and full finalization", async () => {
+    const fake = makeFakeChild();
+    const teardown = deferred<void>();
+    const finalization = deferred<void>();
+    const teardownProcessTree = vi.fn(() => teardown.promise);
+    const beforeTurnFinalization = vi.fn(() => finalization.promise);
+
+    await startFakeAdapterTurn({
+      fake,
+      teardownProcessTree,
+      beforeTurnFinalization,
+      use: async (adapter, threadId) => {
+        const interrupt = Effect.runPromise(adapter.interruptTurn(threadId));
+        await waitFor(() => teardownProcessTree.mock.calls.length === 1);
+        await expectPending(interrupt);
+
+        teardown.resolve(undefined);
+        await expectPending(interrupt);
+        fake.emitClose(null, "SIGTERM");
+        await waitFor(() => beforeTurnFinalization.mock.calls.length === 1);
+        await expectPending(interrupt);
+
+        finalization.resolve(undefined);
+        await interrupt;
+        const sessions = await Effect.runPromise(adapter.listSessions());
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0]).toMatchObject({ status: "ready" });
+        expect(sessions[0]).not.toHaveProperty("activeTurnId");
+        expect(teardownProcessTree).toHaveBeenCalledOnce();
+      },
+    });
+  });
+
+  it("keeps stop pending through shared teardown and full finalization", async () => {
+    const fake = makeFakeChild();
+    const teardown = deferred<void>();
+    const finalization = deferred<void>();
+    const teardownProcessTree = vi.fn(() => teardown.promise);
+    const beforeTurnFinalization = vi.fn(() => finalization.promise);
+
+    await startFakeAdapterTurn({
+      fake,
+      teardownProcessTree,
+      beforeTurnFinalization,
+      use: async (adapter, threadId) => {
+        const stop = Effect.runPromise(adapter.stopSession(threadId));
+        await waitFor(() => teardownProcessTree.mock.calls.length === 1);
+        await expectPending(stop);
+
+        teardown.resolve(undefined);
+        fake.emitClose(null, "SIGTERM");
+        await waitFor(() => beforeTurnFinalization.mock.calls.length === 1);
+        await expectPending(stop);
+        expect(await Effect.runPromise(adapter.hasSession(threadId))).toBe(true);
+
+        finalization.resolve(undefined);
+        await stop;
+        expect(await Effect.runPromise(adapter.hasSession(threadId))).toBe(false);
+        expect(teardownProcessTree).toHaveBeenCalledOnce();
+      },
+    });
+  });
+
+  it("keeps restart pending through the active turn's teardown and finalization", async () => {
+    const fake = makeFakeChild();
+    const teardown = deferred<void>();
+    const finalization = deferred<void>();
+    const teardownProcessTree = vi.fn(() => teardown.promise);
+    const beforeTurnFinalization = vi.fn(() => finalization.promise);
+
+    await startFakeAdapterTurn({
+      fake,
+      teardownProcessTree,
+      beforeTurnFinalization,
+      use: async (adapter, threadId) => {
+        const restart = Effect.runPromise(
+          adapter.startSession({
+            provider: "antigravity",
+            threadId,
+            runtimeMode: "full-access",
+            providerOptions: { antigravity: { binaryPath: "fake-antigravity" } },
+          }),
+        );
+        await waitFor(() => teardownProcessTree.mock.calls.length === 1);
+        await expectPending(restart);
+
+        teardown.resolve(undefined);
+        fake.emitClose(null, "SIGTERM");
+        await waitFor(() => beforeTurnFinalization.mock.calls.length === 1);
+        await expectPending(restart);
+
+        finalization.resolve(undefined);
+        await expect(restart).resolves.toMatchObject({ status: "ready", threadId });
+        const sessions = await Effect.runPromise(adapter.listSessions());
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0]).not.toHaveProperty("activeTurnId");
+        expect(teardownProcessTree).toHaveBeenCalledOnce();
+      },
+    });
+  });
+
+  it("lets teardown failure win over interrupted status and releases turn ownership", async () => {
+    const fake = makeFakeChild();
+    const failure = new Error("descendant survival could not be disproven");
+    const teardownProcessTree = vi.fn(async () => {
+      throw failure;
+    });
+
+    await startFakeAdapterTurn({
+      fake,
+      teardownProcessTree,
+      use: async (adapter, threadId) => {
+        await expect(Effect.runPromise(adapter.interruptTurn(threadId))).rejects.toThrow(
+          "descendant survival could not be disproven",
+        );
+        const sessions = await Effect.runPromise(adapter.listSessions());
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0]).toMatchObject({
+          status: "error",
+          lastError: "descendant survival could not be disproven",
+        });
+        expect(sessions[0]).not.toHaveProperty("activeTurnId");
+        expect(fake.child.listenerCount("close")).toBe(0);
+        expect(teardownProcessTree).toHaveBeenCalledOnce();
+      },
+    });
   });
 });

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -15,6 +15,7 @@ import {
   ThreadId,
   TurnId,
 } from "@synara/contracts";
+import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
 import { Effect, Layer, Queue, Stream } from "effect";
 
 import { ServerConfig } from "../../config.ts";
@@ -38,8 +39,49 @@ const PRINT_TIMEOUT = "30m";
 const POLL_INTERVAL_MS = 75;
 const MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 const PLUGIN_INSTALL_TIMEOUT_MS = 30_000;
-const HELPER_OUTPUT_MAX_CHARS = 128 * 1024;
+export const ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES = 128 * 1024;
 const WINDOWS_PROMPT_MAX_CHARS = 24_000;
+
+type SpawnProcess = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options: SpawnOptions,
+) => ChildProcess;
+
+type TeardownProcessTree = (child: ChildProcess) => Promise<unknown>;
+
+export interface AntigravityProcessDependencies {
+  readonly spawnProcess?: SpawnProcess;
+  readonly prepareProcess?: typeof prepareWindowsSafeProcess;
+  readonly teardownProcessTree?: TeardownProcessTree;
+}
+
+export interface AntigravityProcessOutput {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly outputTruncated: boolean;
+  readonly retainedOutputBytes: number;
+}
+
+export interface AntigravityTurnProcessResult extends AntigravityProcessOutput {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly spawnError?: unknown;
+  readonly teardownError?: unknown;
+  readonly teardownRequested: boolean;
+}
+
+export interface AntigravityTurnProcessLifecycle {
+  readonly child: ChildProcess;
+  readonly finalization: Promise<AntigravityTurnProcessResult>;
+  readonly teardownAndFinalize: () => Promise<AntigravityTurnProcessResult>;
+}
+
+export interface AntigravityAdapterLiveOptions extends AntigravityProcessDependencies {
+  readonly installCapturePlugin?: (binaryPath: string) => Promise<void>;
+  readonly beforeTurnFinalization?: (result: AntigravityTurnProcessResult) => Promise<void>;
+  readonly pollIntervalMs?: number;
+}
 
 type TranscriptStep = {
   readonly step_index?: number;
@@ -72,7 +114,7 @@ type AntigravitySessionContext = {
   readonly binaryPath: string;
   readonly turns: StoredTurn[];
   activeTurnId?: TurnId | undefined;
-  activeProcess?: ChildProcess | undefined;
+  activeLifecycle?: AntigravityTurnProcessLifecycle | undefined;
   activePrompt?: string | undefined;
   eventFile?: string | undefined;
   transcriptPath?: string | undefined;
@@ -166,53 +208,289 @@ export function buildAntigravityHookConfig(
   };
 }
 
-function appendBoundedOutput(current: string, chunk: unknown): string {
-  const next = current + String(chunk);
-  return next.length > HELPER_OUTPUT_MAX_CHARS ? next.slice(-HELPER_OUTPUT_MAX_CHARS) : next;
+function completeUtf8Prefix(buffer: Buffer): Buffer {
+  if (buffer.length === 0) return buffer;
+
+  let leadIndex = buffer.length - 1;
+  while (leadIndex >= 0 && (buffer[leadIndex]! & 0xc0) === 0x80) leadIndex -= 1;
+  if (leadIndex < 0) return Buffer.alloc(0);
+
+  const lead = buffer[leadIndex]!;
+  const expectedBytes =
+    lead < 0x80
+      ? 1
+      : (lead & 0xe0) === 0xc0
+        ? 2
+        : (lead & 0xf0) === 0xe0
+          ? 3
+          : (lead & 0xf8) === 0xf0
+            ? 4
+            : 1;
+  return buffer.length - leadIndex < expectedBytes ? buffer.subarray(0, leadIndex) : buffer;
+}
+
+function makeBoundedProcessOutput() {
+  const chunks: Record<"stdout" | "stderr", Buffer[]> = { stdout: [], stderr: [] };
+  let acceptedBytes = 0;
+  let outputTruncated = false;
+
+  const append = (stream: "stdout" | "stderr", chunk: unknown): void => {
+    if (outputTruncated) return;
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), "utf8");
+    if (bytes.length === 0) return;
+    const remaining = ANTIGRAVITY_PROCESS_OUTPUT_MAX_BYTES - acceptedBytes;
+    if (bytes.length <= remaining) {
+      chunks[stream].push(Buffer.from(bytes));
+      acceptedBytes += bytes.length;
+      return;
+    }
+
+    outputTruncated = true;
+    if (remaining > 0) {
+      chunks[stream].push(Buffer.from(bytes.subarray(0, remaining)));
+      acceptedBytes += remaining;
+    }
+  };
+
+  const snapshot = (): AntigravityProcessOutput => {
+    const stdoutBytes = completeUtf8Prefix(Buffer.concat(chunks.stdout));
+    const stderrBytes = completeUtf8Prefix(Buffer.concat(chunks.stderr));
+    return {
+      stdout: stdoutBytes.toString("utf8"),
+      stderr: stderrBytes.toString("utf8"),
+      outputTruncated,
+      retainedOutputBytes: stdoutBytes.length + stderrBytes.length,
+    };
+  };
+
+  return { append, snapshot };
+}
+
+function spawnAntigravityProcess(
+  command: string,
+  args: ReadonlyArray<string>,
+  options: {
+    readonly cwd?: string;
+    readonly env: NodeJS.ProcessEnv;
+    readonly dependencies?: AntigravityProcessDependencies;
+  },
+): ChildProcess {
+  const prepared = (options.dependencies?.prepareProcess ?? prepareWindowsSafeProcess)(
+    command,
+    args,
+    {
+      cwd: options.cwd,
+      env: options.env,
+    },
+  );
+  return (options.dependencies?.spawnProcess ?? spawn)(prepared.command, prepared.args, {
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    env: options.env,
+    shell: prepared.shell,
+    ...(prepared.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
 }
 
 export async function runAntigravityHelperProcess(
   command: string,
   args: string[],
-  options: { cwd?: string; timeoutMs?: number } = {},
-): Promise<{
-  stdout: string;
-  stderr: string;
-  code: number;
-}> {
+  options: {
+    cwd?: string;
+    timeoutMs?: number;
+    dependencies?: AntigravityProcessDependencies;
+  } = {},
+): Promise<AntigravityProcessOutput & { code: number }> {
+  const env = buildProviderChildEnvironment({ provider: PROVIDER });
+  const child = spawnAntigravityProcess(command, args, {
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+    env,
+    ...(options.dependencies ? { dependencies: options.dependencies } : {}),
+  });
+  if (!child.stdout || !child.stderr) {
+    throw new Error("Antigravity helper process did not expose piped output streams.");
+  }
+  const stdout = child.stdout;
+  const stderr = child.stderr;
+
   return await new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd: options.cwd,
-      env: buildProviderChildEnvironment({ provider: PROVIDER }),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    let settled = false;
+    const output = makeBoundedProcessOutput();
+    let claimed = false;
+    let teardown: Promise<unknown> | undefined;
     const timeoutMs = options.timeoutMs ?? MODEL_DISCOVERY_TIMEOUT_MS;
-    const finish = (callback: () => void) => {
-      if (settled) return;
-      settled = true;
+    const onStdout = (chunk: unknown) => output.append("stdout", chunk);
+    const onStderr = (chunk: unknown) => output.append("stderr", chunk);
+    const cleanup = () => {
       clearTimeout(timer);
-      callback();
+      stdout.removeListener("data", onStdout);
+      stderr.removeListener("data", onStderr);
+      child.removeListener("error", onError);
+      child.removeListener("close", onClose);
+    };
+    const claim = (): boolean => {
+      if (claimed) return false;
+      claimed = true;
+      cleanup();
+      return true;
+    };
+    const beginTeardown = (): Promise<unknown> => {
+      if (!teardown) {
+        try {
+          teardown = Promise.resolve(
+            (options.dependencies?.teardownProcessTree ?? teardownChildProcessTree)(child),
+          );
+        } catch (cause) {
+          teardown = Promise.reject(cause);
+        }
+      }
+      return teardown;
+    };
+    const onError = (cause: Error) => {
+      if (claim()) reject(cause);
+    };
+    const onClose = (code: number | null) => {
+      if (claim()) resolve({ ...output.snapshot(), code: code ?? 1 });
     };
     const timer = setTimeout(() => {
-      child.kill("SIGKILL");
-      finish(() =>
-        reject(
-          new Error(
-            `Antigravity helper timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}`,
+      if (!claim()) return;
+      void beginTeardown().then(
+        () =>
+          reject(
+            new Error(
+              `Antigravity helper timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}`,
+            ),
           ),
-        ),
+        reject,
       );
     }, timeoutMs);
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => (stdout = appendBoundedOutput(stdout, chunk)));
-    child.stderr.on("data", (chunk) => (stderr = appendBoundedOutput(stderr, chunk)));
-    child.once("error", (cause) => finish(() => reject(cause)));
-    child.once("close", (code) => finish(() => resolve({ stdout, stderr, code: code ?? 1 })));
+
+    stdout.on("data", onStdout);
+    stderr.on("data", onStderr);
+    child.once("error", onError);
+    child.once("close", onClose);
   });
+}
+
+export function startAntigravityTurnProcess(input: {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd?: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly dependencies?: AntigravityProcessDependencies;
+  readonly onFinalize: (result: AntigravityTurnProcessResult) => Promise<void>;
+}): AntigravityTurnProcessLifecycle {
+  const child = spawnAntigravityProcess(input.command, input.args, {
+    ...(input.cwd ? { cwd: input.cwd } : {}),
+    env: input.env,
+    ...(input.dependencies ? { dependencies: input.dependencies } : {}),
+  });
+  if (!child.stdout || !child.stderr) {
+    throw new Error("Antigravity turn process did not expose piped output streams.");
+  }
+
+  const output = makeBoundedProcessOutput();
+  let teardown: Promise<unknown> | undefined;
+  let teardownRequested = false;
+  let finalizationStarted = false;
+  let resolveFinalization!: (result: AntigravityTurnProcessResult) => void;
+  let rejectFinalization!: (cause: unknown) => void;
+  const finalization = new Promise<AntigravityTurnProcessResult>((resolve, reject) => {
+    resolveFinalization = resolve;
+    rejectFinalization = reject;
+  });
+  void finalization.catch(() => undefined);
+
+  const onStdout = (chunk: unknown) => output.append("stdout", chunk);
+  const onStderr = (chunk: unknown) => output.append("stderr", chunk);
+  const cleanup = () => {
+    child.stdout?.removeListener("data", onStdout);
+    child.stderr?.removeListener("data", onStderr);
+    child.removeListener("error", onError);
+    child.removeListener("close", onClose);
+  };
+  const beginTeardown = (): Promise<unknown> => {
+    teardownRequested = true;
+    if (!teardown) {
+      try {
+        teardown = Promise.resolve(
+          (input.dependencies?.teardownProcessTree ?? teardownChildProcessTree)(child),
+        );
+      } catch (cause) {
+        teardown = Promise.reject(cause);
+      }
+    }
+    return teardown;
+  };
+  const beginFinalization = (terminal: {
+    readonly code: number | null;
+    readonly signal: NodeJS.Signals | null;
+    readonly spawnError?: unknown;
+    readonly teardownError?: unknown;
+  }): void => {
+    if (finalizationStarted) return;
+    finalizationStarted = true;
+    cleanup();
+    void (async () => {
+      let teardownError = terminal.teardownError;
+      const abnormalExit = terminal.signal !== null || (terminal.code ?? 1) !== 0;
+      const mustAwaitTeardown = teardownRequested || (!terminal.spawnError && abnormalExit);
+      if (mustAwaitTeardown && !teardownError) {
+        try {
+          await beginTeardown();
+        } catch (cause) {
+          teardownError = cause;
+        }
+      }
+      const result: AntigravityTurnProcessResult = {
+        ...output.snapshot(),
+        code: terminal.code,
+        signal: terminal.signal,
+        ...(terminal.spawnError ? { spawnError: terminal.spawnError } : {}),
+        ...(teardownError ? { teardownError } : {}),
+        teardownRequested,
+      };
+      try {
+        await input.onFinalize(result);
+      } catch (cause) {
+        rejectFinalization(teardownError ?? cause);
+        return;
+      }
+      if (teardownError) {
+        rejectFinalization(teardownError);
+      } else if (terminal.spawnError) {
+        rejectFinalization(terminal.spawnError);
+      } else {
+        resolveFinalization(result);
+      }
+    })();
+  };
+  const onError = (cause: Error) => {
+    beginFinalization({ code: child.exitCode, signal: child.signalCode, spawnError: cause });
+  };
+  const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+    beginFinalization({ code, signal });
+  };
+  const teardownAndFinalize = async (): Promise<AntigravityTurnProcessResult> => {
+    if (finalizationStarted) return await finalization;
+    try {
+      await beginTeardown();
+    } catch (cause) {
+      beginFinalization({
+        code: child.exitCode,
+        signal: child.signalCode,
+        teardownError: cause,
+      });
+    }
+    return await finalization;
+  };
+
+  child.stdout.on("data", onStdout);
+  child.stderr.on("data", onStderr);
+  child.once("error", onError);
+  child.once("close", onClose);
+
+  return { child, finalization, teardownAndFinalize };
 }
 
 export async function readCompleteAntigravityLines(
@@ -243,7 +521,10 @@ export async function readCompleteAntigravityLines(
   }
 }
 
-async function ensureCapturePlugin(binaryPath: string): Promise<void> {
+async function ensureCapturePlugin(
+  binaryPath: string,
+  dependencies?: AntigravityProcessDependencies,
+): Promise<void> {
   const pluginDir = path.join(
     os.homedir(),
     ".gemini",
@@ -275,7 +556,10 @@ async function ensureCapturePlugin(binaryPath: string): Promise<void> {
   const installed = await runAntigravityHelperProcess(
     binaryPath,
     ["plugin", "install", pluginDir],
-    { timeoutMs: PLUGIN_INSTALL_TIMEOUT_MS },
+    {
+      timeoutMs: PLUGIN_INSTALL_TIMEOUT_MS,
+      ...(dependencies ? { dependencies } : {}),
+    },
   );
   if (installed.code !== 0) {
     throw new Error(installed.stderr.trim() || installed.stdout.trim() || "Plugin install failed.");
@@ -425,7 +709,7 @@ export function makeAntigravityRuntimeEventBase(input: {
   };
 }
 
-const makeAntigravityAdapter = Effect.gen(function* () {
+const makeAntigravityAdapter = Effect.fn(function* (options: AntigravityAdapterLiveOptions = {}) {
   const serverConfig = yield* ServerConfig;
   const events = yield* Queue.unbounded<ProviderRuntimeEvent>();
   const sessions = new Map<ThreadId, AntigravitySessionContext>();
@@ -473,10 +757,10 @@ const makeAntigravityAdapter = Effect.gen(function* () {
     context: AntigravitySessionContext,
     method: string,
   ): Effect.Effect<void, ProviderAdapterRequestError> => {
-    const child = context.activeProcess;
-    if (!child) return Effect.void;
+    const lifecycle = context.activeLifecycle;
+    if (!lifecycle) return Effect.void;
     return Effect.tryPromise({
-      try: () => teardownChildProcessTree(child),
+      try: () => lifecycle.teardownAndFinalize(),
       catch: (cause) =>
         new ProviderAdapterRequestError({
           provider: PROVIDER,
@@ -707,7 +991,10 @@ const makeAntigravityAdapter = Effect.gen(function* () {
       }
       const binaryPath = trim(input.providerOptions?.antigravity?.binaryPath) ?? "agy";
       yield* Effect.tryPromise({
-        try: () => ensureCapturePlugin(binaryPath),
+        try: () =>
+          options.installCapturePlugin
+            ? options.installCapturePlugin(binaryPath)
+            : ensureCapturePlugin(binaryPath, options),
         catch: (cause) =>
           new ProviderAdapterRequestError({
             provider: PROVIDER,
@@ -778,7 +1065,7 @@ const makeAntigravityAdapter = Effect.gen(function* () {
   const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) =>
     Effect.gen(function* () {
       const context = yield* requireSession(input.threadId);
-      if (context.activeProcess) {
+      if (context.activeLifecycle) {
         return yield* new ProviderAdapterValidationError({
           provider: PROVIDER,
           operation: "turn/start",
@@ -861,12 +1148,6 @@ const makeAntigravityAdapter = Effect.gen(function* () {
         activeTurnId: turnId,
         updatedAt: new Date().toISOString(),
       };
-      offer({
-        ...base(context),
-        type: "turn.started",
-        payload: { model },
-      } satisfies ProviderRuntimeEvent);
-
       const conversationId = context.conversationId;
       const args: string[] = [
         ...(conversationId ? ["--conversation", conversationId] : ["--new-project"]),
@@ -880,99 +1161,153 @@ const makeAntigravityAdapter = Effect.gen(function* () {
         "-p",
         normalizedPrompt,
       ];
-      const child = spawn(context.binaryPath, args, {
-        cwd: context.session.cwd ?? serverConfig.cwd,
-        env: buildProviderChildEnvironment({
-          provider: PROVIDER,
-          inheritedSynaraKeys: ["SYNARA_ANTIGRAVITY_EVENTS", "SYNARA_ANTIGRAVITY_HOOK_DECISION"],
-          overrides: {
-            SYNARA_ANTIGRAVITY_EVENTS: eventFile,
-            SYNARA_ANTIGRAVITY_HOOK_DECISION: "allow",
-          },
-        }),
-        stdio: ["ignore", "pipe", "pipe"],
+      const cwd = context.session.cwd ?? serverConfig.cwd;
+      const env = buildProviderChildEnvironment({
+        provider: PROVIDER,
+        inheritedSynaraKeys: ["SYNARA_ANTIGRAVITY_EVENTS", "SYNARA_ANTIGRAVITY_HOOK_DECISION"],
+        overrides: {
+          SYNARA_ANTIGRAVITY_EVENTS: eventFile,
+          SYNARA_ANTIGRAVITY_HOOK_DECISION: "allow",
+        },
       });
-      context.activeProcess = child;
-      let stdout = "";
-      let stderr = "";
-      child.stdout.setEncoding("utf8");
-      child.stderr.setEncoding("utf8");
-      child.stdout.on("data", (chunk) => (stdout += chunk));
-      child.stderr.on("data", (chunk) => (stderr += chunk));
-      const timer = setInterval(() => void pollHookFile(context), POLL_INTERVAL_MS);
-      child.once("error", (cause) => {
-        clearInterval(timer);
-        if (sessions.get(input.threadId) !== context || context.activeProcess !== child) return;
-        offer({
-          ...base(context, { includeTurn: false }),
-          type: "runtime.error",
-          payload: {
-            message: messageFromCause(cause, "Failed to launch Antigravity CLI."),
-            class: "transport_error",
-          },
-          raw: raw("process-error", cause),
-        } satisfies ProviderRuntimeEvent);
-      });
-      child.once("close", (code, signal) => {
-        clearInterval(timer);
-        void (async () => {
-          if (sessions.get(input.threadId) !== context || context.activeProcess !== child) {
-            await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
-            return;
-          }
-          await pollHookFile(context);
-          if (!context.sawAssistant && stdout.trim()) {
-            emitTextItem(
-              context,
-              { step_index: Number.MAX_SAFE_INTEGER, type: "PRINT_OUTPUT", content: stdout.trim() },
-              "assistant_message",
-              "assistant_text",
-            );
-          }
-          const completionBase = base(context);
-          const interrupted = context.interrupted || signal !== null;
-          const failed = !interrupted && (code ?? 1) !== 0;
-          if (failed && stderr.trim()) {
+      let pollTimer: ReturnType<typeof setInterval> | undefined;
+      let lifecycle!: AntigravityTurnProcessLifecycle;
+      try {
+        lifecycle = startAntigravityTurnProcess({
+          command: context.binaryPath,
+          args,
+          cwd,
+          env,
+          dependencies: options,
+          onFinalize: async (result) => {
+            if (pollTimer) clearInterval(pollTimer);
+            if (sessions.get(input.threadId) !== context || context.activeLifecycle !== lifecycle) {
+              await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
+              return;
+            }
+
+            await pollHookFile(context);
+            if (!context.sawAssistant && result.stdout.trim()) {
+              emitTextItem(
+                context,
+                {
+                  step_index: Number.MAX_SAFE_INTEGER,
+                  type: "PRINT_OUTPUT",
+                  content: result.stdout.trim(),
+                },
+                "assistant_message",
+                "assistant_text",
+              );
+            }
+            let finalizationHookError: unknown;
+            if (options.beforeTurnFinalization) {
+              try {
+                await options.beforeTurnFinalization(result);
+              } catch (cause) {
+                finalizationHookError = cause;
+              }
+            }
+
+            const completionBase = base(context);
+            const lifecycleCause =
+              result.teardownError ?? result.spawnError ?? finalizationHookError;
+            const interrupted = !lifecycleCause && (context.interrupted || result.signal !== null);
+            const failed = Boolean(lifecycleCause) || (!interrupted && (result.code ?? 1) !== 0);
+            const failureMessage = lifecycleCause
+              ? messageFromCause(
+                  lifecycleCause,
+                  "Failed to prove the Antigravity process tree exited.",
+                )
+              : result.stderr.trim() || `Antigravity CLI exited with code ${result.code ?? 1}.`;
+            if (failed) {
+              offer({
+                ...base(context, { includeTurn: false }),
+                type: "runtime.error",
+                payload: {
+                  message: failureMessage,
+                  class: result.spawnError ? "transport_error" : "provider_error",
+                },
+                raw: raw(result.spawnError ? "process-error" : "stderr", {
+                  code: result.code,
+                  signal: result.signal,
+                  stderr: result.stderr,
+                  outputTruncated: result.outputTruncated,
+                  retainedOutputBytes: result.retainedOutputBytes,
+                }),
+              } satisfies ProviderRuntimeEvent);
+            }
+            delete context.activeLifecycle;
+            delete context.activeTurnId;
+            delete context.activePrompt;
+            delete context.eventFile;
+            const {
+              activeTurnId: _activeTurnId,
+              lastError: _lastError,
+              ...inactiveSession
+            } = context.session;
+            context.session = {
+              ...inactiveSession,
+              status: failed ? "error" : "ready",
+              ...(context.conversationId ? { resumeCursor: context.conversationId } : {}),
+              updatedAt: new Date().toISOString(),
+              ...(failed ? { lastError: failureMessage } : {}),
+            };
             offer({
-              ...base(context, { includeTurn: false }),
-              type: "runtime.error",
-              payload: { message: stderr.trim(), class: "provider_error" },
-              raw: raw("stderr", { code, stderr }),
+              ...completionBase,
+              type: "turn.completed",
+              payload: interrupted
+                ? { state: "interrupted", stopReason: "interrupted" }
+                : failed
+                  ? {
+                      state: "failed",
+                      stopReason: "error",
+                      errorMessage: failureMessage,
+                    }
+                  : { state: "completed", stopReason: "model_stop" },
+              raw: raw("process-exit", {
+                code: result.code,
+                signal: result.signal,
+                stdout: result.stdout,
+                stderr: result.stderr,
+                outputTruncated: result.outputTruncated,
+                retainedOutputBytes: result.retainedOutputBytes,
+              }),
             } satisfies ProviderRuntimeEvent);
-          }
-          delete context.activeProcess;
-          delete context.activeTurnId;
-          const {
-            activeTurnId: _activeTurnId,
-            lastError: _lastError,
-            ...inactiveSession
-          } = context.session;
-          context.session = {
-            ...inactiveSession,
-            status: failed ? "error" : "ready",
-            ...(context.conversationId ? { resumeCursor: context.conversationId } : {}),
-            updatedAt: new Date().toISOString(),
-            ...(failed
-              ? { lastError: stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.` }
-              : {}),
-          };
-          offer({
-            ...completionBase,
-            type: "turn.completed",
-            payload: interrupted
-              ? { state: "interrupted", stopReason: "interrupted" }
-              : failed
-                ? {
-                    state: "failed",
-                    stopReason: "error",
-                    errorMessage: stderr.trim() || `Antigravity CLI exited with code ${code ?? 1}.`,
-                  }
-                : { state: "completed", stopReason: "model_stop" },
-            raw: raw("process-exit", { code, signal, stdout, stderr }),
-          } satisfies ProviderRuntimeEvent);
-          await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
-        })();
-      });
+            await fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined);
+            if (finalizationHookError) throw finalizationHookError;
+          },
+        });
+      } catch (cause) {
+        context.turns.pop();
+        delete context.activeTurnId;
+        delete context.activePrompt;
+        delete context.eventFile;
+        const { activeTurnId: _activeTurnId, ...inactiveSession } = context.session;
+        context.session = {
+          ...inactiveSession,
+          status: "ready",
+          updatedAt: new Date().toISOString(),
+        };
+        yield* Effect.promise(() =>
+          fs.rm(runDir, { recursive: true, force: true }).catch(() => undefined),
+        );
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "turn/start",
+          detail: messageFromCause(cause, "Failed to launch Antigravity CLI."),
+          cause,
+        });
+      }
+      context.activeLifecycle = lifecycle;
+      pollTimer = setInterval(
+        () => void pollHookFile(context),
+        options.pollIntervalMs ?? POLL_INTERVAL_MS,
+      );
+      offer({
+        ...base(context),
+        type: "turn.started",
+        payload: { model },
+      } satisfies ProviderRuntimeEvent);
       return {
         threadId: input.threadId,
         turnId,
@@ -1045,6 +1380,7 @@ const makeAntigravityAdapter = Effect.gen(function* () {
           {
             ...(input.cwd ? { cwd: input.cwd } : {}),
             timeoutMs: MODEL_DISCOVERY_TIMEOUT_MS,
+            dependencies: options,
           },
         );
         if (result.code !== 0) throw new Error(result.stderr || "agy models failed");
@@ -1117,8 +1453,8 @@ const makeAntigravityAdapter = Effect.gen(function* () {
   } satisfies AntigravityAdapterShape;
 });
 
-export const AntigravityAdapterLive = Layer.effect(AntigravityAdapter, makeAntigravityAdapter);
+export const AntigravityAdapterLive = Layer.effect(AntigravityAdapter, makeAntigravityAdapter());
 
-export function makeAntigravityAdapterLive() {
-  return Layer.effect(AntigravityAdapter, makeAntigravityAdapter);
+export function makeAntigravityAdapterLive(options: AntigravityAdapterLiveOptions = {}) {
+  return Layer.effect(AntigravityAdapter, makeAntigravityAdapter(options));
 }


### PR DESCRIPTION
Closes #413.

## Summary

- route Antigravity helper and turn launches through the shared Windows-safe process preparation contract with `shell: false`
- preserve native executable and `.cmd` shim handling for spaces, non-ASCII paths, and metacharacter-safe arguments
- supervise teardown across exit, spawn-error, timeout, output-overflow, and racing-finalization paths
- cap aggregate stdout/stderr capture at 128 KiB and preserve deterministic error precedence and listener cleanup

## Failure and regression coverage

- native executable and `.cmd` launch preparation on Windows
- spaces, Unicode, and metacharacter sentinel non-execution
- spawn, timeout, output overflow, signal, nonzero-exit, and teardown failures
- spawn-error/teardown race remains pending until teardown settles; teardown failure wins without losing the spawn error
- descendant teardown behavior remains delegated to the existing supervised teardown primitive; this PR does not claim Goal #412 process-tree ownership

## Verification

- `bun run --cwd apps/server test -- src/provider/Layers/AntigravityAdapter.test.ts src/provider/supervisedProcessTeardown.test.ts src/windowsProcessEffect.test.ts` — 33/33 passed
- `bun run --cwd packages/shared test -- src/windowsProcess.test.ts` — 22/22 passed
- `bun fmt` — passed
- `bun lint` — passed with 235 warnings and 0 errors
- `bun typecheck` — 8/8 packages passed
- `git diff --check` — passed

Exact base: `f4a020d064317f285984ad31a09f4f7d9b2bfd65`.