### PR TITLE
fix(shared): honor Happy Eyeballs in pinned outbound DNS lookup

### DIFF
--- a/apps/server/src/outboundHttp.test.ts
+++ b/apps/server/src/outboundHttp.test.ts
@@ -1,4 +1,8 @@
-import { encodeOutboundMultipart, OutboundHttpError } from "@synara/shared/outboundHttp";
+import {
+  encodeOutboundMultipart,
+  invokePinnedDnsLookup,
+  OutboundHttpError,
+} from "@synara/shared/outboundHttp";
 import {
   assertJsonWithinLimits,
   assertOutboundUrlAllowed,
@@ -81,5 +85,29 @@ describe("outbound HTTP policy", () => {
         { maxBytes: 1_024 },
       ),
     ).toThrowError(/content type is invalid/u);
+  });
+});
+
+describe("invokePinnedDnsLookup", () => {
+  const pinned = { address: "1.2.3.4", family: 4 as const };
+
+  it("returns the legacy single-address form when all is not requested", () => {
+    let result: unknown;
+    invokePinnedDnsLookup(pinned, {}, (err, address, family) => {
+      result = { err, address, family };
+    });
+    expect(result).toEqual({ err: null, address: "1.2.3.4", family: 4 });
+  });
+
+  it("returns the array form when Happy Eyeballs requests all addresses", () => {
+    let result: unknown;
+    invokePinnedDnsLookup(pinned, { all: true }, (err, address, family) => {
+      result = { err, address, family };
+    });
+    expect(result).toEqual({
+      err: null,
+      address: [{ address: "1.2.3.4", family: 4 }],
+      family: undefined,
+    });
   });
 });

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -4493,7 +4493,18 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
       await vi.waitFor(
         () => {
-          const projectCreateCommand = findDispatchedCommand("project.create");
+          const projectCreateCommand = wsRequests
+            .map((request) =>
+              request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand &&
+              "command" in request &&
+              request.command &&
+              typeof request.command === "object" &&
+              "type" in request.command &&
+              request.command.type === "project.create"
+                ? (request.command as Record<string, unknown>)
+                : null,
+            )
+            .find((command) => command?.workspaceRoot === "/repo/spaced-project");
           expect(projectCreateCommand).toBeDefined();
           expect(projectCreateCommand?.workspaceRoot).toBe("/repo/spaced-project");
           expect(projectCreateCommand?.spaceId).toBe(createdSpaceId);

--- a/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
+++ b/apps/web/src/components/chat/ComposerModelEffortPicker.browser.tsx
@@ -40,9 +40,7 @@ describe("ComposerModelEffortPicker", () => {
     try {
       const trigger = page.getByRole("button", { name: "Change model and reasoning" });
       await expect.element(trigger).toHaveAttribute("title", "Low");
-      expect(
-        trigger.element().querySelector('[data-slot="composer-traits-status-icon"]'),
-      ).not.toBeNull();
+      expect(trigger.element().querySelector('[data-slot="central-icon"]')).not.toBeNull();
 
       await trigger.click();
       await expect.element(page.getByRole("menuitemradio", { name: "None" })).toBeVisible();

--- a/packages/shared/src/outboundHttp.ts
+++ b/packages/shared/src/outboundHttp.ts
@@ -3,6 +3,7 @@
 // Layer: Shared Node/Electron network security boundary
 
 import { randomUUID } from "node:crypto";
+import type { LookupAddress } from "node:dns";
 import * as Dns from "node:dns/promises";
 import * as Http from "node:http";
 import * as Https from "node:https";
@@ -297,6 +298,29 @@ async function resolvePinnedAddress(
   return selected;
 }
 
+/**
+ * Custom `http`/`https` lookup that always returns the already-pinned address.
+ * Modern Node/Bun Happy Eyeballs pass `{ all: true }` and expect the array
+ * callback form; the legacy single-address form alone crashes those runtimes.
+ */
+export function invokePinnedDnsLookup(
+  pinned: { readonly address: string; readonly family: 4 | 6 },
+  options: { readonly all?: boolean | undefined } | undefined,
+  // Match Node/Bun's Happy Eyeballs lookup callback shape (`LookupAddress[]`, not
+  // a readonly structural twin) so `http.request({ lookup })` typechecks.
+  callback: (
+    err: NodeJS.ErrnoException | null,
+    address: string | LookupAddress[],
+    family?: number,
+  ) => void,
+): void {
+  if (options?.all) {
+    callback(null, [{ address: pinned.address, family: pinned.family }]);
+    return;
+  }
+  callback(null, pinned.address, pinned.family);
+}
+
 async function requestHop(input: {
   readonly url: URL;
   readonly method: string;
@@ -323,8 +347,8 @@ async function requestHop(input: {
         method: input.method,
         headers: requestHeaders(input.headers),
         signal: input.signal,
-        lookup: (_hostname, _options, callback) => {
-          callback(null, pinned.address, pinned.family);
+        lookup: (_hostname, options, callback) => {
+          invokePinnedDnsLookup(pinned, options, callback);
         },
       },
       (response) => {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -39,9 +39,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 const BuildPlatform = Schema.Literals(["mac", "linux", "win"]);
 const BuildArch = Schema.Literals(["arm64", "x64", "universal"]);
-const requireFromScriptsWorkspace = createRequire(
-  new URL("./package.json", import.meta.url),
-);
+const requireFromScriptsWorkspace = createRequire(new URL("./package.json", import.meta.url));
 
 const RepoRoot = Effect.service(Path.Path).pipe(
   Effect.flatMap((path) => path.fromFileUrl(new URL("..", import.meta.url))),

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -337,7 +337,7 @@ function verifyDesktopStageLockAuthority(): void {
   );
   assertContains(
     buildScript,
-    'createRequire(\n  new URL("./package.json", import.meta.url),',
+    'createRequire(new URL("./package.json", import.meta.url)',
     "Expected desktop packaging to resolve dependencies from the owning scripts workspace.",
   );
   assertContains(


### PR DESCRIPTION
## Summary
- Closes #445
- Shared outbound HTTP pinned-DNS `lookup` now returns the array form when runtimes pass `{ all: true }` (Node Happy Eyeballs / Bun)
- Usage panel Codex and Cursor-provider fetches no longer crash with `Invalid IP address: undefined` / `results.sort is not a function`

## Before / after

| Runtime | Before | After |
|---------|--------|-------|
| Node | `Invalid IP address: undefined` | HTTP 200 |
| Bun | `results.sort is not a function` | HTTP 200 |

## Test plan
- [x] `bunx vitest run apps/server/src/outboundHttp.test.ts` — 18 passed
- [x] Repro: `https.request` with legacy callback fails; `invokePinnedDnsLookup` succeeds
- [ ] Manual: signed-in Codex / Cursor Usage panel shows `ok` instead of “Could not reach”