### PR TITLE
fix(keybindings): keep Cmd+K for search and free Ctrl+K on macOS

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -73,6 +73,23 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }),
   );
 
+  it.effect("defaults sidebar.search to Cmd+K on macOS and Ctrl+K elsewhere", () =>
+    Effect.sync(() => {
+      const searchDefaults = DEFAULT_KEYBINDINGS.filter(
+        (rule) => rule.command === "sidebar.search",
+      );
+      assert.deepEqual(searchDefaults, [
+        { key: "cmd+k", command: "sidebar.search" },
+        { key: "ctrl+k", command: "sidebar.search", when: "!isMac" },
+      ]);
+      assert.isUndefined(
+        DEFAULT_KEYBINDINGS.find(
+          (rule) => rule.command === "sidebar.search" && rule.key === "mod+k",
+        ),
+      );
+    }),
+  );
+
   it.effect("compiles valid rule with parsed when AST", () =>
     Effect.sync(() => {
       const compiled = compileResolvedKeybindingRule({

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -469,6 +469,67 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  it.effect("migrates the old sidebar search default without preserving macOS Ctrl+K", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+k", command: "sidebar.search" },
+      ]);
+
+      const configState = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        return yield* keybindings.loadConfigState;
+      });
+      const searchBindings = configState.keybindings.filter(
+        (entry) => entry.command === "sidebar.search",
+      );
+      assert.deepEqual(
+        searchBindings.map((entry) => ({
+          shortcut: entry.shortcut,
+          whenAst: entry.whenAst,
+        })),
+        [
+          {
+            shortcut: {
+              key: "k",
+              metaKey: true,
+              ctrlKey: false,
+              shiftKey: false,
+              altKey: false,
+              modKey: false,
+            },
+            whenAst: undefined,
+          },
+          {
+            shortcut: {
+              key: "k",
+              metaKey: false,
+              ctrlKey: true,
+              shiftKey: false,
+              altKey: false,
+              modKey: false,
+            },
+            whenAst: { type: "not", node: { type: "identifier", name: "isMac" } },
+          },
+        ],
+      );
+
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        yield* keybindings.syncDefaultKeybindingsOnStartup;
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      assert.deepEqual(
+        persisted.filter((entry) => entry.command === "sidebar.search"),
+        [
+          { key: "cmd+k", command: "sidebar.search" },
+          { key: "ctrl+k", command: "sidebar.search", when: "!isMac" },
+        ],
+      );
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("preserves new-chat Cmd/Option/N while relaxing its terminal guard", () =>
     Effect.gen(function* () {
       const { keybindingsConfigPath } = yield* ServerConfig;

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -65,12 +65,16 @@ type WhenToken =
   | { type: "lparen" }
   | { type: "rparen" };
 
-export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
-  { key: "mod+b", command: "sidebar.toggle", when: "!terminalFocus" },
+const SIDEBAR_SEARCH_DEFAULT_KEYBINDINGS = [
   // Cmd-only on macOS so Ctrl+K stays available for kill-to-end-of-line.
   // Keep Ctrl+K on Windows/Linux (where `mod` would otherwise be Ctrl).
   { key: "cmd+k", command: "sidebar.search" },
   { key: "ctrl+k", command: "sidebar.search", when: "!isMac" },
+] as const satisfies ReadonlyArray<KeybindingRule>;
+
+export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
+  { key: "mod+b", command: "sidebar.toggle", when: "!terminalFocus" },
+  ...SIDEBAR_SEARCH_DEFAULT_KEYBINDINGS,
   { key: "mod+shift+o", command: "sidebar.addProject", when: "!terminalFocus" },
   { key: "mod+i", command: "sidebar.importThread", when: "!terminalFocus" },
   { key: "mod+alt+arrowleft", command: "space.previous", when: "!terminalFocus" },
@@ -579,6 +583,7 @@ const LEGACY_KEYBINDING_COMMAND_ALIASES = {
 const RETIRED_LEGACY_KEYBINDING_COMMANDS = new Set(["chat.newGemini"]);
 const RETIRED_LEGACY_KEYBINDING_COMMAND_PATTERN = /^(?:composer\.)?modelPicker\.jump\.[1-9]$/;
 const OUTDATED_RECENT_VIEW_TERMINAL_GUARD = "!terminalFocus";
+const OUTDATED_SIDEBAR_SEARCH_SHORTCUT = "mod+k";
 const RECENT_VIEW_SHORTCUT_BY_COMMAND: Partial<Record<KeybindingRule["command"], string>> = {
   "view.recent.next": "ctrl+tab",
   "view.recent.previous": "ctrl+shift+tab",
@@ -667,6 +672,29 @@ function migrateOutdatedDefaultKeybindingRule(rule: KeybindingRule): {
     },
     migrated: true,
   };
+}
+
+// The original sidebar search default used `mod+k`, which resolves to Ctrl+K on
+// Windows/Linux but also captures the native kill-to-end-of-line chord on macOS.
+// Expand only that exact shipped default so other user-defined search chords remain intact.
+function migrateOutdatedSidebarSearchDefault(rules: readonly KeybindingRule[]): {
+  readonly rules: KeybindingRule[];
+  readonly migratedCount: number;
+} {
+  let migratedCount = 0;
+  const next = rules.flatMap((rule) => {
+    if (
+      rule.command !== "sidebar.search" ||
+      rule.key !== OUTDATED_SIDEBAR_SEARCH_SHORTCUT ||
+      rule.when !== undefined
+    ) {
+      return [rule];
+    }
+
+    migratedCount += 1;
+    return SIDEBAR_SEARCH_DEFAULT_KEYBINDINGS.map((binding) => ({ ...binding }));
+  });
+  return { rules: next, migratedCount };
 }
 
 // Add the `|| isMac` escape hatch to new-surface creation commands still pinned to the
@@ -939,7 +967,9 @@ const makeKeybindings = Effect.gen(function* () {
       keybindings.push(migratedDefaultRule.rule);
     }
 
-    const relaxed = relaxCreationCommandTerminalGuards(keybindings);
+    const sidebarSearchMigration = migrateOutdatedSidebarSearchDefault(keybindings);
+    migratedDefaultRuleCount += sidebarSearchMigration.migratedCount;
+    const relaxed = relaxCreationCommandTerminalGuards(sidebarSearchMigration.rules);
     migratedDefaultRuleCount += relaxed.migratedCount;
 
     return {

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -67,7 +67,10 @@ type WhenToken =
 
 export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+b", command: "sidebar.toggle", when: "!terminalFocus" },
-  { key: "mod+k", command: "sidebar.search" },
+  // Cmd-only on macOS so Ctrl+K stays available for kill-to-end-of-line.
+  // Keep Ctrl+K on Windows/Linux (where `mod` would otherwise be Ctrl).
+  { key: "cmd+k", command: "sidebar.search" },
+  { key: "ctrl+k", command: "sidebar.search", when: "!isMac" },
   { key: "mod+shift+o", command: "sidebar.addProject", when: "!terminalFocus" },
   { key: "mod+i", command: "sidebar.importThread", when: "!terminalFocus" },
   { key: "mod+alt+arrowleft", command: "space.previous", when: "!terminalFocus" },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4907,20 +4907,6 @@ export default function Sidebar() {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) return;
 
-      if (
-        (event.metaKey || event.ctrlKey) &&
-        event.key === "k" &&
-        !event.shiftKey &&
-        !event.altKey
-      ) {
-        event.preventDefault();
-        event.stopPropagation();
-        setSearchPaletteMode("search");
-        setSearchPaletteInitialQuery(null);
-        setSearchPaletteOpen((prev) => !prev || searchPaletteMode !== "search");
-        return;
-      }
-
       const shortcutContext = getCurrentSidebarShortcutContext();
       if (!shouldIgnoreThreadJumpHintUpdate(event)) {
         const shouldShowHints = shouldShowThreadJumpHints(event, keybindings, {

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -114,7 +114,13 @@ const DEFAULT_BINDINGS = compile([
     command: "sidebar.toggle",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
-  { shortcut: modShortcut("k"), command: "sidebar.search" },
+  // Mirror server defaults: Cmd+K everywhere; Ctrl+K only off macOS.
+  { shortcut: modShortcut("k", { metaKey: true, modKey: false }), command: "sidebar.search" },
+  {
+    shortcut: ctrlShortcut("k"),
+    command: "sidebar.search",
+    whenAst: whenNot(whenIdentifier("isMac")),
+  },
   { shortcut: modShortcut("j"), command: "terminal.toggle" },
   {
     shortcut: modShortcut("d"),
@@ -1128,6 +1134,44 @@ describe("chat/editor shortcuts", () => {
         context: { terminalFocus: true },
       }),
       "sidebar.search",
+    );
+  });
+
+  it("keeps Cmd+K for sidebar.search on macOS and releases Ctrl+K", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "k", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+      "sidebar.search",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "k", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+      null,
+    );
+    assert.strictEqual(
+      shortcutLabelForCommand(DEFAULT_BINDINGS, "sidebar.search", "MacIntel"),
+      "⌘K",
+    );
+  });
+
+  it("keeps Ctrl+K for sidebar.search on Windows and Linux", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "k", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Win32",
+      }),
+      "sidebar.search",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "k", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux x86_64",
+      }),
+      "sidebar.search",
+    );
+    assert.strictEqual(
+      shortcutLabelForCommand(DEFAULT_BINDINGS, "sidebar.search", "Win32"),
+      "Ctrl+K",
     );
   });
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -534,6 +534,14 @@ export function shortcutLabelForCommand(
   const contextProvided = resolvedOptions?.context !== undefined;
 
   if (!contextProvided) {
+    // Honor platform-gated `when` clauses (e.g. `isMac` / `!isMac`) using default
+    // focus flags so labels stay correct without a full UI context.
+    const platformAware = findEffectiveShortcutForCommand(keybindings, command, { platform });
+    if (platformAware) {
+      return formatShortcutLabel(platformAware, platform);
+    }
+    // Fall back to the last binding ignoring `when` so focus-gated chords
+    // (e.g. terminal-only) still surface a label in chrome affordances.
     for (let index = keybindings.length - 1; index >= 0; index -= 1) {
       const binding = keybindings[index];
       if (!binding || binding.command !== command) continue;


### PR DESCRIPTION
## Summary
- Closes #432
- Default `sidebar.search` is now `cmd+k`, plus `ctrl+k` only when `!isMac`
- On macOS, Ctrl+K is left for native kill-to-end-of-line
- Windows/Linux still use Ctrl+K for search
- Shortcut labels without full UI context now honor platform-gated `when` clauses (macOS shows `⌘K`)

## Before / after

| Platform | Cmd/Meta+K | Ctrl+K | Label |
|----------|------------|--------|-------|
| macOS | `sidebar.search` | released | `⌘K` |
| Windows/Linux | — | `sidebar.search` | `Ctrl+K` |

## Test plan
- [x] `bunx vitest run apps/web/src/keybindings.test.ts`
- [x] Server default binding assertion for `sidebar.search`
- [ ] Manual on macOS: Cmd+K opens search; Ctrl+K does not steal kill-to-end-of-line in a text field