### PR TITLE
fix(server): report missing Codex cwd instead of missing CLI

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -21,11 +21,13 @@ import {
   resolveCodexBrowserUsePipePath,
 } from "./codexProcessEnv";
 import {
+  assertCodexWorkingDirectoryExists,
   buildCodexInitializeParams,
   CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
   CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
   CodexAppServerManager,
   classifyCodexStderrLine,
+  formatMissingCodexWorkingDirectoryError,
   isRecoverableThreadResumeError,
   normalizeCodexModelSlug,
   readCodexAccountSnapshot,
@@ -1092,6 +1094,75 @@ describe("startSession", () => {
   it("uses an isolated scratch workspace path when no cwd is provided", () => {
     const cwd = ensureIsolatedScratchWorkspace(asThreadId("thread-1"));
     expect(cwd).toContain(`${path.sep}synara-codex-workspaces${path.sep}thread-1`);
+  });
+
+  it("reports a missing project working directory instead of a missing Codex CLI", () => {
+    const missingCwd = path.join(
+      os.tmpdir(),
+      `synara-missing-cwd-${randomUUID()}`,
+      "old-project",
+    );
+    expect(() => assertCodexWorkingDirectoryExists(missingCwd)).toThrow(
+      formatMissingCodexWorkingDirectoryError(missingCwd),
+    );
+    expect(() => assertCodexWorkingDirectoryExists(missingCwd)).toThrow(
+      /Relocate or reconnect the project/,
+    );
+    expect(formatMissingCodexWorkingDirectoryError(missingCwd)).not.toMatch(
+      /not installed|not executable/i,
+    );
+  });
+
+  it("accepts an existing project working directory", () => {
+    const cwd = mkdtempSync(path.join(os.tmpdir(), "synara-existing-cwd-"));
+    try {
+      expect(() => assertCodexWorkingDirectoryExists(cwd)).not.toThrow();
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("fails session start with missing-cwd guidance instead of missing Codex CLI", async () => {
+    const manager = new CodexAppServerManager();
+    const events: Array<{ method: string; kind: string; message?: string }> = [];
+    manager.on("event", (event) => {
+      events.push({
+        method: event.method,
+        kind: event.kind,
+        ...(event.message ? { message: event.message } : {}),
+      });
+    });
+    const missingCwd = path.join(
+      os.tmpdir(),
+      `synara-missing-session-cwd-${randomUUID()}`,
+      "old-project",
+    );
+
+    try {
+      await expect(
+        manager.startSession({
+          threadId: asThreadId("thread-missing-cwd"),
+          provider: "codex",
+          runtimeMode: "full-access",
+          cwd: missingCwd,
+          providerOptions: {
+            codex: {
+              binaryPath: process.execPath,
+            },
+          },
+        }),
+      ).rejects.toThrow(formatMissingCodexWorkingDirectoryError(missingCwd));
+      expect(events).toEqual([
+        {
+          method: "session/startFailed",
+          kind: "error",
+          message: formatMissingCodexWorkingDirectoryError(missingCwd),
+        },
+      ]);
+      expect(events[0]?.message).not.toMatch(/not installed|not executable/i);
+    } finally {
+      await manager.stopAll();
+    }
   });
 
   it("fails fast with an upgrade message when codex is below the minimum supported version", async () => {

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -21,18 +21,20 @@ import {
   resolveCodexBrowserUsePipePath,
 } from "./codexProcessEnv";
 import {
-  assertCodexWorkingDirectoryExists,
   buildCodexInitializeParams,
   CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
   CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
   CodexAppServerManager,
   classifyCodexStderrLine,
-  formatMissingCodexWorkingDirectoryError,
   isRecoverableThreadResumeError,
   normalizeCodexModelSlug,
   readCodexAccountSnapshot,
   resolveCodexModelForAccount,
 } from "./codexAppServerManager";
+import {
+  assertCodexWorkingDirectoryExists,
+  formatMissingCodexWorkingDirectoryError,
+} from "./codexWorkingDirectory";
 import { CodexJsonlFramer, CodexJsonlWriter } from "./codexAppServerTransport";
 import { ensureIsolatedScratchWorkspace } from "./scratchWorkspaces";
 import { SYNARA_HARNESS_POLICY_MARKER } from "./agentGateway/harnessPolicy.ts";
@@ -1097,11 +1099,7 @@ describe("startSession", () => {
   });
 
   it("reports a missing project working directory instead of a missing Codex CLI", () => {
-    const missingCwd = path.join(
-      os.tmpdir(),
-      `synara-missing-cwd-${randomUUID()}`,
-      "old-project",
-    );
+    const missingCwd = path.join(os.tmpdir(), `synara-missing-cwd-${randomUUID()}`, "old-project");
     expect(() => assertCodexWorkingDirectoryExists(missingCwd)).toThrow(
       formatMissingCodexWorkingDirectoryError(missingCwd),
     );

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -1,7 +1,6 @@
 import { type ChildProcessWithoutNullStreams, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { statSync } from "node:fs";
 
 import {
   ApprovalRequestId,
@@ -51,6 +50,7 @@ import { SYNARA_GATEWAY_HARNESS_POLICY } from "./agentGateway/harnessPolicy.ts";
 import type { AgentGatewaySessionLease } from "./agentGateway/sessionLease.ts";
 import { isNonFatalCodexErrorMessage } from "./codexErrorClassification.ts";
 import { buildCodexProcessEnv } from "./codexProcessEnv.ts";
+import { assertCodexWorkingDirectoryExists } from "./codexWorkingDirectory.ts";
 import {
   teardownChildProcessTree,
   teardownProviderProcessTree,
@@ -3156,31 +3156,6 @@ function readCodexProviderOptions(input: CodexAppServerStartSessionInput): {
     ...(options.binaryPath ? { binaryPath: options.binaryPath } : {}),
     ...(options.homePath ? { homePath: options.homePath } : {}),
   };
-}
-
-/**
- * Missing project CWDs often surface as spawn ENOENT (Node/Effect access the
- * working directory before the binary). Callers must distinguish that from a
- * missing Codex installation so the UI can prompt relocate/reconnect.
- */
-export function formatMissingCodexWorkingDirectoryError(cwd: string): string {
-  return `Project working directory no longer exists: ${cwd}. Relocate or reconnect the project in Synara.`;
-}
-
-export function assertCodexWorkingDirectoryExists(cwd: string): void {
-  try {
-    const stats = statSync(cwd);
-    if (!stats.isDirectory()) {
-      throw new Error(
-        `Project working directory is not a directory: ${cwd}. Relocate or reconnect the project in Synara.`,
-      );
-    }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      throw new Error(formatMissingCodexWorkingDirectoryError(cwd));
-    }
-    throw error;
-  }
 }
 
 function isMissingExecutableSpawnError(error: Error): boolean {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -1,6 +1,7 @@
 import { type ChildProcessWithoutNullStreams, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
+import { statSync } from "node:fs";
 
 import {
   ApprovalRequestId,
@@ -3157,11 +3158,50 @@ function readCodexProviderOptions(input: CodexAppServerStartSessionInput): {
   };
 }
 
+/**
+ * Missing project CWDs often surface as spawn ENOENT (Node/Effect access the
+ * working directory before the binary). Callers must distinguish that from a
+ * missing Codex installation so the UI can prompt relocate/reconnect.
+ */
+export function formatMissingCodexWorkingDirectoryError(cwd: string): string {
+  return `Project working directory no longer exists: ${cwd}. Relocate or reconnect the project in Synara.`;
+}
+
+export function assertCodexWorkingDirectoryExists(cwd: string): void {
+  try {
+    const stats = statSync(cwd);
+    if (!stats.isDirectory()) {
+      throw new Error(
+        `Project working directory is not a directory: ${cwd}. Relocate or reconnect the project in Synara.`,
+      );
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(formatMissingCodexWorkingDirectoryError(cwd));
+    }
+    throw error;
+  }
+}
+
+function isMissingExecutableSpawnError(error: Error): boolean {
+  const lower = error.message.toLowerCase();
+  return (
+    lower.includes("enoent") ||
+    lower.includes("command not found") ||
+    lower.includes("not found") ||
+    lower.includes("filesystem.access")
+  );
+}
+
 async function assertSupportedCodexCliVersion(input: {
   readonly binaryPath: string;
   readonly cwd: string;
   readonly homePath?: string;
 }): Promise<void> {
+  // Prefer an explicit cwd check before spawning. A missing working directory
+  // produces ENOENT that is otherwise misreported as a missing Codex binary.
+  assertCodexWorkingDirectoryExists(input.cwd);
+
   const env = await buildCodexProcessEnv({
     ...(input.homePath ? { homePath: input.homePath } : {}),
   });
@@ -3182,12 +3222,9 @@ async function assertSupportedCodexCliVersion(input: {
   });
 
   if (result.error) {
-    const lower = result.error.message.toLowerCase();
-    if (
-      lower.includes("enoent") ||
-      lower.includes("command not found") ||
-      lower.includes("not found")
-    ) {
+    if (isMissingExecutableSpawnError(result.error)) {
+      // Race: cwd may have disappeared between the pre-check and spawn.
+      assertCodexWorkingDirectoryExists(input.cwd);
       throw new Error(`Codex CLI (${input.binaryPath}) is not installed or not executable.`);
     }
     throw new Error(

--- a/apps/server/src/codexWorkingDirectory.ts
+++ b/apps/server/src/codexWorkingDirectory.ts
@@ -1,0 +1,26 @@
+import { statSync } from "node:fs";
+
+/**
+ * Missing project CWDs often surface as spawn ENOENT (Node/Effect access the
+ * working directory before the binary). Callers must distinguish that from a
+ * missing Codex installation so the UI can prompt relocate/reconnect.
+ */
+export function formatMissingCodexWorkingDirectoryError(cwd: string): string {
+  return `Project working directory no longer exists: ${cwd}. Relocate or reconnect the project in Synara.`;
+}
+
+export function assertCodexWorkingDirectoryExists(cwd: string): void {
+  try {
+    const stats = statSync(cwd);
+    if (!stats.isDirectory()) {
+      throw new Error(
+        `Project working directory is not a directory: ${cwd}. Relocate or reconnect the project in Synara.`,
+      );
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(formatMissingCodexWorkingDirectoryError(cwd));
+    }
+    throw error;
+  }
+}

--- a/apps/server/src/git/Layers/CodexTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.test.ts
@@ -704,6 +704,55 @@ it.layer(CodexTextGenerationTestLayer)("CodexTextGenerationLive", (it) => {
     ),
   );
 
+  it.effect("reports a missing working directory before spawning Codex", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const parent = yield* fs.makeTempDirectoryScoped({ prefix: "synara-missing-cwd-" });
+      const missingCwd = path.join(parent, "removed-project");
+      const textGeneration = yield* TextGeneration;
+
+      const result = yield* textGeneration
+        .generateBranchName({
+          cwd: missingCwd,
+          message: "Fix the missing project.",
+        })
+        .pipe(Effect.flip);
+
+      expect(result).toBeInstanceOf(TextGenerationError);
+      expect(result.message).toContain(`Project working directory no longer exists: ${missingCwd}`);
+      expect(result.message).toContain("Relocate or reconnect the project");
+    }),
+  );
+
+  it.effect("preserves missing Codex binary errors when the working directory exists", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const cwd = yield* fs.makeTempDirectoryScoped({ prefix: "synara-existing-cwd-" });
+      const missingBinary = path.join(cwd, "missing-codex-binary");
+      const textGeneration = yield* TextGeneration;
+
+      const result = yield* textGeneration
+        .generateBranchName({
+          cwd,
+          message: "Generate a branch name.",
+          providerOptions: {
+            codex: {
+              binaryPath: missingBinary,
+            },
+          },
+        })
+        .pipe(Effect.flip);
+
+      expect(result).toBeInstanceOf(TextGenerationError);
+      expect(result.message).toContain(
+        `Codex CLI (${missingBinary}) is required but not available`,
+      );
+      expect(result.message).not.toContain("working directory no longer exists");
+    }),
+  );
+
   it.effect("uses the provided codexHomePath and strips local skills config", () =>
     withFakeCodexEnv(
       {

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -11,6 +11,7 @@ import { prepareWindowsSafeProcess } from "@synara/shared/windowsProcess";
 
 import { resolveProviderAttachmentPath } from "../../provider/providerAttachmentPaths.ts";
 import { buildCodexProcessEnv } from "../../codexProcessEnv.ts";
+import { formatMissingCodexWorkingDirectoryError } from "../../codexWorkingDirectory.ts";
 import { ServerConfig } from "../../config.ts";
 import { TextGenerationError } from "../Errors.ts";
 import {
@@ -50,7 +51,6 @@ function normalizeCodexError(
   operation: string,
   error: unknown,
   fallback: string,
-  cwd?: string,
 ): TextGenerationError {
   if (Schema.is(TextGenerationError)(error)) {
     return error;
@@ -58,27 +58,10 @@ function normalizeCodexError(
 
   if (error instanceof Error) {
     const lower = error.message.toLowerCase();
-    const mentionsMissingCwd =
-      cwd !== undefined &&
-      (error.message.includes(cwd) ||
-        lower.includes("filesystem.access") ||
-        lower.includes("no such file or directory"));
-    if (
-      mentionsMissingCwd &&
-      (lower.includes("enoent") ||
-        lower.includes("notfound") ||
-        lower.includes("filesystem.access") ||
-        lower.includes("no such file or directory"))
-    ) {
-      return new TextGenerationError({
-        operation,
-        detail: `Project working directory no longer exists: ${cwd}. Relocate or reconnect the project in Synara.`,
-        cause: error,
-      });
-    }
     if (
       error.message.includes(`Command not found: ${binaryPath}`) ||
       lower.includes(`spawn ${binaryPath.toLowerCase()}`) ||
+      lower.includes("notfound: childprocess.spawn") ||
       lower.includes("enoent")
     ) {
       return new TextGenerationError({
@@ -320,13 +303,19 @@ const makeCodexTextGeneration = Effect.gen(function* () {
       const outputPath = yield* writeTempFile(operation, "codex-output", "");
       const isolatedCodexHome = yield* prepareIsolatedCodexHome(operation, resolvedCodexHomePath);
 
+      const workingDirectoryExists = fileSystem.stat(cwd).pipe(
+        Effect.map((cwdInfo) => cwdInfo.type === "Directory"),
+        Effect.catch(() => Effect.succeed(false)),
+      );
+      const missingWorkingDirectoryError = () =>
+        new TextGenerationError({
+          operation,
+          detail: formatMissingCodexWorkingDirectoryError(cwd),
+        });
+
       const runCodexCommand = Effect.gen(function* () {
-        const cwdInfo = yield* fileSystem.stat(cwd).pipe(Effect.catch(() => Effect.succeed(null)));
-        if (!cwdInfo || cwdInfo.type !== "Directory") {
-          return yield* new TextGenerationError({
-            operation,
-            detail: `Project working directory no longer exists: ${cwd}. Relocate or reconnect the project in Synara.`,
-          });
+        if (!(yield* workingDirectoryExists)) {
+          return yield* missingWorkingDirectoryError();
         }
 
         const env = yield* Effect.promise(() =>
@@ -365,13 +354,20 @@ const makeCodexTextGeneration = Effect.gen(function* () {
         const child = yield* commandSpawner
           .spawn(command)
           .pipe(
-            Effect.mapError((cause) =>
-              normalizeCodexError(
-                codexBinaryPath,
-                operation,
-                cause,
-                "Failed to spawn Codex CLI process",
-                cwd,
+            Effect.catch((cause) =>
+              workingDirectoryExists.pipe(
+                Effect.flatMap((exists) =>
+                  Effect.fail(
+                    exists
+                      ? normalizeCodexError(
+                          codexBinaryPath,
+                          operation,
+                          cause,
+                          "Failed to spawn Codex CLI process",
+                        )
+                      : missingWorkingDirectoryError(),
+                  ),
+                ),
               ),
             ),
           );

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -50,6 +50,7 @@ function normalizeCodexError(
   operation: string,
   error: unknown,
   fallback: string,
+  cwd?: string,
 ): TextGenerationError {
   if (Schema.is(TextGenerationError)(error)) {
     return error;
@@ -57,6 +58,24 @@ function normalizeCodexError(
 
   if (error instanceof Error) {
     const lower = error.message.toLowerCase();
+    const mentionsMissingCwd =
+      cwd !== undefined &&
+      (error.message.includes(cwd) ||
+        lower.includes("filesystem.access") ||
+        lower.includes("no such file or directory"));
+    if (
+      mentionsMissingCwd &&
+      (lower.includes("enoent") ||
+        lower.includes("notfound") ||
+        lower.includes("filesystem.access") ||
+        lower.includes("no such file or directory"))
+    ) {
+      return new TextGenerationError({
+        operation,
+        detail: `Project working directory no longer exists: ${cwd}. Relocate or reconnect the project in Synara.`,
+        cause: error,
+      });
+    }
     if (
       error.message.includes(`Command not found: ${binaryPath}`) ||
       lower.includes(`spawn ${binaryPath.toLowerCase()}`) ||
@@ -302,6 +321,14 @@ const makeCodexTextGeneration = Effect.gen(function* () {
       const isolatedCodexHome = yield* prepareIsolatedCodexHome(operation, resolvedCodexHomePath);
 
       const runCodexCommand = Effect.gen(function* () {
+        const cwdInfo = yield* fileSystem.stat(cwd).pipe(Effect.catch(() => Effect.succeed(null)));
+        if (!cwdInfo || cwdInfo.type !== "Directory") {
+          return yield* new TextGenerationError({
+            operation,
+            detail: `Project working directory no longer exists: ${cwd}. Relocate or reconnect the project in Synara.`,
+          });
+        }
+
         const env = yield* Effect.promise(() =>
           buildCodexProcessEnv({ homePath: isolatedCodexHome.homePath }),
         );
@@ -344,6 +371,7 @@ const makeCodexTextGeneration = Effect.gen(function* () {
                 operation,
                 cause,
                 "Failed to spawn Codex CLI process",
+                cwd,
               ),
             ),
           );


### PR DESCRIPTION
## Summary
- Closes #435
- When a thread’s project working directory is gone, Synara no longer reports `Codex CLI (…) is not installed or not executable`
- Checks the cwd first and surfaces relocate/reconnect guidance; only then treats binary ENOENT as a missing Codex install
- Same guidance applied on the Codex text-generation spawn path

## Before / after

| Case | Before | After |
|------|--------|-------|
| Missing project cwd | `Codex CLI (…) is not installed or not executable.` | `Project working directory no longer exists: …. Relocate or reconnect the project in Synara.` |
| Truly missing binary (cwd ok) | unchanged | unchanged |

## Test plan
- [x] `bunx vitest run apps/server/src/codexAppServerManager.test.ts -t "missing project|existing project|missing-cwd"`
- [ ] Manual: point a Codex thread at a deleted folder path and send a turn — error should name the missing path, not the CLI