### PR TITLE
fix(providers): preserve blank PATH defaults

### DIFF
--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -1,0 +1,109 @@
+import { DEFAULT_SERVER_SETTINGS, ProviderSessionStartInput } from "@synara/contracts";
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+import { providerStartOptionsFromServerSettings } from "./serverSettings";
+
+const decodeProviderSessionStartInput = Schema.decodeUnknownSync(ProviderSessionStartInput);
+
+describe("providerStartOptionsFromServerSettings", () => {
+  it("omits blank launch settings from provider session input", () => {
+    const settings = {
+      ...DEFAULT_SERVER_SETTINGS,
+      providers: {
+        codex: {
+          ...DEFAULT_SERVER_SETTINGS.providers.codex,
+          binaryPath: "",
+          homePath: "",
+        },
+        claudeAgent: {
+          ...DEFAULT_SERVER_SETTINGS.providers.claudeAgent,
+          binaryPath: "",
+        },
+        cursor: {
+          ...DEFAULT_SERVER_SETTINGS.providers.cursor,
+          binaryPath: "",
+          apiEndpoint: "",
+        },
+        antigravity: {
+          ...DEFAULT_SERVER_SETTINGS.providers.antigravity,
+          binaryPath: "",
+        },
+        grok: {
+          ...DEFAULT_SERVER_SETTINGS.providers.grok,
+          binaryPath: "",
+        },
+        droid: {
+          ...DEFAULT_SERVER_SETTINGS.providers.droid,
+          binaryPath: "",
+        },
+        kilo: {
+          ...DEFAULT_SERVER_SETTINGS.providers.kilo,
+          binaryPath: "",
+          serverUrl: "",
+        },
+        opencode: {
+          ...DEFAULT_SERVER_SETTINGS.providers.opencode,
+          binaryPath: "",
+          serverUrl: "",
+        },
+        pi: {
+          ...DEFAULT_SERVER_SETTINGS.providers.pi,
+          binaryPath: "",
+          agentDir: "",
+        },
+      },
+    };
+
+    const providerOptions = providerStartOptionsFromServerSettings(settings);
+
+    expect(() =>
+      decodeProviderSessionStartInput({
+        threadId: "thread-1",
+        provider: "codex",
+        providerOptions,
+        runtimeMode: "full-access",
+      }),
+    ).not.toThrow();
+    expect(providerOptions.codex).toEqual({});
+    expect(providerOptions.claudeAgent).toEqual({});
+    expect(providerOptions.cursor).toEqual({});
+    expect(providerOptions.antigravity).toEqual({});
+    expect(providerOptions.grok).toEqual({});
+    expect(providerOptions.droid).toEqual({});
+    expect(providerOptions.kilo).toEqual({});
+    expect(providerOptions.opencode).toEqual({ experimentalWebSockets: false });
+    expect(providerOptions.pi).toEqual({});
+  });
+
+  it("preserves configured launch settings", () => {
+    const settings = {
+      ...DEFAULT_SERVER_SETTINGS,
+      providers: {
+        ...DEFAULT_SERVER_SETTINGS.providers,
+        codex: {
+          ...DEFAULT_SERVER_SETTINGS.providers.codex,
+          binaryPath: "/custom/bin/codex",
+          homePath: "/custom/codex-home",
+        },
+        opencode: {
+          ...DEFAULT_SERVER_SETTINGS.providers.opencode,
+          binaryPath: "/custom/bin/opencode",
+          serverUrl: "http://127.0.0.1:4096",
+          experimentalWebSockets: true,
+        },
+      },
+    };
+
+    const providerOptions = providerStartOptionsFromServerSettings(settings);
+
+    expect(providerOptions.codex).toEqual({
+      binaryPath: "/custom/bin/codex",
+      homePath: "/custom/codex-home",
+    });
+    expect(providerOptions.opencode).toEqual({
+      binaryPath: "/custom/bin/opencode",
+      serverUrl: "http://127.0.0.1:4096",
+      experimentalWebSockets: true,
+    });
+  });
+});

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -52,28 +52,36 @@ export function providerStartOptionsFromServerSettings(
   const { providers } = settings;
   return {
     codex: {
-      binaryPath: providers.codex.binaryPath,
+      ...(providers.codex.binaryPath ? { binaryPath: providers.codex.binaryPath } : {}),
       ...(providers.codex.homePath ? { homePath: providers.codex.homePath } : {}),
     },
-    claudeAgent: { binaryPath: providers.claudeAgent.binaryPath },
+    claudeAgent: {
+      ...(providers.claudeAgent.binaryPath ? { binaryPath: providers.claudeAgent.binaryPath } : {}),
+    },
     cursor: {
-      binaryPath: providers.cursor.binaryPath,
+      ...(providers.cursor.binaryPath ? { binaryPath: providers.cursor.binaryPath } : {}),
       ...(providers.cursor.apiEndpoint ? { apiEndpoint: providers.cursor.apiEndpoint } : {}),
     },
-    antigravity: { binaryPath: providers.antigravity.binaryPath },
-    grok: { binaryPath: providers.grok.binaryPath },
-    droid: { binaryPath: providers.droid.binaryPath },
+    antigravity: {
+      ...(providers.antigravity.binaryPath ? { binaryPath: providers.antigravity.binaryPath } : {}),
+    },
+    grok: {
+      ...(providers.grok.binaryPath ? { binaryPath: providers.grok.binaryPath } : {}),
+    },
+    droid: {
+      ...(providers.droid.binaryPath ? { binaryPath: providers.droid.binaryPath } : {}),
+    },
     kilo: {
-      binaryPath: providers.kilo.binaryPath,
+      ...(providers.kilo.binaryPath ? { binaryPath: providers.kilo.binaryPath } : {}),
       ...(providers.kilo.serverUrl ? { serverUrl: providers.kilo.serverUrl } : {}),
     },
     opencode: {
-      binaryPath: providers.opencode.binaryPath,
+      ...(providers.opencode.binaryPath ? { binaryPath: providers.opencode.binaryPath } : {}),
       ...(providers.opencode.serverUrl ? { serverUrl: providers.opencode.serverUrl } : {}),
       experimentalWebSockets: providers.opencode.experimentalWebSockets,
     },
     pi: {
-      binaryPath: providers.pi.binaryPath,
+      ...(providers.pi.binaryPath ? { binaryPath: providers.pi.binaryPath } : {}),
       ...(providers.pi.agentDir ? { agentDir: providers.pi.agentDir } : {}),
     },
   };


### PR DESCRIPTION
## Summary

- Omit blank persisted provider binary paths and optional launch strings before constructing provider session options.
- Preserve explicit binary paths, endpoints, directories, and OpenCode WebSocket configuration.
- Add regression coverage for every provider plus configured override preservation.

## Root cause

The settings UI intentionally stores a blank binary path to mean “use the provider command from PATH.” The server-owned settings mapper added in `af057220` forwarded those blank strings as explicit `ProviderStartOptions`. The provider session contract allows those fields to be absent but rejects empty strings, so every new turn could fail validation before the adapter started.

## Before / after

| Before | After |
| --- | --- |
| Blank provider paths were sent as `binaryPath: ""`. | Blank optional launch settings are omitted. |
| Session startup failed during contract validation. | Providers fall back to their normal PATH command. |
| Explicit overrides were mixed with invalid defaults. | Explicit overrides remain unchanged. |

## Test plan

- [x] Regression test reproduced the exact `providerOptions.codex.binaryPath` validation failure before the fix.
- [x] Real persisted Synara settings pass the provider session contract after the fix.
- [x] `bun run fmt:check`
- [x] `bun run lint` (0 errors)
- [x] `bun run test -- --concurrency=1` (8 tasks; 2,993 web tests and 2,707 server tests passed)
- [x] Shared/provider-focused suites (577 tests passed)
- [ ] `bun run typecheck` is blocked by two pre-existing `origin/main` errors in unchanged files: missing `RuntimeItemId` in `DroidAdapter.ts` and missing `sessionScope` in `GrokAdapter.ts`.
