### PR TITLE
fix(outbound): pin DNS correctly under autoSelectFamily (Happy Eyeballs)

### DIFF
--- a/apps/server/src/outboundHttp.test.ts
+++ b/apps/server/src/outboundHttp.test.ts
@@ -1,4 +1,8 @@
-import { encodeOutboundMultipart, OutboundHttpError } from "@synara/shared/outboundHttp";
+import {
+  createPinnedLookup,
+  encodeOutboundMultipart,
+  OutboundHttpError,
+} from "@synara/shared/outboundHttp";
 import {
   assertJsonWithinLimits,
   assertOutboundUrlAllowed,
@@ -55,6 +59,37 @@ describe("outbound HTTP policy", () => {
     expect(() => assertJsonWithinLimits([1, 2, 3], { maxDepth: 2, maxNodes: 3 })).toThrowError(
       /node limit/u,
     );
+  });
+
+  describe("pinned DNS lookup", () => {
+    const pinned = { address: "203.0.113.7", family: 4 } as const;
+
+    it("returns an address array when Node connects in all mode (autoSelectFamily)", () => {
+      const lookup = createPinnedLookup(pinned);
+      let address: unknown;
+      let family: unknown;
+      // lookupAndConnectMultiple calls the hook with { all: true } and reads addresses[0].
+      lookup("chatgpt.com", { all: true }, (error, result, resultFamily) => {
+        expect(error).toBeNull();
+        address = result;
+        family = resultFamily;
+      });
+      expect(address).toEqual([{ address: "203.0.113.7", family: 4 }]);
+      expect(family).toBeUndefined();
+    });
+
+    it("returns the single address form when Node connects without all", () => {
+      const lookup = createPinnedLookup(pinned);
+      let address: unknown;
+      let family: unknown;
+      lookup("chatgpt.com", { all: false }, (error, result, resultFamily) => {
+        expect(error).toBeNull();
+        address = result;
+        family = resultFamily;
+      });
+      expect(address).toBe("203.0.113.7");
+      expect(family).toBe(4);
+    });
   });
 
   it("encodes multipart bodies under an explicit byte budget", () => {

--- a/packages/shared/src/outboundHttp.ts
+++ b/packages/shared/src/outboundHttp.ts
@@ -297,6 +297,26 @@ async function resolvePinnedAddress(
   return selected;
 }
 
+// Node's `autoSelectFamily` (Happy Eyeballs, default-on since Node 20) connects via
+// `lookupAndConnectMultiple`, which invokes the socket `lookup` hook in `all: true`
+// mode and expects the callback to receive an array of addresses. A hook that always
+// replies with the single `(address, family)` form makes Node read `addresses[0].address`
+// off a bare string, yielding `ERR_INVALID_IP_ADDRESS: Invalid IP address: undefined` and
+// killing every pinned request before it leaves the host. Honor both call conventions so
+// the connection is pinned to exactly the one validated address regardless of the mode.
+export function createPinnedLookup(pinned: {
+  readonly address: string;
+  readonly family: 4 | 6;
+}): Net.LookupFunction {
+  return (_hostname, options, callback) => {
+    if (typeof options === "object" && options !== null && options.all) {
+      callback(null, [{ address: pinned.address, family: pinned.family }]);
+      return;
+    }
+    callback(null, pinned.address, pinned.family);
+  };
+}
+
 async function requestHop(input: {
   readonly url: URL;
   readonly method: string;
@@ -323,9 +343,7 @@ async function requestHop(input: {
         method: input.method,
         headers: requestHeaders(input.headers),
         signal: input.signal,
-        lookup: (_hostname, _options, callback) => {
-          callback(null, pinned.address, pinned.family);
-        },
+        lookup: createPinnedLookup(pinned),
       },
       (response) => {
         const headers = responseHeaders(response.headers);


### PR DESCRIPTION
## Problem

Every origin-pinned (`requirePublicAddress`) outbound request fails on Node 20+ with:

```
OutboundHttpError: Outbound request failed.
  cause: ERR_INVALID_IP_ADDRESS: Invalid IP address: undefined
    at lookupAndConnectMultiple (node:net)
```

`resolvePinnedAddress` resolves each destination to a single validated public IP and pins the socket to it via a custom `lookup` hook. That hook always replied in the single `(address, family)` form. Since Node 20, `autoSelectFamily` (Happy Eyeballs) defaults to on and connects via `lookupAndConnectMultiple`, which invokes the `lookup` hook in `all: true` mode and expects an **array** of addresses. Given a bare string, Node reads `addresses[0].address` off it → `undefined` → the connection is rejected before it ever leaves the host.

This affects **all** origin-pinned outbound calls (voice transcription, favicon fetches, provider usage probes, …), not a single endpoint. Reproduces reliably on Node 24; surfaced first via voice transcription failing with the error above.

## Fix

Extract `createPinnedLookup`, which honors both call conventions: a one-element address array in `all` mode, the single form otherwise. The connection is still pinned to exactly the one validated address, so the SSRF guarantee is unchanged.

## Tests

Added unit coverage for both lookup modes. `outboundHttp` suite passes 18/18; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)