### PR TITLE
Close sidebar terminal pane on shell exit

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -476,6 +476,7 @@ interface ThreadTerminalDrawerProps {
   workspaceCloseShortcutLabel?: string | undefined;
   onActiveTerminalChange: (terminalId: string) => void;
   onCloseTerminal: (terminalId: string) => void;
+  onSessionExited?: (terminalId: string) => void;
   onCloseTerminalGroup: (groupId: string) => void;
   onHeightChange: (height: number) => void;
   onResizeTerminalSplit: (groupId: string, splitId: string, weights: number[]) => void;
@@ -522,6 +523,7 @@ export default function ThreadTerminalDrawer({
   workspaceCloseShortcutLabel,
   onActiveTerminalChange,
   onCloseTerminal,
+  onSessionExited,
   onCloseTerminalGroup,
   onHeightChange,
   onResizeTerminalSplit,
@@ -734,7 +736,7 @@ export default function ThreadTerminalDrawer({
                   terminalCliKind={terminalVisualIdentityById.get(terminalId)?.cliKind ?? null}
                   cwd={cwd}
                   {...(runtimeEnv ? { runtimeEnv } : {})}
-                  onSessionExited={() => onCloseTerminal(terminalId)}
+                  onSessionExited={() => (onSessionExited ?? onCloseTerminal)(terminalId)}
                   onTerminalMetadataChange={onTerminalMetadataChange}
                   onTerminalActivityChange={onTerminalActivityChange}
                   onAddTerminalContext={onAddTerminalContext}

--- a/apps/web/src/components/chat/DockTerminalPane.tsx
+++ b/apps/web/src/components/chat/DockTerminalPane.tsx
@@ -9,7 +9,7 @@
 // "ensure a terminal is open" policy is surface-specific (here: a single terminal-only page).
 
 import { type ProjectId, type ThreadId } from "@synara/contracts";
-import { useMemo, useEffect } from "react";
+import { useMemo, useEffect, useRef } from "react";
 
 import { useTerminalSurfaceController } from "~/hooks/useTerminalSurfaceController";
 import { dockTerminalThreadId } from "~/lib/dockTerminalScope";
@@ -24,6 +24,7 @@ export function DockTerminalPane(props: {
   // When false the pane stays mounted but hidden (another dock tab is active),
   // so the xterm runtime sleeps its visual work without detaching its DOM.
   isActive?: boolean;
+  onClosePanel?: () => void;
 }) {
   const scopeId = dockTerminalThreadId(props.hostThreadId);
   const thread = useStore(
@@ -41,23 +42,35 @@ export function DockTerminalPane(props: {
 
   const terminal = useTerminalSurfaceController(scopeId);
   const { terminalState, openTerminalThreadPage, bumpFocusRequest, newTerminalGroup } = terminal;
+  const closedBySessionExitRef = useRef(false);
 
-  // A dock terminal pane always shows a live terminal: ensure one is open on mount
-  // and re-open if the user closes the last tab (normalize guarantees a default id).
+  // A dock terminal pane normally keeps a live terminal: ensure one is open on mount
+  // and re-open if the user closes the last tab. When the shell exits on its own,
+  // onSessionExited marks the ref so we do not immediately resurrect an empty tab.
   useEffect(() => {
-    if (terminalState.terminalOpen) {
+    if (terminalState.terminalOpen || closedBySessionExitRef.current) {
       return;
     }
     openTerminalThreadPage(scopeId, { terminalOnly: true });
   }, [openTerminalThreadPage, scopeId, terminalState.terminalOpen]);
 
   const createTerminal = () => {
+    closedBySessionExitRef.current = false;
     if (!terminalState.terminalOpen) {
       openTerminalThreadPage(scopeId, { terminalOnly: true });
       bumpFocusRequest();
       return;
     }
     newTerminalGroup();
+  };
+
+  const onSessionExited = (terminalId: string) => {
+    const isLastTerminal = terminalState.terminalIds.length <= 1;
+    if (isLastTerminal) {
+      closedBySessionExitRef.current = true;
+      props.onClosePanel?.();
+    }
+    terminal.onSessionExited(terminalId);
   };
 
   return (
@@ -86,6 +99,7 @@ export function DockTerminalPane(props: {
       onMoveTerminalToGroup={terminal.moveTerminalToNewGroup}
       onActiveTerminalChange={terminal.activateTerminal}
       onCloseTerminal={terminal.closeTerminal}
+      onSessionExited={onSessionExited}
       onCloseTerminalGroup={terminal.closeTerminalGroup}
       onHeightChange={terminal.setTerminalHeight}
       onResizeTerminalSplit={terminal.resizeTerminalSplit}

--- a/apps/web/src/components/chat/SingleChatSurface.tsx
+++ b/apps/web/src/components/chat/SingleChatSurface.tsx
@@ -711,6 +711,7 @@ export function SingleChatSurface(props: {
               hostThreadId={props.threadId}
               projectId={props.projectId}
               isActive={context.isActive && dockState.open}
+              onClosePanel={() => closePane(props.threadId, pane.id)}
             />
           </Suspense>
         );

--- a/apps/web/src/hooks/useTerminalSurfaceController.ts
+++ b/apps/web/src/hooks/useTerminalSurfaceController.ts
@@ -107,6 +107,12 @@ export function useTerminalSurfaceController(threadId: ThreadId) {
     bumpFocusRequest();
   };
 
+  const onSessionExited = (terminalId: string) => {
+    disposeAndCloseTerminalSession({ api: readNativeApi(), threadId, terminalId });
+    closeTerminalStore(threadId, terminalId);
+    bumpFocusRequest();
+  };
+
   const closeTerminalGroup = (groupId: string) => closeTerminalGroupStore(threadId, groupId);
 
   const setTerminalHeight = (height: number) => setTerminalHeightStore(threadId, height);
@@ -133,6 +139,7 @@ export function useTerminalSurfaceController(threadId: ThreadId) {
     moveTerminalToNewGroup,
     activateTerminal,
     closeTerminal,
+    onSessionExited,
     closeTerminalGroup,
     setTerminalHeight,
     resizeTerminalSplit,


### PR DESCRIPTION
## Summary
- When the user types `exit` in a sidebar/dock terminal, close the tab immediately without a confirmation dialog.
- If it is the last terminal in the pane, close the whole terminal panel instead of leaving an empty tab behind.
- Suppress the dock pane's auto-reopen behavior when the close came from a shell exit.

## Test plan
- [x] Open a terminal in the right dock/sidebar, type `exit` → tab closes.
- [x] With only one terminal in the sidebar, type `exit` → the terminal panel closes.
- [x] Manual close (× button) still prompts when a subprocess is running.
- [x] `bun fmt`, `bun lint`, and `bun typecheck` pass.
- [x] Desktop build succeeds and Canary restarts.

Generated with [Devin](https://devin.ai)