### PR TITLE
fix(browser): restore Synara browser control

### DIFF
--- a/apps/desktop/src/browserUsePipeServer.test.ts
+++ b/apps/desktop/src/browserUsePipeServer.test.ts
@@ -97,7 +97,7 @@ describe("browser-use pipe path resolution", () => {
   it("creates a discoverable unix socket path under the Codex browser-use directory", () => {
     const pipePath = resolveDefaultBrowserUsePipePath("darwin");
 
-    expect(dirname(pipePath)).toBe(`${tmpdir()}/codex-browser-use`);
+    expect(dirname(pipePath)).toBe("/tmp/codex-browser-use");
     expect(basename(pipePath)).toMatch(/^synara-iab-\d+-[0-9a-f-]{36}\.sock$/);
   });
 
@@ -161,7 +161,13 @@ describe("browser-use pipe RPC compatibility", () => {
       });
       expect(info).toMatchObject({
         id: 1,
-        result: { type: "iab", metadata: { codexSessionId: "codex-session-1" } },
+        result: {
+          type: "iab",
+          metadata: {
+            codexAppBuildFlavor: "prod",
+            codexSessionId: "codex-session-1",
+          },
+        },
       });
 
       await expect(

--- a/apps/desktop/src/browserUsePipeServer.ts
+++ b/apps/desktop/src/browserUsePipeServer.ts
@@ -21,8 +21,11 @@ const BROWSER_USE_MAX_QUEUED_OUTPUT_BYTES = 1024 * 1024;
 const BROWSER_USE_INITIAL_URL = "about:blank";
 const BROWSER_USE_PANEL_READY_TIMEOUT_MS = 2_000;
 const BROWSER_USE_PANEL_READY_POLL_MS = 50;
-const BROWSER_USE_PIPE_DIR = "codex-browser-use";
+// The Browser plugin scans this fixed directory; OS.tmpdir() differs on macOS.
+const BROWSER_USE_DISCOVERY_DIR = "/tmp/codex-browser-use";
 const BROWSER_USE_PIPE_NAME_PREFIX = "synara-iab";
+// Production Browser plugins reject IAB backends from another build flavor.
+const BROWSER_USE_CODEX_APP_BUILD_FLAVOR = "prod";
 export const SYNARA_BROWSER_USE_PIPE_ENV = "SYNARA_BROWSER_USE_PIPE_PATH";
 
 type BrowserUseRpcId = string | number;
@@ -63,9 +66,8 @@ interface BrowserUsePipeServerOptions {
 
 export function resolveDefaultBrowserUsePipePath(platform = process.platform): string {
   if (platform === "win32") return "";
-  return Path.join(
-    OS.tmpdir(),
-    BROWSER_USE_PIPE_DIR,
+  return Path.posix.join(
+    BROWSER_USE_DISCOVERY_DIR,
     `${BROWSER_USE_PIPE_NAME_PREFIX}-${process.pid}-${Crypto.randomUUID()}.sock`,
   );
 }
@@ -371,7 +373,10 @@ export class BrowserUsePipeServer {
           name: "Synara In-app Browser",
           version: "0.1.0",
           type: "iab",
-          metadata: { codexSessionId },
+          metadata: {
+            codexAppBuildFlavor: BROWSER_USE_CODEX_APP_BUILD_FLAVOR,
+            codexSessionId,
+          },
         };
       }
       case "getTabs":

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -684,6 +684,49 @@ describe("buildCodexProcessEnv", () => {
     expect(env.NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS).toBe("/tmp/codex-browser-use/synara.sock");
   });
 
+  it("forwards the browser-use socket capability to the Browser MCP helper", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "synara-codex-env-"));
+    const runtimeHome = mkdtempSync(path.join(os.tmpdir(), "synara-runtime-home-"));
+    try {
+      writeFileSync(
+        path.join(tempDir, "config.toml"),
+        [
+          "[mcp_servers.node_repl]",
+          'command = "/tmp/node_repl"',
+          'env_vars = ["EXISTING_BROWSER_ENV"]',
+          "",
+          "[mcp_servers.node_repl.env]",
+          'BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"',
+        ].join("\n"),
+        "utf8",
+      );
+
+      const env = await buildCodexProcessEnv({
+        env: {
+          SYNARA_HOME: runtimeHome,
+          SYNARA_BROWSER_USE_PIPE_PATH: "/tmp/codex-browser-use/synara.sock",
+        },
+        homePath: tempDir,
+        platform: "darwin",
+      });
+
+      const codexHome = env.CODEX_HOME;
+      if (typeof codexHome !== "string") {
+        throw new Error("Expected CODEX_HOME to be set.");
+      }
+      const overlayConfig = readFileSync(path.join(codexHome, "config.toml"), "utf8");
+      expect(overlayConfig).toContain(
+        'env_vars = ["NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS", "EXISTING_BROWSER_ENV"]',
+      );
+      expect(readFileSync(path.join(tempDir, "config.toml"), "utf8")).toContain(
+        'env_vars = ["EXISTING_BROWSER_ENV"]',
+      );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+      rmSync(runtimeHome, { recursive: true, force: true });
+    }
+  });
+
   it("resolves the browser-use pipe path from desktop env aliases", () => {
     expect(
       resolveCodexBrowserUsePipePath({

--- a/apps/server/src/codexProcessEnv.ts
+++ b/apps/server/src/codexProcessEnv.ts
@@ -19,6 +19,7 @@ import { buildProviderChildEnvironment } from "./providerChildEnvironment.ts";
 
 const CODEX_PROCESS_SHELL_ENV_NAMES = ["PATH", "SSH_AUTH_SOCK"] as const;
 const NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS = "NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS";
+const NODE_REPL_MCP_SERVER_HEADER = "[mcp_servers.node_repl]";
 const CODEX_OVERLAY_SHARED_STATE_FILES = new Set(["auth.json"]);
 const SYNARA_CONFIG_SUPPRESSIONS_FILE = "synara-config-suppressions-v1.json";
 const MAX_CONFIG_SUPPRESSION_SECTIONS = 32;
@@ -461,11 +462,17 @@ function findTomlArrayEnd(input: string, openBracketIndex: number): number | und
   return undefined;
 }
 
-export function mergeShellEnvPolicyExclude(config: string, envVarName: string): string {
-  if (!envVarName) {
+function mergeTomlStringArrayValues(
+  config: string,
+  tableHeader: string,
+  key: string,
+  values: readonly string[],
+): string {
+  const additions = [...new Set(values.filter(Boolean))];
+  if (additions.length === 0) {
     return config;
   }
-  const headerMatch = findTomlTableHeader(config, "[shell_environment_policy]");
+  const headerMatch = findTomlTableHeader(config, tableHeader);
   if (!headerMatch) {
     return config;
   }
@@ -473,28 +480,40 @@ export function mergeShellEnvPolicyExclude(config: string, envVarName: string): 
   const tableEnd = findNextTomlTableHeaderIndex(config, tableStart);
   const tableBody = config.slice(tableStart, tableEnd);
   const activeTableBody = maskTomlComments(tableBody);
-  const quotedVar = JSON.stringify(envVarName);
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const arrayPattern = new RegExp(`(^[\\t ]*${escapedKey}[\\t ]*=[\\t ]*\\[)`, "m");
+  const arrayMatch = arrayPattern.exec(activeTableBody);
 
-  const excludePattern = /(^[\t ]*exclude[\t ]*=[\t ]*\[)/m;
-  const excludeMatch = excludePattern.exec(activeTableBody);
-  if (excludeMatch) {
-    const openBracketIndex = excludeMatch.index + excludeMatch[0].lastIndexOf("[");
+  if (arrayMatch) {
+    const openBracketIndex = arrayMatch.index + arrayMatch[0].lastIndexOf("[");
     const closeBracketIndex = findTomlArrayEnd(activeTableBody, openBracketIndex);
-    const activeExcludeArray = activeTableBody.slice(
-      openBracketIndex + 1,
-      closeBracketIndex ?? activeTableBody.length,
-    );
-    const escapedEnvVarName = envVarName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const exactStringPattern = new RegExp(`(["'])${escapedEnvVarName}\\1`);
-    if (exactStringPattern.test(activeExcludeArray)) {
+    if (closeBracketIndex === undefined) {
+      return config;
+    }
+    const activeArray = activeTableBody.slice(openBracketIndex + 1, closeBracketIndex);
+    const missing = additions.filter((value) => {
+      const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      return !new RegExp(`(["'])${escapedValue}\\1`).test(activeArray);
+    });
+    if (missing.length === 0) {
       return config;
     }
 
     const insertAt = tableStart + openBracketIndex + 1;
-    return `${config.slice(0, insertAt)}${quotedVar}, ${config.slice(insertAt)}`;
+    const separator = activeArray.trim().length > 0 ? ", " : "";
+    return `${config.slice(0, insertAt)}${missing.map((value) => JSON.stringify(value)).join(", ")}${separator}${config.slice(insertAt)}`;
   }
 
-  return `${config.slice(0, tableStart)}\nexclude = [${quotedVar}]${config.slice(tableStart)}`;
+  return `${config.slice(0, tableStart)}\n${key} = [${additions.map((value) => JSON.stringify(value)).join(", ")}]${config.slice(tableStart)}`;
+}
+
+export function mergeShellEnvPolicyExclude(config: string, envVarName: string): string {
+  return mergeTomlStringArrayValues(
+    config,
+    "[shell_environment_policy]",
+    "exclude",
+    envVarName ? [envVarName] : [],
+  );
 }
 
 function appendManagedCodexConfigSection(config: string, section: string): string {
@@ -600,6 +619,14 @@ async function prepareSynaraCodexHomeOverlayUnlocked(input: {
       overlayConfig = mergeShellEnvPolicyExclude(overlayConfig, tokenEnvVar);
     }
   }
+  // Codex launches stdio MCP helpers with an environment allowlist, so the
+  // Browser helper must opt in to the socket capability set on its parent.
+  overlayConfig = mergeTomlStringArrayValues(
+    overlayConfig,
+    NODE_REPL_MCP_SERVER_HEADER,
+    "env_vars",
+    [NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS],
+  );
   await fs.writeFile(overlayConfigPath, overlayConfig, "utf8");
   await writeSynaraConfigSuppressions(suppressionMarkerPath, suppressedSections);
 


### PR DESCRIPTION
## Summary

- Put Synara's IAB socket in the fixed discovery directory scanned by the Browser plugin.
- Forward the native socket capability to the `node_repl` MCP helper through Synara's Codex config overlay without changing the user's source config.
- Report the production Codex app build flavor required by Browser backend selection.
- Add regression coverage for socket discovery, metadata, and MCP environment forwarding.

## Root cause

The Browser plugin could not select Synara's in-app browser for three independent reasons on macOS: Synara used the platform temp directory instead of `/tmp/codex-browser-use`, the stdio MCP helper did not receive `NODE_REPL_SANDBOX_ALLOWED_UNIX_SOCKETS`, and the IAB metadata omitted `codexAppBuildFlavor`.

## Before / after

| Before | After |
| --- | --- |
| Synara sockets were outside the plugin's scan root on macOS. | Sockets are created under `/tmp/codex-browser-use`. |
| The Browser MCP helper lost the native socket capability. | The overlay adds the capability to `mcp_servers.node_repl.env_vars`. |
| The plugin rejected the IAB backend with no build flavor. | Synara reports `codexAppBuildFlavor: "prod"`. |

## Test plan

- [x] `bun run fmt:check`
- [x] `bun run lint` (0 errors)
- [x] `bun run test` (8 tasks; 2,708 server tests plus package suites)
- [x] `bun run --cwd apps/web test:browser:stable` (188 passed)
- [x] `bun run --cwd apps/web test:browser:geometry` (11 passed)
- [x] `bun run build:desktop` and preload bridge verification
- [x] `bun run test:desktop-smoke`
- [x] `bun run release:smoke`
- [x] Browser helper/plugin discovery smoke against the Synara IAB pipe
- [ ] `bun run typecheck` is blocked by two pre-existing `origin/main` errors in unchanged files: missing `RuntimeItemId` in `DroidAdapter.ts` and missing `sessionScope` in `GrokAdapter.ts`.
